### PR TITLE
[P4-202] Pagination component

### DIFF
--- a/common/assets/scss/components/_all.scss
+++ b/common/assets/scss/components/_all.scss
@@ -1,1 +1,4 @@
 @import "stack-trace";
+
+// Load components from the shared components folder
+@import "pagination/pagination";

--- a/common/components/pagination/_pagination.scss
+++ b/common/components/pagination/_pagination.scss
@@ -1,0 +1,102 @@
+.app-pagination {
+  display: block;
+  list-style: none;
+  margin-left: -(govuk-spacing(3));
+  margin-right: -(govuk-spacing(3));
+}
+
+.app-pagination__list {
+  padding-left: 0;
+  margin: 0;
+}
+
+.app-pagination__list-item {
+  display: block;
+}
+
+.app-pagination__link {
+  display: block;
+  padding: govuk-spacing(3);
+
+  &:link,
+  &:visited,
+  &:active,
+  &:hover {
+    color: $govuk-link-colour;
+  }
+
+  &:focus {
+    background-color: transparent;
+  }
+
+  &:hover {
+    background-color: govuk-colour("grey-4");
+  }
+}
+
+.app-pagination__link-title {
+  @include govuk-font($size: 19, $weight: bold);
+  display: block;
+  font-weight: 700;
+}
+
+.app-pagination__link-text {
+  display: inline-block;
+  text-decoration: none;
+
+  .app-pagination__list-item--prev &,
+  .app-pagination__list-item--next & {
+    margin-left: govuk-spacing(2);
+  }
+}
+
+.app-pagination__link-icon {
+  @include govuk-font($size: 24);
+  float: left;
+  height: 1em;
+  position: relative;
+  top: 1px;
+  width: .63em;
+}
+
+.app-pagination__link-divider {
+  @include govuk-visually-hidden;
+}
+
+.app-pagination__link-label {
+  @include govuk-font($size: 16);
+  display: inline-block;
+  text-decoration: underline;
+  margin-left: 25px;
+  margin-top: 0.1em;
+}
+
+// Modifiers
+.app-pagination--inline {
+  .app-pagination__list-item {
+    display: inline;
+  }
+
+  .app-pagination__link {
+    display: inline-block;
+  }
+
+  .app-pagination__link-text {
+    font-weight: normal;
+  }
+
+  .app-pagination__list-item--next {
+    .app-pagination__link-text {
+      margin-left: 0;
+      margin-right: govuk-spacing(2);
+    }
+
+    .app-pagination__link-icon {
+      float: right;
+    }
+
+    .app-pagination__link-label {
+      margin-left: 0;
+    }
+  }
+}

--- a/common/components/pagination/macro.njk
+++ b/common/components/pagination/macro.njk
@@ -1,0 +1,3 @@
+{% macro appPagination(params) %}
+  {%- include "./template.njk" -%}
+{% endmacro %}

--- a/common/components/pagination/pagination.yaml
+++ b/common/components/pagination/pagination.yaml
@@ -1,0 +1,70 @@
+params:
+- name: classes
+  type: string
+  required: false
+  description: Classes to add to the parent element. Use `app-pagination--inline` to create the inline variation.
+- name: previous
+  type: object
+  required: true
+  description: Previous navigation item
+  params:
+    - name: href
+      type: string
+      required: true
+      description: The destination of the previous link
+    - name: text
+      type: string
+      required: false
+      description: The text to use as the main title. If not provided, defaults to `Previous`
+    - name: label
+      type: string
+      required: false
+      description: Supporting label to give a more detailed description of the previous page
+- name: next
+  type: object
+  required: true
+  description: Next navigation item
+  params:
+    - name: href
+      type: string
+      required: true
+      description: The destination of the next link
+    - name: text
+      type: string
+      required: false
+      description: The text to use as the main title. If not provided, defaults to `Next`
+    - name: label
+      type: string
+      required: false
+      description: Supporting label to give a more detailed description of the next page
+
+examples:
+  - name: default
+    data:
+      previous:
+        href: "/previous-page"
+      next:
+        href: "/next-page"
+  - name: with labels
+    data:
+      previous:
+        href: "/page-1"
+        label: "1 of 300"
+      next:
+        href: "/page-3"
+        label: "3 of 300"
+  - name: with custom title text
+    data:
+      previous:
+        href: "/previous-day"
+        text: "Previous day"
+      next:
+        href: "/next-day"
+        label: "Next day"
+  - name: inline variation
+    data:
+      classes: app-pagination--inline
+      previous:
+        href: "/previous-page"
+      next:
+        href: "/next-page"

