### PR TITLE
 Move permissions redirect to moves feature

### DIFF
--- a/app/home/controllers.js
+++ b/app/home/controllers.js
@@ -1,23 +1,5 @@
-const { get } = require('lodash')
-
-const permissions = require('../../common/middleware/permissions')
-
-function home (req, res, next) {
-  const userPermissions = get(req.session, 'user.permissions')
-  const currentLocation = get(req.session, 'currentLocation.id')
-
-  if (permissions.check('moves:view:all', userPermissions)) {
-    return res.redirect('/moves')
-  }
-
-  if (
-    permissions.check('moves:view:by_location', userPermissions) &&
-    currentLocation
-  ) {
-    return res.redirect(`/moves/${currentLocation}`)
-  }
-
-  next()
+function home (req, res) {
+  return res.redirect('/moves')
 }
 
 module.exports = {

--- a/app/home/controllers.test.js
+++ b/app/home/controllers.test.js
@@ -1,105 +1,14 @@
 const { home } = require('./controllers')
 
-const permissions = require('../../common/middleware/permissions')
+const res = {
+  redirect: sinon.stub(),
+}
 
 describe('Home controllers', function () {
   describe('#home()', function () {
-    let req, res, nextSpy
-
-    beforeEach(function () {
-      sinon.stub(permissions, 'check')
-      nextSpy = sinon.spy()
-      req = {}
-      res = {
-        redirect: sinon.stub(),
-      }
-    })
-
-    context('when user has view all moves permission', function () {
-      beforeEach(function () {
-        req.session = {
-          user: {
-            permissions: ['moves:view:all'],
-          },
-        }
-
-        permissions.check
-          .withArgs('moves:view:all', ['moves:view:all'])
-          .returns(true)
-
-        home(req, res, nextSpy)
-      })
-
-      it('should redirect to all moves', function () {
-        expect(res.redirect).to.have.been.calledOnceWithExactly('/moves')
-      })
-
-      it('should not call next', function () {
-        expect(nextSpy).not.to.have.been.called
-      })
-    })
-
-    context('when user has view by location permission', function () {
-      beforeEach(function () {
-        req.session = {
-          user: {
-            permissions: ['moves:view:by_location'],
-          },
-        }
-
-        permissions.check
-          .withArgs('moves:view:by_location', ['moves:view:by_location'])
-          .returns(true)
-      })
-
-      context('when current location exists', function () {
-        const mockLocationId = 'c249ed09-0cd5-4f52-8aee-0506e2dc7579'
-
-        beforeEach(function () {
-          req.session.currentLocation = {
-            id: mockLocationId,
-          }
-          home(req, res, nextSpy)
-        })
-
-        it('should redirect to moves by location', function () {
-          expect(res.redirect).to.have.been.calledOnceWithExactly(
-            `/moves/${mockLocationId}`
-          )
-        })
-
-        it('should not call next', function () {
-          expect(nextSpy).not.to.have.been.called
-        })
-      })
-
-      context('when current location is missing', function () {
-        beforeEach(function () {
-          home(req, res, nextSpy)
-        })
-
-        it('should not redirect', function () {
-          expect(res.redirect).not.to.have.been.called
-        })
-
-        it('should call next', function () {
-          expect(nextSpy).to.have.been.calledOnceWithExactly()
-        })
-      })
-    })
-
-    context('when user has no matching permissions', function () {
-      beforeEach(function () {
-        home(req, res, nextSpy)
-      })
-
-      it('should not redirect', function () {
-        expect(res.redirect).not.to.have.been.called
-      })
-
-      it('should call next', function () {
-        expect(nextSpy).to.have.been.calledOnceWithExactly()
-      })
+    it('should redirect to moves feature', function () {
+      home({}, res)
+      expect(res.redirect).to.have.been.calledOnceWithExactly('/moves')
     })
   })
 })

--- a/app/move/controllers/cancel.js
+++ b/app/move/controllers/cancel.js
@@ -16,7 +16,7 @@ module.exports = {
         }),
       })
 
-      res.redirect('/')
+      res.redirect('/moves')
     } catch (error) {
       next(error)
     }

