### PR TITLE
Extract development specific middleware out

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,3 +8,7 @@ AUTH_PROVIDER_KEY=
 AUTH_PROVIDER_SECRET=
 AUTH_PROVIDER_URL=
 SERVER_HOST=localhost:3000
+
+## Development only
+# BYPASS_SSO=true
+# USER_PERMISSIONS=moves:view:by_location,moves:download:by_location,move:view,move:create,move:cancel,moves:view:all,moves:download:all

--- a/README.md
+++ b/README.md
@@ -122,9 +122,17 @@ npm run lint
 | SERVER_HOST **(required)** | The (accessible) hostname (and port) of the listening web server. Used by [Grant](https://github.com/simov/grant) to construct redirect URLs after OAuth authentication. For example `localhost:3000` | |
 | FEEDBACK_URL | URL for the feedback link in the phase banner at the top of the page. If empty, the link will not be displayed. | |
 | CURRENT_LOCATION_UUID **(TEMPORARY)** | UUID of the current location to list and create moves for | |
-| BYPASS_SSO | Can be set to bypass SSO authentication. **Note:** Will only work if environment is also development | |
 | SENTRY_KEY | Sentry key | |
 | SENTRY_PROJECT | Sentry project ID | |
+
+### Development specific
+
+The following environment variables can be set to help development.
+
+| Name | Description | Default |
+|:-----|:------------|:--------|
+| BYPASS_SSO | Set to `true` to bypass authentication | |
+| USER_PERMISSIONS | Comma delimited string of available permissions (required if bypassing auth) | |
 
 ## Components
 

--- a/common/middleware/development.js
+++ b/common/middleware/development.js
@@ -1,0 +1,26 @@
+const { addDays, getTime } = require('date-fns')
+
+function bypassAuth (bypass) {
+  return (req, res, next) => {
+    if (bypass) {
+      const future = getTime(addDays(new Date(), 30))
+      req.session.authExpiry = Math.floor(future / 1000)
+    }
+    next()
+  }
+}
+
+function setUserPermissions (permissions) {
+  return (req, res, next) => {
+    if (permissions) {
+      req.session.user = req.session.user || {}
+      req.session.user.permissions = permissions.split(',')
+    }
+    next()
+  }
+}
+
+module.exports = {
+  bypassAuth,
+  setUserPermissions,
+}

--- a/common/middleware/development.test.js
+++ b/common/middleware/development.test.js
@@ -1,0 +1,123 @@
+const middleware = require('./development')
+
+describe('Development specific middleware', function () {
+  let nextSpy
+
+  beforeEach(function () {
+    nextSpy = sinon.spy()
+  })
+
+  describe('#bypassAuth()', function () {
+    let req
+
+    beforeEach(function () {
+      req = {
+        session: {},
+      }
+    })
+
+    context('when should not bypass', function () {
+      beforeEach(function () {
+        middleware.bypassAuth(false)(req, {}, nextSpy)
+      })
+
+      it('should not set auth expiry', function () {
+        expect(req.session).not.to.have.property('authExpiry')
+      })
+
+      it('should call next', function () {
+        expect(nextSpy).to.be.calledOnceWithExactly()
+      })
+    })
+
+    context('when should bypass', function () {
+      beforeEach(function () {
+        this.clock = sinon.useFakeTimers(new Date('2017-08-10').getTime())
+
+        middleware.bypassAuth(true)(req, {}, nextSpy)
+      })
+
+      afterEach(function () {
+        this.clock.restore()
+      })
+
+      it('should not set auth expiry 30 days in future', function () {
+        expect(req.session).to.have.property('authExpiry')
+        expect(req.session.authExpiry).to.equal(1504915200)
+      })
+
+      it('should call next', function () {
+        expect(nextSpy).to.be.calledOnceWithExactly()
+      })
+    })
+  })
+
+  describe('#setUserPermissions()', function () {
+    let req
+
+    beforeEach(function () {
+      req = {
+        session: {
+          user: {
+            permissions: [],
+          },
+        },
+      }
+    })
+
+    context('with permissions', function () {
+      beforeEach(function () {
+        middleware.setUserPermissions('one,two,three')(req, {}, nextSpy)
+      })
+
+      it('should update permissions', function () {
+        expect(req.session.user.permissions).to.deep.equal([
+          'one',
+          'two',
+          'three',
+        ])
+      })
+
+      it('should call next', function () {
+        expect(nextSpy).to.be.calledOnceWithExactly()
+      })
+    })
+
+    context('without permissions', function () {
+      beforeEach(function () {
+        middleware.setUserPermissions()(req, {}, nextSpy)
+      })
+
+      it('should not update permissions', function () {
+        expect(req.session.user.permissions).to.deep.equal([])
+      })
+
+      it('should call next', function () {
+        expect(nextSpy).to.be.calledOnceWithExactly()
+      })
+    })
+
+    context('when no user exists', function () {
+      beforeEach(function () {
+        req.session = {}
+        middleware.setUserPermissions('one,two,three')(req, {}, nextSpy)
+      })
+
+      it('should create a user', function () {
+        expect(req.session).to.have.property('user')
+      })
+
+      it('should set permissions', function () {
+        expect(req.session.user.permissions).to.deep.equal([
+          'one',
+          'two',
+          'three',
+        ])
+      })
+
+      it('should call next', function () {
+        expect(nextSpy).to.be.calledOnceWithExactly()
+      })
+    })
+  })
+})

--- a/common/middleware/ensure-authenticated.js
+++ b/common/middleware/ensure-authenticated.js
@@ -9,14 +9,9 @@ function _isExpired (authExpiry) {
 module.exports = function ensureAuthenticated ({
   provider,
   whitelist = [],
-  bypass,
 } = {}) {
   return (req, res, next) => {
-    if (
-      bypass ||
-      whitelist.includes(req.url) ||
-      !_isExpired(req.session.authExpiry)
-    ) {
+    if (whitelist.includes(req.url) || !_isExpired(req.session.authExpiry)) {
       return next()
     }
 

--- a/common/middleware/ensure-authenticated.test.js
+++ b/common/middleware/ensure-authenticated.test.js
@@ -87,19 +87,5 @@ describe('Authentication middleware', function () {
         expect(res.redirect).not.to.be.called
       })
     })
-
-    context('when bypass config is set', function () {
-      beforeEach(function () {
-        ensureAuthenticated({ provider, bypass: true })(req, res, nextSpy)
-      })
-
-      it('should call next', function () {
-        expect(nextSpy).to.be.calledOnceWithExactly()
-      })
-
-      it('should not redirect', function () {
-        expect(res.redirect).not.to.be.called
-      })
-    })
   })
 })

