### PR TITLE
Add support for GOV.UK Design System textarea

### DIFF
--- a/common/assets/scss/application.scss
+++ b/common/assets/scss/application.scss
@@ -23,6 +23,7 @@ $govuk-font-family: "Inter", system-ui, sans-serif;
 @import "govuk-frontend/components/select/select.scss";
 @import "govuk-frontend/components/skip-link/skip-link.scss";
 @import "govuk-frontend/components/summary-list/summary-list.scss";
+@import "govuk-frontend/components/textarea/textarea.scss";
 
 @import "govuk-frontend/utilities/all";
 @import "govuk-frontend/overrides/all";

--- a/common/templates/layouts/govuk.njk
+++ b/common/templates/layouts/govuk.njk
@@ -9,6 +9,7 @@
 {% from "radios/macro.njk"            import govukRadios %}
 {% from "select/macro.njk"            import govukSelect %}
 {% from "summary-list/macro.njk"      import govukSummaryList %}
+{% from "textarea/macro.njk"          import govukTextarea %}
 
 {# Components that clash with GOV.UK Frontend namespace #}
 {% from "_panel/macro.njk"            import appPanel %}


### PR DESCRIPTION
This adds the textarea component from the Design System.