--- a/app/move/controllers/cancel.test.js
+++ b/app/move/controllers/cancel.test.js
@@ -56,7 +56,7 @@ describe('Move controllers', function () {
       })
 
       it('should redirect correctly', function () {
-        expect(res.redirect).to.be.calledOnceWithExactly('/')
+        expect(res.redirect).to.be.calledOnceWithExactly('/moves')
       })
 
       it('should not call next', function () {

--- a/app/move/controllers/new.save.js
+++ b/app/move/controllers/new.save.js
@@ -44,7 +44,7 @@ class SaveController extends FormController {
       }),
     })
 
-    res.redirect('/')
+    res.redirect('/moves')
   }
 }
 

--- a/app/move/controllers/new.save.test.js
+++ b/app/move/controllers/new.save.test.js
@@ -167,7 +167,7 @@ describe('Move controllers', function () {
 
       it('should redirect correctly', function () {
         expect(res.redirect).to.have.been.calledOnce
-        expect(res.redirect).to.have.been.calledWith('/')
+        expect(res.redirect).to.have.been.calledWith('/moves')
       })
     })
   })

--- a/app/move/views/view.njk
+++ b/app/move/views/view.njk
@@ -12,7 +12,7 @@
   {{ govukBackLink({
     text: t("actions:back_to_dashboard"),
     classes: "app-print--hide",
-    href: "/"
+    href: "/moves"
   }) }}
 
   <a href="javascript:window.print()" class="app-!-float-right app-print--hide govuk-!-margin-top-3">

--- a/app/moves/index.js
+++ b/app/moves/index.js
@@ -4,7 +4,12 @@ const router = require('express').Router()
 // Local dependencies
 const { protectRoute } = require('../../common/middleware/permissions')
 const { download, list } = require('./controllers')
-const { setMoveDate, setFromLocation, setMovesByDate } = require('./middleware')
+const {
+  redirectUsers,
+  setMoveDate,
+  setFromLocation,
+  setMovesByDate,
+} = require('./middleware')
 
 const uuidRegex =
   '[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}'
@@ -14,7 +19,13 @@ router.param('locationId', setFromLocation)
 
 // Define routes
 router.use(setMoveDate)
-router.get('/', protectRoute('moves:view:all'), setMovesByDate, list)
+router.get(
+  '/',
+  redirectUsers,
+  protectRoute('moves:view:all'),
+  setMovesByDate,
+  list
+)
 router.get(
   `/:locationId(${uuidRegex})`,
   protectRoute('moves:view:by_location'),

--- a/app/moves/middleware.js
+++ b/app/moves/middleware.js
@@ -1,8 +1,27 @@
 const { format } = require('date-fns')
+const { get } = require('lodash')
 
 const moveService = require('../../common/services/move')
+const permissions = require('../../common/middleware/permissions')
 
 module.exports = {
+  redirectUsers: (req, res, next) => {
+    const userPermissions = get(req.session, 'user.permissions')
+    const currentLocation = get(req.session, 'currentLocation.id')
+
+    if (permissions.check('moves:view:all', userPermissions)) {
+      return next()
+    }
+
+    if (
+      permissions.check('moves:view:by_location', userPermissions) &&
+      currentLocation
+    ) {
+      return res.redirect(`/moves/${currentLocation}`)
+    }
+
+    next()
+  },
   setMoveDate: (req, res, next) => {
     res.locals.moveDate =
       req.query['move-date'] || format(new Date(), 'YYYY-MM-DD')


### PR DESCRIPTION
This change moves the logic that determines where to redirect a
user based on their permissions to the moves feature folder rather
than the route.

The current logic meant that a user could sign in with no permissions
and would see a `404` at the route so wouldn't necessarily know its
a permission issue.

Moving to the moves feature folder will have a user fallback to the
protectRoute middleware if they have no permissions to do anything
within the moves feature.