### PR TITLE
Include the created date in assessment answers

### DIFF
--- a/app/move/views/_includes/assessment.njk
+++ b/app/move/views/_includes/assessment.njk
@@ -16,9 +16,9 @@
       {% set itemHtml %}
         {{ item.comments if item.comments else '' }}
 
-        {% if item.date %}
-          <div class="govuk-!-font-size-16">
-            {{ item.date | formatDateWithDay }}
+        {% if item.created_at %}
+          <div class="govuk-!-margin-top-2 govuk-!-font-size-16">
+            {{ item.created_at | formatDateWithDay }}
           </div>
         {% endif %}
       {% endset %}

--- a/common/components/_panel/_panel.scss
+++ b/common/components/_panel/_panel.scss
@@ -18,6 +18,6 @@ $_border-width: 2px;
   top: -($_border-width);
 
   & + * {
-    margin-top: govuk-spacing(3);
+    margin-top: govuk-spacing(4);
   }
 }

--- a/common/lib/api-client/models.js
+++ b/common/lib/api-client/models.js
@@ -52,6 +52,8 @@ function defineModels (jsonApi) {
   })
 
   jsonApi.define('assessment_question', {
+    created_at: '',
+    expires_at: '',
     key: '',
     title: '',
     category: '',


### PR DESCRIPTION
This change updates the assessment answers to use the new `created_at`
property the API now supports.

## What it looks like

### Before
![image](https://user-images.githubusercontent.com/3327997/61378441-502d7900-a89d-11e9-91d2-81747184d7e9.png)

### After
![image](https://user-images.githubusercontent.com/3327997/61378414-43108a00-a89d-11e9-934b-19539fced991.png)
