### PR TITLE
Fix race condition when loading config file before dotenv is loaded

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -1,4 +1,6 @@
 /* eslint no-process-env: "off" */
+require('dotenv').config()
+
 const IS_DEV = process.env.NODE_ENV !== 'production'
 const IS_PRODUCTION = process.env.NODE_ENV === 'production'
 

--- a/start.js
+++ b/start.js
@@ -1,4 +1,3 @@
-require('dotenv').config()
 const http = require('http')
 
 const app = require('./server')


### PR DESCRIPTION
This fixes a race condition which I found in the test environment.

In various tests we require the `config/index.js` file, but `dotenv` is not loaded in the test environment so most of the config values are `undefined`.

Not only is this giving us potential false-positives in tests but we can't force a reload the `config` object after that.

So I've moved the initial `dotenv` load to the config file, so that on the first instance it is required it will be loaded. This is the only place in the application where environment variables are referenced directly, and this is enforced with  ESLint, so it should be safe.

After this fix the config object is loaded correctly in the test environment.