### PR TITLE
Refactor getting of a person's fullname

### DIFF
--- a/app/moves/controllers/get.js
+++ b/app/moves/controllers/get.js
@@ -1,10 +1,11 @@
+const personService = require('../../../common/services/person')
 const presenters = require('../../../common/presenters')
 
 module.exports = function get (req, res) {
   const { move } = res.locals
   const { person } = move
   const locals = {
-    fullname: `${person.last_name}, ${person.first_names}`,
+    fullname: personService.getFullname(person),
     moveSummary: presenters.moveToMetaListComponent(move),
     personalDetailsSummary: presenters.personToSummaryListComponent(person),
     tagList: presenters.assessmentToTagList(person.assessment_answers),

--- a/app/moves/controllers/get.test.js
+++ b/app/moves/controllers/get.test.js
@@ -1,14 +1,17 @@
+const personService = require('../../../common/services/person')
 const presenters = require('../../../common/presenters')
 
 const controllers = require('./')
 
 const { data: mockMove } = require('../../../test/fixtures/api-client/move.get.deserialized.json')
+const fullname = `${mockMove.person.last_name}, ${mockMove.person.first_names}`
 
 describe('Moves controllers', function () {
   describe('#get()', function () {
     let req, res
 
     beforeEach(function () {
+      sinon.stub(personService, 'getFullname').returns(fullname)
       sinon.stub(presenters, 'moveToMetaListComponent').returnsArg(0)
       sinon.stub(presenters, 'personToSummaryListComponent').returnsArg(0)
       sinon.stub(presenters, 'assessmentToTagList').returnsArg(0)
@@ -33,7 +36,7 @@ describe('Moves controllers', function () {
     it('should contain fullname param', function () {
       const params = res.render.args[0][1]
       expect(params).to.have.property('fullname')
-      expect(params.fullname).to.equal(`${mockMove.person.last_name}, ${mockMove.person.first_names}`)
+      expect(params.fullname).to.equal(fullname)
     })
 
     it('should call moveToMetaListComponent presenter with correct args', function () {

--- a/app/moves/controllers/save.js
+++ b/app/moves/controllers/save.js
@@ -2,6 +2,7 @@ const { omit } = require('lodash')
 
 const FormController = require('./form')
 const moveService = require('../../../common/services/move')
+const personService = require('../../../common/services/person')
 const filters = require('../../../config/nunjucks/filters')
 
 class SaveController extends FormController {
@@ -28,7 +29,7 @@ class SaveController extends FormController {
       person,
       to_location: toLocation,
     } = req.sessionModel.get('move')
-    const messageContent = `Move for <strong>${person.first_names} ${person.last_name}</strong> to <strong>${toLocation.title}</strong> on <strong>${filters.formatDateWithDay(date)}</strong> has been scheduled.`
+    const messageContent = `Move for <strong>${personService.getFullname(person)}</strong> to <strong>${toLocation.title}</strong> on <strong>${filters.formatDateWithDay(date)}</strong> has been scheduled.`
 
     req.journeyModel.reset()
     req.journeyModel.destroy()

--- a/app/moves/controllers/save.test.js
+++ b/app/moves/controllers/save.test.js
@@ -2,11 +2,13 @@ const FormController = require('hmpo-form-wizard').Controller
 
 const Controller = require('./save')
 const moveService = require('../../../common/services/move')
+const personService = require('../../../common/services/person')
 const filters = require('../../../config/nunjucks/filters')
 
 const controller = new Controller({ route: '/' })
 
 const { data: moveMock } = require('../../../test/fixtures/api-client/move.get.deserialized.json')
+const fullname = `${moveMock.person.last_name}, ${moveMock.person.first_names}`
 const valuesMock = {
   'csrf-secret': 'secret',
   errors: null,
@@ -108,6 +110,7 @@ describe('Moves controllers', function () {
           redirect: sinon.stub(),
         }
 
+        sinon.stub(personService, 'getFullname').returns(fullname)
         sinon.stub(filters, 'formatDateWithDay').returnsArg(0)
         controller.successHandler(req, res)
       })
@@ -115,7 +118,7 @@ describe('Moves controllers', function () {
       it('should set a success message', function () {
         expect(req.flash).to.have.been.calledOnceWith('success', {
           title: 'Move scheduled',
-          content: `Move for <strong>${moveMock.person.first_names} ${moveMock.person.last_name}</strong> to <strong>${moveMock.to_location.title}</strong> on <strong>${moveMock.date}</strong> has been scheduled.`,
+          content: `Move for <strong>${fullname}</strong> to <strong>${moveMock.to_location.title}</strong> on <strong>${moveMock.date}</strong> has been scheduled.`,
         })
       })
 

--- a/common/presenters/move-to-card-component.js
+++ b/common/presenters/move-to-card-component.js
@@ -1,4 +1,5 @@
 const assessmentToTagList = require('./assessment-to-tag-list')
+const personService = require('../services/person')
 const filters = require('../../config/nunjucks/filters')
 
 function _removeEmpty (items, keys) {
@@ -37,7 +38,7 @@ module.exports = function moveToCardComponent ({ id, reference, person }) {
   return {
     href: `/moves/${id}`,
     title: {
-      text: `${person.last_name.toUpperCase()}, ${person.first_names.toUpperCase()}`,
+      text: personService.getFullname(person).toUpperCase(),
     },
     caption: {
       text: reference,

--- a/common/presenters/move-to-card-component.test.js
+++ b/common/presenters/move-to-card-component.test.js
@@ -1,14 +1,17 @@
 const moveToCardComponent = require('./move-to-card-component')
 
 const filters = require('../../config/nunjucks/filters')
+const personService = require('../services/person')
 
 const { data: mockMove } = require('../../test/fixtures/api-client/move.get.deserialized.json')
+const fullname = `${mockMove.person.last_name}, ${mockMove.person.first_names}`
 
 describe('Presenters', function () {
   describe('#moveToCardComponent()', function () {
     beforeEach(function () {
       sinon.stub(filters, 'formatDate').returns('18 Jun 1960')
       sinon.stub(filters, 'calculateAge').returns(50)
+      sinon.stub(personService, 'getFullname').returns(fullname)
     })
 
     context('when provided with a mock move object', function () {
@@ -25,10 +28,9 @@ describe('Presenters', function () {
         })
 
         it('should contain a title', function () {
-          const person = mockMove.person
           expect(transformedResponse).to.have.property('title')
           expect(transformedResponse.title).to.deep.equal({
-            text: `${person.last_name.toUpperCase()}, ${person.first_names.toUpperCase()}`,
+            text: fullname.toUpperCase(),
           })
         })
 

--- a/common/services/person.js
+++ b/common/services/person.js
@@ -2,6 +2,13 @@ const { mapValues } = require('lodash')
 
 const apiClient = require('../lib/api-client')
 
+function getFullname ({
+  first_names: firstNames,
+  last_name: lastName,
+}) {
+  return `${lastName}, ${firstNames}`
+}
+
 function format (data) {
   const relationships = ['gender', 'ethnicity']
 
@@ -20,6 +27,7 @@ function create (data) {
 }
 
 module.exports = {
+  getFullname,
   format,
   create,
 }

--- a/common/services/person.test.js
+++ b/common/services/person.test.js
@@ -14,6 +14,19 @@ describe('Person Service', function () {
     sinon.stub(auth, 'getAccessTokenExpiry').returns(Math.floor(new Date() / 1000) + 100)
   })
 
+  describe('#getFullname()', function () {
+    it('should format full name', function () {
+      const firstNames = 'Firstnames middlename'
+      const lastName = 'Lastname'
+      const fullname = personService.getFullname({
+        first_names: firstNames,
+        last_name: lastName,
+      })
+
+      expect(fullname).to.equal(`${lastName}, ${firstNames}`)
+    })
+  })
+
   describe('#format()', function () {
     context('when relationship field is string', function () {
       let formatted


### PR DESCRIPTION
We are now getting a persons fullname in a few different areas.

This change moves that logic to the Person service and reuses that
in places in the app that need a person's fullname.

This change came out of a suggestion made in #75 