### PR TITLE
Update content on error handler

### DIFF
--- a/common/middleware/errors.js
+++ b/common/middleware/errors.js
@@ -1,19 +1,31 @@
 const logger = require('../../config/logger')
 
-function getStatusMessage (error) {
+function _getMessage (error) {
   if (error.code === 'EBADCSRFTOKEN') {
-    return 'errors:tampered_with.heading'
+    return {
+      heading: 'errors:tampered_with.heading',
+      content: 'errors:tampered_with.content',
+    }
   }
 
   if (error.statusCode === 404) {
-    return 'errors:not_found.heading'
+    return {
+      heading: 'errors:not_found.heading',
+      content: 'errors:not_found.content',
+    }
   }
 
   if (error.statusCode === 403 || error.statusCode === 401) {
-    return 'errors:unauthorized.heading'
+    return {
+      heading: 'errors:unauthorized.heading',
+      content: 'errors:unauthorized.content',
+    }
   }
 
-  return 'errors:default.heading'
+  return {
+    heading: 'errors:default.heading',
+    content: 'errors:default.content',
+  }
 }
 
 function notFound (req, res, next) {
@@ -33,14 +45,12 @@ function catchAll (showStackTrace = false) {
 
     logger[statusCode === 404 ? 'info' : 'error'](error)
 
-    res
-      .status(statusCode)
-      .render('error', {
-        error,
-        statusCode,
-        showStackTrace,
-        statusMessage: getStatusMessage(error),
-      })
+    res.status(statusCode).render('error', {
+      error,
+      statusCode,
+      showStackTrace,
+      message: _getMessage(error),
+    })
   }
 }
 

--- a/common/middleware/errors.test.js
+++ b/common/middleware/errors.test.js
@@ -125,7 +125,10 @@ describe('Error middleware', function () {
           error: mockError,
           statusCode: errorCode404,
           showStackTrace: false,
-          statusMessage: 'errors:not_found.heading',
+          message: {
+            heading: 'errors:not_found.heading',
+            content: 'errors:not_found.content',
+          },
         })
       })
 
@@ -164,7 +167,10 @@ describe('Error middleware', function () {
           error: mockError,
           statusCode: errorCode403,
           showStackTrace: false,
-          statusMessage: 'errors:unauthorized.heading',
+          message: {
+            heading: 'errors:unauthorized.heading',
+            content: 'errors:unauthorized.content',
+          },
         })
       })
 
@@ -204,7 +210,10 @@ describe('Error middleware', function () {
           error: mockError,
           statusCode: errorCode403,
           showStackTrace: false,
-          statusMessage: 'errors:tampered_with.heading',
+          message: {
+            heading: 'errors:tampered_with.heading',
+            content: 'errors:tampered_with.content',
+          },
         })
       })
 
@@ -243,7 +252,10 @@ describe('Error middleware', function () {
           error: mockError,
           statusCode: errorCode500,
           showStackTrace: false,
-          statusMessage: 'errors:default.heading',
+          message: {
+            heading: 'errors:default.heading',
+            content: 'errors:default.content',
+          },
         })
       })
 
@@ -281,7 +293,10 @@ describe('Error middleware', function () {
           error: mockError,
           statusCode: errorCode500,
           showStackTrace: false,
-          statusMessage: 'errors:default.heading',
+          message: {
+            heading: 'errors:default.heading',
+            content: 'errors:default.content',
+          },
         })
       })
 

--- a/common/templates/error.njk
+++ b/common/templates/error.njk
@@ -1,15 +1,9 @@
 {% extends "layouts/govuk.njk" %}
 
 {% block content %}
-  <h1 class="govuk-heading-xl">{{ t(statusMessage) }}</h1>
+  <h1 class="govuk-heading-xl">{{ t(message.heading) }}</h1>
 
-  {% if statusCode == '404' %}
-    <p>{{ t("errors:not_found.content") }}</p>
-  {% elseif statusCode == '403' and error.code === 'EBADCSRFTOKEN' %}
-    <p>{{ t("errors:tampered_with.content") }}</p>
-  {% else %}
-    <p>{{ t("errors:default.content") }}</p>
-  {% endif %}
+  <p>{{ t(message.content) }}</p>
 
   {% if showStackTrace %}
     <dl class="app-stack-trace">

--- a/locales/en/errors.json
+++ b/locales/en/errors.json
@@ -16,6 +16,7 @@
     "content": "Try to submit the form again in a few moments."
   },
   "unauthorized": {
-    "heading": "You don’t have permission to view this page"
+    "heading": "You don’t have permission to view this page",
+    "content": "If you think you should have access please contact the support team."
   }
 }


### PR DESCRIPTION
This change moves the logic for setting content on the error page
to the middleware rather than the template.

It also ensures there is specific content for the forbidden
handler.