### PR TITLE
[P4-410] Replay saved values

### DIFF
--- a/app/moves/controllers/form.js
+++ b/app/moves/controllers/form.js
@@ -33,6 +33,7 @@ class FormController extends Controller {
 
   render (req, res, next) {
     const fields = Object.entries(req.form.options.fields)
+      .map(fieldHelpers.setFieldValue(req.form.values))
       .map(fieldHelpers.renderConditionalFields)
 
     req.form.options.fields = fromPairs(fields)

--- a/app/moves/controllers/form.test.js
+++ b/app/moves/controllers/form.test.js
@@ -146,58 +146,73 @@ describe('Moves controllers', function () {
     })
 
     describe('#render()', function () {
-      context('', function () {
-        let reqMock, nextSpy
+      let reqMock, nextSpy
 
-        before(function () {
-          nextSpy = sinon.spy()
-          sinon
-            .stub(fieldHelpers, 'renderConditionalFields')
-            .callsFake(([key, field]) => {
-              return [ key, { ...field, renderConditionalFields: true } ]
-            })
+      beforeEach(function () {
+        nextSpy = sinon.spy()
+        sinon.spy(FormController.prototype, 'render')
+        sinon
+          .stub(fieldHelpers, 'setFieldValue')
+          .callsFake(() => ([key, field]) => {
+            return [ key, { ...field, setFieldValue: true } ]
+          })
+        sinon
+          .stub(fieldHelpers, 'renderConditionalFields')
+          .callsFake(([key, field]) => {
+            return [ key, { ...field, renderConditionalFields: true } ]
+          })
 
-          reqMock = {
-            form: {
-              options: {
-                fields: {
-                  field_1: {
-                    name: 'Field 1',
-                  },
-                  field_2: {
-                    name: 'Field 2',
-                  },
-                  field_3: {
-                    name: 'Field 3',
-                  },
+        reqMock = {
+          form: {
+            options: {
+              fields: {
+                field_1: {
+                  name: 'Field 1',
+                },
+                field_2: {
+                  name: 'Field 2',
+                },
+                field_3: {
+                  name: 'Field 3',
                 },
               },
             },
-          }
+          },
+        }
 
-          controller.render(reqMock, {}, nextSpy)
-        })
+        controller.render(reqMock, {}, nextSpy)
+      })
 
-        it('should call renderConditionalFields on each field', function () {
-          expect(fieldHelpers.renderConditionalFields).to.be.calledThrice
-        })
+      it('should call renderConditionalFields on each field', function () {
+        expect(fieldHelpers.renderConditionalFields).to.be.calledThrice
+      })
 
-        it('should mutate fields object', function () {
-          expect(reqMock.form.options.fields).to.deep.equal({
-            field_1: {
-              renderConditionalFields: true,
-              name: 'Field 1',
-            },
-            field_2: {
-              renderConditionalFields: true,
-              name: 'Field 2',
-            },
-            field_3: {
-              renderConditionalFields: true,
-              name: 'Field 3',
-            },
-          })
+      it('should call setFieldValue', function () {
+        expect(fieldHelpers.setFieldValue).to.be.calledOnce
+      })
+
+      it('should mutate fields object', function () {
+        expect(reqMock.form.options.fields).to.deep.equal({
+          field_1: {
+            renderConditionalFields: true,
+            setFieldValue: true,
+            name: 'Field 1',
+          },
+          field_2: {
+            renderConditionalFields: true,
+            setFieldValue: true,
+            name: 'Field 2',
+          },
+          field_3: {
+            renderConditionalFields: true,
+            setFieldValue: true,
+            name: 'Field 3',
+          },
         })
+      })
+
+      it('should call parent render method', function () {
+        expect(FormController.prototype.render).to.be.calledOnceWithExactly(reqMock, {}, nextSpy)
       })
     })
   })

--- a/app/moves/views/create/move-details.njk
+++ b/app/moves/views/create/move-details.njk
@@ -18,6 +18,7 @@
       {
         value: "court",
         text: "Court",
+        checked: values.to_location_type === "court",
         conditional: {
           html: govukSelect(options.fields.to_location_court)
         }
@@ -25,6 +26,7 @@
       {
         value: "prison",
         text: "Prison",
+        checked: values.to_location_type === "prison",
         conditional: {
           html: govukSelect(options.fields.to_location_prison)
         }
@@ -43,15 +45,18 @@
     items: [
       {
         value: "today",
-        text: "Today (" + TODAY | formatDateWithDay + ")"
+        text: "Today (" + TODAY | formatDateWithDay + ")",
+        checked: values.date_type === "today"
       },
       {
         value: "tomorrow",
-        text: "Tomorrow (" + TOMORROW | formatDateWithDay + ")"
+        text: "Tomorrow (" + TOMORROW | formatDateWithDay + ")",
+        checked: values.date_type === "tomorrow"
       },
       {
         value: "custom",
         text: "Another date",
+        checked: values.date_type === "custom",
         conditional: {
           html: govukInput(options.fields.date_custom)
         }

--- a/common/helpers/field.js
+++ b/common/helpers/field.js
@@ -57,6 +57,40 @@ function renderConditionalFields ([key, field], index, obj) {
   ]
 }
 
+function setFieldValue (values) {
+  return ([key, field]) => {
+    if (!field.items) {
+      return [
+        key,
+        { ...field, value: values[key] },
+      ]
+    }
+
+    return [
+      key,
+      {
+        ...field,
+        items: field.items.map((item) => {
+          const value = values[key]
+          let selected = false
+
+          if (!value) {
+            return item
+          }
+
+          if (Array.isArray(value)) {
+            selected = value.includes(item.value)
+          } else {
+            selected = item.value === value
+          }
+
+          return { ...item, selected, checked: selected }
+        }),
+      },
+    ]
+  }
+}
+
 function insertInitialOption (items, label = 'option') {
   const initialOption = {
     text: `--- Choose ${label} ---`,
@@ -69,5 +103,6 @@ module.exports = {
   mapReferenceDataToOption,
   mapAssessmentQuestionToConditionalField,
   renderConditionalFields,
+  setFieldValue,
   insertInitialOption,
 }

--- a/common/helpers/field.test.js
+++ b/common/helpers/field.test.js
@@ -2,6 +2,7 @@ const {
   mapReferenceDataToOption,
   mapAssessmentQuestionToConditionalField,
   renderConditionalFields,
+  setFieldValue,
   insertInitialOption,
 } = require('./field')
 
@@ -258,6 +259,148 @@ describe('Form helpers', function () {
               html: '<strong>HTML</strong> content',
             },
           }])
+        })
+      })
+    })
+  })
+
+  describe('#setFieldValue()', function () {
+    context('when field doesn\'t contain items', function () {
+      context('when value doesn\'t exists', function () {
+        it('should set empty value property', function () {
+          const field = [
+            'court',
+            { name: 'court' },
+          ]
+          const response = setFieldValue({})(field)
+
+          expect(response).to.deep.equal([
+            'court',
+            {
+              name: 'court',
+              value: undefined,
+            },
+          ])
+        })
+      })
+
+      context('when value exists', function () {
+        it('should set value property', function () {
+          const values = {
+            court: 'court val',
+          }
+          const field = [
+            'court',
+            { name: 'court' },
+          ]
+          const response = setFieldValue(values)(field)
+
+          expect(response).to.deep.equal([
+            'court',
+            {
+              name: 'court',
+              value: 'court val',
+            },
+          ])
+        })
+      })
+    })
+
+    context('when field contains items', function () {
+      context('when value doesn\'t exists', function () {
+        it('should set return original items', function () {
+          const field = [
+            'court',
+            {
+              name: 'court',
+              items: [{
+                value: 'one',
+                text: 'Item one',
+              }, {
+                value: 'two',
+                text: 'Item two',
+              }],
+            },
+          ]
+          const response = setFieldValue({})(field)
+
+          expect(response).to.deep.equal(field)
+        })
+      })
+
+      context('when value exists', function () {
+        context('when item value is in array', function () {
+          it('should correctly set selected/checked', function () {
+            const values = {
+              court: ['one', 'three'],
+            }
+            const field = [
+              'court',
+              {
+                name: 'court',
+                items: [{
+                  value: 'one',
+                  text: 'Item one',
+                }, {
+                  value: 'two',
+                  text: 'Item two',
+                }],
+              },
+            ]
+            const response = setFieldValue(values)(field)
+
+            expect(response[1].items).to.deep.equal([
+              {
+                value: 'one',
+                text: 'Item one',
+                selected: true,
+                checked: true,
+              },
+              {
+                value: 'two',
+                text: 'Item two',
+                selected: false,
+                checked: false,
+              },
+            ])
+          })
+        })
+
+        context('when item value is not in array', function () {
+          it('should correctly set selected/checked', function () {
+            const values = {
+              court: 'two',
+            }
+            const field = [
+              'court',
+              {
+                name: 'court',
+                items: [{
+                  value: 'one',
+                  text: 'Item one',
+                }, {
+                  value: 'two',
+                  text: 'Item two',
+                }],
+              },
+            ]
+            const response = setFieldValue(values)(field)
+
+            expect(response[1].items).to.deep.equal([
+              {
+                value: 'one',
+                text: 'Item one',
+                selected: false,
+                checked: false,
+              },
+              {
+                value: 'two',
+                text: 'Item two',
+                selected: true,
+                checked: true,
+              },
+            ])
+          })
         })
       })
     })


### PR DESCRIPTION
This changes uses the saved form values to set on field objects
so that the value will be carried through if a user ever visits
previous steps.

## Before
![localhost_3000_moves_new_personal-details (1)](https://user-images.githubusercontent.com/3327997/60031163-1d2c0700-969c-11e9-9945-4e6113dc7b1a.png)

## After
![localhost_3000_moves_new_personal-details](https://user-images.githubusercontent.com/3327997/60031139-11404500-969c-11e9-8521-bc93ae1a85cd.png)