--- a/common/components/pagination/template.njk
+++ b/common/components/pagination/template.njk
@@ -1,0 +1,46 @@
+{% set prevText = params.previous.text or "Previous" %}
+{% set nextText = params.next.text or "Next" %}
+
+<nav class="app-pagination {%- if params.classes %} {{ params.classes }}{% endif %}" role="navigation" aria-label="Pagination">
+  <ul class="app-pagination__list">
+    {% if params.previous %}
+      <li class="app-pagination__list-item app-pagination__list-item--prev">
+        <a href="{{ params.previous.href }}" class="app-pagination__link" rel="prev">
+          <span class="app-pagination__link-title">
+            <svg class="app-pagination__link-icon" xmlns="http://www.w3.org/2000/svg" height="13" width="17" viewBox="0 0 17 13">
+              <path fill="currentColor" d="m6.5938-0.0078125-6.7266 6.7266 6.7441 6.4062 1.377-1.449-4.1856-3.9768h12.896v-2h-12.984l4.2931-4.293-1.414-1.414z"></path>
+            </svg><!--
+            --><span class="app-pagination__link-text">{{ prevText }}</span>
+          </span>
+
+          {% if params.previous.label %}
+            <span class="app-pagination__link-divider">:</span>
+            <span class="app-pagination__link-label">
+              {{ params.previous.label }}
+            </span>
+          {% endif %}
+        </a>
+      </li>
+    {% endif %}
+
+    {% if params.next %}
+      <li class="app-pagination__list-item app-pagination__list-item--next">
+        <a href="{{ params.next.href }}" class="app-pagination__link" rel="next">
+          <span class="app-pagination__link-title">
+            <svg class="app-pagination__link-icon" xmlns="http://www.w3.org/2000/svg" height="13" width="17" viewBox="0 0 17 13">
+              <path fill="currentColor" d="m10.107-0.0078125-1.4136 1.414 4.2926 4.293h-12.986v2h12.896l-4.1855 3.9766 1.377 1.4492 6.7441-6.4062-6.7246-6.7266z"></path>
+            </svg><!--
+            --><span class="app-pagination__link-text">{{ nextText }}</span>
+          </span>
+
+          {% if params.next.label %}
+            <span class="app-pagination__link-divider">:</span>
+            <span class="app-pagination__link-label">
+              {{ params.next.label }}
+            </span>
+          {% endif %}
+        </a>
+      </li>
+    {% endif %}
+  </ul>
+</nav>

