### PR TITLE
Fix keyline separator with card component

### DIFF
--- a/common/components/card/_card.scss
+++ b/common/components/card/_card.scss
@@ -2,11 +2,13 @@
   @include govuk-clearfix;
   display: flex;
   align-items: flex-start;
+  border-bottom: 1px solid $govuk-border-colour;
+  border-top: 1px solid $govuk-border-colour;
   padding-top: govuk-spacing(3);
   padding-bottom: govuk-spacing(3);
 
   & + & {
-    border-top: 1px solid $govuk-border-colour;
+    border-top: 0;
   }
 }
 


### PR DESCRIPTION
During a rebase the styles that applied the border were missed off
the styles for the card component.

This change adds them back in.

The `& + &` selector removes the top border when cards appear
next to each other in the DOM avoiding double borders being
displayed.

## Before
![image](https://user-images.githubusercontent.com/3327997/58024961-4987bd00-7b0b-11e9-931c-a7c561580c0b.png)

## After
![image](https://user-images.githubusercontent.com/3327997/58025002-615f4100-7b0b-11e9-8a13-ccae80508d75.png)
