### PR TITLE
Display a different list template based on permissions

### DIFF
--- a/app/move/controllers/cancel.js
+++ b/app/move/controllers/cancel.js
@@ -16,7 +16,7 @@ module.exports = {
         }),
       })
 
-      res.redirect('/moves')
+      res.redirect('/')
     } catch (error) {
       next(error)
     }

--- a/app/move/controllers/cancel.test.js
+++ b/app/move/controllers/cancel.test.js
@@ -56,7 +56,7 @@ describe('Move controllers', function () {
       })
 
       it('should redirect correctly', function () {
-        expect(res.redirect).to.be.calledOnceWithExactly('/moves')
+        expect(res.redirect).to.be.calledOnceWithExactly('/')
       })
 
       it('should not call next', function () {

--- a/app/move/views/view.njk
+++ b/app/move/views/view.njk
@@ -12,7 +12,7 @@
   {{ govukBackLink({
     text: t("actions:back_to_dashboard"),
     classes: "app-print--hide",
-    href: "/moves"
+    href: "/"
   }) }}
 
   <a href="javascript:window.print()" class="app-!-float-right app-print--hide govuk-!-margin-top-3">

--- a/app/moves/controllers/list.js
+++ b/app/moves/controllers/list.js
@@ -1,12 +1,19 @@
 const { format, addDays, subDays } = require('date-fns')
+const { get } = require('lodash')
 
 const { getQueryString } = require('../../../common/lib/request')
+const permissions = require('../../../common/middleware/permissions')
 const presenters = require('../../../common/presenters')
 
 module.exports = function list (req, res) {
   const { moveDate, movesByDate } = res.locals
   const yesterday = format(subDays(moveDate, 1), 'YYYY-MM-DD')
   const tomorrow = format(addDays(moveDate, 1), 'YYYY-MM-DD')
+  const canViewMove = permissions.check(
+    'move:view',
+    get(req.session, 'user.permissions')
+  )
+  const template = canViewMove ? 'moves/views/list' : 'moves/views/download'
   const locals = {
     pageTitle: 'moves:dashboard.upcoming_moves',
     destinations: presenters.movesByToLocation(movesByDate),
@@ -20,5 +27,5 @@ module.exports = function list (req, res) {
     },
   }
 
-  res.render('moves/views/list', locals)
+  res.render(template, locals)
 }

--- a/app/moves/views/_layout.njk
+++ b/app/moves/views/_layout.njk
@@ -1,0 +1,43 @@
+{% extends "layouts/govuk.njk" %}
+
+{% block pageTitle %}
+  {{ t(pageTitle, {
+    date: moveDate | formatDateAsRelativeDay
+  }) }}
+{% endblock %}
+
+{% block content %}
+
+  {% block pageHeader %}
+    <header class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <span class="govuk-caption-xl">{{ t(pageTitle) }}</span>
+        <h1 class="govuk-heading-xl govuk-!-margin-bottom-2">
+          {{ appTime({
+            datetime: moveDate,
+            text: moveDate | formatDateAsRelativeDay
+          }) }}
+        </h1>
+
+        {{ appPagination({
+          classes: "app-pagination--inline app-print--hide",
+          previous: {
+            href: pagination.prevUrl,
+            text: t("actions:previous_day")
+          },
+          next: {
+            href: pagination.nextUrl,
+            text: t("actions:next_day")
+          }
+        }) }}
+
+        {% block headerActions %}{% endblock %}
+      </div>
+
+      {% block headerNav %}{% endblock %}
+    </header>
+  {% endblock %}
+
+  {% block pageContent %}{% endblock %}
+
+{% endblock %}

--- a/app/moves/views/download.njk
+++ b/app/moves/views/download.njk
@@ -1,0 +1,11 @@
+{% extends "./_layout.njk" %}
+
+{% block pageContent %}
+  {% if canAccess('moves:download:all') or canAccess('moves:download:by_location') %}
+    {{ govukButton({
+      text: t("actions:download"),
+      href: ORIGINAL_PATH + "/download.csv?move-date=" + moveDate,
+      classes: "govuk-button--start govuk-!-margin-top-2 app-print--hide"
+    }) }}
+  {% endif %}
+{% endblock %}

--- a/app/moves/views/list.njk
+++ b/app/moves/views/list.njk
@@ -1,4 +1,4 @@
-{% extends "layouts/govuk.njk" %}
+{% extends "./_layout.njk" %}
 
 {% block pageTitle %}
   {{ t(pageTitle, {
@@ -6,58 +6,37 @@
   }) }}
 {% endblock %}
 
-{% block content %}
+{% block headerActions %}
+  {% if canAccess('move:create') %}
+    {{ govukButton({
+      text: t("actions:create_move"),
+      href: "/move/new",
+      classes: "govuk-button--start govuk-!-margin-top-2 app-print--hide"
+    }) }}
+  {% endif %}
+{% endblock %}
 
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      <span class="govuk-caption-xl">{{ t(pageTitle) }}</span>
-      <h1 class="govuk-heading-xl govuk-!-margin-bottom-2">
-        {{ appTime({
-          datetime: moveDate,
-          text: moveDate | formatDateAsRelativeDay
-        }) }}
-      </h1>
-
-      {{ appPagination({
-        classes: "app-pagination--inline app-print--hide",
-        previous: {
-          href: pagination.prevUrl,
-          text: t("actions:previous_day")
-        },
-        next: {
-          href: pagination.nextUrl,
-          text: t("actions:next_day")
-        }
-      }) }}
-
-      {% if canAccess('move:create') %}
-        {{ govukButton({
-          text: t("actions:create_move"),
-          href: "/move/new",
-          classes: "govuk-button--start govuk-!-margin-top-2 app-print--hide"
-        }) }}
-      {% endif %}
-    </div>
-
-    <div class="govuk-grid-column-one-third">
-      <ul class="govuk-list govuk-!-font-size-16 app-!-float-right app-print--hide">
-        {% if canAccess('moves:download:all') or canAccess('moves:download:by_location') %}
-          <li>
-            <a href="{{ ORIGINAL_PATH }}/download.csv?move-date={{ moveDate }}">
-              {{ t("actions:download_csv") }}
-            </a>
-          </li>
-        {% endif %}
-
+{% block headerNav %}
+  <div class="govuk-grid-column-one-third">
+    <ul class="govuk-list govuk-!-font-size-16 app-!-float-right app-print--hide">
+      {% if canAccess('moves:download:all') or canAccess('moves:download:by_location') %}
         <li>
-          <a href="javascript:window.print()">
-            {{ t("actions:print_move_list") }}
+          <a href="{{ ORIGINAL_PATH }}/download.csv?move-date={{ moveDate }}">
+            {{ t("actions:download_csv") }}
           </a>
         </li>
-      </ul>
-    </div>
-  </div>
+      {% endif %}
 
+      <li>
+        <a href="javascript:window.print()">
+          {{ t("actions:print_move_list") }}
+        </a>
+      </li>
+    </ul>
+  </div>
+{% endblock %}
+
+{% block pageContent %}
   {% for destination in destinations %}
     <div class="
       govuk-!-margin-top-7
@@ -78,5 +57,4 @@
       {% endfor %}
     </div>
   {% endfor %}
-
 {% endblock %}

--- a/locales/en/actions.json
+++ b/locales/en/actions.json
@@ -10,6 +10,7 @@
   "restart": "Restart",
   "cancel_move": "Cancel this move",
   "cancel_move_confirmation": "Cancel move",
+  "download": "Download moves",
   "download_csv": "Download moves (.csv)",
   "print_move_list": "Print moves",
   "print_move_detail": "Print move",


### PR DESCRIPTION
This change accomdates the supplier role where they cannot view
individual moves. If that permission is missing it renders an
alternative template without the list of moves.

## What it looks like

### Supplier user dashboard

![localhost_3000_moves (1)](https://user-images.githubusercontent.com/3327997/61449450-e10f5d80-a94c-11e9-81e9-463091ecb7f0.png)

### Police user dashboard

![localhost_3000_moves_c249ed09-0cd5-4f52-8aee-0506e2dc7579](https://user-images.githubusercontent.com/3327997/61449778-8f1b0780-a94d-11e9-9af1-1885aa9b522f.png)
