### PR TITLE
[P4-273] Add "today" shortcut to pagination

### DIFF
--- a/app/moves/controllers/list.js
+++ b/app/moves/controllers/list.js
@@ -7,8 +7,9 @@ const presenters = require('../../../common/presenters')
 
 module.exports = function list (req, res) {
   const { moveDate, movesByDate } = res.locals
-  const yesterday = format(subDays(moveDate, 1), 'YYYY-MM-DD')
-  const tomorrow = format(addDays(moveDate, 1), 'YYYY-MM-DD')
+  const today = format(new Date(), 'YYYY-MM-DD')
+  const previousDay = format(subDays(moveDate, 1), 'YYYY-MM-DD')
+  const nextDay = format(addDays(moveDate, 1), 'YYYY-MM-DD')
   const canViewMove = permissions.check(
     'move:view',
     get(req.session, 'user.permissions')
@@ -18,11 +19,14 @@ module.exports = function list (req, res) {
     pageTitle: 'moves:dashboard.upcoming_moves',
     destinations: presenters.movesByToLocation(movesByDate),
     pagination: {
+      todayUrl: getQueryString(req.query, {
+        'move-date': today,
+      }),
       nextUrl: getQueryString(req.query, {
-        'move-date': tomorrow,
+        'move-date': nextDay,
       }),
       prevUrl: getQueryString(req.query, {
-        'move-date': yesterday,
+        'move-date': previousDay,
       }),
     },
   }

--- a/app/moves/controllers/list.test.js
+++ b/app/moves/controllers/list.test.js
@@ -11,6 +11,7 @@ describe('Moves controllers', function () {
     let req, res
 
     beforeEach(function () {
+      this.clock = sinon.useFakeTimers(new Date(mockMoveDate).getTime())
       sinon.stub(presenters, 'movesByToLocation').returnsArg(0)
       req = { query: {} }
       res = {
@@ -20,6 +21,10 @@ describe('Moves controllers', function () {
         },
         render: sinon.spy(),
       }
+    })
+
+    afterEach(function () {
+      this.clock.restore()
     })
 
     describe('template params', function () {
@@ -34,6 +39,7 @@ describe('Moves controllers', function () {
       it('should contain pagination with correct links', function () {
         const params = res.render.args[0][1]
         expect(params).to.have.property('pagination')
+        expect(params.pagination.todayUrl).to.equal('?move-date=2019-10-10')
         expect(params.pagination.nextUrl).to.equal('?move-date=2019-10-11')
         expect(params.pagination.prevUrl).to.equal('?move-date=2019-10-09')
       })

--- a/app/moves/views/_layout.njk
+++ b/app/moves/views/_layout.njk
@@ -28,7 +28,11 @@
           next: {
             href: pagination.nextUrl,
             text: t("actions:next_day")
-          }
+          },
+          items: [{
+            href: pagination.todayUrl,
+            text: t("actions:current_day")
+          }]
         }) }}
 
         {% block headerActions %}{% endblock %}

--- a/common/components/pagination/pagination.yaml
+++ b/common/components/pagination/pagination.yaml
@@ -68,3 +68,16 @@ examples:
         href: "/previous-page"
       next:
         href: "/next-page"
+  - name: with items
+    data:
+      previous:
+        href: "/previous-page"
+      next:
+        href: "/next-page"
+      items:
+      - href: "/page-1"
+        text: "one"
+      - href: "/page-2"
+        text: "two"
+      - href: "/page-3"
+        text: "three"

--- a/common/components/pagination/template.njk
+++ b/common/components/pagination/template.njk
@@ -23,6 +23,16 @@
       </li>
     {% endif %}
 
+    {% for item in params.items %}
+      <li class="app-pagination__list-item">
+        <a href="{{ item.href }}" class="app-pagination__link">
+          <span class="app-pagination__link-title">
+            <span class="app-pagination__link-text">{{ item.text }}</span>
+          </span>
+        </a>
+      </li>
+    {% endfor %}
+
     {% if params.next %}
       <li class="app-pagination__list-item app-pagination__list-item--next">
         <a href="{{ params.next.href }}" class="app-pagination__link" rel="next">

--- a/common/components/pagination/template.test.js
+++ b/common/components/pagination/template.test.js
@@ -129,4 +129,56 @@ describe('Pagination component', function () {
       expect($itemLink.attr('href')).to.equal('/next-day')
     })
   })
+
+  context('with items', function () {
+    let $, $component, items
+
+    beforeEach(function () {
+      $ = render('pagination', examples['with items'])
+      $component = $('.app-pagination')
+      items = $component.find('.app-pagination__list-item')
+    })
+
+    it('should render correct number of items', function () {
+      const $items = $component.find('.app-pagination__list-item')
+      expect($items.length).to.equal(5)
+    })
+
+    it('should render previous label', function () {
+      const $item = $component.find('.app-pagination__list-item--prev')
+      expect($item.length).to.equal(1)
+    })
+
+    it('should render next label', function () {
+      const $item = $component.find('.app-pagination__list-item--next')
+      expect($item.length).to.equal(1)
+    })
+
+    it('should render first item', function () {
+      const $item = $(items[1])
+      const $itemText = $item.find('.app-pagination__link-text')
+      const $itemLink = $item.find('a')
+
+      expect($itemText.text().trim()).to.equal('one')
+      expect($itemLink.attr('href')).to.equal('/page-1')
+    })
+
+    it('should render second item', function () {
+      const $item = $(items[2])
+      const $itemText = $item.find('.app-pagination__link-text')
+      const $itemLink = $item.find('a')
+
+      expect($itemText.text().trim()).to.equal('two')
+      expect($itemLink.attr('href')).to.equal('/page-2')
+    })
+
+    it('should render third item', function () {
+      const $item = $(items[3])
+      const $itemText = $item.find('.app-pagination__link-text')
+      const $itemLink = $item.find('a')
+
+      expect($itemText.text().trim()).to.equal('three')
+      expect($itemLink.attr('href')).to.equal('/page-3')
+    })
+  })
 })

--- a/locales/en/actions.json
+++ b/locales/en/actions.json
@@ -2,6 +2,7 @@
   "create_move": "Create a move",
   "previous_day": "Previous day",
   "next_day": "Next day",
+  "current_day": "Today",
   "back": "Back",
   "back_to_dashboard": "$t(actions:back) to dashboard",
   "back_to_move": "$t(actions:back) to move",


### PR DESCRIPTION
This PR extends the pagination component to support list items in the middle and then adds the today shortcut to the moves listing template.