### PR TITLE
Add sign out link in header

### DIFF
--- a/app/auth/controllers.js
+++ b/app/auth/controllers.js
@@ -1,3 +1,5 @@
+const { AUTH_PROVIDERS, DEFAULT_AUTH_PROVIDER } = require('../../config')
+
 module.exports = {
   redirect: (req, res) => {
     const url = req.session.postAuthRedirect || '/'
@@ -5,5 +7,11 @@ module.exports = {
     req.session.postAuthRedirect = null
 
     res.redirect(url)
+  },
+  signOut: (req, res) => {
+    const authProviderLogoutUrl = AUTH_PROVIDERS[DEFAULT_AUTH_PROVIDER].logout_url
+
+    req.session.destroy()
+    res.redirect(authProviderLogoutUrl)
   },
 }

--- a/app/auth/controllers.test.js
+++ b/app/auth/controllers.test.js
@@ -1,4 +1,18 @@
-const controllers = require('./controllers')
+const proxyquire = require('proxyquire').noCallThru()
+
+const logOutUrl = 'http://test/test'
+const mockConfig = {
+  AUTH_PROVIDERS: {
+    test: {
+      logout_url: logOutUrl,
+    },
+  },
+  DEFAULT_AUTH_PROVIDER: 'test',
+}
+
+const controllers = proxyquire('./controllers', {
+  '../../config': mockConfig,
+})
 
 const url = '/test'
 
@@ -40,6 +54,32 @@ describe('Authentication app', function () {
       it('unsets session.postAuthRedirect', function () {
         expect(req.session.postAuthRedirect).to.equal(null)
       })
+    })
+  })
+
+  describe('#signOut()', function () {
+    let req, res
+
+    beforeEach(function () {
+      req = {
+        query: {},
+        session: {
+          destroy: sinon.spy(),
+        },
+      }
+      res = {
+        redirect: sinon.spy(),
+      }
+
+      controllers.signOut(req, res)
+    })
+
+    it('destroys the session', function () {
+      expect(req.session.destroy).to.be.called
+    })
+
+    it('redirects to the auth provider logout URL', function () {
+      expect(res.redirect).to.be.calledWith(logOutUrl)
     })
   })
 })

--- a/app/auth/index.js
+++ b/app/auth/index.js
@@ -2,12 +2,13 @@
 const router = require('express').Router()
 
 // Local dependencies
-const { redirect } = require('./controllers')
+const { redirect, signOut } = require('./controllers')
 const { processAuthResponse } = require('./middleware')
 
 // Define routes
 router.get('/', redirect)
 router.get('/callback', processAuthResponse, redirect)
