### PR TITLE
[P4-209] Create meta list component

### DIFF
--- a/common/assets/scss/components/_all.scss
+++ b/common/assets/scss/components/_all.scss
@@ -5,4 +5,5 @@
 @import "card/card";
 @import "data/data";
 @import "internal-header/internal-header";
+@import "meta-list/meta-list";
 @import "pagination/pagination";

--- a/common/components/meta-list/_meta-list.scss
+++ b/common/components/meta-list/_meta-list.scss
@@ -1,0 +1,24 @@
+.app-meta-list {
+  @include govuk-font($size: 19);
+  width: 100%;
+  margin: govuk-spacing(2) 0 0;
+}
+
+.app-meta-list__item {
+  & + & {
+    margin-top: govuk-spacing(3);
+  }
+}
+
+.app-meta-list__key,
+.app-meta-list__value {
+  display: block;
+}
+
+.app-meta-list__key {
+  @include govuk-typography-weight-bold;
+}
+
+.app-meta-list__value {
+  margin: 0;
+}

--- a/common/components/meta-list/macro.njk
+++ b/common/components/meta-list/macro.njk
@@ -1,0 +1,3 @@
+{% macro appMetaList(params) %}
+  {%- include "./template.njk" -%}
+{% endmacro %}

--- a/common/components/meta-list/meta-list.yaml
+++ b/common/components/meta-list/meta-list.yaml
@@ -1,0 +1,49 @@
+params:
+- name: classes
+  type: string
+  required: false
+  description: Classes to add to the parent element.
+- name: items
+  type: array
+  required: true
+  description: Array of item objects.
+  params:
+  - name: key
+    type: string
+    required: true
+    description: Key object for an item
+    params:
+    - name: text
+      type: string
+      required: true
+      description: If `html` is set, this is not required. Text to use within each item key. If `html` is provided, the `text` argument will be ignored.
+    - name: html
+      type: string
+      required: true
+      description: If `text` is set, this is not required. HTML to use within each item key. If `html` is provided, the `text` argument will be ignored.
+  - name: value
+    type: string
+    required: true
+    description: Value object for an item
+    params:
+    - name: text
+      type: string
+      required: true
+      description: If `html` is set, this is not required. Text to use within each item value. If `html` is provided, the `text` argument will be ignored.
+    - name: html
+      type: string
+      required: true
+      description: If `text` is set, this is not required. HTML to use within each item value. If `html` is provided, the `text` argument will be ignored.
+
+examples:
+  - name: default
+    data:
+      items:
+      - key:
+          text: From
+        value:
+          text: Home
+      - key:
+          text: To
+        value:
+          text: Work

--- a/common/components/meta-list/template.njk
+++ b/common/components/meta-list/template.njk
@@ -1,0 +1,14 @@
+<dl class="app-meta-list {% if params.classes -%} {{ params.classes }}{%- endif %}">
+  {% for item in params.items %}
+    {% if item.value.text or item.value.html %}
+      <div class="app-meta-list__item">
+        <dt class="app-meta-list__key">
+          {{ item.key.html | safe if item.key.html else item.key.text }}
+        </dt>
+        <dd class="app-meta-list__value">
+          {{ item.value.html | safe if item.value.html else item.value.text }}
+        </dd>
+      </div>
+    {% endif %}
+  {% endfor %}
+</dl>

--- a/common/components/meta-list/template.test.js
+++ b/common/components/meta-list/template.test.js
@@ -1,0 +1,109 @@
+const { render, getExamples } = require('../../../test/unit/component-helpers')
+
+const examples = getExamples('meta-list')
+
+describe('Meta list component', () => {
+  context('default', () => {
+    let $, $component, $items
+
+    beforeEach(() => {
+      $ = render('meta-list', examples.default)
+      $component = $('.app-meta-list')
+      $items = $component.find('.app-meta-list__item')
+    })
+
+    it('should render', () => {
+      expect($component.length).to.equal(1)
+    })
+
+    it('should render correct number of items', () => {
+      expect($items.length).to.equal(2)
+    })
+  })
+
+  context('with classes', () => {
+    it('should render classes', () => {
+      const $ = render('meta-list', {
+        classes: 'app-meta-list--custom-class',
+      })
+
+      const $component = $('.app-meta-list')
+      expect($component.hasClass('app-meta-list--custom-class')).to.be.true
+    })
+  })
+
+  context('items with text', () => {
+    let $, $items
+
+    beforeEach(() => {
+      $ = render('meta-list', {
+        items: [
+          {
+            key: {
+              text: 'From',
+            },
+            value: {
+              text: 'Home',
+            },
+          },
+          {
+            key: {
+              text: '<span>To</span>',
+            },
+            value: {
+              text: '<em>Work</em>',
+            },
+          },
+        ],
+      })
+      $items = $('.app-meta-list').find('.app-meta-list__item')
+    })
+
+    it('should render text', () => {
+      const $item1 = $($items[0])
+      const $key = $item1.find('.app-meta-list__key')
+      const $value = $item1.find('.app-meta-list__value')
+
+      expect($key.html().trim()).to.equal('From')
+      expect($value.html().trim()).to.equal('Home')
+    })
+
+    it('should escape HTML', () => {
+      const $item2 = $($items[1])
+      const $key = $item2.find('.app-meta-list__key')
+      const $value = $item2.find('.app-meta-list__value')
+
+      expect($key.html().trim()).to.equal('&lt;span&gt;To&lt;/span&gt;')
+      expect($value.html().trim()).to.equal('&lt;em&gt;Work&lt;/em&gt;')
+    })
+  })
+
+  context('items with html', () => {
+    let $, $items
+
+    beforeEach(() => {
+      $ = render('meta-list', {
+        items: [
+          {
+            key: {
+              html: '<span>To</span>',
+            },
+            value: {
+              html: '<em>Work</em>',
+            },
+          },
+        ],
+      })
+      $items = $('.app-meta-list').find('.app-meta-list__item')
+    })
+
+    it('should render HTML', () => {
+      const $item1 = $($items[0])
+      const $key = $item1.find('.app-meta-list__key')
+      const $value = $item1.find('.app-meta-list__value')
+
+      expect($key.html().trim()).to.equal('<span>To</span>')
+      expect($value.html().trim()).to.equal('<em>Work</em>')
+    })
+  })
+})

--- a/common/templates/layouts/govuk.njk
+++ b/common/templates/layouts/govuk.njk
@@ -10,6 +10,7 @@
 {% from "card/macro.njk"              import appCard %}
 {% from "data/macro.njk"              import appData %}
 {% from "internal-header/macro.njk"   import appInternalHeader %}
+{% from "meta-list/macro.njk"         import appMetaList %}
 {% from "pagination/macro.njk"        import appPagination %}
 {% from "time/macro.njk"              import appTime %}
 


### PR DESCRIPTION
This creates a component to display a list of meta data
in as definition list markup and styled appropriately.

This component is currently used to display a summary of the move
on the right hand side of the main content area.

#### Question

I'm not convinced on the name `meta-list` for this component but was all I could think of at the time. 

Would welcome any other suggestions.

## What it looks like

### Just the component

![image](https://user-images.githubusercontent.com/3327997/58720813-1840a400-83cb-11e9-8c04-dd46893d6580.png)

### Within a page context

![image](https://user-images.githubusercontent.com/3327997/58720831-268ec000-83cb-11e9-8633-5b35d16c1ffe.png)
