### PR TITLE
Fix URL for sign out link

### DIFF
--- a/common/templates/layouts/govuk.njk
+++ b/common/templates/layouts/govuk.njk
@@ -42,7 +42,7 @@
     containerClasses: "govuk-width-container",
     navigation: [
       {
-        href: "/sign-out",
+        href: "/auth/sign-out",
         text: t("actions:sign_out")
       }
     ]


### PR DESCRIPTION
The sign out link in the header was missing the auth path after
a refactor to move the controler into the auth feature.