### PR TITLE
Ensure mapped object remains the same in helpers

### DIFF
--- a/app/moves/controllers/form.js
+++ b/app/moves/controllers/form.js
@@ -1,4 +1,4 @@
-const { map } = require('lodash')
+const { map, fromPairs } = require('lodash')
 const { Controller } = require('hmpo-form-wizard')
 
 const fieldHelpers = require('../../../common/helpers/field')
@@ -35,7 +35,7 @@ class FormController extends Controller {
     const fields = Object.entries(req.form.options.fields)
       .map(fieldHelpers.renderConditionalFields)
 
-    req.form.options.fields = Object.assign(...fields)
+    req.form.options.fields = fromPairs(fields)
 
     super.render(req, res, next)
   }

--- a/app/moves/controllers/form.test.js
+++ b/app/moves/controllers/form.test.js
@@ -154,7 +154,7 @@ describe('Moves controllers', function () {
           sinon
             .stub(fieldHelpers, 'renderConditionalFields')
             .callsFake(([key, field]) => {
-              return { [key]: { ...field, renderConditionalFields: true } }
+              return [ key, { ...field, renderConditionalFields: true } ]
             })
 
           reqMock = {

--- a/common/helpers/field.js
+++ b/common/helpers/field.js
@@ -28,15 +28,17 @@ function mapAssessmentQuestionToConditionalField (item) {
 
 function renderConditionalFields ([key, field], index, obj) {
   if (!field.items) {
-    return {
-      [key]: field,
-    }
+    return [
+      key,
+      field,
+    ]
   }
 
   const fields = fromPairs(obj)
 
-  return {
-    [key]: {
+  return [
+    key,
+    {
       ...field,
       items: field.items.map((item) => {
         const fieldName = item.conditional
@@ -52,7 +54,7 @@ function renderConditionalFields ([key, field], index, obj) {
         return { ...item, conditional: { html } }
       }),
     },
-  }
+  ]
 }
 
 function insertInitialOption (items, label = 'option') {

--- a/common/helpers/field.test.js
+++ b/common/helpers/field.test.js
@@ -107,9 +107,10 @@ describe('Form helpers', function () {
         ]
         const response = renderConditionalFields(field)
 
-        expect(response).to.deep.equal({
-          court: { name: 'court' },
-        })
+        expect(response).to.deep.equal([
+          'court',
+          { name: 'court' },
+        ])
       })
     })
 
@@ -177,7 +178,7 @@ describe('Form helpers', function () {
           })
 
           it('should render conditional content', function () {
-            expect(response.field.items).to.deep.equal([{
+            expect(response[1].items).to.deep.equal([{
               value: '31b90233-7043-4633-8055-f24854545ead',
               text: 'Item one',
               conditional: {
@@ -216,7 +217,7 @@ describe('Form helpers', function () {
           })
 
           it('should render original item', function () {
-            expect(response.field.items).to.deep.equal([{
+            expect(response[1].items).to.deep.equal([{
               value: '31b90233-7043-4633-8055-f24854545ead',
               text: 'Item one',
               conditional: 'doesnotexist',
@@ -250,7 +251,7 @@ describe('Form helpers', function () {
         })
 
         it('should render conditional content', function () {
-          expect(response.field.items).to.deep.equal([{
+          expect(response[1].items).to.deep.equal([{
             value: '31b90233-7043-4633-8055-f24854545ead',
             text: 'Item one',
             conditional: {


### PR DESCRIPTION
When mapping the field objects in helpers like renderConditionalFields
the item was being changed from an Array to an Object.

This meant it wasn't possibly to chain more maps to the initial call.

This change ensures the mapped item is returned in the same format
so that it can be further manipulated.

## Before

```js
{
  court: { name: 'court' },
}
```
## After
```js
[
  'court',
  { name: 'court' },
]
```