### PR TITLE
[P4-410] Refactor when assessment conditionals are rendered

### DIFF
--- a/app/moves/controllers/assessment.js
+++ b/app/moves/controllers/assessment.js
@@ -21,7 +21,7 @@ class AssessmentController extends FormController {
             .getAssessmentQuestions(key)
             .then((response) => {
               field.items = response
-                .map(fieldHelpers.mapAssessmentConditionalFields(fields))
+                .map(fieldHelpers.mapAssessmentQuestionToConditionalField)
                 .map(fieldHelpers.mapReferenceDataToOption)
             })
         }))

--- a/app/moves/controllers/assessment.test.js
+++ b/app/moves/controllers/assessment.test.js
@@ -10,6 +10,7 @@ const questionsMock = [
     id: 'd3a50d7a-6cf4-4eeb-a013-1ff8c5c47cc1',
     type: 'profile_attribute_types',
     category: 'risk',
+    key: 'violent',
     title: 'Violent',
     nomis_alert_type: null,
     nomis_alert_code: null,
@@ -18,6 +19,7 @@ const questionsMock = [
     id: '9b978b79-d19b-4a15-b3fe-9e45570cac70',
     type: 'profile_attribute_types',
     category: 'risk',
+    key: 'escape',
     title: 'Escape',
     nomis_alert_type: null,
     nomis_alert_code: null,
@@ -64,8 +66,18 @@ describe('Moves controllers', function () {
           expect(req.form.options.fields.risk).to.deep.equal({
             name: 'risk',
             items: [
-              { value: 'd3a50d7a-6cf4-4eeb-a013-1ff8c5c47cc1', text: 'Violent' },
-              { value: '9b978b79-d19b-4a15-b3fe-9e45570cac70', text: 'Escape' },
+              {
+                value: 'd3a50d7a-6cf4-4eeb-a013-1ff8c5c47cc1',
+                key: 'violent',
+                text: 'Violent',
+                conditional: 'risk__violent',
+              },
+              {
+                value: '9b978b79-d19b-4a15-b3fe-9e45570cac70',
+                key: 'escape',
+                text: 'Escape',
+                conditional: 'risk__escape',
+              },
             ],
           })
         })

--- a/app/moves/controllers/form.js
+++ b/app/moves/controllers/form.js
@@ -1,6 +1,8 @@
 const { map } = require('lodash')
 const { Controller } = require('hmpo-form-wizard')
 
+const fieldHelpers = require('../../../common/helpers/field')
+
 class FormController extends Controller {
   getErrors (req, res) {
     const errors = super.getErrors(req, res)
@@ -27,6 +29,15 @@ class FormController extends Controller {
     }
 
     super.errorHandler(err, req, res, next)
+  }
+
+  render (req, res, next) {
+    const fields = Object.entries(req.form.options.fields)
+      .map(fieldHelpers.renderConditionalFields)
+
+    req.form.options.fields = Object.assign(...fields)
+
+    super.render(req, res, next)
   }
 }
 

--- a/app/moves/controllers/form.test.js
+++ b/app/moves/controllers/form.test.js
@@ -1,6 +1,7 @@
 const FormController = require('hmpo-form-wizard').Controller
 
 const Controller = require('./form')
+const fieldHelpers = require('../../../common/helpers/field')
 
 const controller = new Controller({ route: '/' })
 
@@ -140,6 +141,62 @@ describe('Moves controllers', function () {
           controller.errorHandler(errorMock, {}, {}, nextSpy)
 
           expect(FormController.prototype.errorHandler).to.be.calledWith(errorMock, {}, {}, nextSpy)
+        })
+      })
+    })
+
+    describe('#render()', function () {
+      context('', function () {
+        let reqMock, nextSpy
+
+        before(function () {
+          nextSpy = sinon.spy()
+          sinon
+            .stub(fieldHelpers, 'renderConditionalFields')
+            .callsFake(([key, field]) => {
+              return { [key]: { ...field, renderConditionalFields: true } }
+            })
+
+          reqMock = {
+            form: {
+              options: {
+                fields: {
+                  field_1: {
+                    name: 'Field 1',
+                  },
+                  field_2: {
+                    name: 'Field 2',
+                  },
+                  field_3: {
+                    name: 'Field 3',
+                  },
+                },
+              },
+            },
+          }
+
+          controller.render(reqMock, {}, nextSpy)
+        })
+
+        it('should call renderConditionalFields on each field', function () {
+          expect(fieldHelpers.renderConditionalFields).to.be.calledThrice
+        })
+
+        it('should mutate fields object', function () {
+          expect(reqMock.form.options.fields).to.deep.equal({
+            field_1: {
+              renderConditionalFields: true,
+              name: 'Field 1',
+            },
+            field_2: {
+              renderConditionalFields: true,
+              name: 'Field 2',
+            },
+            field_3: {
+              renderConditionalFields: true,
+              name: 'Field 3',
+            },
+          })
         })
       })
     })

