### PR TITLE
Add docker-compose file for local Docker environment testing

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,27 @@
+# Simplify running the application inside a container locally.
+# Usage: `docker-compose up`
+#
+# Do not use docker-compose in production environments.
+#
+version: '3'
+
+services:
+  db:
+    image: redis
+  web:
+    build: .
+    environment:
+      - REDIS_URL=redis://db:6379
+      - SESSION_SECRET=example-secret
+      - API_BASE_URL=http://localhost:4000/api/v1
+      - API_AUTH_URL=http://localhost:4000/oauth/token
+      - API_CLIENT_ID=
+      - API_SECRET=
+      - AUTH_PROVIDER_KEY=
+      - AUTH_PROVIDER_SECRET=
+      - AUTH_PROVIDER_URL=
+      - SERVER_HOST=localhost:3000
+    ports:
+      - "3000:3000"
+    depends_on:
+      - db


### PR DESCRIPTION
This allows us to test the service running locally under Docker with a working Redis connection. Note you need to set the secrets in the file before it will run properly.