### PR TITLE
Update assessment "other" field keys

### DIFF
--- a/app/moves/fields.js
+++ b/app/moves/fields.js
@@ -172,7 +172,7 @@ module.exports = {
   health__medication: assessmentQuestionComments(),
   health__wheelchair: assessmentQuestionComments(),
   health__pregnant: assessmentQuestionComments(),
-  health__other_requirements: assessmentQuestionComments({
+  health__other_health: assessmentQuestionComments({
     required: true,
   }),
   // court information
@@ -193,7 +193,7 @@ module.exports = {
   },
   court__solicitor: assessmentQuestionComments(),
   court__interpreter: assessmentQuestionComments(),
-  court__other_information: assessmentQuestionComments({
+  court__other_court: assessmentQuestionComments({
     required: true,
   }),
 }

--- a/app/moves/steps.js
+++ b/app/moves/steps.js
@@ -53,7 +53,7 @@ module.exports = {
       'court',
       'court__solicitor',
       'court__interpreter',
-      'court__other_information',
+      'court__other_court',
     ],
   },
   '/risk-information': {
@@ -81,7 +81,7 @@ module.exports = {
       'health__medication',
       'health__wheelchair',
       'health__pregnant',
-      'health__other_requirements',
+      'health__other_health',
     ],
   },
   '/save': {


### PR DESCRIPTION
The keys for these properties have been changed in the API so this
change reflects that so the values are stored correctly.

Relates to this API change: ministryofjustice/hmpps-book-secure-move-api/pull/75