### PR TITLE
[P4-225] Use custom error handler for API client

### DIFF
--- a/common/lib/api-client/errors.js
+++ b/common/lib/api-client/errors.js
@@ -1,0 +1,19 @@
+module.exports = {
+  name: 'errors',
+  error: function error (payload = {}) {
+    if (!payload.response) {
+      if (payload instanceof Error) {
+        return payload
+      }
+
+      return null
+    }
+
+    const { status, statusText, data = {} } = payload.response
+    const error = new Error(data.error_description || statusText)
+    error.statusCode = status || 500
+    error.errors = data.errors
+
+    return error
+  },
+}

--- a/common/lib/api-client/errors.test.js
+++ b/common/lib/api-client/errors.test.js
@@ -1,0 +1,115 @@
+const errorMiddleware = require('./errors')
+
+describe('API Client', function () {
+  describe('Error middleware', function () {
+    describe('#error()', function () {
+      context('when payload does not include a response', function () {
+        context('when payload is an Error', function () {
+          it('should return error', function () {
+            const error = errorMiddleware.error(new Error('Payload error'))
+
+            expect(error).to.be.an.instanceOf(Error)
+            expect(error.message).to.equal('Payload error')
+          })
+        })
+
+        context('when payload is not an Error', function () {
+          it('should return null', function () {
+            expect(errorMiddleware.error()).to.equal(null)
+          })
+        })
+      })
+
+      context('when payload contains a response', function () {
+        let response
+
+        before(function () {
+          response = {
+            statusText: 'API Error',
+          }
+        })
+
+        context('without error description', function () {
+          it('should set message to statusText', function () {
+            const error = errorMiddleware.error({ response })
+
+            expect(error).to.be.an.instanceOf(Error)
+            expect(error.message).to.equal('API Error')
+          })
+        })
+
+        context('with error description', function () {
+          it('should set message to error description', function () {
+            const error = errorMiddleware.error({
+              response: {
+                ...response,
+                data: {
+                  error_description: 'Error description',
+                },
+              },
+            })
+
+            expect(error).to.be.an.instanceOf(Error)
+            expect(error.message).to.equal('Error description')
+          })
+        })
+
+        context('without response status', function () {
+          it('should set status to 500', function () {
+            const error = errorMiddleware.error({ response })
+
+            expect(error).to.be.an.instanceOf(Error)
+            expect(error.statusCode).to.equal(500)
+          })
+        })
+
+        context('with response status', function () {
+          it('should set status to response status', function () {
+            const error = errorMiddleware.error({
+              response: {
+                ...response,
+                status: 422,
+              },
+            })
+
+            expect(error).to.be.an.instanceOf(Error)
+            expect(error.statusCode).to.equal(422)
+          })
+        })
+
+        context('without data errors', function () {
+          it('should set errors to undefined', function () {
+            const error = errorMiddleware.error({ response })
+
+            expect(error).to.be.an.instanceOf(Error)
+            expect(error.errors).to.equal(undefined)
+          })
+        })
+
+        context('with data errors', function () {
+          it('should append errors to error class', function () {
+            const error = errorMiddleware.error({
+              response: {
+                ...response,
+                data: {
+                  errors: [{
+                    name: 'Error 1',
+                  }, {
+                    name: 'Error 2',
+                  }],
+                },
+              },
+            })
+
+            expect(error).to.be.an.instanceOf(Error)
+            expect(error.errors).to.deep.equal([{
+              name: 'Error 1',
+            }, {
+              name: 'Error 2',
+            }])
+          })
+        })
+      })
+    })
+  })
+})

--- a/common/lib/api-client/json-api.js
+++ b/common/lib/api-client/json-api.js
@@ -2,6 +2,7 @@ const JsonApi = require('devour-client')
 
 const { API, IS_DEV } = require('../../../config')
 const { devourAuthMiddleware } = require('./auth')
+const errorMiddleware = require('./errors')
 const defineModels = require('./models')
 
 const jsonApi = new JsonApi({
@@ -9,6 +10,7 @@ const jsonApi = new JsonApi({
   logger: IS_DEV,
 })
 
+jsonApi.replaceMiddleware('errors', errorMiddleware)
 jsonApi.insertMiddlewareBefore('axios-request', devourAuthMiddleware)
 
 defineModels(jsonApi)


### PR DESCRIPTION
This change overrides the error handler provided by the devour
library.

Previously it would attempt to format error responses into an
object with each field as the key.

Unfortunately it didn't provide any further information with the
formatting, like status codes so other parts of the app wouldn't
know how to handle a validation error (`422`) different to a
genuine server error returned by the API.

It also wasn't being handled correctly by the app error handler as
no stack trace or status code was being passed through.

For now the errors are retained in the same format. This may be changed
in a future change that uses them better to provide form validation
feedback.

## Error response

### Before

Error response (JS Object):
```js
{
  last_name: {
    title: 'Unprocessable entity',
    detail: 'Last name can\'t be blank',
  },
  first_names: {
    title: 'Unprocessable entity',
    detail: 'First names can\'t be blank',
  }
}
```

App error handler:

![localhost_3000_moves_new_personal-details](https://user-images.githubusercontent.com/3327997/60109820-f1278900-9762-11e9-9057-d85f14bc2bab.png)

### After

Error response (Error):

```js
{
  Error: Unprocessable Entity
    at error (/Users/domsmith/Projects/hmpps/pecs-frontend/common/lib/api-client/errors.js:13:19)
    at process._tickCallback (internal/process/next_tick.js:68:7)
  statusCode: 422,
  errors: [{
    title: 'Unprocessable entity',
    detail: 'Last name can\'t be blank',
    source: [Object],
    code: 'blank',
  }, {
    title: 'Unprocessable entity',
    detail: 'First names can\'t be blank',
    source: [Object],
    code: 'blank',
  }]
}
```

App error handler:
![localhost_3000_moves_new_personal-details (1)](https://user-images.githubusercontent.com/3327997/60109893-11efde80-9763-11e9-89e7-87e908102c61.png)
