### PR TITLE
Catch missing authorities property on auth token

### DIFF
--- a/common/lib/user.js
+++ b/common/lib/user.js
@@ -1,7 +1,8 @@
 function User (token) {
   const permissions = []
+  const authorities = token.authorities || []
 
-  if (token.authorities.includes('ROLE_PECS_POLICE')) {
+  if (authorities.includes('ROLE_PECS_POLICE')) {
     permissions.push(
       ...[
         'moves:view:by_location',
@@ -13,7 +14,7 @@ function User (token) {
     )
   }
 
-  if (token.authorities.includes('ROLE_PECS_SUPPLIER')) {
+  if (authorities.includes('ROLE_PECS_SUPPLIER')) {
     permissions.push(...['moves:view:all', 'moves:download:all'])
   }
 

--- a/common/lib/user.test.js
+++ b/common/lib/user.test.js
@@ -1,6 +1,26 @@
 const User = require('./user')
 
 describe('User class', function () {
+  context('when user has no authorities', function () {
+    let user
+
+    beforeEach(function () {
+      user = new User({
+        user_name: 'Testuser',
+      })
+    })
+
+    it('should contain a username', function () {
+      expect(user).to.have.property('userName')
+      expect(user.userName).to.equal('Testuser')
+    })
+
+    it('should contain empty permissions', function () {
+      expect(user).to.have.property('permissions')
+      expect(user.permissions).to.deep.equal([])
+    })
+  })
+
   context('when user has ROLE_PECS_POLICE', function () {
     let user
 


### PR DESCRIPTION
When an auth token is returned from the current auth provider (HMPPS SSO)
and that user doesn't have a role assocaited with it, there will be
no `authorities` property on the token.

When the user is missing this property the User class would throw an
error as it expected it to exist.

This fix will set a default value if that property doesn't exist and
return an empty permissions array.