### PR TITLE
Ensure only requested moves are displayed on dashboard

### DIFF
--- a/app/dashboard/controllers.js
+++ b/app/dashboard/controllers.js
@@ -12,7 +12,7 @@ module.exports = {
   get: async (req, res, next) => {
     try {
       const moveDate = req.query['move-date'] || format(new Date(), 'YYYY-MM-DD')
-      const response = await moveService.getMovesByDate(moveDate)
+      const response = await moveService.getRequestedMovesByDate(moveDate)
       const yesterday = format(subDays(moveDate, 1), 'YYYY-MM-DD')
       const tomorrow = format(addDays(moveDate, 1), 'YYYY-MM-DD')
       const locals = {

--- a/app/dashboard/controllers.test.js
+++ b/app/dashboard/controllers.test.js
@@ -22,7 +22,7 @@ describe('Dashboard app', function () {
       let req, res
 
       beforeEach(async function () {
-        sinon.stub(moveService, 'getMovesByDate').resolves(movesStub)
+        sinon.stub(moveService, 'getRequestedMovesByDate').resolves(movesStub)
         this.clock = sinon.useFakeTimers(new Date(mockDate).getTime())
 
         req = { query: {} }
@@ -70,7 +70,7 @@ describe('Dashboard app', function () {
       let req, res
 
       beforeEach(async function () {
-        sinon.stub(moveService, 'getMovesByDate').resolves(movesStub)
+        sinon.stub(moveService, 'getRequestedMovesByDate').resolves(movesStub)
 
         req = {
           query: {
@@ -116,7 +116,7 @@ describe('Dashboard app', function () {
       let req, res, nextSpy
 
       beforeEach(async function () {
-        sinon.stub(moveService, 'getMovesByDate').throws(errorStub)
+        sinon.stub(moveService, 'getRequestedMovesByDate').throws(errorStub)
 
         req = {
           query: {},

--- a/common/services/move.js
+++ b/common/services/move.js
@@ -13,8 +13,9 @@ function format (data) {
   })
 }
 
-function getMovesByDate (moveDate) {
+function getRequestedMovesByDate (moveDate) {
   return apiClient.findAll('move', {
+    'filter[status]': 'requested',
     'filter[date_from]': moveDate,
     'filter[date_to]': moveDate,
   })
@@ -32,7 +33,7 @@ function create (data) {
 
 module.exports = {
   format,
-  getMovesByDate,
+  getRequestedMovesByDate,
   getMoveById,
   create,
 }

--- a/common/services/move.test.js
+++ b/common/services/move.test.js
@@ -75,7 +75,7 @@ describe('Move Service', function () {
     })
   })
 
-  describe('#getMovesByDate()', function () {
+  describe('#getRequestedMovesByDate()', function () {
     context('when request returns 200', function () {
       const mockDate = '2017-08-10'
       let moves
@@ -87,13 +87,14 @@ describe('Move Service', function () {
           .get('/moves')
           .query({
             filter: {
+              status: 'requested',
               date_from: mockDate,
               date_to: mockDate,
             },
           })
           .reply(200, movesGetSerialized)
 
-        moves = await moveService.getMovesByDate(mockDate)
+        moves = await moveService.getRequestedMovesByDate(mockDate)
       })
 
       afterEach(function () {


### PR DESCRIPTION
When we extend the app to allow moves statuses to be changed, for
example if a user cancels a move, we don't want those other statuses
to appear on the main dashboard.

This change filters the moves displayed on the dashboard to only
include the status it cares about (`requested`).