### PR TITLE
[P4-266] Refactor list controller

### DIFF
--- a/app/moves/controllers/list.js
+++ b/app/moves/controllers/list.js
@@ -6,30 +6,23 @@ const {
 
 const { getQueryString } = require('../../../common/lib/request')
 const presenters = require('../../../common/presenters')
-const moveService = require('../../../common/services/move')
 
-module.exports = async function get (req, res, next) {
-  try {
-    const moveDate = req.query['move-date'] || format(new Date(), 'YYYY-MM-DD')
-    const response = await moveService.getRequestedMovesByDate(moveDate)
-    const yesterday = format(subDays(moveDate, 1), 'YYYY-MM-DD')
-    const tomorrow = format(addDays(moveDate, 1), 'YYYY-MM-DD')
-    const locals = {
-      moveDate,
-      pageTitle: 'dashboard.upcoming_moves',
-      destinations: presenters.movesByToLocation(response.data),
-      pagination: {
-        nextUrl: getQueryString(req.query, {
-          'move-date': tomorrow,
-        }),
-        prevUrl: getQueryString(req.query, {
-          'move-date': yesterday,
-        }),
-      },
-    }
-
-    res.render('moves/views/list', locals)
-  } catch (error) {
-    next(error)
+module.exports = function list (req, res) {
+  const { moveDate, movesByDate } = res.locals
+  const yesterday = format(subDays(moveDate, 1), 'YYYY-MM-DD')
+  const tomorrow = format(addDays(moveDate, 1), 'YYYY-MM-DD')
+  const locals = {
+    pageTitle: 'dashboard.upcoming_moves',
+    destinations: presenters.movesByToLocation(movesByDate),
+    pagination: {
+      nextUrl: getQueryString(req.query, {
+        'move-date': tomorrow,
+      }),
+      prevUrl: getQueryString(req.query, {
+        'move-date': yesterday,
+      }),
+    },
   }
+
+  res.render('moves/views/list', locals)
 }

--- a/app/moves/controllers/list.test.js
+++ b/app/moves/controllers/list.test.js
@@ -1,139 +1,55 @@
 const presenters = require('../../../common/presenters')
-const moveService = require('../../../common/services/move')
 
 const controllers = require('./')
 
-const movesStub = {
-  data: [
-    { foo: 'bar' },
-    { fizz: 'buzz' },
-  ],
-}
-const errorStub = new Error('Problem')
+const mockMovesByDate = [
+  { foo: 'bar' },
+  { fizz: 'buzz' },
+]
 
 describe('Moves controllers', function () {
   describe('#list()', function () {
+    const mockMoveDate = '2019-10-10'
+    let req, res
+
     beforeEach(function () {
       sinon.stub(presenters, 'movesByToLocation').returnsArg(0)
+      req = { query: {} }
+      res = {
+        locals: {
+          moveDate: mockMoveDate,
+          movesByDate: mockMovesByDate,
+        },
+        render: sinon.spy(),
+      }
+
+      controllers.list(req, res)
     })
 
-    context('when query contains no move date', function () {
-      const mockDate = '2017-08-10'
-      let req, res
-
-      beforeEach(async function () {
-        sinon.stub(moveService, 'getRequestedMovesByDate').resolves(movesStub)
-        this.clock = sinon.useFakeTimers(new Date(mockDate).getTime())
-
-        req = { query: {} }
-        res = { render: sinon.spy() }
-
-        await controllers.list(req, res)
-      })
-
-      afterEach(function () {
-        this.clock.restore()
-      })
-
-      it('should render a template', function () {
-        expect(res.render.calledOnce).to.be.true
-      })
-
-      describe('template params', function () {
-        it('should contain a page title', function () {
-          expect(res.render.args[0][1]).to.have.property('pageTitle')
-        })
-
-        it('should contain move date as current date', function () {
-          const params = res.render.args[0][1]
-          expect(params).to.have.property('moveDate')
-          expect(params.moveDate).to.equal(mockDate)
-        })
-
-        it('should contain pagination with correct links', function () {
-          const params = res.render.args[0][1]
-          expect(params).to.have.property('pagination')
-          expect(params.pagination.nextUrl).to.equal('?move-date=2017-08-11')
-          expect(params.pagination.prevUrl).to.equal('?move-date=2017-08-09')
-        })
-
-        it('should contain destinations property', function () {
-          const params = res.render.args[0][1]
-          expect(params).to.have.property('destinations')
-          expect(params.destinations).to.deep.equal(movesStub.data)
-        })
-      })
+    it('should render a template', function () {
+      expect(res.render.calledOnce).to.be.true
     })
 
-    context('when query contatins a move date', function () {
-      const mockDate = '2018-05-10'
-      let req, res
-
-      beforeEach(async function () {
-        sinon.stub(moveService, 'getRequestedMovesByDate').resolves(movesStub)
-
-        req = {
-          query: {
-            'move-date': mockDate,
-          },
-        }
-        res = { render: sinon.spy() }
-
-        await controllers.list(req, res)
+    describe('template params', function () {
+      it('should contain a page title', function () {
+        expect(res.render.args[0][1]).to.have.property('pageTitle')
       })
 
-      it('should render a template', function () {
-        expect(res.render.calledOnce).to.be.true
+      it('should contain pagination with correct links', function () {
+        const params = res.render.args[0][1]
+        expect(params).to.have.property('pagination')
+        expect(params.pagination.nextUrl).to.equal('?move-date=2019-10-11')
+        expect(params.pagination.prevUrl).to.equal('?move-date=2019-10-09')
       })
 
-      describe('template params', function () {
-        it('should contain a page title', function () {
-          expect(res.render.args[0][1]).to.have.property('pageTitle')
-        })
-
-        it('should contain move date as current date', function () {
-          const params = res.render.args[0][1]
-          expect(params).to.have.property('moveDate')
-          expect(params.moveDate).to.equal(mockDate)
-        })
-
-        it('should contain pagination with correct links', function () {
-          const params = res.render.args[0][1]
-          expect(params).to.have.property('pagination')
-          expect(params.pagination.nextUrl).to.equal('?move-date=2018-05-11')
-          expect(params.pagination.prevUrl).to.equal('?move-date=2018-05-09')
-        })
-
-        it('should contain destinations property', function () {
-          const params = res.render.args[0][1]
-          expect(params).to.have.property('destinations')
-          expect(params.destinations).to.deep.equal(movesStub.data)
-        })
-      })
-    })
-
-    context('when API call returns an error', function () {
-      let req, res, nextSpy
-
-      beforeEach(async function () {
-        sinon.stub(moveService, 'getRequestedMovesByDate').throws(errorStub)
-
-        req = {
-          query: {},
-        }
-        res = { render: sinon.spy() }
-        nextSpy = sinon.spy()
-
-        await controllers.list(req, res, nextSpy)
+      it('should call movesByToLocation presenter', function () {
+        expect(presenters.movesByToLocation).to.be.calledOnceWithExactly(mockMovesByDate)
       })
 
-      it('should not render a template', function () {
-        expect(res.render.calledOnce).to.be.false
-      })
-
-      it('should send error to next function', function () {
-        expect(nextSpy.calledOnce).to.be.true
-        expect(nextSpy).to.be.calledWith(errorStub)
+      it('should contain destinations property', function () {
+        const params = res.render.args[0][1]
+        expect(params).to.have.property('destinations')
+        expect(params.destinations).to.deep.equal(mockMovesByDate)
       })
     })
   })

--- a/app/moves/index.js
+++ b/app/moves/index.js
@@ -6,7 +6,7 @@ const wizard = require('hmpo-form-wizard')
 const steps = require('./steps')
 const fields = require('./fields')
 const { detail, list, Form } = require('./controllers')
-const { setMove } = require('./middleware')
+const { setMove, setMoveDate, setMovesByDate } = require('./middleware')
 const { ensureAuthenticated } = require('../../common/middleware/authentication')
 
 const wizardConfig = {
@@ -23,7 +23,7 @@ router.param('moveId', setMove)
 router.use(ensureAuthenticated)
 
 // Define routes
-router.get('/', list)
+router.get('/', setMoveDate, setMovesByDate, list)
 router.use('/new', wizard(steps, fields, wizardConfig))
 router.get('/:moveId', detail)
 

--- a/app/moves/middleware.js
+++ b/app/moves/middleware.js
@@ -1,3 +1,5 @@
+const { format } = require('date-fns')
+
 const moveService = require('../../common/services/move')
 
 module.exports = {
@@ -10,6 +12,26 @@ module.exports = {
       const move = await moveService.getMoveById(moveId)
 
       res.locals.move = move.data
+
+      next()
+    } catch (error) {
+      next(error)
+    }
+  },
+  setMoveDate: (req, res, next) => {
+    res.locals.moveDate = req.query['move-date'] || format(new Date(), 'YYYY-MM-DD')
+
+    next()
+  },
+  setMovesByDate: async (req, res, next) => {
+    const { moveDate } = res.locals
+
+    if (!moveDate) {
+      return next()
+    }
+
+    try {
+      res.locals.movesByDate = await moveService.getRequestedMovesByDate(moveDate)
 
       next()
     } catch (error) {

--- a/app/moves/middleware.test.js
+++ b/app/moves/middleware.test.js
@@ -8,6 +8,10 @@ const moveStub = {
     { fizz: 'buzz' },
   ],
 }
+const movesStub = [
+  { foo: 'bar' },
+  { fizz: 'buzz' },
+]
 const mockMoveId = '6904dea1-017f-48d8-a5ad-2723dee9d146'
 const errorStub = new Error('Problem')
 
@@ -26,8 +30,7 @@ describe('Moves middleware', function () {
       })
 
       it('should call next with no argument', function () {
-        expect(nextSpy.calledOnce).to.be.true
-        expect(nextSpy).to.be.calledWith()
+        expect(nextSpy).to.be.calledOnceWithExactly()
       })
 
       it('should not call API with move ID', function () {
@@ -62,8 +65,7 @@ describe('Moves middleware', function () {
         })
 
         it('should call next with no argument', function () {
-          expect(nextSpy.calledOnce).to.be.true
-          expect(nextSpy).to.be.calledWith()
+          expect(nextSpy).to.be.calledOnceWithExactly()
         })
       })
 
@@ -84,8 +86,135 @@ describe('Moves middleware', function () {
         })
 
         it('should send error to next function', function () {
-          expect(nextSpy.calledOnce).to.be.true
-          expect(nextSpy).to.be.calledWith(errorStub)
+          expect(nextSpy).to.be.calledOnceWithExactly(errorStub)
+        })
+      })
+    })
+  })
+
+  describe('#setMoveDate()', function () {
+    let req, res, nextSpy
+
+    beforeEach(function () {
+      res = { locals: {} }
+      nextSpy = sinon.spy()
+    })
+
+    context('when no move date exists in query', function () {
+      const mockDate = '2019-08-10'
+
+      beforeEach(function () {
+        this.clock = sinon.useFakeTimers(new Date(mockDate).getTime())
+
+        req = { query: {} }
+
+        middleware.setMoveDate(req, res, nextSpy)
+      })
+
+      afterEach(function () {
+        this.clock.restore()
+      })
+
+      it('should set move date to current date', function () {
+        expect(res.locals).to.have.property('moveDate')
+        expect(res.locals.moveDate).to.equal('2019-08-10')
+      })
+
+      it('should call next', function () {
+        expect(nextSpy).to.be.calledOnceWithExactly()
+      })
+    })
+
+    context('when move date exists in query', function () {
+      beforeEach(function () {
+        req = {
+          query: {
+            'move-date': '2019-10-10',
+          },
+        }
+
+        middleware.setMoveDate(req, res, nextSpy)
+      })
+
+      it('should set move date to query value', function () {
+        expect(res.locals).to.have.property('moveDate')
+        expect(res.locals.moveDate).to.equal('2019-10-10')
+      })
+
+      it('should call next', function () {
+        expect(nextSpy).to.be.calledOnceWithExactly()
+      })
+    })
+  })
+
+  describe('#setMovesByDate()', function () {
+    let res, nextSpy
+
+    beforeEach(async function () {
+      sinon.stub(moveService, 'getRequestedMovesByDate')
+      nextSpy = sinon.spy()
+      res = { locals: {} }
+    })
+
+    context('when no move date exists', function () {
+      beforeEach(async function () {
+        await middleware.setMovesByDate({}, res, nextSpy)
+      })
+
+      it('should call next with no argument', function () {
+        expect(nextSpy).to.be.calledOnceWithExactly()
+      })
+
+      it('should not call API with move date', function () {
+        expect(moveService.getRequestedMovesByDate).not.to.be.called
+      })
+
+      it('should not set response data to locals object', function () {
+        expect(res.locals).not.to.have.property('movesByDate')
+      })
+    })
+
+    context('when move date exists', function () {
+      beforeEach(function () {
+        res = {
+          locals: {
+            moveDate: '2010-10-10',
+          },
+        }
+      })
+
+      context('when API call returns succesfully', function () {
+        beforeEach(async function () {
+          moveService.getRequestedMovesByDate.resolves(movesStub)
+          await middleware.setMovesByDate({}, res, nextSpy)
+        })
+
+        it('should call API with move ID', function () {
+          expect(moveService.getRequestedMovesByDate).to.be.calledWith(res.locals.moveDate)
+        })
+
+        it('should set response to locals object', function () {
+          expect(res.locals).to.have.property('movesByDate')
+          expect(res.locals.movesByDate).to.equal(movesStub)
+        })
+
+        it('should call next with no argument', function () {
+          expect(nextSpy).to.be.calledOnceWithExactly()
+        })
+      })
+
+      context('when API call returns an error', function () {
+        beforeEach(async function () {
+          moveService.getRequestedMovesByDate.throws(errorStub)
+          await middleware.setMovesByDate({}, res, nextSpy)
+        })
+
+        it('should not set a value on the locals object', function () {
+          expect(res.locals).not.to.have.property('movesByDate')
+        })
+
+        it('should send error to next function', function () {
+          expect(nextSpy).to.be.calledOnceWithExactly(errorStub)
         })
       })
     })

--- a/common/services/move.js
+++ b/common/services/move.js
@@ -14,11 +14,13 @@ function format (data) {
 }
 
 function getRequestedMovesByDate (moveDate) {
-  return apiClient.findAll('move', {
-    'filter[status]': 'requested',
-    'filter[date_from]': moveDate,
-    'filter[date_to]': moveDate,
-  })
+  return apiClient
+    .findAll('move', {
+      'filter[status]': 'requested',
+      'filter[date_from]': moveDate,
+      'filter[date_to]': moveDate,
+    })
+    .then(response => response.data)
 }
 
 function getMoveById (id) {

--- a/common/services/move.test.js
+++ b/common/services/move.test.js
@@ -106,7 +106,7 @@ describe('Move Service', function () {
       })
 
       it('should contain moves with correct data', function () {
-        expect(moves.data).to.deep.equal(movesGetDeserialized.data)
+        expect(moves).to.deep.equal(movesGetDeserialized.data)
       })
     })
   })


### PR DESCRIPTION
This change moves the setting of certain variables to middleware
so that they can be shared in future changes being made around
download/viewing a list of moves in different formats.