### PR TITLE
[P4-475] Update button text for final create step

### DIFF
--- a/app/moves/steps.js
+++ b/app/moves/steps.js
@@ -74,6 +74,7 @@ module.exports = {
     controller: Assessment,
     next: 'save',
     heading: 'moves:steps.health_information.heading',
+    buttonText: 'actions:schedule_move',
     fields: [
       'health',
       'health__special_diet_or_allergy',

--- a/common/templates/form-wizard.njk
+++ b/common/templates/form-wizard.njk
@@ -41,7 +41,7 @@
     {% endblock %}
 
     {{ govukButton({
-      text: t("actions:continue")
+      text: t(options.buttonText or "actions:continue")
     }) }}
   </form>
 {% endblock %}

--- a/locales/en/actions.json
+++ b/locales/en/actions.json
@@ -5,6 +5,7 @@
   "back": "Back",
   "back_to_dashboard": "$t(actions:back) to dashboard",
   "back_to_move": "$t(actions:back) to move",
+  "schedule_move": "Scheduled move",
   "continue": "Continue",
   "restart": "Restart",
   "cancel_move": "Cancel this move",


### PR DESCRIPTION
This change allows custom text to be passed to the form wizard
on any step by adding a `buttonText` property to the step
options.

It also includes updating the final step of the creation journey
to change the text to reflect the action that will happen after
clicking it.