### PR TITLE
Set grant return protocol based on environment

### DIFF
--- a/server.js
+++ b/server.js
@@ -107,7 +107,7 @@ app.use(locals)
 app.use(
   grant({
     defaults: {
-      protocol: 'http',
+      protocol: config.IS_PRODUCTION ? 'https' : 'http',
       host: config.SERVER_HOST,
       callback: '/auth/callback',
       transport: 'session',


### PR DESCRIPTION
Currently in production grant will attempt to redirect to http
protocol.

Although this isn't the best way to determine protocol currently
we can say that if the app is in production the protocol is `https`.

**Note:** I'm not sure I really like this but it will allow us to have staging working
to start with.