### PR TITLE
[P4-242] Add time component

### DIFF
--- a/common/components/time/macro.njk
+++ b/common/components/time/macro.njk
@@ -1,0 +1,3 @@
+{% macro appTime(params) %}
+  {%- include "./template.njk" -%}
+{% endmacro %}

--- a/common/components/time/template.njk
+++ b/common/components/time/template.njk
@@ -1,0 +1,3 @@
+<time class="{{ params.classes }}" datetime="{{ params.datetime }}">
+  {{ params.text or params.datetime }}
+</time>

--- a/common/components/time/template.test.js
+++ b/common/components/time/template.test.js
@@ -1,0 +1,60 @@
+const { render, getExamples } = require('../../../test/unit/component-helpers')
+
+const examples = getExamples('time')
+
+describe('Time component', () => {
+  context('by default', () => {
+    let $component
+
+    beforeEach(() => {
+      const $ = render('time', examples.default)
+      $component = $('time')
+    })
+
+    it('should render', () => {
+      expect($component.length).to.equal(1)
+    })
+
+    it('should contain a datetime attribute', () => {
+      const $datetimeAttr = $component.attr('datetime')
+      expect($datetimeAttr).to.equal('2019-01-10')
+    })
+
+    it('should use the datetime as element text', () => {
+      expect($component.text().trim()).to.equal('2019-01-10')
+    })
+  })
+
+  context('with classes', () => {
+    it('should render classes', () => {
+      const $ = render('time', {
+        classes: 'custom-class',
+      })
+
+      const $component = $('time')
+      expect($component.hasClass('custom-class')).to.be.true
+    })
+  })
+
+  context('with custom text', () => {
+    let $component
+
+    beforeEach(() => {
+      const $ = render('time', {
+        datetime: '2019-01-10',
+        text: 'Today',
+      })
+
+      $component = $('time')
+    })
+
+    it('should contain a datetime attribute', () => {
+      const $datetimeAttr = $component.attr('datetime')
+      expect($datetimeAttr).to.equal('2019-01-10')
+    })
+
+    it('should contain custom text', () => {
+      expect($component.text().trim()).to.equal('Today')
+    })
+  })
+})

--- a/common/components/time/time.yaml
+++ b/common/components/time/time.yaml
@@ -1,0 +1,22 @@
+params:
+  - name: datetime
+    type: datetime
+    required: true
+    description: The value to be used for the datetime attribute. Follow accepted formats for the <time> element.
+  - name: text
+    type: string
+    required: false
+    description: Alternative text to be displayed within the element.
+  - name: classes
+    type: string
+    required: false
+    description: Classes to add to the element.
+
+examples:
+  - name: default
+    data:
+      datetime: "2019-01-10"
+  - name: with custom text
+    data:
+      datetime: "2019-01-10"
+      text: "Today"

--- a/common/templates/layouts/govuk.njk
+++ b/common/templates/layouts/govuk.njk
@@ -1,6 +1,7 @@
 {% extends "template.njk" %}
 
 {% from "pagination/macro.njk"        import appPagination %}
+{% from "time/macro.njk"              import appTime %}
 
 {% block head %}
   <!--[if lte IE 8]><link href="/stylesheets/styles-ie8.css" rel="stylesheet" type="text/css" /><![endif]-->


### PR DESCRIPTION
This adds a simple time component to semantically display
dates or times within the app.

This component doesn't contain any associated style.

This change will be used for #17 