### PR TITLE
Update service name to match latest name

### DIFF
--- a/config/nunjucks/globals.js
+++ b/config/nunjucks/globals.js
@@ -1,3 +1,3 @@
 module.exports = {
-  SERVICE_NAME: 'Move a prisoner',
+  SERVICE_NAME: 'Book a secure move',
 }


### PR DESCRIPTION
The service name has recently been updated so this change
reflects that.

In the future with different establishments we'll also need
a way to conditionally display the local term used for that
person, ie prisoner, detainee, young person...