### PR TITLE
[P4-342] Add new panel component

### DIFF
--- a/common/assets/scss/components/_all.scss
+++ b/common/assets/scss/components/_all.scss
@@ -1,6 +1,7 @@
 @import "stack-trace";
 
 // Load components from the shared components folder
+@import "_panel/panel";
 @import "_tag/tag";
 @import "card/card";
 @import "data/data";

--- a/common/components/_panel/_panel.scss
+++ b/common/components/_panel/_panel.scss
@@ -1,0 +1,23 @@
+$_border-width: 2px;
+
+.app-panel {
+  background-color: govuk-colour("grey-4");
+  border: $_border-width solid govuk-colour("grey-2");
+  padding: govuk-spacing(3);
+  position: relative;
+
+  & + & {
+    margin-top: govuk-spacing(2);
+  }
+}
+
+// If panel contains a tag component, style based on this parent
+.app-panel .app-tag {
+  position: absolute;
+  left: -($_border-width);
+  top: -($_border-width);
+
+  & + * {
+    margin-top: govuk-spacing(3);
+  }
+}

--- a/common/components/_panel/macro.njk
+++ b/common/components/_panel/macro.njk
@@ -1,0 +1,3 @@
+{% macro appPanel(params) %}
+  {%- include "./template.njk" -%}
+{% endmacro %}

--- a/common/components/_panel/panel.yaml
+++ b/common/components/_panel/panel.yaml
@@ -1,0 +1,31 @@
+params:
+- name: classes
+  type: string
+  required: false
+  description: Classes to add to the parent element.
+- name: attributes
+  type: object
+  required: false
+  description: HTML attributes (for example data attributes) to add to the component.
+- name: text
+  type: string
+  required: true
+  description: If `html` is set, this is not required. Text to use within the panel content. If `html` is provided, the `text` argument will be ignored.
+- name: html
+  type: string
+  required: true
+  description: If `text` is set, this is not required. HTML to use within the panel content. If `html` is provided, the `text` argument will be ignored.
+- name: tag
+  type: object
+  required: false
+  description: Params to pass to the tag component.
+
+examples:
+  - name: default
+    data:
+      text: Panel contents
+  - name: with tag
+    data:
+      text: Panel contents
+      tag:
+        text: An example tag

--- a/common/components/_panel/template.njk
+++ b/common/components/_panel/template.njk
@@ -1,0 +1,17 @@
+{% from "_tag/macro.njk" import appTag %}
+
+{% set element = params.element | default('div') %}
+{% set content = params.html | safe if params.html else params.text %}
+
+<{{ element }}
+  class="app-panel{% if params.classes %} {{ params.classes }}{% endif %}"
+  {%- for attribute, value in params.attributes %}
+    {{ attribute }}="{{ value }}"
+  {% endfor -%}
+  >
+  {% if params.tag %}
+    {{ appTag(params.tag) }}
+  {% endif %}
+
+  {{ caller() if caller else content }}
+</{{ element }}>

--- a/common/components/_panel/template.test.js
+++ b/common/components/_panel/template.test.js
@@ -1,0 +1,103 @@
+const { render, getExamples } = require('../../../test/unit/component-helpers')
+
+const examples = getExamples('_panel')
+
+describe('Panel component', function () {
+  context('by default', function () {
+    let $component
+
+    beforeEach(function () {
+      const $ = render('_panel', examples.default)
+      $component = $('.app-panel')
+    })
+
+    it('should render component', function () {
+      expect($component.get(0).tagName).to.equal('div')
+    })
+
+    it('should render text', function () {
+      expect($component.html().trim()).to.equal('Panel contents')
+    })
+
+    it('should not render tag component', function () {
+      expect($component.find('.app-tag').length).to.equal(0)
+    })
+  })
+
+  context('with classes param', function () {
+    it('should render classes', function () {
+      const $ = render('_panel', {
+        classes: 'app-panel--inactive',
+      })
+
+      const $component = $('.app-panel')
+      expect($component.hasClass('app-panel--inactive')).to.be.true
+    })
+  })
+
+  context('with attributes param', function () {
+    it('should render attributes', function () {
+      const $ = render('_panel', {
+        attributes: {
+          'data-attribute': 'my data value',
+        },
+      })
+
+      const $component = $('.app-panel')
+      expect($component.attr('data-attribute')).to.equal('my data value')
+    })
+  })
+
+  context('when html is passed to text', function () {
+    it('should render escaped html', function () {
+      const $ = render('_panel', {
+        text: 'Content with <strong>bold text</strong>',
+      })
+
+      const $component = $('.app-panel')
+      expect($component.html()).to.contain('Content with &lt;strong&gt;bold text&lt;/strong&gt;')
+    })
+  })
+
+  context('when html is passed to html', function () {
+    it('should render unescaped html', function () {
+      const $ = render('_panel', {
+        html: 'Content with <strong>bold text</strong>',
+      })
+
+      const $component = $('.app-panel')
+      expect($component.html()).to.contain('Content with <strong>bold text</strong>')
+    })
+  })
+
+  context('when both html and text params are used', function () {
+    it('should render unescaped html', function () {
+      const $ = render('_panel', {
+        html: 'Content with <strong>bold text</strong>',
+        text: 'Content with <strong>bold text</strong>',
+      })
+
+      const $component = $('.app-panel')
+      expect($component.html()).to.contain('Content with <strong>bold text</strong>')
+    })
+  })
+
+  context('when tag component is added', function () {
+    let $, $component
+    beforeEach(function () {
+      $ = render('_panel', examples['with tag'])
+      $component = $('.app-panel')
+    })
+
+    it('should render a tag component', function () {
+      const $tag = $component.find('.app-tag')
+
+      expect($tag.length).to.equal(1)
+      expect($tag.html().trim()).to.equal('An example tag')
+    })
+
+    it('should render content', function () {
+      expect($component.html()).to.contain('Panel contents')
+    })
+  })
+})

--- a/common/templates/layouts/govuk.njk
+++ b/common/templates/layouts/govuk.njk
@@ -11,6 +11,7 @@
 {% from "summary-list/macro.njk"      import govukSummaryList %}
 
 {# Components that clash with GOV.UK Frontend namespace #}
+{% from "_panel/macro.njk"            import appPanel %}
 {% from "_tag/macro.njk"              import appTag %}
 
 {# App level components #}


### PR DESCRIPTION
This is the base for a panel component that may have future
style variations. Initially it will be used on the move details
page to display alerts/flags for an individual being moved.

## What it looks like

### Default

![image](https://user-images.githubusercontent.com/3327997/59883233-4b63cb00-93ac-11e9-876f-c899e221dfd1.png)

### With tag component

![image](https://user-images.githubusercontent.com/3327997/59883180-266f5800-93ac-11e9-9a0e-1bcc024a77aa.png)

