### PR TITLE
[P4-223] Render form validation errors properly

### DIFF
--- a/app/moves/controllers/form.js
+++ b/app/moves/controllers/form.js
@@ -8,9 +8,12 @@ class FormController extends Controller {
     const errors = super.getErrors(req, res)
 
     errors.errorList = map(errors, (error) => {
+      const label = req.translate(`fields.${error.key}.label`)
+      const message = req.translate(`validation.${error.type}`)
+
       return {
-        text: `${error.key} ${error.type}`,
-        href: `#${error.key}-error`,
+        text: `${label} ${message}`,
+        href: `#${error.key}`,
       }
     })
 
@@ -34,6 +37,7 @@ class FormController extends Controller {
   render (req, res, next) {
     const fields = Object.entries(req.form.options.fields)
       .map(fieldHelpers.setFieldValue(req.form.values))
+      .map(fieldHelpers.setFieldError(req.form.errors, req.translate))
       .map(fieldHelpers.translateField(req.translate))
       .map(fieldHelpers.renderConditionalFields)
 

--- a/app/moves/controllers/form.test.js
+++ b/app/moves/controllers/form.test.js
@@ -39,7 +39,10 @@ describe('Moves controllers', function () {
               url: '/step-url',
             },
           })
-          errors = controller.getErrors({}, {})
+          const reqMock = {
+            translate: sinon.stub().returnsArg(0),
+          }
+          errors = controller.getErrors(reqMock, {})
         })
 
         it('should contain correct number of errors', function () {
@@ -60,12 +63,12 @@ describe('Moves controllers', function () {
             },
             errorList: [
               {
-                href: '#fieldOne-error',
-                text: 'fieldOne required',
+                href: '#fieldOne',
+                text: 'fields.fieldOne.label validation.required',
               },
               {
-                href: '#fieldTwo-error',
-                text: 'fieldTwo required',
+                href: '#fieldTwo',
+                text: 'fields.fieldTwo.label validation.required',
               },
             ],
           })
@@ -157,6 +160,11 @@ describe('Moves controllers', function () {
             return [ key, { ...field, setFieldValue: true } ]
           })
         sinon
+          .stub(fieldHelpers, 'setFieldError')
+          .callsFake(() => ([key, field]) => {
+            return [ key, { ...field, setFieldError: true } ]
+          })
+        sinon
           .stub(fieldHelpers, 'translateField')
           .callsFake(() => ([key, field]) => {
             return [ key, { ...field, translateField: true } ]
@@ -196,6 +204,10 @@ describe('Moves controllers', function () {
         expect(fieldHelpers.setFieldValue).to.be.calledOnce
       })
 
+      it('should call setFieldError', function () {
+        expect(fieldHelpers.setFieldError).to.be.calledOnce
+      })
+
       it('should call translateField', function () {
         expect(fieldHelpers.setFieldValue).to.be.calledOnce
       })
@@ -205,18 +217,21 @@ describe('Moves controllers', function () {
           field_1: {
             renderConditionalFields: true,
             setFieldValue: true,
+            setFieldError: true,
             translateField: true,
             name: 'Field 1',
           },
           field_2: {
             renderConditionalFields: true,
             setFieldValue: true,
+            setFieldError: true,
             translateField: true,
             name: 'Field 2',
           },
           field_3: {
             renderConditionalFields: true,
             setFieldValue: true,
+            setFieldError: true,
             translateField: true,
             name: 'Field 3',
           },

--- a/common/helpers/field.js
+++ b/common/helpers/field.js
@@ -91,6 +91,32 @@ function setFieldValue (values) {
   }
 }
 
+function setFieldError (errors, translate) {
+  return ([key, field]) => {
+    const fieldError = errors[key]
+
+    if (!fieldError) {
+      return [
+        key,
+        field,
+      ]
+    }
+
+    const label = translate(`fields.${fieldError.key}.label`)
+    const message = translate(`validation.${fieldError.type}`)
+
+    return [
+      key,
+      {
+        ...field,
+        errorMessage: {
+          text: `${label} ${message}`,
+        },
+      },
+    ]
+  }
+}
+
 function translateField (translate) {
   return ([key, field]) => {
     const translated = cloneDeep(field)
@@ -131,6 +157,7 @@ module.exports = {
   mapAssessmentQuestionToConditionalField,
   renderConditionalFields,
   setFieldValue,
+  setFieldError,
   translateField,
   insertInitialOption,
 }

--- a/common/helpers/field.test.js
+++ b/common/helpers/field.test.js
@@ -5,6 +5,7 @@ const {
   mapAssessmentQuestionToConditionalField,
   renderConditionalFields,
   setFieldValue,
+  setFieldError,
   translateField,
   insertInitialOption,
 } = require('./field')
@@ -405,6 +406,81 @@ describe('Form helpers', function () {
             ])
           })
         })
+      })
+    })
+  })
+
+  describe('#setFieldError()', function () {
+    let translateStub
+
+    beforeEach(function () {
+      translateStub = sinon.stub().returnsArg(0)
+    })
+
+    context('when no error exists', function () {
+      let response
+      const field = [
+        'field',
+        { name: 'field' },
+      ]
+
+      beforeEach(function () {
+        response = setFieldError({}, translateStub)(field)
+      })
+
+      it('should not call translation method', function () {
+        expect(translateStub).not.to.be.called
+      })
+
+      it('should return original field', function () {
+        expect(response).to.deep.equal(field)
+      })
+    })
+
+    context('when error exists', function () {
+      const errors = {
+        'error_field': {
+          type: 'required',
+          key: 'error_field',
+        },
+      }
+      let field, response
+
+      beforeEach(function () {
+        field = [
+          'error_field',
+          { name: 'error_field' },
+        ]
+
+        response = setFieldError(errors, translateStub)(field)
+      })
+
+      it('should call translation correct amount of times', function () {
+        expect(translateStub).to.be.calledTwice
+      })
+
+      it('should call translation with correct values', function () {
+        expect(translateStub.firstCall).to.be.calledWithExactly('fields.error_field.label')
+        expect(translateStub.secondCall).to.be.calledWithExactly('validation.required')
+      })
+
+      it('should return field with error message', function () {
+        expect(response).to.deep.equal([
+          'error_field',
+          {
+            name: 'error_field',
+            errorMessage: {
+              text: 'fields.error_field.label validation.required',
+            },
+          },
+        ])
+      })
+
+      it('should not mutate original field', function () {
+        expect(field).to.deep.equal([
+          'error_field',
+          { name: 'error_field' },
+        ])
       })
     })
   })

--- a/locales/en/default.json
+++ b/locales/en/default.json
@@ -120,5 +120,13 @@
     "unauthorized": {
       "heading": "You don’t have permission to view this page"
     }
+  },
+  "validation": {
+    "required": "cannot be blank",
+    "numeric": "can only contain numbers",
+    "date": "must be a valid date",
+    "after": "must be in the future",
+    "before": "must be in the past",
+    "default": "is required"
   }
 }


### PR DESCRIPTION
This change involves:
- using i18n translations to render error summary messages
- render error messages on each field where the validation applies

## What it looks like

### Before
![localhost_3000_moves_new_personal-details (3)](https://user-images.githubusercontent.com/3327997/60259210-a165d080-98ce-11e9-86f1-88c6565a4766.png)

### After
![localhost_3000_moves_new_personal-details (2)](https://user-images.githubusercontent.com/3327997/60259186-9448e180-98ce-11e9-8944-fed0b18db173.png)
