### PR TITLE
[P4-447] Add support for a phase banner with optional feedback

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ npm run lint
 | AUTH_PROVIDER_SECRET **(required)** | Client secret provided by the OAuth2 provider for user authentication | |
 | AUTH_PROVIDER_URL **(required)** | Base URL for the auth provider server | |
 | SERVER_HOST **(required)** | The (accessible) hostname (and port) of the listening web server. Used by [Grant](https://github.com/simov/grant) to construct redirect URLs after OAuth authentication. For example `localhost:3000` | |
+| FEEDBACK_URL | URL for the feedback link in the phase banner at the top of the page. If empty, the link will not be displayed. | |
 
 ## Components
 

--- a/app/moves/views/detail.njk
+++ b/app/moves/views/detail.njk
@@ -9,12 +9,12 @@
 {% endblock %}
 
 {% block beforeContent %}
+  {{ super() }}
+
   {{ govukBackLink({
     text: t("actions:back_to_dashboard"),
     href: "/moves"
   }) }}
-
-  {{ super() }}
 {% endblock %}
 
 {% block content %}

--- a/common/assets/scss/application.scss
+++ b/common/assets/scss/application.scss
@@ -19,6 +19,7 @@ $govuk-font-family: "Inter", system-ui, sans-serif;
 @import "govuk-frontend/components/footer/footer.scss";
 @import "govuk-frontend/components/header/header.scss";
 @import "govuk-frontend/components/input/input.scss";
+@import "govuk-frontend/components/phase-banner/phase-banner.scss";
 @import "govuk-frontend/components/radios/radios.scss";
 @import "govuk-frontend/components/select/select.scss";
 @import "govuk-frontend/components/skip-link/skip-link.scss";

--- a/common/assets/scss/overrides/_font-corrections.scss
+++ b/common/assets/scss/overrides/_font-corrections.scss
@@ -3,3 +3,8 @@
 .govuk-back-link {
   padding-bottom: 3px;
 }
+
+.govuk-tag {
+  padding-top: 3px;
+  padding-bottom: 3px;
+}

--- a/common/components/internal-header/_internal-header.scss
+++ b/common/components/internal-header/_internal-header.scss
@@ -10,7 +10,6 @@ $govuk-header-nav-item-border-color: #2e3133;
 .app-header {
   @include govuk-font($size: 16);
 
-  border-bottom: govuk-spacing(2) solid govuk-colour("white");
   color: $govuk-header-text;
   background: $govuk-header-background;
 }

--- a/common/components/message/_message.scss
+++ b/common/components/message/_message.scss
@@ -26,6 +26,10 @@
   & + & {
     margin-top: govuk-spacing(2);
   }
+
+  * + & {
+    margin-top: govuk-spacing(4);
+  }
 }
 
 .app-message__heading {

--- a/common/templates/form-wizard.njk
+++ b/common/templates/form-wizard.njk
@@ -1,14 +1,14 @@
 {% extends "layouts/govuk.njk" %}
 
 {% block beforeContent %}
+  {{ super() }}
+
   {% if backLink %}
     {{ govukBackLink({
       text: t("actions:back"),
       href: backLink
     }) }}
   {% endif %}
-
-  {{ super() }}
 {% endblock %}
 
 {% block content %}

--- a/common/templates/layouts/govuk.njk
+++ b/common/templates/layouts/govuk.njk
@@ -6,6 +6,7 @@
 {% from "checkboxes/macro.njk"        import govukCheckboxes %}
 {% from "error-summary/macro.njk"     import govukErrorSummary %}
 {% from "input/macro.njk"             import govukInput %}
+{% from "phase-banner/macro.njk"      import govukPhaseBanner %}
 {% from "radios/macro.njk"            import govukRadios %}
 {% from "select/macro.njk"            import govukSelect %}
 {% from "summary-list/macro.njk"      import govukSummaryList %}
@@ -43,6 +44,16 @@
 {% endblock %}
 
 {% block beforeContent %}
+  {{ govukPhaseBanner({
+    tag: {
+      text: "alpha"
+    },
+    html: t("phase_banner", {
+      context: "with_feedback" if FEEDBACK_URL,
+      url: FEEDBACK_URL
+    })
+  }) }}
+
   {% include "includes/messages.njk" %}
 {% endblock %}
 

--- a/config/index.js
+++ b/config/index.js
@@ -18,6 +18,7 @@ module.exports = {
   SERVER_HOST: process.env.SERVER_HOST,
   LOG_LEVEL: process.env.LOG_LEVEL || (IS_DEV ? 'debug' : 'error'),
   NO_CACHE: process.env.CACHE_ASSETS ? false : IS_DEV,
+  FEEDBACK_URL: process.env.FEEDBACK_URL,
   API: {
     BASE_URL: process.env.API_BASE_URL || 'http://localhost:4000/api/v1',
     AUTH_URL: process.env.API_AUTH_URL,

--- a/config/nunjucks/globals.js
+++ b/config/nunjucks/globals.js
@@ -1,8 +1,10 @@
 const { isFunction } = require('lodash')
 
+const { FEEDBACK_URL } = require('../')
 const logger = require('../logger')
 
 module.exports = {
+  FEEDBACK_URL,
   SERVICE_NAME: 'Book a secure move',
   callAsMacro (name) {
     const macro = this.ctx[name]

--- a/locales/en/default.json
+++ b/locales/en/default.json
@@ -1,1 +1,4 @@
-{}
+{
+  "phase_banner": "This is a new service",
+  "phase_banner_with_feedback": "This is a new service – your <a class=\"govuk-link\" href=\"{{url}}\">feedback</a> will help us to improve it."
+}


### PR DESCRIPTION
This adds in the GOV.UK Design System phase banner component and
will conditionally add feedback text if a `FEEDBACK_URL` environment
variable is set.

### Todo

- [x] Replace text using translations (waiting on new method introduced in #105)

## What it looks like

### With feedback link
![localhost_3000_moves (2)](https://user-images.githubusercontent.com/3327997/60522749-7c63ca00-9ce1-11e9-86b1-a3d6818f6aeb.png)

### Without feedback link

![localhost_3000_moves (3)](https://user-images.githubusercontent.com/3327997/60522780-88e82280-9ce1-11e9-876e-b645abcf48f0.png)