+router.get('/sign-out', signOut)
 
 // Export
 module.exports = {

--- a/common/components/internal-header/_internal-header.scss
+++ b/common/components/internal-header/_internal-header.scss
@@ -181,6 +181,7 @@ $govuk-header-nav-item-border-color: #2e3133;
   margin: 0;
   padding: 0;
   list-style: none;
+  float: right;
 }
 
 .js-enabled {

--- a/common/helpers/index.js
+++ b/common/helpers/index.js
@@ -1,5 +1,7 @@
 const field = require('./field')
+const url = require('./url')
 
 module.exports = {
   field,
+  url,
 }

--- a/common/helpers/url.js
+++ b/common/helpers/url.js
@@ -1,0 +1,10 @@
+const { IS_PRODUCTION, SERVER_HOST } = require('../../config')
+
+function buildUrl (path = '', domain = SERVER_HOST, secure = IS_PRODUCTION) {
+  const protocol = secure ? 'https' : 'http'
+  return new URL(path, `${protocol}://${domain}`).href
+}
+
+module.exports = {
+  buildUrl,
+}

--- a/common/helpers/url.test.js
+++ b/common/helpers/url.test.js
@@ -1,0 +1,95 @@
+const proxyquire = require('proxyquire').noCallThru()
+
+describe('URL helpers', function () {
+  describe('#buildUrl()', function () {
+    let buildUrl, result
+
+    const host = 'test'
+
+    const getHelper = function (production = false) {
+      const mockConfig = {
+        IS_PRODUCTION: production,
+        SERVER_HOST: host,
+      }
+
+      const helpers = proxyquire('./url', {
+        '../../config': mockConfig,
+      })
+
+      return helpers.buildUrl
+    }
+
+    beforeEach(function () {
+      buildUrl = getHelper()
+    })
+
+    context('with no parameters', function () {
+      beforeEach(function () {
+        result = buildUrl()
+      })
+
+      it('returns the root URL for the host specified in the SERVER_HOST environment variable', function () {
+        expect(result).to.equal(`http://${host}/`)
+      })
+
+      context('in a non-production mode', function () {
+        it('returns HTTP protocol', function () {
+          expect(result).to.equal(`http://${host}/`)
+        })
+      })
+
+      context('in production mode', function () {
+        beforeEach(function () {
+          buildUrl = getHelper(true)
+          result = buildUrl()
+        })
+
+        it('returns HTTPS protocol', function () {
+          expect(result).to.equal(`https://${host}/`)
+        })
+      })
+    })
+
+    context('with path parameter', function () {
+      beforeEach(function () {
+        result = buildUrl('test')
+      })
+
+      it('returns a URL with the supplied path appended', function () {
+        expect(result).to.equal(`http://${host}/test`)
+      })
+    })
+
+    context('with domain parameter', function () {
+      beforeEach(function () {
+        result = buildUrl('test', 'test123')
+      })
+
+      it('returns a URL for the supplied domain', function () {
+        expect(result).to.equal('http://test123/test')
+      })
+    })
+
+    context('with secure parameter', function () {
+      context('which is falsy', function () {
+        beforeEach(function () {
+          result = buildUrl('test', 'test123', false)
+        })
+
+        it('returns HTTP protocol', function () {
+          expect(result).to.equal('http://test123/test')
+        })
+      })
+
+      context('which is truthy', function () {
+        beforeEach(function () {
+          result = buildUrl('test', 'test123', true)
+        })
+
+        it('returns HTTP protocol', function () {
+          expect(result).to.equal('https://test123/test')
+        })
+      })
+    })
+  })
+})

--- a/common/templates/layouts/govuk.njk
+++ b/common/templates/layouts/govuk.njk
@@ -39,7 +39,13 @@
     homepageUrl: "/",
     siteName: "HMPPS",
     productName: SERVICE_NAME,
-    containerClasses: "govuk-width-container"
+    containerClasses: "govuk-width-container",
+    navigation: [
+      {
+        href: "/sign-out",
+        text: t("actions:sign_out")
+      }
+    ]
   }) }}
 {% endblock %}
 

--- a/config/index.js
+++ b/config/index.js
@@ -1,6 +1,8 @@
 /* eslint no-process-env: "off" */
 require('dotenv').config()
 
+const { buildUrl } = require('../common/helpers/url')
+
 const IS_DEV = process.env.NODE_ENV !== 'production'
 const IS_PRODUCTION = process.env.NODE_ENV === 'production'
 const AUTH_BASE_URL = process.env.AUTH_PROVIDER_URL
@@ -74,6 +76,9 @@ module.exports = {
         : '',
       healthcheck_url: AUTH_BASE_URL
         ? new URL('/auth/ping', AUTH_BASE_URL).href
+        : '',
+      logout_url: AUTH_BASE_URL
+        ? new URL(`/auth/logout?client_id=${process.env.AUTH_PROVIDER_KEY}&redirect_uri=${buildUrl()}`, AUTH_BASE_URL).href
         : '',
       key: process.env.AUTH_PROVIDER_KEY,
       secret: process.env.AUTH_PROVIDER_SECRET,

--- a/locales/en/actions.json
+++ b/locales/en/actions.json
@@ -12,5 +12,6 @@
   "cancel_move_confirmation": "Cancel move",
   "download_csv": "Download moves (.csv)",
   "print_move_list": "Print moves",
-  "print_move_detail": "Print move"
+  "print_move_detail": "Print move",
+  "sign_out": "Sign out"
 }


### PR DESCRIPTION
The order of events is:

* We destroy the session on our service
* We redirect the user to the HMPPS SSO logout URL, which logs them out of that session as well
* HMPPS SSO redirects back to our service at the URL we specify, or failing that, back to its own login screen