### PR TITLE
[P4-266] Separate all moves from location based moves

### DIFF
--- a/app/moves/controllers/list.js
+++ b/app/moves/controllers/list.js
@@ -1,8 +1,4 @@
-const {
-  format,
-  addDays,
-  subDays,
-} = require('date-fns')
+const { format, addDays, subDays } = require('date-fns')
 
 const { getQueryString } = require('../../../common/lib/request')
 const presenters = require('../../../common/presenters')

--- a/app/moves/index.js
+++ b/app/moves/index.js
@@ -3,16 +3,23 @@ const router = require('express').Router()
 
 // Local dependencies
 const { download, list } = require('./controllers')
-const { setMoveDate, setMovesByDateAndLocation } = require('./middleware')
+const { setMoveDate, setFromLocation, setMovesByDate } = require('./middleware')
+
+const uuidRegex =
+  '[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}'
 
 // Define param middleware
+router.param('locationId', setFromLocation)
 
 // Define routes
-router.get('/', setMoveDate, setMovesByDateAndLocation, list)
-router.use(
-  '/download.:extension(csv|json)',
-  setMoveDate,
-  setMovesByDateAndLocation,
+router.use(setMoveDate)
+router.get(['/', `/:locationId(${uuidRegex})`], setMovesByDate, list)
+router.get(
+  [
+    '/download.:extension(csv|json)',
+    `/:locationId(${uuidRegex})/download.:extension(csv|json)`,
+  ],
+  setMovesByDate,
   download
 )
 

--- a/app/moves/middleware.js
+++ b/app/moves/middleware.js
@@ -1,4 +1,3 @@
-const { get } = require('lodash')
 const { format } = require('date-fns')
 
 const moveService = require('../../common/services/move')
@@ -10,7 +9,11 @@ module.exports = {
 
     next()
   },
-  setMovesByDateAndLocation: async (req, res, next) => {
+  setFromLocation: (req, res, next, locationId) => {
+    res.locals.fromLocationId = locationId
+    next()
+  },
+  setMovesByDate: async (req, res, next) => {
     const { moveDate } = res.locals
 
     if (!moveDate) {
@@ -20,7 +23,7 @@ module.exports = {
     try {
       res.locals.movesByDate = await moveService.getRequestedMovesByDateAndLocation(
         moveDate,
-        get(req.session, 'currentLocation.id')
+        res.locals.fromLocationId
       )
 
       next()

--- a/app/moves/views/list.njk
+++ b/app/moves/views/list.njk
@@ -40,7 +40,7 @@
     <div class="govuk-grid-column-one-third">
       <ul class="govuk-list govuk-!-font-size-16 app-!-float-right app-print--hide">
         <li>
-          <a href="/moves/download.csv?move-date={{ moveDate }}">
+          <a href="{{ ORIGINAL_PATH }}/download.csv?move-date={{ moveDate }}">
             {{ t("actions:download_csv") }}
           </a>
         </li>

--- a/common/middleware/locals/index.js
+++ b/common/middleware/locals/index.js
@@ -4,6 +4,7 @@ module.exports = function setLocals (req, res, next) {
   const locals = {
     TODAY: new Date(),
     TOMORROW: startOfTomorrow(),
+    ORIGINAL_PATH: req.originalUrl.split('?').shift(),
     CURRENT_LOCATION: req.session.currentLocation,
     getLocal: key => res.locals[key],
     getMessages: () => req.flash(),


### PR DESCRIPTION
This creates a new route to view moves from a specific location and
now displays all moves when visiting the route moves path.

Routes are now:

`/moves` - display all moves
`/moves/download.(csv|json)` - download all moves
`/moves/:locationId` - display moves from location
`/moves/:locationId/download.(csv|json)` - download moves from location