### PR TITLE
Fix browsersync setup within Webpack

### DIFF
--- a/webpack.config.develop.js
+++ b/webpack.config.develop.js
@@ -5,9 +5,8 @@ const { PORT } = require('./config')
 module.exports = {
   plugins: [
     new BrowserSyncPlugin({
-      script: './start.js',
-    }, {
       proxy: `http://localhost:${PORT}`,
+      port: '3001',
       open: false,
       files: [
         '.build/**/*.*',


### PR DESCRIPTION
Browsersync wasn't creating a correct instance of the app as
the first argument to the plugin was wrong.

This fixes the call to the webpack browsersync plugin so that
it will create the correct URL to auto-refresh changes to the app.

It also specifically sets the port number so that it will always
match what is in the README.