--- a/config/index.js
+++ b/config/index.js
@@ -55,6 +55,7 @@ module.exports = {
       ttl: SESSION.TTL / 1000, // convert nanoseconds to seconds
     },
   },
+  USER_PERMISSIONS: process.env.USER_PERMISSIONS,
   AUTH_BYPASS_SSO: process.env.BYPASS_SSO && IS_DEV,
   AUTH_WHITELIST_URLS: [
     '/auth',

--- a/server.js
+++ b/server.js
@@ -127,11 +127,16 @@ app.use(
     ...config.AUTH_PROVIDERS,
   })
 )
+// Development environment helpers
+if (config.IS_DEV) {
+  const development = require('./common/middleware/development')
+  app.use(development.bypassAuth(config.AUTH_BYPASS_SSO))
+  app.use(development.setUserPermissions(config.USER_PERMISSIONS))
+}
 app.use(
   ensureAuthenticated({
     provider: config.DEFAULT_AUTH_PROVIDER,
     whitelist: config.AUTH_WHITELIST_URLS,
-    bypass: config.AUTH_BYPASS_SSO,
   })
 )
 app.use(helmet())


### PR DESCRIPTION
This change moves setting of certain conditions for development
only purposes into its own middleware.

The main functions are to bypass authentication and to set user
permissions for development purposes.

This will be used to improve how we bypass routes in #131 