--- a/common/helpers/field.test.js
+++ b/common/helpers/field.test.js
@@ -1,6 +1,7 @@
 const {
   mapReferenceDataToOption,
-  mapAssessmentConditionalFields,
+  mapAssessmentQuestionToConditionalField,
+  renderConditionalFields,
   insertInitialOption,
 } = require('./field')
 
@@ -8,7 +9,7 @@ const componentService = require('../services/component')
 
 describe('Form helpers', function () {
   describe('#mapReferenceDataToOption()', function () {
-    context('be default', function () {
+    context('by default', function () {
       it('should return correctly formatted option', function () {
         const option = mapReferenceDataToOption({
           id: '416badc8-e3ac-47d7-b116-ae3f5b2e4697',
@@ -55,63 +56,207 @@ describe('Form helpers', function () {
     })
   })
 
-  describe('#mapAssessmentConditionalFields()', function () {
-    beforeEach(function () {
-      sinon.stub(componentService, 'getComponent').returnsArg(0)
-    })
+  describe('#mapAssessmentQuestionToConditionalField()', function () {
+    context('by default', function () {
+      let item, response
 
-    context('when no field exists in the step', function () {
-      it('should return the original item', function () {
-        const item = {
+      beforeEach(function () {
+        item = {
+          id: '416badc8-e3ac-47d7-b116-ae3f5b2e4697',
           category: 'risk',
           key: 'violent',
         }
-        const response = mapAssessmentConditionalFields({})(item)
 
-        expect(response).to.deep.equal(item)
-      })
-    })
-
-    context('when field exists in step', function () {
-      const fields = {
-        'risk__violent': {
-          component: 'govukInput',
-          classes: 'input-classes',
-        },
-      }
-      const item = {
-        category: 'risk',
-        key: 'violent',
-      }
-      let response
-
-      beforeEach(function () {
-        response = mapAssessmentConditionalFields(fields)(item)
+        response = mapAssessmentQuestionToConditionalField(item)
       })
 
-      it('should return extra conditional content', function () {
-        expect(componentService.getComponent).to.be.calledOnceWithExactly('govukInput', {
-          component: 'govukInput',
-          classes: 'input-classes',
-          id: 'risk__violent',
-          name: 'risk__violent',
-        })
+      it('should add conditional property', function () {
+        expect(response).to.have.property('conditional')
+        expect(response.conditional).to.equal('risk__violent')
       })
 
-      it('should return extra conditional content', function () {
+      it('should keep original properties', function () {
         expect(response).to.deep.equal({
+          id: '416badc8-e3ac-47d7-b116-ae3f5b2e4697',
           category: 'risk',
           key: 'violent',
-          conditional: {
-            html: 'govukInput',
-          },
+          conditional: 'risk__violent',
         })
       })
 
       it('should not mutate original item', function () {
         expect(item).to.deep.equal({
+          id: '416badc8-e3ac-47d7-b116-ae3f5b2e4697',
           category: 'risk',
           key: 'violent',
+        })
+      })
+    })
+  })
+
+  describe('#renderConditionalFields()', function () {
+    beforeEach(function () {
+      sinon.stub(componentService, 'getComponent').returnsArg(0)
+    })
+
+    context('when field doesn\'t contain items', function () {
+      it('should return the original field as object', function () {
+        const field = [
+          'court',
+          { name: 'court' },
+        ]
+        const response = renderConditionalFields(field)
+
+        expect(response).to.deep.equal({
+          court: { name: 'court' },
+        })
+      })
+    })
+
+    context('when field contains items', function () {
+      context('when conditional is a string', function () {
+        context('when field exists', function () {
+          const field = [
+            'field',
+            {
+              name: 'field',
+              items: [{
+                value: '31b90233-7043-4633-8055-f24854545ead',
+                text: 'Item one',
+                conditional: 'conditional_field_one',
+              }, {
+                value: '31b90233-7043-4633-8055-f24854545eac',
+                text: 'Item two',
+                conditional: 'conditional_field_two',
+              }],
+            },
+          ]
+          const fields = [
+            ...field,
+            [
+              'conditional_field_one',
+              {
+                component: 'govukInput',
+                classes: 'input-classes',
+              },
+            ],
+            [
+              'conditional_field_two',
+              {
+                component: 'govukTextarea',
+                classes: 'input-classes',
+              },
+            ],
+          ]
+          let response
+
+          beforeEach(function () {
+            response = renderConditionalFields(field, 0, fields)
+          })
+
+          it('should call component service for each item', function () {
+            expect(componentService.getComponent).to.be.calledTwice
+          })
+
+          it('should call component service with correct args', function () {
+            expect(componentService.getComponent.firstCall).to.be.calledWithExactly('govukInput', {
+              component: 'govukInput',
+              classes: 'input-classes',
+              id: 'conditional_field_one',
+              name: 'conditional_field_one',
+            })
+          })
+
+          it('should call component service with correct args', function () {
+            expect(componentService.getComponent.secondCall).to.be.calledWithExactly('govukTextarea', {
+              component: 'govukTextarea',
+              classes: 'input-classes',
+              id: 'conditional_field_two',
+              name: 'conditional_field_two',
+            })
+          })
+
+          it('should render conditional content', function () {
+            expect(response.field.items).to.deep.equal([{
+              value: '31b90233-7043-4633-8055-f24854545ead',
+              text: 'Item one',
+              conditional: {
+                html: 'govukInput',
+              },
+            }, {
+              value: '31b90233-7043-4633-8055-f24854545eac',
+              text: 'Item two',
+              conditional: {
+                html: 'govukTextarea',
+              },
+            }])
+          })
+        })
+
+        context('when field doesn\'t exist', function () {
+          const field = [
+            'field',
+            {
+              name: 'field',
+              items: [{
+                value: '31b90233-7043-4633-8055-f24854545ead',
+                text: 'Item one',
+                conditional: 'doesnotexist',
+              }],
+            },
+          ]
+          let response
+
+          beforeEach(function () {
+            response = renderConditionalFields(field)
+          })
+
+          it('should not call component service for each item', function () {
+            expect(componentService.getComponent).not.to.be.called
+          })
+
+          it('should render original item', function () {
+            expect(response.field.items).to.deep.equal([{
+              value: '31b90233-7043-4633-8055-f24854545ead',
+              text: 'Item one',
+              conditional: 'doesnotexist',
+            }])
+          })
+        })
+      })
+
+      context('when conditional is not a string ', function () {
+        const field = [
+          'field',
+          {
+            name: 'field',
+            items: [{
+              value: '31b90233-7043-4633-8055-f24854545ead',
+              text: 'Item one',
+              conditional: {
+                html: '<strong>HTML</strong> content',
+              },
+            }],
+          },
+        ]
+        let response
+
+        beforeEach(function () {
+          response = renderConditionalFields(field)
+        })
+
+        it('should not call component service for each item', function () {
+          expect(componentService.getComponent).not.to.be.called
+        })
+
+        it('should render conditional content', function () {
+          expect(response.field.items).to.deep.equal([{
+            value: '31b90233-7043-4633-8055-f24854545ead',
+            text: 'Item one',
+            conditional: {
+              html: '<strong>HTML</strong> content',
+            },
+          }])
         })
       })
     })


### PR DESCRIPTION
Previously the conditional content was rendered into HTML during
the configure step which happens at the start of the lifecycle.

This meant that any steps in between to populate values, or in the
future, error messages were not part of the field object when it
was converted into HTML.

This change moves the rendering of the conditional content into
the final render method of the assessment controller.

This means the fields can be manipulated during the lifecycle as
other fields are before it is rendered into HTML.