### PR TITLE
[P4-419] Ensure formatTime doesn't return a time for falsey values

### DIFF
--- a/config/nunjucks/filters.js
+++ b/config/nunjucks/filters.js
@@ -94,7 +94,7 @@ function calculateAge (value) {
 function formatTime (value) {
   const parsedDate = parseDate(value)
 
-  if (!isValidDate(parsedDate)) {
+  if (!value || !isValidDate(parsedDate)) {
     return value
   }
 

--- a/config/nunjucks/filters.test.js
+++ b/config/nunjucks/filters.test.js
@@ -179,6 +179,33 @@ describe('Nunjucks filters', function () {
       })
     })
 
+    context('when given falsey values', function () {
+      it('should return input value', function () {
+        const age = filters.formatTime(undefined)
+        expect(age).to.equal(undefined)
+      })
+
+      it('should return input value', function () {
+        const age = filters.formatTime(null)
+        expect(age).to.equal(null)
+      })
+
+      it('should return input value', function () {
+        const age = filters.formatTime(false)
+        expect(age).to.equal(false)
+      })
+
+      it('should return input value', function () {
+        const age = filters.formatTime(0)
+        expect(age).to.equal(0)
+      })
+
+      it('should return input value', function () {
+        const age = filters.formatTime('')
+        expect(age).to.equal('')
+      })
+    })
+
     context('when given a valid datetime', function () {
       context('when the time is 12am', function () {
         it('should midnight as a string', function () {


### PR DESCRIPTION
Previously when `formatTime()` was given a `null` or `false`
value it was parsing the date as `1970-01-01T00:00:00.000Z`
which would cause it to return a time for falsey values.

This change ensures it won't return a valid time and adds some
more tests to prevent this happening in the future.