### PR TITLE
[P4-209] Include move summary in move detail page

### DIFF
--- a/app/moves/controllers.js
+++ b/app/moves/controllers.js
@@ -2,9 +2,11 @@ const presenters = require('../../common/presenters')
 
 module.exports = {
   get: (req, res) => {
-    const { person } = res.locals.move
+    const { move } = res.locals
+    const { person } = move
     const locals = {
       fullname: `${person.last_name}, ${person.first_names}`,
+      moveSummary: presenters.moveToMetaListComponent(move),
       personalDetailsSummary: presenters.personToSummaryListComponent(person),
     }
 

--- a/app/moves/controllers.test.js
+++ b/app/moves/controllers.test.js
@@ -2,12 +2,7 @@ const presenters = require('../../common/presenters')
 
 const controllers = require('./controllers')
 
-const mockMove = {
-  person: {
-    first_names: 'STEVE',
-    last_name: 'Smith',
-  },
-}
+const { data: mockMove } = require('../../test/fixtures/api-client/move.get.deserialized.json')
 
 describe('Moves controllers', function () {
   describe('#get()', function () {
@@ -34,7 +29,7 @@ describe('Moves controllers', function () {
     it('should contain fullname param', function () {
       const params = res.render.args[0][1]
       expect(params).to.have.property('fullname')
-      expect(params.fullname).to.equal('Smith, STEVE')
+      expect(params.fullname).to.equal(`${mockMove.person.last_name}, ${mockMove.person.first_names}`)
     })
 
     it('should contain personal details summary param', function () {

--- a/app/moves/detail.njk
+++ b/app/moves/detail.njk
@@ -1,5 +1,11 @@
 {% extends "layouts/govuk.njk" %}
 
+{% set relativeMoveDate = move.date | formatDateAsRelativeDay(false) %}
+
+{% block pageTitle %}
+  Move details for {{ fullname | upper }}
+{% endblock %}
+
 {% block beforeContent %}
   {{ super() }}
 
@@ -24,6 +30,13 @@
 
       {{ govukSummaryList(personalDetailsSummary) }}
     </div>
-  </div>
 
+    <div class="govuk-grid-column-one-third">
+      <div class="app-border-top-2 app-border--blue govuk-!-padding-top-4">
+        <h3 class="govuk-heading-m">{{ fullname | upper }}</h3>
+
+        {{ appMetaList(moveSummary) }}
+      </div>
+    </div>
+  </div>
 {% endblock %}

--- a/common/assets/scss/utilities/_border.scss
+++ b/common/assets/scss/utilities/_border.scss
@@ -52,6 +52,10 @@ $_border-widths: (
   .app-border--black {
     border-color: govuk-colour("black");
   }
+
+  .app-border--blue {
+    border-color: govuk-colour("blue");
+  }
 }
 
 @include _app-generate-border-classes;

--- a/common/presenters/index.js
+++ b/common/presenters/index.js
@@ -1,9 +1,11 @@
 const moveToCardComponent = require('./move-to-card-component')
+const moveToMetaListComponent = require('./move-to-meta-list-component')
 const personToSummaryListComponent = require('./person-to-summary-list-component')
 const movesByToLocation = require('./moves-by-to-location')
 
 module.exports = {
   moveToCardComponent,
+  moveToMetaListComponent,
   personToSummaryListComponent,
   movesByToLocation,
 }

--- a/common/presenters/move-to-meta-list-component.js
+++ b/common/presenters/move-to-meta-list-component.js
@@ -1,0 +1,57 @@
+/* eslint-disable camelcase */
+const {
+  isToday,
+  isTomorrow,
+  isYesterday,
+} = require('date-fns')
+
+const filters = require('../../config/nunjucks/filters')
+
+function _isRelativeDate (date) {
+  if (isToday(date) || isTomorrow(date) || isYesterday(date)) {
+    return true
+  }
+
+  return false
+}
+
+module.exports = function moveToMetaListComponent ({ date, time_due, from_location, to_location }) {
+  const items = [
+    {
+      key: {
+        text: 'From',
+      },
+      value: {
+        text: from_location.description,
+      },
+    },
+    {
+      key: {
+        text: 'To',
+      },
+      value: {
+        text: to_location.description,
+      },
+    },
+    {
+      key: {
+        text: 'Date',
+      },
+      value: {
+        text: _isRelativeDate(date) ? `${filters.formatDateWithDay(date)} (${filters.formatDateAsRelativeDay(date)})` : filters.formatDateWithDay(date),
+      },
+    },
+    {
+      key: {
+        text: 'Time due',
+      },
+      value: {
+        text: filters.formatTime(time_due),
+      },
+    },
+  ]
+
+  return {
+    items,
+  }
+}

--- a/common/presenters/move-to-meta-list-component.test.js
+++ b/common/presenters/move-to-meta-list-component.test.js
@@ -1,0 +1,141 @@
+const { subDays, addDays } = require('date-fns')
+
+const moveToMetaListComponent = require('./move-to-meta-list-component')
+
+const { data: mockMove } = require('../../test/fixtures/api-client/move.get.deserialized.json')
+
+describe('Presenters', function () {
+  describe('#moveToMetaListComponent()', function () {
+    context('when provided with a mock move object', function () {
+      let transformedResponse
+
+      beforeEach(function () {
+        this.clock = sinon.useFakeTimers(subDays(new Date(mockMove.date), 3).getTime())
+
+        transformedResponse = moveToMetaListComponent(mockMove)
+      })
+
+      afterEach(function () {
+        this.clock.restore()
+      })
+
+      describe('response', function () {
+        it('should contain items list', function () {
+          expect(transformedResponse).to.have.property('items')
+          expect(transformedResponse.items.length).to.equal(4)
+        })
+
+        it('should contain from location as first item', function () {
+          const item = transformedResponse.items[0]
+
+          expect(item).to.deep.equal({
+            key: { text: 'From' },
+            value: { text: mockMove.from_location.description },
+          })
+        })
+
+        it('should contain to location as second item', function () {
+          const item = transformedResponse.items[1]
+
+          expect(item).to.deep.equal({
+            key: { text: 'To' },
+            value: { text: mockMove.to_location.description },
+          })
+        })
+
+        it('should contain date as third item', function () {
+          const item = transformedResponse.items[2]
+
+          expect(item).to.deep.equal({
+            key: { text: 'Date' },
+            value: { text: 'Sunday 9 Jun 2019' },
+          })
+        })
+
+        it('should contain time due as forth item', function () {
+          const item = transformedResponse.items[3]
+
+          expect(item).to.deep.equal({
+            key: { text: 'Time due' },
+            value: { text: '2pm' },
+          })
+        })
+      })
+    })
+
+    context('when date is today', function () {
+      let transformedResponse
+
+      beforeEach(function () {
+        this.clock = sinon.useFakeTimers(new Date(mockMove.date).getTime())
+
+        transformedResponse = moveToMetaListComponent(mockMove)
+      })
+
+      afterEach(function () {
+        this.clock.restore()
+      })
+
+      describe('response', function () {
+        it('should contain today in date value', function () {
+          const item = transformedResponse.items[2]
+
+          expect(item).to.deep.equal({
+            key: { text: 'Date' },
+            value: { text: 'Sunday 9 Jun 2019 (Today)' },
+          })
+        })
+      })
+    })
+
+    context('when date is yesterday', function () {
+      let transformedResponse
+
+      beforeEach(function () {
+        this.clock = sinon.useFakeTimers(subDays(new Date(mockMove.date), 1).getTime())
+
+        transformedResponse = moveToMetaListComponent(mockMove)
+      })
+
+      afterEach(function () {
+        this.clock.restore()
+      })
+
+      describe('response', function () {
+        it('should contain tomorrow in date value', function () {
+          const item = transformedResponse.items[2]
+
+          expect(item).to.deep.equal({
+            key: { text: 'Date' },
+            value: { text: 'Sunday 9 Jun 2019 (Tomorrow)' },
+          })
+        })
+      })
+    })
+
+    context('when date is tomorrow', function () {
+      let transformedResponse
+
+      beforeEach(function () {
+        this.clock = sinon.useFakeTimers(addDays(new Date(mockMove.date), 1).getTime())
+
+        transformedResponse = moveToMetaListComponent(mockMove)
+      })
+
+      afterEach(function () {
+        this.clock.restore()
+      })
+
+      describe('response', function () {
+        it('should contain yesterday in date value', function () {
+          const item = transformedResponse.items[2]
+
+          expect(item).to.deep.equal({
+            key: { text: 'Date' },
+            value: { text: 'Sunday 9 Jun 2019 (Yesterday)' },
+          })
+        })
+      })
+    })
+  })
+})


### PR DESCRIPTION
This change adds the move summary panel to the move detail page.

## What it looks like

![localhost_3000_moves_34422add-ccdd-4dc6-8de6-1e805b43638a](https://user-images.githubusercontent.com/3327997/58966305-f9b32200-87a9-11e9-8987-06c5c1f9c96f.png)
