### PR TITLE
[P4-353] Add locations to the user object

### DIFF
--- a/app/auth/index.js
+++ b/app/auth/index.js
@@ -4,10 +4,11 @@ const router = require('express').Router()
 // Local dependencies
 const { redirect, signOut } = require('./controllers')
 const { processAuthResponse } = require('./middleware')
+const { CURRENT_LOCATION_UUID } = require('../../config')
 
 // Define routes
 router.get('/', redirect)
-router.get('/callback', processAuthResponse, redirect)
+router.get('/callback', processAuthResponse([CURRENT_LOCATION_UUID]), redirect)
 router.get('/sign-out', signOut)
 
 // Export

--- a/app/auth/middleware.js
+++ b/app/auth/middleware.js
@@ -1,30 +1,41 @@
 const User = require('../../common/lib/user')
+const referenceData = require('../../common/services/reference-data')
 
 function _decodeAccessToken (token) {
   const payload = token.split('.')[1]
   return JSON.parse(Buffer.from(payload, 'base64').toString('utf8'))
 }
 
-function processAuthResponse (req, res, next) {
-  const { grant, postAuthRedirect } = req.session
+function processAuthResponse (defaultLocations = []) {
+  return async function middleware (req, res, next) {
+    const { grant, postAuthRedirect } = req.session
 
-  if (!grant) {
-    return next()
-  }
-
-  req.session.regenerate(error => {
-    if (error) {
-      return next(error)
+    if (!grant) {
+      return next()
     }
 
-    const accessToken = _decodeAccessToken(grant.response.access_token)
+    try {
+      const accessToken = _decodeAccessToken(grant.response.access_token)
+      const locations = await referenceData.getLocationsById(defaultLocations)
 
-    req.session.authExpiry = accessToken.exp
-    req.session.postAuthRedirect = postAuthRedirect
-    req.session.user = new User(accessToken)
+      req.session.regenerate(error => {
+        if (error) {
+          return next(error)
+        }
 
-    next()
-  })
+        req.session.authExpiry = accessToken.exp
+        req.session.postAuthRedirect = postAuthRedirect
+        req.session.user = new User({
+          ...accessToken,
+          locations,
+        })
+
+        next()
+      })
+    } catch (error) {
+      next(error)
+    }
+  }
 }
 
 module.exports = {

--- a/app/auth/middleware.test.js
+++ b/app/auth/middleware.test.js
@@ -1,5 +1,7 @@
 const proxyquire = require('proxyquire')
 
+const referenceDataService = require('../../common/services/reference-data')
+
 function UserStub (token) {
   this.user_name = token.user_name
 }
@@ -16,6 +18,17 @@ const payload = {
   exp: expiryTime,
 }
 const encodedPayload = Buffer.from(JSON.stringify(payload)).toString('base64')
+const mockLocations = [
+  {
+    id: '1111',
+  },
+  {
+    id: '2222',
+  },
+  {
+    id: '3333',
+  },
+]
 
 describe('Authentication middleware', function () {
   describe('#processAuthResponse', function () {
@@ -34,7 +47,7 @@ describe('Authentication middleware', function () {
 
     context('when there is no grant response', function () {
       beforeEach(function () {
-        authentication.processAuthResponse(req, {}, nextSpy)
+        authentication.processAuthResponse()(req, {}, nextSpy)
       })
 
       it('returns next', function () {
@@ -48,6 +61,7 @@ describe('Authentication middleware', function () {
 
     context('when there is a grant response', function () {
       beforeEach(function () {
+        sinon.stub(referenceDataService, 'getLocationsById')
         req.session.grant = {
           response: {
             access_token: `test.${encodedPayload}.test`,
@@ -55,52 +69,110 @@ describe('Authentication middleware', function () {
         }
       })
 
-      context('when session regeneration throws an error', function () {
+      context('when getLocationsById rejects', function () {
         const errorMock = new Error('Session Error')
 
-        beforeEach(function () {
-          req.session.regenerate = callback => callback(errorMock)
-          authentication.processAuthResponse(req, {}, nextSpy)
+        beforeEach(async function () {
+          referenceDataService.getLocationsById.rejects(errorMock)
+
+          await authentication.processAuthResponse()(req, {}, nextSpy)
         })
 
-        it('should call next with error', function () {
-          expect(nextSpy).to.be.calledOnceWithExactly(errorMock)
+        it('call next with error', function () {
+          expect(nextSpy).to.be.calledOnce
+          expect(nextSpy.args[0][0] instanceof Error).to.be.true
+          expect(nextSpy.args[0][0].message).to.equal('Session Error')
+        })
+
+        it("doesn't regenerate the session", function () {
+          expect(req.session.regenerate).not.to.be.called
         })
       })
 
-      context('when session regenerates successfully', function () {
+      context('when getLocationsById resolves', function () {
         beforeEach(function () {
-          // Stub the express-session #regenerate function which takes a callback
-          req.session.regenerate = callback => {
-            req.session = {
-              id: '456',
-            }
-            callback()
-          }
-
-          authentication.processAuthResponse(req, {}, nextSpy)
+          referenceDataService.getLocationsById.resolves(mockLocations)
         })
 
-        it('regenerates the session', function () {
-          expect(req.session.id).to.equal('456')
-        })
+        context('when session regeneration throws an error', function () {
+          const errorMock = new Error('Session Error')
 
-        it('sets the auth expiry time on the session', function () {
-          expect(req.session.authExpiry).to.equal(expiryTime)
-        })
+          beforeEach(async function () {
+            req.session.regenerate = callback => callback(errorMock)
+            await authentication.processAuthResponse()(req, {}, nextSpy)
+          })
 
-        it('sets the user info on the session', function () {
-          expect(req.session.user).to.deep.equal({
-            user_name: payload.user_name,
+          it('should call next with error', function () {
+            expect(nextSpy).to.be.calledOnceWithExactly(errorMock)
           })
         })
 
-        it('sets the redirect URL in the session', function () {
-          expect(req.session.postAuthRedirect).to.equal('/test')
+        context('when default locations are set', function () {
+          const locations = ['1', '2', '3']
+
+          beforeEach(async function () {
+            await authentication.processAuthResponse(
+              locations
+            )(req, {}, nextSpy)
+          })
+
+          it('should call reference data with locations', function () {
+            expect(
+              referenceDataService.getLocationsById
+            ).to.be.calledWithExactly(locations)
+          })
         })
 
-        it('calls the next action', function () {
-          expect(nextSpy).to.be.calledOnceWithExactly()
+        context('when no default locations are set', function () {
+          beforeEach(async function () {
+            await authentication.processAuthResponse()(req, {}, nextSpy)
+          })
+
+          it('should call reference with empty array', function () {
+            expect(
+              referenceDataService.getLocationsById
+            ).to.be.calledWithExactly([])
+          })
+        })
+
+        context('when session regenerates successfully', function () {
+          let user
+
+          beforeEach(async function () {
+            // Stub the express-session #regenerate function which takes a callback
+            req.session.regenerate = callback => {
+              req.session = {
+                id: '456',
+              }
+              callback()
+            }
+
+            user = new UserStub({
+              user_name: payload.user_name,
+            })
+
+            await authentication.processAuthResponse()(req, {}, nextSpy)
+          })
+
+          it('regenerates the session', function () {
+            expect(req.session.id).to.equal('456')
+          })
+
+          it('sets the auth expiry time on the session', function () {
+            expect(req.session.authExpiry).to.equal(expiryTime)
+          })
+
+          it('sets the user info on the session', function () {
+            expect(req.session.user).to.deep.equal(user)
+          })
+
+          it('sets the redirect URL in the session', function () {
+            expect(req.session.postAuthRedirect).to.equal('/test')
+          })
+
+          it('calls the next action', function () {
+            expect(nextSpy).to.be.calledOnceWithExactly()
+          })
         })
       })
     })

--- a/common/lib/user.js
+++ b/common/lib/user.js
@@ -1,25 +1,31 @@
-function User (token) {
-  const permissions = []
-  const authorities = token.authorities || []
-
-  if (authorities.includes('ROLE_PECS_POLICE')) {
-    permissions.push(
-      ...[
-        'moves:view:by_location',
-        'moves:download:by_location',
-        'move:view',
-        'move:create',
-        'move:cancel',
-      ]
-    )
-  }
-
-  if (authorities.includes('ROLE_PECS_SUPPLIER')) {
-    permissions.push(...['moves:view:all', 'moves:download:all'])
-  }
-
+function User (token = {}) {
   this.userName = token.user_name
-  this.permissions = permissions
+  this.locations = token.locations || []
+  this.permissions = this.getPermissions(token.authorities)
+}
+
+User.prototype = {
+  getPermissions (authorities = []) {
+    const permissions = []
+
+    if (authorities.includes('ROLE_PECS_POLICE')) {
+      permissions.push(
+        ...[
+          'moves:view:by_location',
+          'moves:download:by_location',
+          'move:view',
+          'move:create',
+          'move:cancel',
+        ]
+      )
+    }
+
+    if (authorities.includes('ROLE_PECS_SUPPLIER')) {
+      permissions.push(...['moves:view:all', 'moves:download:all'])
+    }
+
+    return permissions
+  },
 }
 
 module.exports = User

--- a/common/lib/user.test.js
+++ b/common/lib/user.test.js
@@ -1,106 +1,136 @@
 const User = require('./user')
 
 describe('User class', function () {
-  context('when user has no authorities', function () {
+  describe('when instantiated', function () {
     let user
 
-    beforeEach(function () {
-      user = new User({
-        user_name: 'Testuser',
-      })
-    })
-
-    it('should contain a username', function () {
-      expect(user).to.have.property('userName')
-      expect(user.userName).to.equal('Testuser')
-    })
-
-    it('should contain empty permissions', function () {
-      expect(user).to.have.property('permissions')
-      expect(user.permissions).to.deep.equal([])
-    })
-  })
-
-  context('when user has ROLE_PECS_POLICE', function () {
-    let user
-
-    beforeEach(function () {
-      user = new User({
-        user_name: 'Testuser',
-        authorities: ['ROLE_PECS_POLICE'],
-      })
-    })
-
-    it('should contain a username', function () {
-      expect(user).to.have.property('userName')
-      expect(user.userName).to.equal('Testuser')
-    })
-
-    it('should contain correct permission', function () {
-      expect(user).to.have.property('permissions')
-      expect(user.permissions).to.deep.equal([
-        'moves:view:by_location',
-        'moves:download:by_location',
-        'move:view',
-        'move:create',
-        'move:cancel',
-      ])
-    })
-  })
-
-  context('when user has ROLE_PECS_SUPPLIER role', function () {
-    let user
-
-    beforeEach(function () {
-      user = new User({
-        user_name: 'Testuser',
-        authorities: ['ROLE_PECS_SUPPLIER'],
-      })
-    })
-
-    it('should contain a username', function () {
-      expect(user).to.have.property('userName')
-      expect(user.userName).to.equal('Testuser')
-    })
-
-    it('should contain correct permission', function () {
-      expect(user).to.have.property('permissions')
-      expect(user.permissions).to.deep.equal([
-        'moves:view:all',
-        'moves:download:all',
-      ])
-    })
-  })
-
-  context(
-    'when user has both ROLE_PECS_POLICE and ROLE_PECS_SUPPLIER roles',
-    function () {
-      let user
-
-      beforeEach(function () {
+    context('with username', function () {
+      it('should set username', function () {
         user = new User({
-          user_name: 'Testuser',
-          authorities: ['ROLE_PECS_POLICE', 'ROLE_PECS_SUPPLIER'],
+          user_name: 'USERNAME',
         })
+
+        expect(user.userName).to.equal('USERNAME')
+      })
+    })
+
+    context('without username', function () {
+      it('should not set username', function () {
+        user = new User()
+
+        expect(user.userName).to.equal(undefined)
+      })
+    })
+
+    context('with authorities', function () {
+      beforeEach(function () {
+        sinon.stub(User.prototype, 'getPermissions').returnsArg(0)
       })
 
-      it('should contain a username', function () {
-        expect(user).to.have.property('userName')
-        expect(user.userName).to.equal('Testuser')
+      it('should set permissions', function () {
+        user = new User({
+          authorities: ['ROLE_SUPPLIER'],
+        })
+
+        expect(user.permissions).to.deep.equal(['ROLE_SUPPLIER'])
+      })
+    })
+
+    context('without authorities', function () {
+      it('should not set permissions to empty array', function () {
+        user = new User()
+
+        expect(user.permissions).to.deep.equal([])
+      })
+    })
+
+    context('with locations', function () {
+      it('should set locations', function () {
+        user = new User({
+          locations: ['111', '222'],
+        })
+
+        expect(user.locations).to.deep.equal(['111', '222'])
+      })
+    })
+
+    context('without locations', function () {
+      it('should set locations to empty array', function () {
+        user = new User()
+
+        expect(user.locations).to.deep.equal([])
+      })
+    })
+  })
+
+  describe('#getPermissions()', function () {
+    let user, permissions
+
+    beforeEach(function () {
+      user = new User()
+    })
+
+    context('when user has no authorities', function () {
+      beforeEach(function () {
+        permissions = user.getPermissions()
+      })
+
+      it('should contain empty permissions', function () {
+        expect(permissions).to.deep.equal([])
+      })
+    })
+
+    context('when user has ROLE_PECS_POLICE', function () {
+      beforeEach(function () {
+        permissions = user.getPermissions(['ROLE_PECS_POLICE'])
       })
 
       it('should contain correct permission', function () {
-        expect(user).to.have.property('permissions')
-        expect(user.permissions).to.deep.equal([
+        expect(permissions).to.deep.equal([
           'moves:view:by_location',
           'moves:download:by_location',
           'move:view',
           'move:create',
           'move:cancel',
+        ])
+      })
+    })
+
+    context('when user has ROLE_PECS_SUPPLIER role', function () {
+      beforeEach(function () {
+        permissions = user.getPermissions(['ROLE_PECS_SUPPLIER'])
+      })
+
+      it('should contain correct permission', function () {
+        expect(permissions).to.deep.equal([
           'moves:view:all',
           'moves:download:all',
         ])
       })
-    }
-  )
+    })
+
+    context(
+      'when user has both ROLE_PECS_POLICE and ROLE_PECS_SUPPLIER roles',
+      function () {
+        beforeEach(function () {
+          permissions = user.getPermissions([
+            'ROLE_PECS_POLICE',
+            'ROLE_PECS_SUPPLIER',
+          ])
+        })
+
+        it('should contain correct permission', function () {
+          expect(permissions).to.deep.equal([
+            'moves:view:by_location',
+            'moves:download:by_location',
+            'move:view',
+            'move:create',
+            'move:cancel',
+            'moves:view:all',
+            'moves:download:all',
+          ])
+        })
+      }
+    )
+  })
 })

--- a/common/services/reference-data.js
+++ b/common/services/reference-data.js
@@ -3,15 +3,11 @@ const { flattenDeep, sortBy } = require('lodash')
 const apiClient = require('../lib/api-client')
 
 function getGenders () {
-  return apiClient
-    .findAll('gender')
-    .then(response => response.data)
+  return apiClient.findAll('gender').then(response => response.data)
 }
 
 function getEthnicities () {
-  return apiClient
-    .findAll('ethnicity')
-    .then(response => response.data)
+  return apiClient.findAll('ethnicity').then(response => response.data)
 }
 
 function getAssessmentQuestions (category) {
@@ -23,26 +19,38 @@ function getAssessmentQuestions (category) {
 }
 
 function getLocations (type, combinedData, page = 1) {
-  return apiClient.findAll('location', {
-    page,
-    per_page: 100,
-    'filter[location_type]': type,
-  }).then((response) => {
-    const { data, links } = response
-    const locations = combinedData ? flattenDeep([combinedData, ...response.data]) : data
+  return apiClient
+    .findAll('location', {
+      page,
+      per_page: 100,
+      'filter[location_type]': type,
+    })
+    .then(response => {
+      const { data, links } = response
+      const locations = combinedData
+        ? flattenDeep([combinedData, ...response.data])
+        : data
 
-    if (!links.next) {
-      return sortBy(locations, 'title')
-    }
+      if (!links.next) {
+        return sortBy(locations, 'title')
+      }
 
-    return getLocations(type, locations, page + 1)
-  })
+      return getLocations(type, locations, page + 1)
+    })
 }
 
 function getLocationById (id) {
-  return apiClient
-    .find('location', id)
-    .then(response => response.data)
+  return apiClient.find('location', id).then(response => response.data)
+}
+
+function getLocationsById (locations = []) {
+  const locationPromises = locations.map(locationId => {
+    return getLocationById(locationId).catch(() => false)
+  })
+
+  return Promise.all(locationPromises).then(locations =>
+    locations.filter(Boolean)
+  )
 }
 
 module.exports = {
@@ -51,4 +59,5 @@ module.exports = {
   getAssessmentQuestions,
   getLocations,
   getLocationById,
+  getLocationsById,
 }

--- a/common/services/reference-data.test.js
+++ b/common/services/reference-data.test.js
@@ -4,6 +4,7 @@ const {
   getAssessmentQuestions,
   getLocations,
   getLocationById,
+  getLocationsById,
 } = require('./reference-data')
 const { API } = require('../../config')
 const auth = require('../lib/api-client/auth')
@@ -151,6 +152,82 @@ describe('Reference Service', function () {
 
       it('should contain location with correct data', function () {
         expect(location).to.deep.equal(locationDeserialized.data)
+      })
+    })
+  })
+
+  describe('#getLocationsById()', function () {
+    context('when request returns 200', function () {
+      let locations
+
+      beforeEach(async function () {
+        nock(API.BASE_URL)
+          .get(`/reference/locations/1`)
+          .reply(200, locationSerialized)
+        nock(API.BASE_URL)
+          .get(`/reference/locations/2`)
+          .reply(200, locationSerialized)
+        nock(API.BASE_URL)
+          .get(`/reference/locations/3`)
+          .reply(200, locationSerialized)
+
+        locations = await getLocationsById(['1', '2', '3'])
+      })
+
+      it('should get location from API', function () {
+        expect(nock.isDone()).to.be.true
+      })
+
+      it('should contain location with correct data', function () {
+        expect(locations).to.deep.equal([
+          locationDeserialized.data,
+          locationDeserialized.data,
+          locationDeserialized.data,
+        ])
+      })
+    })
+
+    context('when locations are not found', function () {
+      let locations
+
+      beforeEach(async function () {
+        nock(API.BASE_URL)
+          .get(`/reference/locations/1`)
+          .reply(200, locationSerialized)
+        nock(API.BASE_URL)
+          .get(`/reference/locations/2`)
+          .reply(404, {})
+        nock(API.BASE_URL)
+          .get(`/reference/locations/3`)
+          .reply(200, locationSerialized)
+        nock(API.BASE_URL)
+          .get(`/reference/locations/4`)
+          .reply(404, {})
+
+        locations = await getLocationsById(['1', '2', '3', '4'])
+      })
+
+      it('should get location from API', function () {
+        expect(nock.isDone()).to.be.true
+      })
+
+      it('should filter out locations', function () {
+        expect(locations).to.deep.equal([
+          locationDeserialized.data,
+          locationDeserialized.data,
+        ])
+      })
+    })
+
+    context('when called with empty locations', function () {
+      let locations
+
+      beforeEach(async function () {
+        locations = await getLocationsById()
+      })
+
+      it('should return empty array', function () {
+        expect(locations).to.deep.equal([])
       })
     })
   })


### PR DESCRIPTION
This change extends the user class to set the locations available
to that user on the user session object.

This PR is a precursor to some future changes:
- ensure user can access location being viewed
- if user only has access to only one location, default to that location
- if user has access to multiple locations, allow them to choose