### PR TITLE
Add slashify to standardise URLs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4550,6 +4550,21 @@
       "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.6.tgz",
       "integrity": "sha512-q8BZ89jjc+mz08rSxROs8VsrBBcn1SIw1kq9NjolL509tkABRk9io01RAjSaEv1Xb2uFLt8VtRiZbGp5H8iDtg=="
     },
+    "fast-url-parser": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/fast-url-parser/-/fast-url-parser-1.1.3.tgz",
+      "integrity": "sha1-9K8+qfNNiicc9YrSs3WfQx8LMY0=",
+      "requires": {
+        "punycode": "^1.3.2"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+        }
+      }
+    },
     "feature-policy": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/feature-policy/-/feature-policy-0.3.0.tgz",
@@ -4583,6 +4598,11 @@
       "requires": {
         "flat-cache": "^2.0.1"
       }
+    },
+    "file-exists": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/file-exists/-/file-exists-0.1.1.tgz",
+      "integrity": "sha1-mT0//7W0nRH+/Mj0XCNVAnRAgDw="
     },
     "file-loader": {
       "version": "3.0.1",
@@ -10571,6 +10591,15 @@
       "resolved": "https://registry.npmjs.org/sinon-chai/-/sinon-chai-3.3.0.tgz",
       "integrity": "sha512-r2JhDY7gbbmh5z3Q62pNbrjxZdOAjpsqW/8yxAZRSqLZqowmfGZPGUZPFf3UX36NLis0cv8VEM5IJh9HgkSOAA==",
       "dev": true
+    },
+    "slashify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/slashify/-/slashify-1.0.0.tgz",
+      "integrity": "sha1-JEumpIR/0Hpklei4/b9FteQIlSg=",
+      "requires": {
+        "fast-url-parser": "^1.0.6-0",
+        "file-exists": "^0.1.1"
+      }
     },
     "slice-ansi": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "npm-run-all": "^4.1.5",
     "nunjucks": "^3.2.0",
     "query-string": "^6.5.0",
+    "slashify": "^1.0.0",
     "winston": "^3.2.1"
   },
   "devDependencies": {

--- a/server.js
+++ b/server.js
@@ -11,6 +11,7 @@ const morgan = require('morgan')
 const session = require('express-session')
 const grant = require('grant-express')
 const flash = require('connect-flash')
+const slashify = require('slashify')
 const i18next = require('i18next')
 const Backend = require('i18next-node-fs-backend')
 const i18nMiddleware = require('i18next-express-middleware')
@@ -65,6 +66,8 @@ if (config.IS_PRODUCTION) {
 }
 
 app.use(Sentry.Handlers.requestHandler())
+
+app.use(slashify())
 
 // Load the healthcheck app manually before anything
 // else to ensure it will return some kind of response


### PR DESCRIPTION
Slashify redirects any routes containing a trailing slash to
a URL without a slash.

This keeps our URLs more consistent for things like analytics and
avoids any duplicates.