### PR TITLE
Dynamically load express routers from sub app folders

### DIFF
--- a/app/auth/index.js
+++ b/app/auth/index.js
@@ -1,21 +1,18 @@
 // NPM dependencies
-const express = require('express')
+const router = require('express').Router()
 
 // Local dependencies
-const auth = require('../../common/middleware/authentication')
-const controllers = require('./controllers')
+const { get } = require('./controllers')
+const { processAuthResponse } = require('../../common/middleware/authentication')
 
-// Initialisation
-const router = new express.Router()
-const paths = {
-  index: '/auth',
-}
+// Load router middleware
+router.use(processAuthResponse)
 
-// Routing
-router.get(paths.index, auth.processAuthResponse, controllers.get)
+// Define routes
+router.get('/', get)
 
 // Export
 module.exports = {
   router,
-  paths,
+  mountpath: '/auth',
 }

--- a/app/dashboard/index.js
+++ b/app/dashboard/index.js
@@ -1,21 +1,18 @@
 // NPM dependencies
-const express = require('express')
+const router = require('express').Router()
 
 // Local dependencies
-const auth = require('../../common/middleware/authentication')
-const controllers = require('./controllers')
+const { get } = require('./controllers')
+const { ensureAuthenticated } = require('../../common/middleware/authentication')
 
-// Initialisation
-const router = new express.Router()
-const paths = {
-  index: '/',
-}
+// Load router middleware
+router.use(ensureAuthenticated)
 
-// Routing
-router.get(paths.index, auth.ensureAuthenticated, controllers.get)
+// Define routes
+router.get('/', get)
 
 // Export
 module.exports = {
   router,
-  paths,
+  mountpath: '/',
 }

--- a/app/moves/index.js
+++ b/app/moves/index.js
@@ -1,22 +1,22 @@
 // NPM dependencies
-const express = require('express')
+const router = require('express').Router()
 
 // Local dependencies
 const { get } = require('./controllers')
 const { setMove } = require('./middleware')
+const { ensureAuthenticated } = require('../../common/middleware/authentication')
 
-// Initialisation
-const router = new express.Router()
-const paths = {
-  index: '/moves/:moveId',
-}
-
-// Routing
+// Define param middleware
 router.param('moveId', setMove)
-router.get(paths.index, get)
+
+// Load router middleware
+router.use(ensureAuthenticated)
+
+// Define routes
+router.get('/:moveId', get)
 
 // Export
 module.exports = {
   router,
-  paths,
+  mountpath: '/moves',
 }

--- a/app/router.js
+++ b/app/router.js
@@ -1,11 +1,20 @@
-// Local dependencies
-const dashboard = require('./dashboard')
-const moves = require('./moves')
-const auth = require('./auth')
+const router = require('express').Router()
+const fs = require('fs')
 
-// Export
-module.exports.bind = app => {
-  app.use(dashboard.router)
-  app.use(moves.router)
-  app.use(auth.router)
-}
+const subApps = fs.readdirSync(__dirname)
+
+const appRouters = subApps.map(subAppDir => {
+  const subApp = require(`./${subAppDir}`)
+
+  if (subApp.router) {
+    if (subApp.mountpath) {
+      return router.use(subApp.mountpath, subApp.router)
+    }
+
+    return router.use(subApp.router)
+  }
+
+  return (req, res, next) => next()
+})
+
+module.exports = appRouters

--- a/server.js
+++ b/server.js
@@ -73,7 +73,7 @@ app.use('/assets', express.static(path.join(__dirname, '/node_modules/govuk-fron
 app.use(locals)
 
 // Routing
-router.bind(app)
+app.use(router)
 
 // error handling
 app.use(errorHandlers.notFound)


### PR DESCRIPTION
This change introduces dynamic loading of sub-app routers rather
than needing to manually load them in the router.

This change also introduces support for express mountpaths to
allow apps to be mounted from a particular url path if one is
defined.

This also fixes an issue with middleware defined in sub-apps being
globally loaded and should scope them to only their particular
router.