### PR TITLE
[P4-410] Refactor move date processing

### DIFF
--- a/app/moves/controllers/move-details.js
+++ b/app/moves/controllers/move-details.js
@@ -1,3 +1,5 @@
+const dateFns = require('date-fns')
+
 const FormController = require('./form')
 const referenceDataService = require('../../../common/services/reference-data')
 
@@ -25,8 +27,11 @@ class MoveDetailsController extends FormController {
     } = req.form.values
 
     // process move date
-    if (dateType !== 'custom') {
-      req.form.values.date = dateType
+    if (dateType === 'custom') {
+      req.form.values.date = req.form.values.date_custom
+    } else {
+      req.form.values.date_custom = ''
+      req.form.values.date = dateType === 'today' ? dateFns.startOfToday() : dateFns.startOfTomorrow()
     }
 
     // process to location

--- a/app/moves/controllers/move-details.test.js
+++ b/app/moves/controllers/move-details.test.js
@@ -1,4 +1,5 @@
 const FormController = require('hmpo-form-wizard').Controller
+const dateFns = require('date-fns')
 
 const Controller = require('./move-details')
 const referenceDataService = require('../../../common/services/reference-data')
@@ -112,8 +113,9 @@ describe('Moves controllers', function () {
           req = {
             form: {
               values: {
-                date: '2019-10-17',
+                date: '',
                 date_type: 'custom',
+                date_custom: '2019-10-17',
               },
             },
           }
@@ -121,8 +123,15 @@ describe('Moves controllers', function () {
           controller.process(req, {}, nextSpy)
         })
 
-        it('should not change the value of date field', function () {
+        it('should set the value of date field to the custom date', function () {
           expect(req.form.values.date).to.equal('2019-10-17')
+        })
+
+        it('should store the value of custom date', function () {
+          expect(req.form.values.date_custom).to.equal('2019-10-17')
+        })
+
+        it('should set date type to custom', function () {
           expect(req.form.values.date_type).to.equal('custom')
         })
 
@@ -131,24 +140,57 @@ describe('Moves controllers', function () {
         })
       })
 
-      context('when date type is not custom', function () {
+      context('when date type is today', function () {
         beforeEach(function () {
           nextSpy = sinon.spy()
           req = {
             form: {
               values: {
                 date: '',
-                date_type: '2019-10-19',
+                date_type: 'today',
               },
             },
           }
 
+          sinon.stub(dateFns, 'startOfToday').returns('2019-10-19')
           controller.process(req, {}, nextSpy)
         })
 
-        it('should set value of date to date type', function () {
+        it('should set value of date to today', function () {
           expect(req.form.values.date).to.equal('2019-10-19')
-          expect(req.form.values.date_type).to.equal('2019-10-19')
+        })
+
+        it('should set date type to today', function () {
+          expect(req.form.values.date_type).to.equal('today')
+        })
+
+        it('should call next without error', function () {
+          expect(nextSpy).to.be.calledOnceWithExactly()
+        })
+      })
+
+      context('when date type is tomorrow', function () {
+        beforeEach(function () {
+          nextSpy = sinon.spy()
+          req = {
+            form: {
+              values: {
+                date: '',
+                date_type: 'tomorrow',
+              },
+            },
+          }
+
+          sinon.stub(dateFns, 'startOfTomorrow').returns('2019-10-20')
+          controller.process(req, {}, nextSpy)
+        })
+
+        it('should set value of date to tomorrow', function () {
+          expect(req.form.values.date).to.equal('2019-10-20')
+        })
+
+        it('should set date type to tomorrow', function () {
+          expect(req.form.values.date_type).to.equal('tomorrow')
         })
 
         it('should call next without error', function () {

--- a/app/moves/fields.js
+++ b/app/moves/fields.js
@@ -131,11 +131,13 @@ module.exports = {
     },
     items: [],
   },
+  date: {},
   date_type: {
   },
-  date: {
-    id: 'date',
-    name: 'date',
+  date_custom: {
+    formatter: [date],
+    id: 'date_custom',
+    name: 'date_custom',
     label: {
       text: 'Date of travel',
       classes: 'govuk-label--s',

--- a/app/moves/steps.js
+++ b/app/moves/steps.js
@@ -40,8 +40,9 @@ module.exports = {
       'to_location_type',
       'to_location_court',
       'to_location_prison',
-      'date_type',
       'date',
+      'date_type',
+      'date_custom',
     ],
   },
   '/court-information': {

--- a/app/moves/views/create/move-details.njk
+++ b/app/moves/views/create/move-details.njk
@@ -42,18 +42,18 @@
     },
     items: [
       {
-        value: TODAY,
-        text: "Today (" + TODAY | formatDateWithDay + ")"
+        value: "today",
+        text: "Today (" + TODAY | formatDateWithDay + ")",
       },
       {
-        value: TOMORROW,
-        text: "Tomorrow (" + TOMORROW | formatDateWithDay + ")"
+        value: "tomorrow",
+        text: "Tomorrow (" + TOMORROW | formatDateWithDay + ")",
       },
       {
         value: "custom",
         text: "Another date",
         conditional: {
-          html: govukInput(options.fields.date)
+          html: govukInput(options.fields.date_custom)
         }
       }
     ]


### PR DESCRIPTION
Whilst looking into populating fields with their current session
value the way the date is stored/structured was sometimes confusing -
if you selected "Today" then went back to select "Another date" the
conditional text field would have the value from today.

This change splits the custom date into its own field so it can have its
own value stored in the session to avoid confusion in the UI.