### PR TITLE
[P4-299] Add google analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ npm run lint
 | CURRENT_LOCATION_UUID **(TEMPORARY)** | UUID of the current location to list and create moves for | |
 | SENTRY_KEY | Sentry key | |
 | SENTRY_PROJECT | Sentry project ID | |
+| GOOGLE_ANALYTICS_ID | Google analytics tracking ID to use for the environment | |
 
 ### Development specific
 

--- a/app/move/views/cancel.njk
+++ b/app/move/views/cancel.njk
@@ -1,5 +1,9 @@
 {% extends "layouts/govuk.njk" %}
 
+{% block customGtagConfig %}
+  gtag('set', {'page_title': 'Cancel move'});
+{% endblock %}
+
 {% block pageTitle %}
   {{ t("moves::cancel.page_title", { name: fullname | upper }) }}
 {% endblock %}

--- a/app/move/views/view.njk
+++ b/app/move/views/view.njk
@@ -1,5 +1,9 @@
 {% extends "layouts/govuk.njk" %}
 
+{% block customGtagConfig %}
+  gtag('set', {'page_title': 'Move details'});
+{% endblock %}
+
 {% block pageTitle %}
   {{ t("moves::detail.page_title", {
     name: fullname | upper

--- a/app/moves/views/_layout.njk
+++ b/app/moves/views/_layout.njk
@@ -1,5 +1,9 @@
 {% extends "layouts/govuk.njk" %}
 
+{% block customGtagConfig %}
+  gtag('set', {'page_title': 'Upcoming moves'});
+{% endblock %}
+
 {% block pageTitle %}
   {{ t(pageTitle, {
     date: moveDate | formatDateAsRelativeDay

--- a/app/moves/views/download.njk
+++ b/app/moves/views/download.njk
@@ -4,7 +4,7 @@
   {% if canAccess('moves:download:all') or canAccess('moves:download:by_location') %}
     {{ govukButton({
       text: t("actions::download"),
-      href: ORIGINAL_PATH + "/download.csv?move-date=" + moveDate,
+      href: REQUEST_PATH + "/download.csv?move-date=" + moveDate,
       classes: "govuk-button--start govuk-!-margin-top-2 app-print--hide"
     }) }}
   {% endif %}

--- a/app/moves/views/list.njk
+++ b/app/moves/views/list.njk
@@ -21,7 +21,7 @@
     <ul class="govuk-list govuk-!-font-size-16 app-!-float-right app-print--hide">
       {% if canAccess('moves:download:all') or canAccess('moves:download:by_location') %}
         <li>
-          <a href="{{ ORIGINAL_PATH }}/download.csv?move-date={{ moveDate }}">
+          <a href="{{ REQUEST_PATH }}/download.csv?move-date={{ moveDate }}">
             {{ t("actions::download_csv") }}
           </a>
         </li>

--- a/common/middleware/locals.js
+++ b/common/middleware/locals.js
@@ -4,10 +4,13 @@ const { startOfTomorrow } = require('date-fns')
 const { check } = require('./permissions')
 
 module.exports = function setLocals(req, res, next) {
+  const protocol = req.encrypted ? 'https' : req.protocol
+  const baseUrl = `${protocol}://${req.get('host')}`
   const locals = {
+    CANONICAL_URL: baseUrl + req.path,
     TODAY: new Date(),
     TOMORROW: startOfTomorrow(),
-    ORIGINAL_PATH: req.originalUrl.split('?').shift(),
+    REQUEST_PATH: req.path,
     CURRENT_LOCATION: req.session.currentLocation,
     getLocal: key => res.locals[key],
     getMessages: () => req.flash(),

--- a/common/templates/layouts/govuk.njk
+++ b/common/templates/layouts/govuk.njk
@@ -26,6 +26,8 @@
 {% from "time/macro.njk"              import appTime %}
 
 {% block head %}
+  <link rel="canonical" href="{{ CANONICAL_URL }}">
+
   <!--[if lte IE 8]><link href="{{ getAssetPath('styles-ie8.css') }}" rel="stylesheet" type="text/css" /><![endif]-->
   <!--[if gt IE 8]><!--><link href="{{ getAssetPath('styles.css') }}" media="all" rel="stylesheet" type="text/css" /><!--<![endif]-->
 {% endblock %}

--- a/common/templates/layouts/govuk.njk
+++ b/common/templates/layouts/govuk.njk
@@ -30,6 +30,19 @@
 
   <!--[if lte IE 8]><link href="{{ getAssetPath('styles-ie8.css') }}" rel="stylesheet" type="text/css" /><![endif]-->
   <!--[if gt IE 8]><!--><link href="{{ getAssetPath('styles.css') }}" media="all" rel="stylesheet" type="text/css" /><!--<![endif]-->
+
+  {% if GA_ID %}
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id={{ GA_ID }}"></script>
+    <script>
+      var canonical = document.querySelector('link[rel=canonical]');
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      {% block customGtagConfig %}{% endblock %}
+      gtag('config', '{{ GA_ID }}')
+    </script>
+  {% endif %}
 {% endblock %}
 
 {% block pageTitle %}

--- a/config/index.js
+++ b/config/index.js
@@ -85,6 +85,9 @@ module.exports = {
     },
   },
   DEFAULT_AUTH_PROVIDER: 'hmpps',
+  ANALYTICS: {
+    GA_ID: process.env.GOOGLE_ANALYTICS_ID,
+  },
   TAG_CATEGORY_WHITELIST: {
     risk: {
       tagClass: 'app-tag--destructive',

--- a/config/nunjucks/globals.js
+++ b/config/nunjucks/globals.js
@@ -1,6 +1,6 @@
 const { isFunction } = require('lodash')
 
-const { ASSETS_HOST, FEEDBACK_URL } = require('../')
+const { ANALYTICS, ASSETS_HOST, FEEDBACK_URL } = require('../')
 const { manifest: manifestPath } = require('../paths')
 const logger = require('../logger')
 
@@ -18,6 +18,7 @@ try {
 module.exports = {
   FEEDBACK_URL,
   SERVICE_NAME: 'Book a secure move',
+  GA_ID: ANALYTICS.GA_ID,
   callAsMacro(name) {
     const macro = this.ctx[name]
 

--- a/config/nunjucks/globals.test.js
+++ b/config/nunjucks/globals.test.js
@@ -64,6 +64,7 @@ describe('Nunjucks globals', function() {
         globals = proxyquire('./globals', {
           '../': {
             ASSETS_HOST: mockAssetHost,
+            ANALYTICS: {},
           },
           '../paths': {
             manifest: 'path/to/manifest.json',


### PR DESCRIPTION
This change adds support for Google Analytics tracking if there is an environment variable set.

It includes some code to filter out any Personal Identifiable Information (PII) that could be sent within page titles.

We will need to ensure that any future changes don't start sending any PII to google as we add them.