### PR TITLE
Remove use of strict mode in node start command

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "scripts": {
     "clean": "del .build/",
     "build": "npm run clean && webpack --config webpack.config.js",
-    "start": "node --use-strict start.js",
+    "start": "node start.js",
     "develop": "run-p watch:js:*",
     "test": "NODE_ENV=test LOG_LEVEL=silent mocha './app/**/*.test.js' './common/**/*.test.js' './config/**/*.test.js' --opts ./test/unit/mocha.opts",
     "lint": "eslint ./",


### PR DESCRIPTION
The use of strict mode is currently throwing an error in a
dependency library due to its use of Octal literals.

For more information see this issue:
https://github.com/mixu/minilog/pull/43

This change removes the `--use-strict` flag temporarily to
prevent the error being thrown on starting the application.

This creates a temporary fix for #32 