### PR TITLE
[P4-518] Fix typo in scheduled move button

### DIFF
--- a/locales/en/actions.json
+++ b/locales/en/actions.json
@@ -6,7 +6,7 @@
   "back": "Back",
   "back_to_dashboard": "$t(actions:back) to dashboard",
   "back_to_move": "$t(actions:back) to move",
-  "schedule_move": "Scheduled move",
+  "schedule_move": "Schedule move",
   "continue": "Continue",
   "restart": "Restart",
   "cancel_move": "Cancel this move",


### PR DESCRIPTION
Schedule move text should be future, not past.