--- a/common/components/pagination/template.test.js
+++ b/common/components/pagination/template.test.js
@@ -1,0 +1,132 @@
+const { render, getExamples } = require('../../../test/unit/component-helpers')
+
+const examples = getExamples('pagination')
+
+describe('Pagination component', () => {
+  context('default', () => {
+    it('should render previous link', () => {
+      const $ = render('pagination', examples.default)
+
+      const $component = $('.app-pagination')
+      const $item = $component.find('.app-pagination__list-item--prev')
+      const $itemText = $item.find('.app-pagination__link-text')
+      const $itemLink = $item.find('a')
+
+      expect($itemText.text()).to.equal('Previous')
+      expect($itemLink.attr('href')).to.equal('/previous-page')
+    })
+
+    it('should render next link', () => {
+      const $ = render('pagination', examples.default)
+
+      const $component = $('.app-pagination')
+      const $item = $component.find('.app-pagination__list-item--next')
+      const $itemText = $item.find('.app-pagination__link-text')
+      const $itemLink = $item.find('a')
+
+      expect($itemText.text()).to.equal('Next')
+      expect($itemLink.attr('href')).to.equal('/next-page')
+    })
+  })
+
+  context('without next or previous', () => {
+    it('should not render previous link', () => {
+      const $ = render('pagination', {})
+
+      const $component = $('.app-pagination')
+      const $item = $component.find('.app-pagination__list-item--prev')
+      expect($item.length).to.equal(0)
+    })
+
+    it('should not render next link', () => {
+      const $ = render('pagination', {})
+
+      const $component = $('.app-pagination')
+      const $item = $component.find('.app-pagination__list-item--next')
+      expect($item.length).to.equal(0)
+    })
+  })
+
+  context('with classes', () => {
+    it('should render classes', () => {
+      const $ = render('pagination', {
+        classes: 'app-pagination--custom-class',
+      })
+
+      const $component = $('.app-pagination')
+      expect($component.hasClass('app-pagination--custom-class')).to.be.true
+    })
+  })
+
+  context('with labels', () => {
+    it('should render previous label', () => {
+      const $ = render('pagination', {
+        previous: {
+          href: '/page-1',
+          label: '1 of 300',
+        },
+      })
+
+      const $component = $('.app-pagination')
+      const $item = $component.find('.app-pagination__list-item--prev')
+      const $itemLabel = $item.find('.app-pagination__link-label')
+      const $itemLink = $item.find('a')
+
+      expect($itemLabel.text().trim()).to.equal('1 of 300')
+      expect($itemLink.attr('href')).to.equal('/page-1')
+    })
+
+    it('should render next label', () => {
+      const $ = render('pagination', {
+        next: {
+          href: '/page-3',
+          label: '3 of 300',
+        },
+      })
+
+      const $component = $('.app-pagination')
+      const $item = $component.find('.app-pagination__list-item--next')
+      const $itemLabel = $item.find('.app-pagination__link-label')
+      const $itemLink = $item.find('a')
+
+      expect($itemLabel.text().trim()).to.equal('3 of 300')
+      expect($itemLink.attr('href')).to.equal('/page-3')
+    })
+  })
+
+  context('with custom text', () => {
+    it('should render previous text', () => {
+      const $ = render('pagination', {
+        previous: {
+          href: '/previous-day',
+          text: 'Previous day',
+        },
+      })
+
+      const $component = $('.app-pagination')
+      const $item = $component.find('.app-pagination__list-item--prev')
+      const $itemText = $item.find('.app-pagination__link-text')
+      const $itemLink = $item.find('a')
+
+      expect($itemText.text().trim()).to.equal('Previous day')
+      expect($itemLink.attr('href')).to.equal('/previous-day')
+    })
+
+    it('should render next label', () => {
+      const $ = render('pagination', {
+        next: {
+          href: '/next-day',
+          text: 'Next day',
+        },
+      })
+
+      const $component = $('.app-pagination')
+      const $item = $component.find('.app-pagination__list-item--next')
+      const $itemText = $item.find('.app-pagination__link-text')
+      const $itemLink = $item.find('a')
+
+      expect($itemText.text().trim()).to.equal('Next day')
+      expect($itemLink.attr('href')).to.equal('/next-day')
+    })
+  })
+})

--- a/common/templates/layouts/govuk.njk
+++ b/common/templates/layouts/govuk.njk
@@ -1,5 +1,7 @@
 {% extends "template.njk" %}
 
+{% from "pagination/macro.njk"        import appPagination %}
+
 {% block head %}
   <!--[if lte IE 8]><link href="/stylesheets/styles-ie8.css" rel="stylesheet" type="text/css" /><![endif]-->
   <!--[if gt IE 8]><!--><link href="/stylesheets/styles.css" media="all" rel="stylesheet" type="text/css" /><!--<![endif]-->


### PR DESCRIPTION
This change adds a pagination component that will be used on the dashboard
to paginate between days.

Right now it mimics the [pagination component used on GOV.UK](https://www.gov.uk/types-of-prison-sentence/suspended-prison-sentences) but support custom text and optional labels.

## What it looks like

### Default
![image](https://user-images.githubusercontent.com/3327997/57388700-a94ba300-71b0-11e9-91d3-740fcac3c3f7.png)


### Custom text
![image](https://user-images.githubusercontent.com/3327997/57388739-bc5e7300-71b0-11e9-90f4-2c4c26a4ab8b.png)

### With labels
![image](https://user-images.githubusercontent.com/3327997/57388772-d304ca00-71b0-11e9-8a74-ce284af19c5e.png)

### Inline variation
![image](https://user-images.githubusercontent.com/3327997/57388920-1bbc8300-71b1-11e9-87a0-1882e82b55d6.png)
