### PR TITLE
Display move reference

### DIFF
--- a/app/moves/detail.njk
+++ b/app/moves/detail.njk
@@ -17,6 +17,9 @@
 
 {% block content %}
   <header>
+    <span class="govuk-caption-xl">
+      {{ move.reference }}
+    </span>
     <h1 class="govuk-heading-xl">
       {{ fullname | upper }}
     </h1>

--- a/common/lib/api-client.js
+++ b/common/lib/api-client.js
@@ -9,6 +9,7 @@ const jsonApi = new JsonApi({
 
 function defineModels (jsonApi) {
   jsonApi.define('move', {
+    reference: '',
     type: '',
     status: '',
     updated_at: '',

--- a/common/presenters/move-to-card-component.js
+++ b/common/presenters/move-to-card-component.js
@@ -14,7 +14,7 @@ function _removeEmpty (items, keys) {
   })
 }
 
-module.exports = function moveToCardComponent ({ id, person }) {
+module.exports = function moveToCardComponent ({ id, reference, person }) {
   const meta = [
     {
       label: 'Date of birth',
@@ -39,7 +39,7 @@ module.exports = function moveToCardComponent ({ id, person }) {
       text: `${person.last_name.toUpperCase()}, ${person.first_names.toUpperCase()}`,
     },
     caption: {
-      text: id,
+      text: reference,
     },
     meta: {
       items: _removeEmpty(meta, ['text', 'html']),

--- a/common/presenters/move-to-card-component.test.js
+++ b/common/presenters/move-to-card-component.test.js
@@ -34,7 +34,7 @@ describe('Presenters', function () {
         it('should contain a caption', function () {
           expect(transformedResponse).to.have.property('caption')
           expect(transformedResponse.caption).to.deep.equal({
-            text: mockMove.id,
+            text: mockMove.reference,
           })
         })
 

--- a/test/fixtures/api-client/move.get.deserialized.json
+++ b/test/fixtures/api-client/move.get.deserialized.json
@@ -2,6 +2,7 @@
   "data": {
     "id": "c017c5b6-a4bf-4046-9eda-210d417a7e46",
     "type": "court",
+    "reference": "KE6CYT9M",
     "status": "scheduled",
     "updated_at": "2019-06-05T10:57:43Z",
     "time_due": "2000-01-01T14:00:00Z",


### PR DESCRIPTION
This replaces the display of the GUID with the move reference.

## What it looks like

![image](https://user-images.githubusercontent.com/3327997/59266318-46ca4480-8c3f-11e9-9a60-f2394472ea93.png)

![image](https://user-images.githubusercontent.com/3327997/59266343-56e22400-8c3f-11e9-9184-4ad2db47fb4b.png)
