### PR TITLE
Add defaults for env variables to the config

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,17 +109,17 @@ npm run lint
 
 ## Environment variables
 
-| Name | Description |
-|:-----|:------------|
-| API_BASE_URL | The base url for the backend API server for this service |
-| SERVER_HOST | The (accessible) hostname (and port) of the listening web server, e.g. `localhost:3000`. Used by Grant to construct re-direct URLs after OAuth authentication |
-| SESSION_SECRET | A complex string unique to the environment, used to encrypt cookies |
-| AUTH_PROVIDER_KEY | The client key provided by the OAuth2 provider for user authentication |
-| AUTH_PROVIDER_SECRET | The client secret provided by the OAuth2 provider for user authentication |
-| OKTA_SUBDOMAIN | The Okta subdomain provided to you (while Okta is the OAuth2 provider). Should be unique to the environment |
-| REDIS_HOST | The hostname or IP address the Redis server is listening on |
-| REDIS_PORT | The port number the Redis server is listening on (e.g. 6379) |
-| REDIS_SESSION_DB | The Redis database index in which to store session data (e.g. 0) |
+| Name | Description | Default |
+|:-----|:------------|:--------|
+| API_BASE_URL | The base url for the backend API server for this service | http://localhost:5000/api/v1 |
+| SERVER_HOST | The (accessible) hostname (and port) of the listening web server, e.g. `localhost:3000`. Used by Grant to construct re-direct URLs after OAuth authentication | localhost:{PORT} |
+| SESSION_SECRET | A complex string unique to the environment, used to encrypt cookies | |
+| AUTH_PROVIDER_KEY | The client key provided by the OAuth2 provider for user authentication | |
+| AUTH_PROVIDER_SECRET | The client secret provided by the OAuth2 provider for user authentication | |
+| OKTA_SUBDOMAIN | The Okta subdomain provided to you (while Okta is the OAuth2 provider). Should be unique to the environment | |
+| REDIS_HOST | The hostname or IP address the Redis server is listening on | localhost |
+| REDIS_PORT | The port number the Redis server is listening on | 6379 |
+| REDIS_SESSION_DB | The Redis database index in which to store session data | 0 |
 
 ## Components
 

--- a/config/index.js
+++ b/config/index.js
@@ -1,12 +1,13 @@
 /* eslint no-process-env: "off" */
 const IS_DEV = process.env.NODE_ENV !== 'production'
 const IS_PRODUCTION = process.env.NODE_ENV === 'production'
+const PORT = process.env.PORT || 3000
 
 module.exports = {
   IS_DEV,
   IS_PRODUCTION,
-  PORT: process.env.PORT || 3000,
-  SERVER_HOST: process.env.SERVER_HOST,
+  PORT,
+  SERVER_HOST: process.env.SERVER_HOST || `localhost:${PORT}`,
   LOG_LEVEL: process.env.LOG_LEVEL || (IS_DEV ? 'debug' : 'error'),
   NO_CACHE: process.env.CACHE_ASSETS ? false : IS_DEV,
   API: {
@@ -20,11 +21,11 @@ module.exports = {
   ASSETS_HOST: process.env.ASSETS_HOST || '',
   SESSION: {
     SECRET: process.env.SESSION_SECRET,
-    REDIS_STORE_DATABASE: process.env.REDIS_SESSION_DB,
+    REDIS_STORE_DATABASE: process.env.REDIS_SESSION_DB || 0,
   },
   REDIS: {
-    HOST: process.env.REDIS_HOST,
-    PORT: process.env.REDIS_PORT,
+    HOST: process.env.REDIS_HOST || 'localhost',
+    PORT: process.env.REDIS_PORT || 6379,
   },
   AUTH: {
     PROVIDER_KEY: process.env.AUTH_PROVIDER_KEY,


### PR DESCRIPTION
This avoids the need for having to set all environment variables
in your dotenv file if there are standard defaults that can be used.