### PR TITLE
[P4-473] Fix the current location for a user

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ npm run lint
 | AUTH_PROVIDER_URL **(required)** | Base URL for the auth provider server | |
 | SERVER_HOST **(required)** | The (accessible) hostname (and port) of the listening web server. Used by [Grant](https://github.com/simov/grant) to construct redirect URLs after OAuth authentication. For example `localhost:3000` | |
 | FEEDBACK_URL | URL for the feedback link in the phase banner at the top of the page. If empty, the link will not be displayed. | |
+| CURRENT_LOCATION_UUID **(TEMPORARY)** | UUID of the current location to list and create moves for | |
 
 ## Components
 

--- a/app/moves/controllers/form.js
+++ b/app/moves/controllers/form.js
@@ -4,6 +4,20 @@ const { Controller } = require('hmpo-form-wizard')
 const fieldHelpers = require('../../../common/helpers/field')
 
 class FormController extends Controller {
+  middlewareChecks () {
+    super.middlewareChecks()
+    this.use(this.checkCurrentLocation)
+  }
+
+  checkCurrentLocation (req, res, next) {
+    if (!req.session.currentLocation) {
+      const error = new Error('Current location is not set. Check environment variable is correctly set.')
+      return next(error)
+    }
+
+    next()
+  }
+
   getErrors (req, res) {
     const errors = super.getErrors(req, res)
 

--- a/app/moves/controllers/form.test.js
+++ b/app/moves/controllers/form.test.js
@@ -7,6 +7,59 @@ const controller = new Controller({ route: '/' })
 
 describe('Moves controllers', function () {
   describe('Form', function () {
+    describe('#middlewareChecks()', function () {
+      beforeEach(function () {
+        sinon.stub(FormController.prototype, 'middlewareChecks')
+        sinon.stub(controller, 'use')
+
+        controller.middlewareChecks()
+      })
+
+      it('should call parent method', function () {
+        expect(FormController.prototype.middlewareChecks).to.have.been.calledOnce
+      })
+
+      it('should call check current location method', function () {
+        expect(controller.use).to.have.been.calledWith(controller.checkCurrentLocation)
+      })
+    })
+
+    describe('#checkCurrentLocation()', function () {
+      let req, nextSpy
+
+      beforeEach(function () {
+        nextSpy = sinon.spy()
+        req = {
+          session: {},
+        }
+      })
+
+      context('when current location exists', function () {
+        beforeEach(function () {
+          req.session = {
+            currentLocation: {},
+          }
+          controller.checkCurrentLocation(req, {}, nextSpy)
+        })
+
+        it('should call next without error', function () {
+          expect(nextSpy).to.be.calledOnceWithExactly()
+        })
+      })
+
+      context('when no current location exists', function () {
+        beforeEach(function () {
+          controller.checkCurrentLocation(req, {}, nextSpy)
+        })
+
+        it('should call next with error', function () {
+          expect(nextSpy).to.be.calledOnce
+          expect(nextSpy.args[0][0] instanceof Error).to.be.true
+          expect(nextSpy.args[0][0].message).to.equal('Current location is not set. Check environment variable is correctly set.')
+        })
+      })
+    })
+
     describe('#getErrors()', function () {
       let errors
 

--- a/app/moves/controllers/move-details.js
+++ b/app/moves/controllers/move-details.js
@@ -39,12 +39,10 @@ class MoveDetailsController extends FormController {
 
     req.form.values.date = dateFns.format(moveDate, 'YYYY-MM-DD')
 
-    // process to location
+    // process locations
     req.form.values.to_location = req.form.values[`to_location_${locationType}`]
-
-    // TODO: Until we can get the location based on the user's location
-    // we need to mock it
-    req.form.values.from_location = req.form.values[`to_location_${locationType}`]
+    // if req.session.currentLocation doesn't exist the parent controller will error
+    req.form.values.from_location = req.session.currentLocation.id
 
     next()
   }

--- a/app/moves/controllers/move-details.test.js
+++ b/app/moves/controllers/move-details.test.js
@@ -24,6 +24,10 @@ const prisonsMock = [
     title: 'Prison 4444',
   },
 ]
+const mockCurrentLocation = {
+  id: '5555',
+  title: 'Prison 5555',
+}
 
 describe('Moves controllers', function () {
   describe('Move Details', function () {
@@ -106,17 +110,29 @@ describe('Moves controllers', function () {
     describe('#process()', function () {
       let req, nextSpy
 
+      beforeEach(function () {
+        nextSpy = sinon.spy()
+        req = {
+          form: {
+            values: {},
+          },
+          session: {
+            currentLocation: mockCurrentLocation,
+          },
+        }
+      })
+
+      it('should set from location to current location from session', function () {
+        controller.process(req, {}, nextSpy)
+        expect(req.form.values.from_location).to.equal('5555')
+      })
+
       context('when date type is custom', function () {
         beforeEach(function () {
-          nextSpy = sinon.spy()
-          req = {
-            form: {
-              values: {
-                date: '',
-                date_type: 'custom',
-                date_custom: '2019-10-17',
-              },
-            },
+          req.form.values = {
+            date: '',
+            date_type: 'custom',
+            date_custom: '2019-10-17',
           }
 
           controller.process(req, {}, nextSpy)
@@ -145,14 +161,9 @@ describe('Moves controllers', function () {
 
         beforeEach(function () {
           this.clock = sinon.useFakeTimers(new Date(mockDate).getTime())
-          nextSpy = sinon.spy()
-          req = {
-            form: {
-              values: {
-                date: '',
-                date_type: 'today',
-              },
-            },
+          req.form.values = {
+            date: '',
+            date_type: 'today',
           }
 
           controller.process(req, {}, nextSpy)
@@ -181,14 +192,9 @@ describe('Moves controllers', function () {
 
         beforeEach(function () {
           this.clock = sinon.useFakeTimers(new Date(mockDate).getTime())
-          nextSpy = sinon.spy()
-          req = {
-            form: {
-              values: {
-                date: '',
-                date_type: 'tomorrow',
-              },
-            },
+          req.form.values = {
+            date: '',
+            date_type: 'tomorrow',
           }
 
           controller.process(req, {}, nextSpy)
@@ -209,15 +215,10 @@ describe('Moves controllers', function () {
 
       context('when location type is court', function () {
         beforeEach(function () {
-          nextSpy = sinon.spy()
-          req = {
-            form: {
-              values: {
-                to_location: '',
-                to_location_court: '12345',
-                to_location_type: 'court',
-              },
-            },
+          req.form.values = {
+            to_location: '',
+            to_location_court: '12345',
+            to_location_type: 'court',
           }
 
           controller.process(req, {}, nextSpy)
@@ -234,15 +235,10 @@ describe('Moves controllers', function () {
 
       context('when location type is prison', function () {
         beforeEach(function () {
-          nextSpy = sinon.spy()
-          req = {
-            form: {
-              values: {
-                to_location: '',
-                to_location_prison: '67890',
-                to_location_type: 'prison',
-              },
-            },
+          req.form.values = {
+            to_location: '',
+            to_location_prison: '67890',
+            to_location_type: 'prison',
           }
 
           controller.process(req, {}, nextSpy)

--- a/app/moves/index.js
+++ b/app/moves/index.js
@@ -6,7 +6,7 @@ const wizard = require('hmpo-form-wizard')
 const steps = require('./steps')
 const fields = require('./fields')
 const { cancelMove, detail, download, list, Form } = require('./controllers')
-const { setMove, setMoveDate, setMovesByDate } = require('./middleware')
+const { setMove, setMoveDate, setMovesByDateAndLocation } = require('./middleware')
 const { ensureAuthenticated } = require('../../common/middleware/authentication')
 
 const wizardConfig = {
@@ -23,8 +23,8 @@ router.param('moveId', setMove)
 router.use(ensureAuthenticated)
 
 // Define routes
-router.get('/', setMoveDate, setMovesByDate, list)
-router.use('/download.:extension(csv|json)', setMoveDate, setMovesByDate, download)
+router.get('/', setMoveDate, setMovesByDateAndLocation, list)
+router.use('/download.:extension(csv|json)', setMoveDate, setMovesByDateAndLocation, download)
 router.use('/new', wizard(steps, fields, wizardConfig))
 router.get('/:moveId', detail)
 router.route('/:moveId/cancel')

--- a/app/moves/middleware.js
+++ b/app/moves/middleware.js
@@ -1,3 +1,4 @@
+const { get } = require('lodash')
 const { format } = require('date-fns')
 
 const moveService = require('../../common/services/move')
@@ -23,7 +24,7 @@ module.exports = {
 
     next()
   },
-  setMovesByDate: async (req, res, next) => {
+  setMovesByDateAndLocation: async (req, res, next) => {
     const { moveDate } = res.locals
 
     if (!moveDate) {
@@ -31,7 +32,7 @@ module.exports = {
     }
 
     try {
-      res.locals.movesByDate = await moveService.getRequestedMovesByDate(moveDate)
+      res.locals.movesByDate = await moveService.getRequestedMovesByDateAndLocation(moveDate, get(req.session, 'currentLocation.id'))
 
       next()
     } catch (error) {

--- a/app/moves/views/create/move-details.njk
+++ b/app/moves/views/create/move-details.njk
@@ -6,7 +6,7 @@
   </h3>
 
   <p class="govuk-!-margin-bottom-6">
-    { CURRENT LOCATION }
+    {{ CURRENT_LOCATION.title }}
   </p>
 {% endblock %}
 

--- a/common/middleware/current-location.js
+++ b/common/middleware/current-location.js
@@ -1,0 +1,17 @@
+const referenceDataService = require('../../common/services/reference-data')
+
+module.exports = function currentLocation (locationUUID) {
+  return (req, res, next) => {
+    if (req.session.currentLocation) {
+      return next()
+    }
+
+    referenceDataService
+      .getLocationById(locationUUID)
+      .then((location) => {
+        req.session.currentLocation = location
+        next()
+      })
+      .catch(next)
+  }
+}

--- a/common/middleware/current-location.test.js
+++ b/common/middleware/current-location.test.js
@@ -1,0 +1,108 @@
+const currentLocation = require('./current-location')
+
+const referenceDataService = require('../../common/services/reference-data')
+
+const mockId = 'ce337679-1741-4ced-b592-fab7b5c0d388'
+const mockLocation = {
+  id: 'ce337679-1741-4ced-b592-fab7b5c0d388',
+  key: 'hmirc_dover',
+  title: 'HMIRC Dover',
+}
+
+describe('Current location middleware', function () {
+  let req, nextSpy
+
+  beforeEach(function () {
+    sinon.stub(referenceDataService, 'getLocationById')
+    nextSpy = sinon.spy()
+    req = { session: {} }
+  })
+
+  context('when location already exists in session', function () {
+    beforeEach(function () {
+      req.session.currentLocation = 'location-value'
+      currentLocation(mockId)(req, {}, nextSpy)
+    })
+
+    it('should not mutate value on session', function () {
+      expect(req.session.currentLocation).to.equal('location-value')
+    })
+
+    it('should call next without error', function () {
+      expect(nextSpy).to.be.calledOnceWithExactly()
+    })
+
+    it('should not call reference service', function () {
+      expect(referenceDataService.getLocationById).not.to.be.called
+    })
+  })
+
+  context('when location doesn\'t exist in session', function () {
+    context('when location service returns a location', function () {
+      beforeEach(async function () {
+        referenceDataService.getLocationById.resolves(mockLocation)
+        await currentLocation(mockId)(req, {}, nextSpy)
+      })
+
+      it('should call location service with location ID', function () {
+        expect(referenceDataService.getLocationById).to.be.calledOnceWithExactly(mockId)
+      })
+
+      it('should add a current location property to the session', function () {
+        expect(req.session).to.have.property('currentLocation')
+      })
+
+      it('should set correct value to session property', function () {
+        expect(req.session.currentLocation).to.equal(mockLocation)
+      })
+
+      it('should call next without error', function () {
+        expect(nextSpy).to.be.calledOnceWithExactly()
+      })
+    })
+
+    context('when location service doesn\'t return a location', function () {
+      beforeEach(async function () {
+        referenceDataService.getLocationById.resolves(undefined)
+        await currentLocation(mockId)(req, {}, nextSpy)
+      })
+
+      it('should call location service with location ID', function () {
+        expect(referenceDataService.getLocationById).to.be.calledOnceWithExactly(mockId)
+      })
+
+      it('should add a current location property to the session', function () {
+        expect(req.session).to.have.property('currentLocation')
+      })
+
+      it('should set value to undefined', function () {
+        expect(req.session.currentLocation).to.equal(undefined)
+      })
+
+      it('should call next without error', function () {
+        expect(nextSpy).to.be.calledOnceWithExactly()
+      })
+    })
+
+    context('when location service return an error', function () {
+      const mockError = new Error('Location error')
+
+      beforeEach(async function () {
+        referenceDataService.getLocationById.rejects(mockError)
+        await currentLocation(mockId)(req, {}, nextSpy)
+      })
+
+      it('should call location service with location ID', function () {
+        expect(referenceDataService.getLocationById).to.be.calledOnceWithExactly(mockId)
+      })
+
+      it('should not add a current location property to the session', function () {
+        expect(req.session).not.to.have.property('currentLocation')
+      })
+
+      it('should call next with error', function () {
+        expect(nextSpy).to.be.calledOnceWithExactly(mockError)
+      })
+    })
+  })
+})

--- a/common/middleware/locals/index.js
+++ b/common/middleware/locals/index.js
@@ -4,6 +4,7 @@ module.exports = function setLocals (req, res, next) {
   const locals = {
     TODAY: new Date(),
     TOMORROW: startOfTomorrow(),
+    CURRENT_LOCATION: req.session.currentLocation,
     getLocal: key => res.locals[key],
     getMessages: () => req.flash(),
   }

--- a/common/services/move.js
+++ b/common/services/move.js
@@ -13,12 +13,13 @@ function format (data) {
   })
 }
 
-function getRequestedMovesByDate (moveDate) {
+function getRequestedMovesByDateAndLocation (moveDate, locationId) {
   return apiClient
     .findAll('move', {
       'filter[status]': 'requested',
       'filter[date_from]': moveDate,
       'filter[date_to]': moveDate,
+      'filter[from_location_id]': locationId,
     })
     .then(response => response.data)
 }
@@ -48,7 +49,7 @@ function cancel (id) {
 
 module.exports = {
   format,
-  getRequestedMovesByDate,
+  getRequestedMovesByDateAndLocation,
   getMoveById,
   create,
   cancel,

--- a/common/services/move.test.js
+++ b/common/services/move.test.js
@@ -75,7 +75,7 @@ describe('Move Service', function () {
     })
   })
 
-  describe('#getRequestedMovesByDate()', function () {
+  describe('#getRequestedMovesByDateAndLocation()', function () {
     context('when request returns 200', function () {
       const mockDate = '2017-08-10'
       let moves
@@ -94,7 +94,7 @@ describe('Move Service', function () {
           })
           .reply(200, movesGetSerialized)
 
-        moves = await moveService.getRequestedMovesByDate(mockDate)
+        moves = await moveService.getRequestedMovesByDateAndLocation(mockDate)
       })
 
       afterEach(function () {

--- a/common/services/reference-data.js
+++ b/common/services/reference-data.js
@@ -39,9 +39,16 @@ function getLocations (type, combinedData, page = 1) {
   })
 }
 
+function getLocationById (id) {
+  return apiClient
+    .find('location', id)
+    .then(response => response.data)
+}
+
 module.exports = {
   getGenders,
   getEthnicities,
   getAssessmentQuestions,
   getLocations,
+  getLocationById,
 }

--- a/common/services/reference-data.test.js
+++ b/common/services/reference-data.test.js
@@ -3,6 +3,7 @@ const {
   getEthnicities,
   getAssessmentQuestions,
   getLocations,
+  getLocationById,
 } = require('./reference-data')
 const { API } = require('../../config')
 const auth = require('../lib/api-client/auth')
@@ -16,6 +17,8 @@ const assessmentSerialized = require('../../test/fixtures/api-client/reference.a
 const locationsDeserialized = require('../../test/fixtures/api-client/reference.locations.deserialized.json')
 const locationsPage1Serialized = require('../../test/fixtures/api-client/reference.locations.page-1.serialized.json')
 const locationsPage2Serialized = require('../../test/fixtures/api-client/reference.locations.page-2.serialized.json')
+const locationDeserialized = require('../../test/fixtures/api-client/reference.location.deserialized.json')
+const locationSerialized = require('../../test/fixtures/api-client/reference.location.serialized.json')
 
 describe('Reference Service', function () {
   beforeEach(function () {
@@ -120,6 +123,28 @@ describe('Reference Service', function () {
       it('should return a full list of locations', function () {
         expect(response.length).to.deep.equal(locationsDeserialized.data.length)
         expect(response).to.deep.equal(locationsDeserialized.data)
+      })
+    })
+  })
+
+  describe('#getLocationById()', function () {
+    context('when request returns 200', function () {
+      let location
+
+      beforeEach(async function () {
+        nock(API.BASE_URL)
+          .get(`/reference/locations/${locationDeserialized.data.id}`)
+          .reply(200, locationSerialized)
+
+        location = await getLocationById(locationDeserialized.data.id)
+      })
+
+      it('should get location from API', function () {
+        expect(nock.isDone()).to.be.true
+      })
+
+      it('should contain location with correct data', function () {
+        expect(location).to.deep.equal(locationDeserialized.data)
       })
     })
   })

--- a/config/index.js
+++ b/config/index.js
@@ -27,6 +27,7 @@ module.exports = {
   LOG_LEVEL: process.env.LOG_LEVEL || (IS_DEV ? 'debug' : 'error'),
   NO_CACHE: process.env.CACHE_ASSETS ? false : IS_DEV,
   FEEDBACK_URL: process.env.FEEDBACK_URL,
+  CURRENT_LOCATION_UUID: process.env.CURRENT_LOCATION_UUID,
   API: {
     BASE_URL: process.env.API_BASE_URL || 'http://localhost:4000/api/v1',
     AUTH_URL: process.env.API_AUTH_URL,

--- a/server.js
+++ b/server.js
@@ -18,6 +18,7 @@ const i18nMiddleware = require('i18next-express-middleware')
 const config = require('./config')
 const configPaths = require('./config/paths')
 const nunjucks = require('./config/nunjucks')
+const currentLocation = require('./common/middleware/current-location')
 const errorHandlers = require('./common/middleware/errors')
 const router = require('./app/router')
 const locals = require('./common/middleware/locals')
@@ -72,6 +73,7 @@ app.use(session({
     httpOnly: true,
   },
 }))
+app.use(currentLocation(config.CURRENT_LOCATION_UUID))
 app.use(flash())
 app.use(locals)
 app.use(grant({

--- a/test/fixtures/api-client/reference.location.deserialized.json
+++ b/test/fixtures/api-client/reference.location.deserialized.json
@@ -1,0 +1,10 @@
+{
+  "data": {
+    "id": "2c952ca0-f750-4ac3-ac76-fb631445f974",
+    "type": "locations",
+    "key": "axminster_crown_court",
+    "title": "Axminster Crown Court",
+    "location_type": "court",
+    "location_code": null
+  }
+}

--- a/test/fixtures/api-client/reference.location.serialized.json
+++ b/test/fixtures/api-client/reference.location.serialized.json
@@ -1,0 +1,12 @@
+{
+  "data": {
+    "id": "2c952ca0-f750-4ac3-ac76-fb631445f974",
+    "type": "locations",
+    "attributes": {
+      "key": "axminster_crown_court",
+      "title": "Axminster Crown Court",
+      "location_type": "court",
+      "location_code": null
+    }
+  }
+}


### PR DESCRIPTION
This change uses an environment variable to set the UUID of the current location.

This current location is then used in other parts of the application, for example listing moves for only that location or creating moves for only that location.

## Todo

- [x] We could look at replacing the call to get a location by ID based on how soon we can look at the [corresponding backend ticket](https://dsdmoj.atlassian.net/browse/P4-474).

## Waiting on

- [x] Change to the API to support getting reference data by ID (ministryofjustice/hmpps-book-secure-move-api/pull/78)