### PR TITLE
Rename skip flag in form wizard

### DIFF
--- a/app/moves/fields.js
+++ b/app/moves/fields.js
@@ -4,7 +4,7 @@ function assessmentQuestionComments ({ required = false } = {}) {
   const labelPath = required ? 'required' : 'optional'
 
   return {
-    isConditional: true,
+    skip: true,
     component: 'govukTextarea',
     classes: 'govuk-input--width-20',
     rows: 3,
@@ -17,7 +17,7 @@ function assessmentQuestionComments ({ required = false } = {}) {
 
 module.exports = {
   // personal details
-  'athena_reference': {
+  athena_reference: {
     component: 'govukInput',
     label: {
       text: 'fields:athena_reference.label',
@@ -113,7 +113,7 @@ module.exports = {
     ],
   },
   to_location_prison: {
-    isConditional: true,
+    skip: true,
     component: 'govukSelect',
     id: 'to_location_prison',
     name: 'to_location_prison',
@@ -125,7 +125,7 @@ module.exports = {
     items: [],
   },
   to_location_court: {
-    isConditional: true,
+    skip: true,
     component: 'govukSelect',
     id: 'to_location_court',
     name: 'to_location_court',
@@ -163,7 +163,7 @@ module.exports = {
     ],
   },
   date_custom: {
-    isConditional: true,
+    skip: true,
     formatter: [date],
     component: 'govukInput',
     id: 'date_custom',

--- a/common/templates/form-wizard.njk
+++ b/common/templates/form-wizard.njk
@@ -34,7 +34,7 @@
 
     {% block fields %}
       {% for key, fieldsOptions in options.fields %}
-        {% if fieldsOptions.component and not fieldsOptions.isConditional %}
+        {% if fieldsOptions.component and not fieldsOptions.skip %}
           {{ callAsMacro(fieldsOptions.component)(fieldsOptions) }}
         {% endif %}
       {% endfor %}


### PR DESCRIPTION
Previously the form wizard would not output a field if
the `isConditional` property returned truthy.

This change renames that property to be something more generic (`skip`)
as we might want to skip a field for other reasons. It unties
the property from a specific scenario and offers more flexibility.