### PR TITLE
Update test coverage

### DIFF
--- a/config/nunjucks/filters.test.js
+++ b/config/nunjucks/filters.test.js
@@ -12,6 +12,14 @@ const filters = proxyquire('./filters', {
 
 describe('Nunjucks filters', function () {
   describe('#formatDate()', function () {
+    context('when no date is provided', function () {
+      it('should return input value', function () {
+        const formattedDate = filters.formatDate('')
+
+        expect(formattedDate).to.equal('')
+      })
+    })
+
     context('when given an invalid date', function () {
       it('should return input value', function () {
         const formattedDate = filters.formatDate('2010-45-5')


### PR DESCRIPTION
This adds a couple more tests that cover some statements that were
being missed that were picked up by the test coverage.

## Before
![_Users_domsmith_Projects_hmpps_pecs-frontend_coverage_index html (1)](https://user-images.githubusercontent.com/3327997/59291699-595e7100-8c73-11e9-8b1f-4552eab03112.png)

## After
![_Users_domsmith_Projects_hmpps_pecs-frontend_coverage_index html](https://user-images.githubusercontent.com/3327997/59291626-40ee5680-8c73-11e9-85cf-faab179a2075.png)
