### PR TITLE
[P4-342] Display assessment answers on the move detail page

### DIFF
--- a/app/moves/controllers/get.js
+++ b/app/moves/controllers/get.js
@@ -7,6 +7,7 @@ module.exports = function get (req, res) {
     fullname: `${person.last_name}, ${person.first_names}`,
     moveSummary: presenters.moveToMetaListComponent(move),
     personalDetailsSummary: presenters.personToSummaryListComponent(person),
+    tagList: presenters.assessmentToTagList(person.assessment_answers),
   }
 
   res.render('moves/detail', locals)

--- a/app/moves/controllers/get.test.js
+++ b/app/moves/controllers/get.test.js
@@ -9,7 +9,9 @@ describe('Moves controllers', function () {
     let req, res
 
     beforeEach(function () {
+      sinon.stub(presenters, 'moveToMetaListComponent').returnsArg(0)
       sinon.stub(presenters, 'personToSummaryListComponent').returnsArg(0)
+      sinon.stub(presenters, 'assessmentToTagList').returnsArg(0)
 
       req = {}
       res = {
@@ -32,10 +34,22 @@ describe('Moves controllers', function () {
       expect(params.fullname).to.equal(`${mockMove.person.last_name}, ${mockMove.person.first_names}`)
     })
 
+    it('should contain a move summary param', function () {
+      const params = res.render.args[0][1]
+      expect(params).to.have.property('moveSummary')
+      expect(params.moveSummary).to.equal(mockMove)
+    })
+
     it('should contain personal details summary param', function () {
       const params = res.render.args[0][1]
       expect(params).to.have.property('personalDetailsSummary')
       expect(params.personalDetailsSummary).to.equal(mockMove.person)
+    })
+
+    it('should contain tag list param', function () {
+      const params = res.render.args[0][1]
+      expect(params).to.have.property('tagList')
+      expect(params.tagList).to.equal(mockMove.person.assessment_answers)
     })
   })
 })

--- a/app/moves/detail.njk
+++ b/app/moves/detail.njk
@@ -16,13 +16,22 @@
 {% endblock %}
 
 {% block content %}
-  <header>
+  <header class="govuk-!-margin-bottom-8">
     <span class="govuk-caption-xl">
       {{ move.reference }}
     </span>
-    <h1 class="govuk-heading-xl">
+
+    <h1 class="govuk-heading-xl govuk-!-margin-bottom-0">
       {{ fullname | upper }}
     </h1>
+
+    {% if tagList | length %}
+      <div class="govuk-!-margin-top-2">
+        {% for tag in tagList %}
+          {{ appTag(tag) }}
+        {% endfor %}
+      <div>
+    {% endif %}
   </header>
 
   <div class="govuk-grid-row">


### PR DESCRIPTION
This reuses the assessment answers changes from #73 to display the flags on the move detail page.

## What it looks like

![localhost_3000_moves_76d604ae-fe18-4f90-b5b7-bc012d4a64ab](https://user-images.githubusercontent.com/3327997/59753923-0d1bbe00-927d-11e9-9863-5f0cf60de041.png)
