### PR TITLE
Ensure mocha tests don't use arrow functions

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -38,6 +38,7 @@ module.exports = {
       rules: {
         'no-unused-expressions': 'off',
         'mocha/no-exclusive-tests': 'error',
+        'mocha/no-mocha-arrows': 'error',
       },
       plugins: [
         'mocha',

--- a/app/auth/controllers.test.js
+++ b/app/auth/controllers.test.js
@@ -1,10 +1,10 @@
 const controllers = require('./controllers')
 
-describe('Authentication app', () => {
-  describe('#get()', () => {
+describe('Authentication app', function () {
+  describe('#get()', function () {
     let req, res, url
 
-    beforeEach(async () => {
+    beforeEach(async function () {
       url = '/test'
       req = {
         query: {},
@@ -19,11 +19,11 @@ describe('Authentication app', () => {
       await controllers.get(req, res)
     })
 
-    it('redirects to the intended URL', () => {
+    it('redirects to the intended URL', function () {
       expect(res.redirect).to.be.calledWith(url)
     })
 
-    it('unsets session.postAuthRedirect', () => {
+    it('unsets session.postAuthRedirect', function () {
       expect(req.session.postAuthRedirect).to.equal(null)
     })
   })

--- a/app/dashboard/controllers.test.js
+++ b/app/dashboard/controllers.test.js
@@ -13,15 +13,15 @@ const errorStub = new Error('Problem')
 
 describe('Dashboard app', function () {
   describe('#getController()', function () {
-    beforeEach(() => {
+    beforeEach(function () {
       sinon.stub(presenters, 'movesByToLocation').returnsArg(0)
     })
 
-    context('when query contains no move date', () => {
+    context('when query contains no move date', function () {
       const mockDate = '2017-08-10'
       let req, res
 
-      beforeEach(async () => {
+      beforeEach(async function () {
         sinon.stub(apiClient, 'getMovesByDate').resolves(movesStub)
         this.clock = sinon.useFakeTimers(new Date(mockDate).getTime())
 
@@ -31,7 +31,7 @@ describe('Dashboard app', function () {
         await controllers.get(req, res)
       })
 
-      afterEach(() => {
+      afterEach(function () {
         this.clock.restore()
       })
 
@@ -39,7 +39,7 @@ describe('Dashboard app', function () {
         expect(res.render.calledOnce).to.be.true
       })
 
-      describe('template params', () => {
+      describe('template params', function () {
         it('should contain a page title', function () {
           expect(res.render.args[0][1]).to.have.property('pageTitle')
         })
@@ -65,11 +65,11 @@ describe('Dashboard app', function () {
       })
     })
 
-    context('when query contatins a move date', () => {
+    context('when query contatins a move date', function () {
       const mockDate = '2018-05-10'
       let req, res
 
-      beforeEach(async () => {
+      beforeEach(async function () {
         sinon.stub(apiClient, 'getMovesByDate').resolves(movesStub)
 
         req = {
@@ -86,7 +86,7 @@ describe('Dashboard app', function () {
         expect(res.render.calledOnce).to.be.true
       })
 
-      describe('template params', () => {
+      describe('template params', function () {
         it('should contain a page title', function () {
           expect(res.render.args[0][1]).to.have.property('pageTitle')
         })
@@ -112,10 +112,10 @@ describe('Dashboard app', function () {
       })
     })
 
-    context('when API call returns an error', () => {
+    context('when API call returns an error', function () {
       let req, res, nextSpy
 
-      beforeEach(async () => {
+      beforeEach(async function () {
         sinon.stub(apiClient, 'getMovesByDate').throws(errorStub)
 
         req = {
@@ -127,11 +127,11 @@ describe('Dashboard app', function () {
         await controllers.get(req, res, nextSpy)
       })
 
-      it('should not render a template', () => {
+      it('should not render a template', function () {
         expect(res.render.calledOnce).to.be.false
       })
 
-      it('should send error to next function', () => {
+      it('should send error to next function', function () {
         expect(nextSpy.calledOnce).to.be.true
         expect(nextSpy).to.be.calledWith(errorStub)
       })

--- a/app/moves/middleware.test.js
+++ b/app/moves/middleware.test.js
@@ -16,7 +16,7 @@ describe('Moves middleware', function () {
     context('when no move ID exists', function () {
       let res, nextSpy
 
-      beforeEach(async () => {
+      beforeEach(async function () {
         sinon.stub(apiClient, 'getMoveById').resolves(moveStub)
 
         res = { locals: {} }
@@ -25,16 +25,16 @@ describe('Moves middleware', function () {
         await middleware.setMove({}, res, nextSpy)
       })
 
-      it('should call next with no argument', () => {
+      it('should call next with no argument', function () {
         expect(nextSpy.calledOnce).to.be.true
         expect(nextSpy).to.be.calledWith()
       })
 
-      it('should not call API with move ID', () => {
+      it('should not call API with move ID', function () {
         expect(apiClient.getMoveById).not.to.be.called
       })
 
-      it('should not set response data to locals object', () => {
+      it('should not set response data to locals object', function () {
         expect(res.locals).not.to.have.property('move')
       })
     })
@@ -43,7 +43,7 @@ describe('Moves middleware', function () {
       context('when API call returns succesfully', function () {
         let res, nextSpy
 
-        beforeEach(async () => {
+        beforeEach(async function () {
           sinon.stub(apiClient, 'getMoveById').resolves(moveStub)
 
           res = { locals: {} }
@@ -52,16 +52,16 @@ describe('Moves middleware', function () {
           await middleware.setMove({}, res, nextSpy, mockMoveId)
         })
 
-        it('should call API with move ID', () => {
+        it('should call API with move ID', function () {
           expect(apiClient.getMoveById).to.be.calledWith(mockMoveId)
         })
 
-        it('should set response data to locals object', () => {
+        it('should set response data to locals object', function () {
           expect(res.locals).to.have.property('move')
           expect(res.locals.move).to.equal(moveStub.data)
         })
 
-        it('should call next with no argument', () => {
+        it('should call next with no argument', function () {
           expect(nextSpy.calledOnce).to.be.true
           expect(nextSpy).to.be.calledWith()
         })
@@ -70,7 +70,7 @@ describe('Moves middleware', function () {
       context('when API call returns an error', function () {
         let res, nextSpy
 
-        beforeEach(async () => {
+        beforeEach(async function () {
           sinon.stub(apiClient, 'getMoveById').throws(errorStub)
 
           res = { locals: {} }
@@ -79,11 +79,11 @@ describe('Moves middleware', function () {
           await middleware.setMove({}, res, nextSpy, mockMoveId)
         })
 
-        it('should not set a value on the locals object', () => {
+        it('should not set a value on the locals object', function () {
           expect(res.locals).not.to.have.property('move')
         })
 
-        it('should send error to next function', () => {
+        it('should send error to next function', function () {
           expect(nextSpy.calledOnce).to.be.true
           expect(nextSpy).to.be.calledWith(errorStub)
         })

--- a/common/components/_tag/template.test.js
+++ b/common/components/_tag/template.test.js
@@ -2,26 +2,26 @@ const { render, getExamples } = require('../../../test/unit/component-helpers')
 
 const examples = getExamples('_tag')
 
-describe('Tag component', () => {
-  context('by default', () => {
+describe('Tag component', function () {
+  context('by default', function () {
     let $component
 
-    beforeEach(() => {
+    beforeEach(function () {
       const $ = render('_tag', examples.default)
       $component = $('.app-tag')
     })
 
-    it('should render with strong element', () => {
+    it('should render with strong element', function () {
       expect($component.get(0).tagName).to.equal('strong')
     })
 
-    it('should render text', () => {
+    it('should render text', function () {
       expect($component.text()).to.contain('alpha')
     })
   })
 
-  context('with classes param', () => {
-    it('should render classes', () => {
+  context('with classes param', function () {
+    it('should render classes', function () {
       const $ = render('_tag', {
         classes: 'app-tag--inactive',
         text: 'alpha',
@@ -32,10 +32,10 @@ describe('Tag component', () => {
     })
   })
 
-  context('with href param', () => {
+  context('with href param', function () {
     let $component
 
-    beforeEach(() => {
+    beforeEach(function () {
       const $ = render('_tag', {
         text: 'alpha',
         href: '/a-link',
@@ -43,17 +43,17 @@ describe('Tag component', () => {
       $component = $('.app-tag')
     })
 
-    it('should render with anchor element', () => {
+    it('should render with anchor element', function () {
       expect($component.get(0).tagName).to.equal('a')
     })
 
-    it('should render href attribute', () => {
+    it('should render href attribute', function () {
       expect($component.attr('href')).to.equal('/a-link')
     })
   })
 
-  context('when html is passed to text', () => {
-    it('should render escaped html', () => {
+  context('when html is passed to text', function () {
+    it('should render escaped html', function () {
       const $ = render('_tag', {
         text: '<span>alpha</span>',
       })
@@ -63,8 +63,8 @@ describe('Tag component', () => {
     })
   })
 
-  context('when html is passed to html', () => {
-    it('should render unescaped html', () => {
+  context('when html is passed to html', function () {
+    it('should render unescaped html', function () {
       const $ = render('_tag', {
         html: '<span>alpha</span>',
       })
@@ -74,8 +74,8 @@ describe('Tag component', () => {
     })
   })
 
-  context('when both html and text params are used', () => {
-    it('should render unescaped html', () => {
+  context('when both html and text params are used', function () {
+    it('should render unescaped html', function () {
       const $ = render('_tag', {
         html: '<span>alpha</span>',
         text: '<span>alpha</span>',

--- a/common/components/card/template.test.js
+++ b/common/components/card/template.test.js
@@ -2,52 +2,52 @@ const { render, getExamples } = require('../../../test/unit/component-helpers')
 
 const examples = getExamples('card')
 
-describe('Card component', () => {
-  context('by default', () => {
+describe('Card component', function () {
+  context('by default', function () {
     let $component
 
-    beforeEach(() => {
+    beforeEach(function () {
       const $ = render('card', examples.default)
       $component = $('.app-card')
     })
 
-    it('should render component', () => {
+    it('should render component', function () {
       expect($component.get(0).tagName).to.equal('div')
     })
 
-    it('should render title', () => {
+    it('should render title', function () {
       const $title = $component.find('.app-card__title')
       expect($title.text().trim()).to.equal('Card title')
     })
 
-    it('should not render image', () => {
+    it('should not render image', function () {
       const $image = $component.find('.app-card__image')
       expect($image.length).to.equal(0)
     })
 
-    it('should not render caption', () => {
+    it('should not render caption', function () {
       const $caption = $component.find('.app-card__caption')
       expect($caption.length).to.equal(0)
     })
 
-    it('should not render as link', () => {
+    it('should not render as link', function () {
       const $link = $component.find('.app-card__link')
       expect($link.length).to.equal(0)
     })
 
-    it('should not render meta data', () => {
+    it('should not render meta data', function () {
       const $metaList = $component.find('.app-card__meta-list')
       expect($metaList.length).to.equal(0)
     })
 
-    it('should not render tags', () => {
+    it('should not render tags', function () {
       const $tagList = $component.find('.app-card__tag-list')
       expect($tagList.length).to.equal(0)
     })
   })
 
-  context('with image', () => {
-    it('should render image', () => {
+  context('with image', function () {
+    it('should render image', function () {
       const $ = render('card', examples['with image'])
       const $image = $('.app-card__image')
 
@@ -56,8 +56,8 @@ describe('Card component', () => {
     })
   })
 
-  context('with classes param', () => {
-    it('should render classes', () => {
+  context('with classes param', function () {
+    it('should render classes', function () {
       const $ = render('card', {
         title: { text: 'Title' },
         classes: 'app-card--compact',
@@ -68,9 +68,9 @@ describe('Card component', () => {
     })
   })
 
-  context('with caption', () => {
-    context('when html is passed to text', () => {
-      it('should render escaped html', () => {
+  context('with caption', function () {
+    context('when html is passed to text', function () {
+      it('should render escaped html', function () {
         const $ = render('card', {
           title: { text: 'Title' },
           caption: {
@@ -83,9 +83,9 @@ describe('Card component', () => {
       })
     })
 
-    context('when html is passed to html', () => {
-      it('should render unescaped html', () => {
-        it('should render escaped html', () => {
+    context('when html is passed to html', function () {
+      it('should render unescaped html', function () {
+        it('should render escaped html', function () {
           const $ = render('card', {
             title: { text: 'Title' },
             caption: {
@@ -99,8 +99,8 @@ describe('Card component', () => {
       })
     })
 
-    context('when both html and text params are used', () => {
-      it('should render unescaped html', () => {
+    context('when both html and text params are used', function () {
+      it('should render unescaped html', function () {
         const $ = render('card', {
           title: { text: 'Title' },
           caption: {
@@ -115,8 +115,8 @@ describe('Card component', () => {
     })
   })
 
-  context('with link', () => {
-    it('should render link', () => {
+  context('with link', function () {
+    it('should render link', function () {
       const $ = render('card', examples['with link'])
       const $link = $('.app-card__link')
 
@@ -125,9 +125,9 @@ describe('Card component', () => {
     })
   })
 
-  context('with meta data', () => {
-    context('with empty items array', () => {
-      it('should not render meta', () => {
+  context('with meta data', function () {
+    context('with empty items array', function () {
+      it('should not render meta', function () {
         const $ = render('card', {
           title: { text: 'Title' },
           meta: { items: [] },
@@ -138,20 +138,20 @@ describe('Card component', () => {
       })
     })
 
-    context('with items', () => {
+    context('with items', function () {
       let $, $items
 
-      beforeEach(() => {
+      beforeEach(function () {
         $ = render('card', examples['with meta items'])
         const $meta = $('.app-card__meta-list')
         $items = $meta.find('.app-card__meta-list-item')
       })
 
-      it('should render correct number of items', () => {
+      it('should render correct number of items', function () {
         expect($items.length).to.equal(3)
       })
 
-      it('should render correct items', () => {
+      it('should render correct items', function () {
         const $item1 = $($items[0])
         const $item2 = $($items[1])
         const $item3 = $($items[2])
@@ -168,9 +168,9 @@ describe('Card component', () => {
     })
   })
 
-  context('with tags', () => {
-    context('with empty items array', () => {
-      it('should not render tags', () => {
+  context('with tags', function () {
+    context('with empty items array', function () {
+      it('should not render tags', function () {
         const $ = render('card', {
           title: { text: 'Title' },
           tags: { items: [] },
@@ -181,8 +181,8 @@ describe('Card component', () => {
       })
     })
 
-    context('with items', () => {
-      it('should render correct number of items', () => {
+    context('with items', function () {
+      it('should render correct number of items', function () {
         const $ = render('card', examples['with tags'])
         const $meta = $('.app-card__tag-list')
         const $items = $meta.find('.app-card__tag-list-item')

--- a/common/components/data/template.test.js
+++ b/common/components/data/template.test.js
@@ -2,55 +2,55 @@ const { render, getExamples } = require('../../../test/unit/component-helpers')
 
 const examples = getExamples('data')
 
-describe('Data component', () => {
-  context('by default', () => {
+describe('Data component', function () {
+  context('by default', function () {
     let $component
 
-    beforeEach(() => {
+    beforeEach(function () {
       const $ = render('data', examples.default)
       $component = $('.app-data')
     })
 
-    it('should render a div', () => {
+    it('should render a div', function () {
       expect($component.get(0).tagName).to.equal('div')
     })
 
-    it('should render value', () => {
+    it('should render value', function () {
       expect($component.find('.app-data__value').text().trim()).to.equal('25')
     })
 
-    it('should render label', () => {
+    it('should render label', function () {
       expect($component.find('.app-data__label').text().trim()).to.equal('emails sent')
     })
 
-    it('should render value first', () => {
+    it('should render value first', function () {
       expect($component.children().first().hasClass('app-data__value')).to.be.true
     })
 
-    it('should render label second', () => {
+    it('should render label second', function () {
       expect($component.children().last().hasClass('app-data__label')).to.be.true
     })
   })
 
-  context('inverted', () => {
+  context('inverted', function () {
     let $component
 
-    beforeEach(() => {
+    beforeEach(function () {
       const $ = render('data', examples.inverted)
       $component = $('.app-data')
     })
 
-    it('should render label first', () => {
+    it('should render label first', function () {
       expect($component.children().first().hasClass('app-data__label')).to.be.true
     })
 
-    it('should render value second', () => {
+    it('should render value second', function () {
       expect($component.children().last().hasClass('app-data__value')).to.be.true
     })
   })
 
-  context('with classes', () => {
-    it('should render classes', () => {
+  context('with classes', function () {
+    it('should render classes', function () {
       const $ = render('data', examples['extra large variation'])
       const $component = $('.app-data')
 
@@ -58,8 +58,8 @@ describe('Data component', () => {
     })
   })
 
-  context('with custom element', () => {
-    it('should render custom element', () => {
+  context('with custom element', function () {
+    it('should render custom element', function () {
       const $ = render('data', examples['with heading as element'])
       const $component = $('.app-data')
 

--- a/common/components/internal-header/template.test.js
+++ b/common/components/internal-header/template.test.js
@@ -2,15 +2,15 @@ const { render, getExamples } = require('../../../test/unit/component-helpers')
 
 const examples = getExamples('internal-header')
 
-describe('Internal header component', () => {
-  it('has a role of `banner`', () => {
+describe('Internal header component', function () {
+  it('has a role of `banner`', function () {
     const $ = render('internal-header', {})
 
     const $component = $('.app-header')
     expect($component.attr('role')).to.equal('banner')
   })
 
-  it('renders attributes correctly', () => {
+  it('renders attributes correctly', function () {
     const $ = render('internal-header', {
       attributes: {
         'data-test-attribute': 'value',
@@ -23,7 +23,7 @@ describe('Internal header component', () => {
     expect($component.attr('data-test-attribute-2')).to.equal('value-2')
   })
 
-  it('renders classes', () => {
+  it('renders classes', function () {
     const $ = render('internal-header', {
       classes: 'app-header--custom-modifier',
     })
@@ -32,7 +32,7 @@ describe('Internal header component', () => {
     expect($component.hasClass('app-header--custom-modifier')).to.be.true
   })
 
-  it('renders custom container classes', () => {
+  it('renders custom container classes', function () {
     const $ = render('internal-header', {
       containerClasses: 'app-width-container',
     })
@@ -43,7 +43,7 @@ describe('Internal header component', () => {
     expect($container.hasClass('app-width-container')).to.be.true
   })
 
-  it('renders home page URL', () => {
+  it('renders home page URL', function () {
     const $ = render('internal-header', {
       homepageUrl: '/',
     })
@@ -53,8 +53,8 @@ describe('Internal header component', () => {
     expect($homepageLink.attr('href')).to.equal('/')
   })
 
-  describe('with product name', () => {
-    it('renders product name', () => {
+  describe('with product name', function () {
+    it('renders product name', function () {
       const $ = render('internal-header', examples['full width'])
 
       const $component = $('.app-header')
@@ -63,8 +63,8 @@ describe('Internal header component', () => {
     })
   })
 
-  describe('with service name', () => {
-    it('renders service name', () => {
+  describe('with service name', function () {
+    it('renders service name', function () {
       const $ = render('internal-header', examples['with service name'])
 
       const $component = $('.app-header')
@@ -73,8 +73,8 @@ describe('Internal header component', () => {
     })
   })
 
-  describe('with navigation', () => {
-    it('renders navigation', () => {
+  describe('with navigation', function () {
+    it('renders navigation', function () {
       const $ = render('internal-header', examples['with navigation'])
 
       const $component = $('.app-header')
@@ -86,7 +86,7 @@ describe('Internal header component', () => {
       expect($firstItem.text()).to.contain('Navigation item 1')
     })
 
-    it('renders navigation item anchor with attributes', () => {
+    it('renders navigation item anchor with attributes', function () {
       const $ = render('internal-header', {
         navigation: [
           {
@@ -104,8 +104,8 @@ describe('Internal header component', () => {
       expect($navigationLink.attr('data-attribute')).to.equal('my-attribute')
       expect($navigationLink.attr('data-attribute-2')).to.equal('my-attribute-2')
     })
-    describe('menu button', () => {
-      it('has an explicit type="button" so it does not act as a submit button', () => {
+    describe('menu button', function () {
+      it('has an explicit type="button" so it does not act as a submit button', function () {
         const $ = render('internal-header', examples['with navigation'])
 
         const $button = $('.app-header__menu-button')
@@ -115,26 +115,26 @@ describe('Internal header component', () => {
     })
   })
 
-  describe('SVG logo', () => {
+  describe('SVG logo', function () {
     const $ = render('internal-header', {})
     const $svg = $('.app-header__logotype-crest')
 
-    it('sets focusable="false" so that IE does not treat it as an interactive element', () => {
+    it('sets focusable="false" so that IE does not treat it as an interactive element', function () {
       expect($svg.attr('focusable')).to.equal('false')
     })
 
-    it('sets role="presentation" so that it is ignored by assistive technologies', () => {
+    it('sets role="presentation" so that it is ignored by assistive technologies', function () {
       expect($svg.attr('focusable')).to.equal('false')
     })
 
-    describe('fallback PNG', () => {
+    describe('fallback PNG', function () {
       const $fallbackImage = $('.app-header__logotype-crest-fallback-image')
 
-      it('uses the <image> tag which is a valid SVG element', () => {
+      it('uses the <image> tag which is a valid SVG element', function () {
         expect($fallbackImage[0].tagName).to.equal('image')
       })
 
-      it('sets a blank xlink:href to prevent IE from downloading both the SVG and the PNG', () => {
+      it('sets a blank xlink:href to prevent IE from downloading both the SVG and the PNG', function () {
         // Cheerio converts xhref to href - https://github.com/cheeriojs/cheerio/issues/1101
         expect($fallbackImage.attr('href')).to.equal('')
       })

--- a/common/components/meta-list/template.test.js
+++ b/common/components/meta-list/template.test.js
@@ -2,27 +2,27 @@ const { render, getExamples } = require('../../../test/unit/component-helpers')
 
 const examples = getExamples('meta-list')
 
-describe('Meta list component', () => {
-  context('default', () => {
+describe('Meta list component', function () {
+  context('default', function () {
     let $, $component, $items
 
-    beforeEach(() => {
+    beforeEach(function () {
       $ = render('meta-list', examples.default)
       $component = $('.app-meta-list')
       $items = $component.find('.app-meta-list__item')
     })
 
-    it('should render', () => {
+    it('should render', function () {
       expect($component.length).to.equal(1)
     })
 
-    it('should render correct number of items', () => {
+    it('should render correct number of items', function () {
       expect($items.length).to.equal(2)
     })
   })
 
-  context('with classes', () => {
-    it('should render classes', () => {
+  context('with classes', function () {
+    it('should render classes', function () {
       const $ = render('meta-list', {
         classes: 'app-meta-list--custom-class',
       })
@@ -32,10 +32,10 @@ describe('Meta list component', () => {
     })
   })
 
-  context('items with text', () => {
+  context('items with text', function () {
     let $, $items
 
-    beforeEach(() => {
+    beforeEach(function () {
       $ = render('meta-list', {
         items: [
           {
@@ -59,7 +59,7 @@ describe('Meta list component', () => {
       $items = $('.app-meta-list').find('.app-meta-list__item')
     })
 
-    it('should render text', () => {
+    it('should render text', function () {
       const $item1 = $($items[0])
       const $key = $item1.find('.app-meta-list__key')
       const $value = $item1.find('.app-meta-list__value')
@@ -68,7 +68,7 @@ describe('Meta list component', () => {
       expect($value.html().trim()).to.equal('Home')
     })
 
-    it('should escape HTML', () => {
+    it('should escape HTML', function () {
       const $item2 = $($items[1])
       const $key = $item2.find('.app-meta-list__key')
       const $value = $item2.find('.app-meta-list__value')
@@ -78,10 +78,10 @@ describe('Meta list component', () => {
     })
   })
 
-  context('items with html', () => {
+  context('items with html', function () {
     let $, $items
 
-    beforeEach(() => {
+    beforeEach(function () {
       $ = render('meta-list', {
         items: [
           {
@@ -97,7 +97,7 @@ describe('Meta list component', () => {
       $items = $('.app-meta-list').find('.app-meta-list__item')
     })
 
-    it('should render HTML', () => {
+    it('should render HTML', function () {
       const $item1 = $($items[0])
       const $key = $item1.find('.app-meta-list__key')
       const $value = $item1.find('.app-meta-list__value')

--- a/common/components/pagination/template.test.js
+++ b/common/components/pagination/template.test.js
@@ -2,9 +2,9 @@ const { render, getExamples } = require('../../../test/unit/component-helpers')
 
 const examples = getExamples('pagination')
 
-describe('Pagination component', () => {
-  context('default', () => {
-    it('should render previous link', () => {
+describe('Pagination component', function () {
+  context('default', function () {
+    it('should render previous link', function () {
       const $ = render('pagination', examples.default)
 
       const $component = $('.app-pagination')
@@ -16,7 +16,7 @@ describe('Pagination component', () => {
       expect($itemLink.attr('href')).to.equal('/previous-page')
     })
 
-    it('should render next link', () => {
+    it('should render next link', function () {
       const $ = render('pagination', examples.default)
 
       const $component = $('.app-pagination')
@@ -29,8 +29,8 @@ describe('Pagination component', () => {
     })
   })
 
-  context('without next or previous', () => {
-    it('should not render previous link', () => {
+  context('without next or previous', function () {
+    it('should not render previous link', function () {
       const $ = render('pagination', {})
 
       const $component = $('.app-pagination')
@@ -38,7 +38,7 @@ describe('Pagination component', () => {
       expect($item.length).to.equal(0)
     })
 
-    it('should not render next link', () => {
+    it('should not render next link', function () {
       const $ = render('pagination', {})
 
       const $component = $('.app-pagination')
@@ -47,8 +47,8 @@ describe('Pagination component', () => {
     })
   })
 
-  context('with classes', () => {
-    it('should render classes', () => {
+  context('with classes', function () {
+    it('should render classes', function () {
       const $ = render('pagination', {
         classes: 'app-pagination--custom-class',
       })
@@ -58,8 +58,8 @@ describe('Pagination component', () => {
     })
   })
 
-  context('with labels', () => {
-    it('should render previous label', () => {
+  context('with labels', function () {
+    it('should render previous label', function () {
       const $ = render('pagination', {
         previous: {
           href: '/page-1',
@@ -76,7 +76,7 @@ describe('Pagination component', () => {
       expect($itemLink.attr('href')).to.equal('/page-1')
     })
 
-    it('should render next label', () => {
+    it('should render next label', function () {
       const $ = render('pagination', {
         next: {
           href: '/page-3',
@@ -94,8 +94,8 @@ describe('Pagination component', () => {
     })
   })
 
-  context('with custom text', () => {
-    it('should render previous text', () => {
+  context('with custom text', function () {
+    it('should render previous text', function () {
       const $ = render('pagination', {
         previous: {
           href: '/previous-day',
@@ -112,7 +112,7 @@ describe('Pagination component', () => {
       expect($itemLink.attr('href')).to.equal('/previous-day')
     })
 
-    it('should render next label', () => {
+    it('should render next label', function () {
       const $ = render('pagination', {
         next: {
           href: '/next-day',

--- a/common/components/time/template.test.js
+++ b/common/components/time/template.test.js
@@ -2,31 +2,31 @@ const { render, getExamples } = require('../../../test/unit/component-helpers')
 
 const examples = getExamples('time')
 
-describe('Time component', () => {
-  context('by default', () => {
+describe('Time component', function () {
+  context('by default', function () {
     let $component
 
-    beforeEach(() => {
+    beforeEach(function () {
       const $ = render('time', examples.default)
       $component = $('time')
     })
 
-    it('should render', () => {
+    it('should render', function () {
       expect($component.length).to.equal(1)
     })
 
-    it('should contain a datetime attribute', () => {
+    it('should contain a datetime attribute', function () {
       const $datetimeAttr = $component.attr('datetime')
       expect($datetimeAttr).to.equal('2019-01-10')
     })
 
-    it('should use the datetime as element text', () => {
+    it('should use the datetime as element text', function () {
       expect($component.text().trim()).to.equal('2019-01-10')
     })
   })
 
-  context('with classes', () => {
-    it('should render classes', () => {
+  context('with classes', function () {
+    it('should render classes', function () {
       const $ = render('time', {
         classes: 'custom-class',
       })
@@ -36,10 +36,10 @@ describe('Time component', () => {
     })
   })
 
-  context('with custom text', () => {
+  context('with custom text', function () {
     let $component
 
-    beforeEach(() => {
+    beforeEach(function () {
       const $ = render('time', {
         datetime: '2019-01-10',
         text: 'Today',
@@ -48,12 +48,12 @@ describe('Time component', () => {
       $component = $('time')
     })
 
-    it('should contain a datetime attribute', () => {
+    it('should contain a datetime attribute', function () {
       const $datetimeAttr = $component.attr('datetime')
       expect($datetimeAttr).to.equal('2019-01-10')
     })
 
-    it('should contain custom text', () => {
+    it('should contain custom text', function () {
       expect($component.text().trim()).to.equal('Today')
     })
   })

--- a/common/lib/api-client.test.js
+++ b/common/lib/api-client.test.js
@@ -8,11 +8,11 @@ const movesGetSerialized = require('../../test/fixtures/api-client/moves.get.ser
 
 describe('API Client', function () {
   describe('#getMovesByDate()', function () {
-    context('when request returns 200', () => {
+    context('when request returns 200', function () {
       const mockDate = '2017-08-10'
       let moves
 
-      beforeEach(async () => {
+      beforeEach(async function () {
         this.clock = sinon.useFakeTimers(new Date(mockDate).getTime())
 
         nock(API.BASE_URL)
@@ -28,11 +28,11 @@ describe('API Client', function () {
         moves = await apiClient.getMovesByDate(mockDate)
       })
 
-      afterEach(() => {
+      afterEach(function () {
         this.clock.restore()
       })
 
-      it('should get moves from API with current date', () => {
+      it('should get moves from API with current date', function () {
         expect(nock.isDone()).to.be.true
       })
 

--- a/common/lib/request.test.js
+++ b/common/lib/request.test.js
@@ -2,8 +2,8 @@ const requestLib = require('./request')
 
 describe('Request library', function () {
   describe('#getQueryString()', function () {
-    context('when existing query is empty', () => {
-      it('should return a merged object as a query string', () => {
+    context('when existing query is empty', function () {
+      it('should return a merged object as a query string', function () {
         const requestQuery = {}
         const newQuery = {
           foo: 'bar',
@@ -15,9 +15,9 @@ describe('Request library', function () {
       })
     })
 
-    context('when existing query is not empty', () => {
-      context('when no properties clash', () => {
-        it('should return a merged object as a query string', () => {
+    context('when existing query is not empty', function () {
+      context('when no properties clash', function () {
+        it('should return a merged object as a query string', function () {
           const requestQuery = {
             hello: 'world',
           }
@@ -31,8 +31,8 @@ describe('Request library', function () {
         })
       })
 
-      context('when properties clash', () => {
-        it('should return a merged object as a query string', () => {
+      context('when properties clash', function () {
+        it('should return a merged object as a query string', function () {
           const target = {
             hello: 'world',
             foo: 'bar',

--- a/common/middleware/authentication.test.js
+++ b/common/middleware/authentication.test.js
@@ -2,11 +2,11 @@ const authentication = require('./authentication')
 const nock = require('nock')
 const { AUTH } = require('../../config')
 
-describe('Authentication middleware', () => {
-  describe('#ensureAuthenticated()', () => {
+describe('Authentication middleware', function () {
+  describe('#ensureAuthenticated()', function () {
     let req, res, nextSpy
 
-    beforeEach(() => {
+    beforeEach(function () {
       nextSpy = sinon.spy()
       req = {
         originalUrl: '/test',
@@ -19,51 +19,51 @@ describe('Authentication middleware', () => {
       }
     })
 
-    context('when there is no access token', () => {
-      beforeEach(() => {
+    context('when there is no access token', function () {
+      beforeEach(function () {
         authentication.ensureAuthenticated(req, res, nextSpy)
       })
 
-      it('redirects to the Okta authentication URL', () => {
+      it('redirects to the Okta authentication URL', function () {
         expect(res.redirect).to.be.calledWith('/connect/okta')
       })
 
-      it('sets the redirect URL in the session', () => {
+      it('sets the redirect URL in the session', function () {
         expect(req.session.postAuthRedirect).to.equal('/test')
       })
     })
 
-    context('when the access token has expired', () => {
-      beforeEach(() => {
+    context('when the access token has expired', function () {
+      beforeEach(function () {
         req.session.authExpiry = Math.floor(new Date() / 1000) - 1000
         authentication.ensureAuthenticated(req, res, nextSpy)
       })
 
-      it('redirects to the Okta authentication URL', () => {
+      it('redirects to the Okta authentication URL', function () {
         expect(res.redirect).to.be.calledWith('/connect/okta')
       })
 
-      it('sets the redirect URL in the session', () => {
+      it('sets the redirect URL in the session', function () {
         expect(req.session.postAuthRedirect).to.equal('/test')
       })
     })
 
-    context('when the access token has not expired', () => {
-      beforeEach(() => {
+    context('when the access token has not expired', function () {
+      beforeEach(function () {
         req.session.authExpiry = Math.floor(new Date() / 1000) + 1000
         authentication.ensureAuthenticated(req, res, nextSpy)
       })
 
-      it('calls the next action', () => {
+      it('calls the next action', function () {
         expect(nextSpy.calledOnce).to.be.true
       })
     })
   })
 
-  describe('#processAuthResponse', () => {
+  describe('#processAuthResponse', function () {
     let req, res, nextSpy
 
-    beforeEach(() => {
+    beforeEach(function () {
       nextSpy = sinon.spy()
 
       req = {
@@ -77,17 +77,17 @@ describe('Authentication middleware', () => {
       }
     })
 
-    context('when there is no grant response', () => {
-      it('redirects to root', () => {
+    context('when there is no grant response', function () {
+      it('redirects to root', function () {
         authentication.processAuthResponse(req, res, nextSpy)
         expect(res.redirect).to.be.calledWith('/')
       })
     })
 
-    context('when there is a grant response', () => {
+    context('when there is a grant response', function () {
       let accessToken, expiryTime, userInfo
 
-      beforeEach(async () => {
+      beforeEach(async function () {
         accessToken = 'test'
         expiryTime = 1000
         userInfo = {
@@ -122,23 +122,23 @@ describe('Authentication middleware', () => {
         await authentication.processAuthResponse(req, res, nextSpy)
       })
 
-      it('regenerates the session', async () => {
+      it('regenerates the session', async function () {
         expect(req.session.id).to.equal('456')
       })
 
-      it('sets the auth expiry time on the session', () => {
+      it('sets the auth expiry time on the session', function () {
         expect(req.session.authExpiry).to.equal(expiryTime)
       })
 
-      it('sets the user info on the session', () => {
+      it('sets the user info on the session', function () {
         expect(req.session.userInfo.test).to.equal(userInfo.test)
       })
 
-      it('sets the redirect URL in the session', () => {
+      it('sets the redirect URL in the session', function () {
         expect(req.session.postAuthRedirect).to.equal('/test')
       })
 
-      it('calls the next action', () => {
+      it('calls the next action', function () {
         expect(nextSpy.calledOnce).to.be.true
       })
     })

--- a/common/middleware/errors.test.js
+++ b/common/middleware/errors.test.js
@@ -6,37 +6,37 @@ const errorCode404 = 404
 const errorCode403 = 403
 const errorCode500 = 500
 
-describe('Error middleware', () => {
-  beforeEach(() => {
+describe('Error middleware', function () {
+  beforeEach(function () {
     sinon.stub(logger, 'info')
     sinon.stub(logger, 'error')
   })
 
-  describe('#notFound', () => {
+  describe('#notFound', function () {
     let nextSpy
 
-    beforeEach(() => {
+    beforeEach(function () {
       nextSpy = sinon.spy()
       errors.notFound(null, null, nextSpy)
     })
 
-    it('should set a 404 status code', () => {
+    it('should set a 404 status code', function () {
       expect(nextSpy.args[0][0].statusCode).to.equal(errorCode404)
     })
 
-    it('should call next with an error', () => {
+    it('should call next with an error', function () {
       expect(nextSpy.calledOnce).to.be.true
       expect(nextSpy.args[0][0] instanceof Error).to.be.true
       expect(nextSpy.args[0][0].message).to.equal('Not Found')
     })
   })
 
-  describe('#catchAll', () => {
+  describe('#catchAll', function () {
     let nextSpy
     let mockError
     let mockRes
 
-    beforeEach(() => {
+    beforeEach(function () {
       nextSpy = sinon.spy()
       mockError = new Error('A mock error')
       mockRes = {
@@ -45,82 +45,82 @@ describe('Error middleware', () => {
       }
     })
 
-    context('when headers have already been sent', () => {
-      beforeEach(() => {
+    context('when headers have already been sent', function () {
+      beforeEach(function () {
         mockRes.headersSent = true
         errors.catchAll()(mockError, null, mockRes, nextSpy)
       })
 
-      it('should call next middleware with error', () => {
+      it('should call next middleware with error', function () {
         expect(nextSpy).to.have.been.calledOnce
         expect(nextSpy).to.have.been.calledWith(mockError)
       })
 
-      it('should not render a template', () => {
+      it('should not render a template', function () {
         expect(nextSpy).to.have.been.calledOnce
         expect(mockRes.render).not.to.have.been.called
       })
     })
 
-    context('when stack trace should be visible', () => {
-      beforeEach(() => {
+    context('when stack trace should be visible', function () {
+      beforeEach(function () {
         errors.catchAll(true)(mockError, null, mockRes, nextSpy)
       })
 
-      it('should send showStackTrace property to template', () => {
+      it('should send showStackTrace property to template', function () {
         expect(mockRes.render.args[0][1]).to.have.property('showStackTrace')
       })
 
-      it('should set showStackTrace to true', () => {
+      it('should set showStackTrace to true', function () {
         expect(mockRes.render.args[0][1].showStackTrace).to.equal(true)
       })
     })
 
-    context('when stack trace should not be visible', () => {
-      beforeEach(() => {
+    context('when stack trace should not be visible', function () {
+      beforeEach(function () {
         errors.catchAll(false)(mockError, null, mockRes, nextSpy)
       })
 
-      it('should send showStackTrace property to template', () => {
+      it('should send showStackTrace property to template', function () {
         expect(mockRes.render.args[0][1]).to.have.property('showStackTrace')
       })
 
-      it('should set showStackTrace to false', () => {
+      it('should set showStackTrace to false', function () {
         expect(mockRes.render.args[0][1].showStackTrace).to.equal(false)
       })
     })
 
-    context('when show stack trace is not set', () => {
-      beforeEach(() => {
+    context('when show stack trace is not set', function () {
+      beforeEach(function () {
         errors.catchAll()(mockError, null, mockRes, nextSpy)
       })
 
-      it('should send showStackTrace property to template', () => {
+      it('should send showStackTrace property to template', function () {
         expect(mockRes.render.args[0][1]).to.have.property('showStackTrace')
       })
 
-      it('should set showStackTrace to false', () => {
+      it('should set showStackTrace to false', function () {
         expect(mockRes.render.args[0][1].showStackTrace).to.equal(false)
       })
     })
 
-    context('with a 404 error status code', () => {
-      beforeEach(() => {
+    context('with a 404 error status code', function () {
+      beforeEach(function () {
         mockError.statusCode = errorCode404
         errors.catchAll()(mockError, null, mockRes, nextSpy)
       })
 
-      it('should set correct status code on response', () => {
+      it('should set correct status code on response', function () {
         expect(mockRes.status).to.have.been.calledOnce
         expect(mockRes.status).to.have.been.calledWith(errorCode404)
       })
 
-      it('should render the error template', () => {
+      it('should render the error template', function () {
         expect(mockRes.render).to.have.been.calledOnce
         expect(mockRes.render.args[0][0]).to.equal('error')
       })
 
-      it('should pass correct values to template', () => {
+      it('should pass correct values to template', function () {
         expect(mockRes.render.args[0][1]).to.deep.equal({
           error: mockError,
           statusCode: errorCode404,
@@ -129,37 +129,37 @@ describe('Error middleware', () => {
         })
       })
 
-      it('should log info level message to logger', () => {
+      it('should log info level message to logger', function () {
         expect(logger.info).to.have.been.calledOnce
         expect(logger.info).to.have.been.calledWith(mockError)
       })
 
-      it('should not log error level message to logger', () => {
+      it('should not log error level message to logger', function () {
         expect(logger.error).not.to.have.been.called
       })
 
-      it('should not call next', () => {
+      it('should not call next', function () {
         expect(nextSpy).not.to.have.been.called
       })
     })
 
-    context('with a standard 403 error status code', () => {
-      beforeEach(() => {
+    context('with a standard 403 error status code', function () {
+      beforeEach(function () {
         mockError.statusCode = errorCode403
         errors.catchAll()(mockError, null, mockRes, nextSpy)
       })
 
-      it('should set correct status code on response', () => {
+      it('should set correct status code on response', function () {
         expect(mockRes.status).to.have.been.calledOnce
         expect(mockRes.status).to.have.been.calledWith(errorCode403)
       })
 
-      it('should render the error template', () => {
+      it('should render the error template', function () {
         expect(mockRes.render).to.have.been.calledOnce
         expect(mockRes.render.args[0][0]).to.equal('error')
       })
 
-      it('should pass correct values to template', () => {
+      it('should pass correct values to template', function () {
         expect(mockRes.render.args[0][1]).to.deep.equal({
           error: mockError,
           statusCode: errorCode403,
@@ -168,38 +168,38 @@ describe('Error middleware', () => {
         })
       })
 
-      it('should log error level message to logger', () => {
+      it('should log error level message to logger', function () {
         expect(logger.error).to.have.been.calledOnce
         expect(logger.error).to.have.been.calledWith(mockError)
       })
 
-      it('should not log info level message to logger', () => {
+      it('should not log info level message to logger', function () {
         expect(logger.info).not.to.have.been.called
       })
 
-      it('should not call next', () => {
+      it('should not call next', function () {
         expect(nextSpy).not.to.have.been.called
       })
     })
 
-    context('with a CSRF 403 error status code', () => {
-      beforeEach(() => {
+    context('with a CSRF 403 error status code', function () {
+      beforeEach(function () {
         mockError.statusCode = errorCode403
         mockError.code = 'EBADCSRFTOKEN'
         errors.catchAll()(mockError, null, mockRes, nextSpy)
       })
 
-      it('should set correct status code on response', () => {
+      it('should set correct status code on response', function () {
         expect(mockRes.status).to.have.been.calledOnce
         expect(mockRes.status).to.have.been.calledWith(errorCode403)
       })
 
-      it('should render the error template', () => {
+      it('should render the error template', function () {
         expect(mockRes.render).to.have.been.calledOnce
         expect(mockRes.render.args[0][0]).to.equal('error')
       })
 
-      it('should pass correct values to template', () => {
+      it('should pass correct values to template', function () {
         expect(mockRes.render.args[0][1]).to.deep.equal({
           error: mockError,
           statusCode: errorCode403,
@@ -208,37 +208,37 @@ describe('Error middleware', () => {
         })
       })
 
-      it('should log error level message to logger', () => {
+      it('should log error level message to logger', function () {
         expect(logger.error).to.have.been.calledOnce
         expect(logger.error).to.have.been.calledWith(mockError)
       })
 
-      it('should not log info level message to logger', () => {
+      it('should not log info level message to logger', function () {
         expect(logger.info).not.to.have.been.called
       })
 
-      it('should not call next', () => {
+      it('should not call next', function () {
         expect(nextSpy).not.to.have.been.called
       })
     })
 
-    context('with a 500 error status code', () => {
-      beforeEach(() => {
+    context('with a 500 error status code', function () {
+      beforeEach(function () {
         mockError.statusCode = errorCode500
         errors.catchAll()(mockError, null, mockRes, nextSpy)
       })
 
-      it('should set correct status code on response', () => {
+      it('should set correct status code on response', function () {
         expect(mockRes.status).to.have.been.calledOnce
         expect(mockRes.status).to.have.been.calledWith(errorCode500)
       })
 
-      it('should render the error template', () => {
+      it('should render the error template', function () {
         expect(mockRes.render).to.have.been.calledOnce
         expect(mockRes.render.args[0][0]).to.equal('error')
       })
 
-      it('should pass correct values to template', () => {
+      it('should pass correct values to template', function () {
         expect(mockRes.render.args[0][1]).to.deep.equal({
           error: mockError,
           statusCode: errorCode500,
@@ -247,36 +247,36 @@ describe('Error middleware', () => {
         })
       })
 
-      it('should log error level message to logger', () => {
+      it('should log error level message to logger', function () {
         expect(logger.error).to.have.been.calledOnce
         expect(logger.error).to.have.been.calledWith(mockError)
       })
 
-      it('should not log info level message to logger', () => {
+      it('should not log info level message to logger', function () {
         expect(logger.info).not.to.have.been.called
       })
 
-      it('should not call next', () => {
+      it('should not call next', function () {
         expect(nextSpy).not.to.have.been.called
       })
     })
 
-    context('with no error status code', () => {
-      beforeEach(() => {
+    context('with no error status code', function () {
+      beforeEach(function () {
         errors.catchAll()(mockError, null, mockRes, nextSpy)
       })
 
-      it('should set correct status code on response', () => {
+      it('should set correct status code on response', function () {
         expect(mockRes.status).to.have.been.calledOnce
         expect(mockRes.status).to.have.been.calledWith(errorCode500)
       })
 
-      it('should render the error template', () => {
+      it('should render the error template', function () {
         expect(mockRes.render).to.have.been.calledOnce
         expect(mockRes.render.args[0][0]).to.equal('error')
       })
 
-      it('should pass correct values to template', () => {
+      it('should pass correct values to template', function () {
         expect(mockRes.render.args[0][1]).to.deep.equal({
           error: mockError,
           statusCode: errorCode500,
@@ -285,16 +285,16 @@ describe('Error middleware', () => {
         })
       })
 
-      it('should log error level message to logger', () => {
+      it('should log error level message to logger', function () {
         expect(logger.error).to.have.been.calledOnce
         expect(logger.error).to.have.been.calledWith(mockError)
       })
 
-      it('should not log info level message to logger', () => {
+      it('should not log info level message to logger', function () {
         expect(logger.info).not.to.have.been.called
       })
 
-      it('should not call next', () => {
+      it('should not call next', function () {
         expect(nextSpy).not.to.have.been.called
       })
     })

--- a/common/middleware/locals/get-asset-path.test.js
+++ b/common/middleware/locals/get-asset-path.test.js
@@ -6,36 +6,36 @@ const getAssetPath = require('./get-asset-path')
 const existingManifestPath = path.join(configPaths.fixtures, 'manifest.json')
 const missingManifestPath = path.join(configPaths.fixtures, 'MISSING.json')
 
-describe('getAssetPath', () => {
-  context('when manifest file exists', () => {
-    context('when key exists', () => {
-      it('should find path', () => {
+describe('getAssetPath', function () {
+  context('when manifest file exists', function () {
+    context('when key exists', function () {
+      it('should find path', function () {
         const assetPath = getAssetPath('styles.css', existingManifestPath)
         expect(assetPath).to.equal('/stylesheets/styles.123.css')
       })
     })
 
-    context('when key does not exist', () => {
-      it('should return the key', () => {
+    context('when key does not exist', function () {
+      it('should return the key', function () {
         const assetPath = getAssetPath('foo.css', existingManifestPath)
         expect(assetPath).to.equal('/foo.css')
       })
     })
   })
 
-  context('when manifest does not exist', () => {
+  context('when manifest does not exist', function () {
     let assetPath
 
-    beforeEach(() => {
+    beforeEach(function () {
       sinon.spy(logger, 'error')
       assetPath = getAssetPath('styles.css', missingManifestPath)
     })
 
-    it('should log an error', () => {
+    it('should log an error', function () {
       expect(logger.error).to.have.been.calledOnce
     })
 
-    it('should return the key', () => {
+    it('should return the key', function () {
       expect(assetPath).to.equal('/styles.css')
     })
   })

--- a/config/nunjucks/filters.test.js
+++ b/config/nunjucks/filters.test.js
@@ -9,27 +9,27 @@ const filters = proxyquire('./filters', {
   },
 })
 
-describe('Nunjucks filters', () => {
-  describe('#formatDate()', () => {
-    context('when given an invalid date', () => {
-      it('should return input value', () => {
+describe('Nunjucks filters', function () {
+  describe('#formatDate()', function () {
+    context('when given an invalid date', function () {
+      it('should return input value', function () {
         const formattedDate = filters.formatDate('2010-45-5')
 
         expect(formattedDate).to.equal('2010-45-5')
       })
     })
 
-    context('when given a valid date', () => {
-      context('when no format is specified', () => {
-        it('should return date in default format', () => {
+    context('when given a valid date', function () {
+      context('when no format is specified', function () {
+        it('should return date in default format', function () {
           const formattedDate = filters.formatDate('2010-05-15')
 
           expect(formattedDate).to.equal('15 May 2010')
         })
       })
 
-      context('when a format is specified', () => {
-        it('should return date in that format', () => {
+      context('when a format is specified', function () {
+        it('should return date in that format', function () {
           const formattedDate = filters.formatDate('2010-05-01', 'DD/MM/YY')
 
           expect(formattedDate).to.equal('01/05/10')
@@ -38,55 +38,55 @@ describe('Nunjucks filters', () => {
     })
   })
 
-  describe('#formatDateWithDay()', () => {
-    it('should return config date with day format', () => {
+  describe('#formatDateWithDay()', function () {
+    it('should return config date with day format', function () {
       const formattedDate = filters.formatDateWithDay('2010-01-05')
 
       expect(formattedDate).to.equal('Tuesday 5 Jan 2010')
     })
   })
 
-  describe('#formatDateAsRelativeDay()', () => {
-    beforeEach(() => {
+  describe('#formatDateAsRelativeDay()', function () {
+    beforeEach(function () {
       const mockDate = new Date('2017-08-10')
       this.clock = sinon.useFakeTimers(mockDate.getTime())
     })
 
-    afterEach(() => {
+    afterEach(function () {
       this.clock.restore()
     })
 
-    context('when current date is today', () => {
-      it('should return `Today`', () => {
+    context('when current date is today', function () {
+      it('should return `Today`', function () {
         const formattedDate = filters.formatDateAsRelativeDay('2017-08-10')
         expect(formattedDate).to.equal('Today')
       })
     })
 
-    context('when current date is tomorrow', () => {
-      it('should return `Tomorrow`', () => {
+    context('when current date is tomorrow', function () {
+      it('should return `Tomorrow`', function () {
         const formattedDate = filters.formatDateAsRelativeDay('2017-08-11')
         expect(formattedDate).to.equal('Tomorrow')
       })
     })
 
-    context('when current date is yesterday', () => {
-      it('should return `Yesterday`', () => {
+    context('when current date is yesterday', function () {
+      it('should return `Yesterday`', function () {
         const formattedDate = filters.formatDateAsRelativeDay('2017-08-09')
         expect(formattedDate).to.equal('Yesterday')
       })
     })
 
-    context('when date is another date', () => {
-      context('when no custom format is supplied', () => {
-        it('should return date in default format', () => {
+    context('when date is another date', function () {
+      context('when no custom format is supplied', function () {
+        it('should return date in default format', function () {
           const formattedDate = filters.formatDateAsRelativeDay('2017-08-01')
           expect(formattedDate).to.equal('Tuesday 1 Aug 2017')
         })
       })
 
-      context('when a custom format is supplied', () => {
-        it('should return date in custom formatt', () => {
+      context('when a custom format is supplied', function () {
+        it('should return date in custom formatt', function () {
           const formattedDate = filters.formatDateAsRelativeDay('2017-08-01', 'DD/MM/YY')
           expect(formattedDate).to.equal('01/08/17')
         })
@@ -94,62 +94,62 @@ describe('Nunjucks filters', () => {
     })
   })
 
-  describe('#calculateAge()', () => {
-    context('when given an invalid date', () => {
-      it('should return input value', () => {
+  describe('#calculateAge()', function () {
+    context('when given an invalid date', function () {
+      it('should return input value', function () {
         const age = filters.calculateAge('2010-45-5')
         expect(age).to.equal('2010-45-5')
       })
 
-      it('should return input value', () => {
+      it('should return input value', function () {
         const age = filters.calculateAge('not a date')
         expect(age).to.equal('not a date')
       })
     })
 
-    context('when given a valid date', () => {
+    context('when given a valid date', function () {
       let dateOfBirth = '1979-01-10'
 
-      context('the day before a birthday', () => {
-        beforeEach(() => {
+      context('the day before a birthday', function () {
+        beforeEach(function () {
           this.clock = sinon.useFakeTimers(new Date('2019-01-09').getTime())
         })
 
-        afterEach(() => {
+        afterEach(function () {
           this.clock.restore()
         })
 
-        it('should return the age in years', () => {
+        it('should return the age in years', function () {
           const age = filters.calculateAge(dateOfBirth)
           expect(age).to.equal(39)
         })
       })
 
-      context('on a birthday', () => {
-        beforeEach(() => {
+      context('on a birthday', function () {
+        beforeEach(function () {
           this.clock = sinon.useFakeTimers(new Date('2019-01-10').getTime())
         })
 
-        afterEach(() => {
+        afterEach(function () {
           this.clock.restore()
         })
 
-        it('should return the age in years', () => {
+        it('should return the age in years', function () {
           const age = filters.calculateAge(dateOfBirth)
           expect(age).to.equal(40)
         })
       })
 
-      context('the day after a birthday', () => {
-        beforeEach(() => {
+      context('the day after a birthday', function () {
+        beforeEach(function () {
           this.clock = sinon.useFakeTimers(new Date('2019-01-11').getTime())
         })
 
-        afterEach(() => {
+        afterEach(function () {
           this.clock.restore()
         })
 
-        it('should return the age in years', () => {
+        it('should return the age in years', function () {
           const age = filters.calculateAge(dateOfBirth)
           expect(age).to.equal(40)
         })


### PR DESCRIPTION
Mocha [discourages](https://mochajs.org/#arrow-functions) passing it arrow functions as arguments.

This change removes any previous arrow functions and creates a
rule to prevent their use in future. If they are desired they
can be used by disabling the [`mocha/no-mocha-arrows`](https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-mocha-arrows.md) rule for
that particular case.

*Confession:* Most of these were me due to using Visual Studio code
snippets that were  using arrow functions 😳