### PR TITLE
Update caption style for card component

### DIFF
--- a/common/components/card/_card.scss
+++ b/common/components/card/_card.scss
@@ -2,14 +2,9 @@
   @include govuk-clearfix;
   display: flex;
   align-items: flex-start;
-  border-bottom: 1px solid $govuk-border-colour;
   border-top: 1px solid $govuk-border-colour;
   padding-top: govuk-spacing(3);
   padding-bottom: govuk-spacing(3);
-
-  & + & {
-    border-top: 0;
-  }
 }
 
 .app-card__aside {
@@ -21,17 +16,21 @@
 }
 
 .app-card__caption {
-  @include govuk-font($size: 19, $weight: bold);
+  @include govuk-clearfix;
+}
 
-  @include mq ($from: desktop) {
-    margin-right: govuk-spacing(2);
-    float: left;
-  }
+.app-card__caption {
+  @include govuk-font($size: 19);
 }
 
 .app-card__title {
   @include govuk-font($size: 19, $weight: bold);
   margin: 0;
+
+  @include mq ($from: desktop) {
+    margin-right: govuk-spacing(2);
+    float: left;
+  }
 }
 
 .app-card__content {

--- a/common/components/card/template.njk
+++ b/common/components/card/template.njk
@@ -11,12 +11,6 @@
 
   <div class="app-card__content">
     <header class="app-card__header">
-      {% if params.caption.html or params.caption.text %}
-        <span class="app-card__caption">
-          {{ params.caption.html | safe if params.caption.html else params.caption.text }}
-        </span>
-      {% endif %}
-
       <h2 class="app-card__title">
         {% if params.href %}
           <a href="{{ params.href }}"  class="app-card__link">
@@ -26,6 +20,12 @@
           </a>
         {% endif %}
       </h2>
+
+      {% if params.caption.html or params.caption.text %}
+        <span class="app-card__caption">
+          {{ params.caption.html | safe if params.caption.html else params.caption.text }}
+        </span>
+      {% endif %}
     </header>
 
     {% if params.meta.items.length %}


### PR DESCRIPTION
The current caption style is given the impression it is a
higher priority than the link to the details of the card.

This change reduces the visual impact of the caption and changes
the order of the elements to reflect the more common action of
clicking the link.

## Before
![localhost_3001__move-date=2019-05-23 (4)](https://user-images.githubusercontent.com/3327997/58483593-7b76d000-8158-11e9-93e0-f2cca06bb1ed.png)

## After
![localhost_3001__move-date=2019-05-23 (3)](https://user-images.githubusercontent.com/3327997/58483585-774ab280-8158-11e9-884f-48bb2f977545.png)
