### PR TITLE
[P4-411] Store the person's reference number

### DIFF
--- a/app/moves/fields.js
+++ b/app/moves/fields.js
@@ -17,17 +17,17 @@ function assessmentQuestionComments ({ required = false } = {}) {
 
 module.exports = {
   // personal details
-  reference: {
+  'athena_reference': {
     component: 'govukInput',
     label: {
-      text: 'fields:reference.label',
+      text: 'fields:athena_reference.label',
       classes: 'govuk-label--s',
     },
     hint: {
-      text: 'fields:reference.hint',
+      text: 'fields:athena_reference.hint',
     },
-    id: 'reference',
-    name: 'reference',
+    id: 'athena_reference',
+    name: 'athena_reference',
     classes: 'govuk-input--width-20',
     autocomplete: 'off',
   },

--- a/app/moves/steps.js
+++ b/app/moves/steps.js
@@ -18,7 +18,7 @@ module.exports = {
     heading: 'moves:steps.personal_details.heading',
     next: 'move-details',
     fields: [
-      'reference',
+      'athena_reference',
       'last_name',
       'first_names',
       'date_of_birth',

--- a/common/services/person.js
+++ b/common/services/person.js
@@ -11,13 +11,32 @@ function getFullname ({
 
 function format (data) {
   const relationships = ['gender', 'ethnicity']
+  const identifiers = [
+    'police_national_computer',
+    'criminal_records_office',
+    'prison_number',
+    'niche_reference',
+    'athena_reference',
+  ]
 
-  return mapValues(data, (value, key) => {
-    if (relationships.includes(key) && typeof value === 'string') {
-      return { id: value }
+  const formatted = mapValues(data, (value, key) => {
+    if (typeof value === 'string') {
+      if (relationships.includes(key)) {
+        return { id: value }
+      }
+
+      if (identifiers.includes(key)) {
+        return { value, identifier_type: key }
+      }
     }
+
     return value
   })
+
+  return {
+    ...formatted,
+    identifiers: identifiers.map(key => formatted[key]).filter(Boolean),
+  }
 }
 
 function create (data) {

--- a/common/services/person.test.js
+++ b/common/services/person.test.js
@@ -87,6 +87,137 @@ describe('Person Service', function () {
         expect(formatted.first_names).to.equal('Foo')
       })
     })
+
+    context('when identifiers field is string', function () {
+      let formatted
+
+      beforeEach(async function () {
+        formatted = await personService.format({
+          first_names: 'Foo',
+          police_national_computer: 'PNC number',
+          athena_reference: 'Athena reference',
+          criminal_records_office: 'CRO number',
+          prison_number: 'Prison number',
+          niche_reference: 'Niche reference',
+        })
+      })
+
+      it('should format as relationship object', function () {
+        expect(formatted.police_national_computer).to.deep.equal({
+          value: 'PNC number',
+          identifier_type: 'police_national_computer',
+        })
+      })
+
+      it('should format as relationship object', function () {
+        expect(formatted.athena_reference).to.deep.equal({
+          value: 'Athena reference',
+          identifier_type: 'athena_reference',
+        })
+      })
+
+      it('should format as relationship object', function () {
+        expect(formatted.criminal_records_office).to.deep.equal({
+          value: 'CRO number',
+          identifier_type: 'criminal_records_office',
+        })
+      })
+
+      it('should format as relationship object', function () {
+        expect(formatted.prison_number).to.deep.equal({
+          value: 'Prison number',
+          identifier_type: 'prison_number',
+        })
+      })
+
+      it('should format as relationship object', function () {
+        expect(formatted.niche_reference).to.deep.equal({
+          value: 'Niche reference',
+          identifier_type: 'niche_reference',
+        })
+      })
+
+      it('should not affect non relationship fields', function () {
+        expect(formatted.first_names).to.equal('Foo')
+      })
+
+      it('should include identifiers property', function () {
+        expect(formatted.identifiers).to.deep.equal([
+          {
+            identifier_type: 'police_national_computer',
+            value: 'PNC number',
+          },
+          {
+            identifier_type: 'criminal_records_office',
+            value: 'CRO number',
+          },
+          {
+            identifier_type: 'prison_number',
+            value: 'Prison number',
+          },
+          {
+            identifier_type: 'niche_reference',
+            value: 'Niche reference',
+          },
+          {
+            identifier_type: 'athena_reference',
+            value: 'Athena reference',
+          },
+        ])
+      })
+    })
+
+    context('when identifiers field is not a string', function () {
+      let formatted
+
+      beforeEach(async function () {
+        formatted = await personService.format({
+          first_names: 'Foo',
+          police_national_computer: {
+            value: 'PNC number',
+            identifier_type: 'police_national_computer',
+          },
+        })
+      })
+
+      it('should return its original value', function () {
+        expect(formatted.police_national_computer).to.deep.equal({
+          value: 'PNC number',
+          identifier_type: 'police_national_computer',
+        })
+      })
+
+      it('should include identifiers property', function () {
+        expect(formatted.identifiers).to.deep.equal([
+          {
+            identifier_type: 'police_national_computer',
+            value: 'PNC number',
+          },
+        ])
+      })
+
+      it('should not affect non relationship fields', function () {
+        expect(formatted.first_names).to.equal('Foo')
+      })
+    })
+
+    context('when no identifiers present', function () {
+      let formatted
+
+      beforeEach(async function () {
+        formatted = await personService.format({
+          first_names: 'Foo',
+        })
+      })
+
+      it('should include empty identifiers property', function () {
+        expect(formatted.identifiers).to.deep.equal([])
+      })
+
+      it('should not affect non relationship fields', function () {
+        expect(formatted.first_names).to.equal('Foo')
+      })
+    })
   })
 
   describe('#create()', function () {

--- a/locales/en/fields.json
+++ b/locales/en/fields.json
@@ -1,5 +1,5 @@
 {
-  "reference": {
+  "athena_reference": {
     "label": "Reference number",
     "hint": "Your reference for the person"
   },


### PR DESCRIPTION
This change sets the current reference field to the specific
custody suite being used for the pilot.

It also adds support to the Person service formatter to correctly
handle any identifiers that are passed to it.