### PR TITLE
Rename variable passed to render method

### DIFF
--- a/app/dashboard/controllers.js
+++ b/app/dashboard/controllers.js
@@ -15,7 +15,7 @@ module.exports = {
       const response = await api.getMovesByDate(moveDate)
       const yesterday = format(subDays(moveDate, 1), 'YYYY-MM-DD')
       const tomorrow = format(addDays(moveDate, 1), 'YYYY-MM-DD')
-      const params = {
+      const locals = {
         moveDate,
         pageTitle: 'Upcoming moves',
         destinations: presenters.movesByToLocation(response.data),
@@ -29,7 +29,7 @@ module.exports = {
         },
       }
 
-      res.render('dashboard/dashboard', params)
+      res.render('dashboard/dashboard', locals)
     } catch (error) {
       next(error)
     }

--- a/app/moves/controllers.js
+++ b/app/moves/controllers.js
@@ -3,11 +3,11 @@ const presenters = require('../../common/presenters')
 module.exports = {
   get: (req, res) => {
     const { person } = res.locals.move
-    const params = {
+    const locals = {
       fullname: `${person.last_name}, ${person.first_names}`,
       personalDetailsSummary: presenters.personToSummaryListComponent(person),
     }
 
-    res.render('moves/detail', params)
+    res.render('moves/detail', locals)
   },
 }


### PR DESCRIPTION
Based on a previous [comment in a PR](https://github.com/ministryofjustice/pecs-frontend/pull/47#discussion_r290742274) this variable is being
renamed to be more descriptive of what it is doing.

This rename fits more inline with what the `res.render` method [accepts](https://expressjs.com/en/api.html#res.render) for this
parameter.