### PR TITLE
[P4-515] Filter disabled options

### DIFF
--- a/app/move/controllers/new.assessment.js
+++ b/app/move/controllers/new.assessment.js
@@ -3,6 +3,7 @@ const { flatten, values } = require('lodash')
 const FormController = require('./new.form')
 const fieldHelpers = require('../../../common/helpers/field')
 const referenceDataService = require('../../../common/services/reference-data')
+const referenceDataHelpers = require('../../../common/helpers/reference-data')
 
 class AssessmentController extends FormController {
   async configure (req, res, next) {
@@ -21,6 +22,7 @@ class AssessmentController extends FormController {
             .getAssessmentQuestions(key)
             .then(response => {
               field.items = response
+                .filter(referenceDataHelpers.filterDisabled())
                 .map(fieldHelpers.mapAssessmentQuestionToConditionalField)
                 .map(fieldHelpers.mapReferenceDataToOption)
             })

--- a/app/move/controllers/new.assessment.test.js
+++ b/app/move/controllers/new.assessment.test.js
@@ -2,6 +2,7 @@ const FormController = require('hmpo-form-wizard').Controller
 
 const Controller = require('./new.assessment')
 const referenceDataService = require('../../../common/services/reference-data')
+const referenceDataHelpers = require('../../../common/helpers/reference-data')
 
 const controller = new Controller({ route: '/' })
 
@@ -40,6 +41,9 @@ describe('Move controllers', function () {
         let req
 
         beforeEach(async function () {
+          sinon.stub(referenceDataHelpers, 'filterDisabled').callsFake(() => {
+            return () => true
+          })
           sinon
             .stub(referenceDataService, 'getAssessmentQuestions')
             .resolves(questionsMock)

--- a/app/move/controllers/new.move-details.js
+++ b/app/move/controllers/new.move-details.js
@@ -4,6 +4,7 @@ const FormController = require('./new.form')
 const filters = require('../../../config/nunjucks/filters')
 const fieldHelpers = require('../../../common/helpers/field')
 const referenceDataService = require('../../../common/services/reference-data')
+const referenceDataHelpers = require('../../../common/helpers/reference-data')
 
 class MoveDetailsController extends FormController {
   async configure (req, res, next) {
@@ -17,11 +18,15 @@ class MoveDetailsController extends FormController {
       } = req.form.options.fields
 
       toLocationCourt.items = fieldHelpers.insertInitialOption(
-        courts.map(fieldHelpers.mapReferenceDataToOption),
+        courts
+          .filter(referenceDataHelpers.filterDisabled())
+          .map(fieldHelpers.mapReferenceDataToOption),
         'court'
       )
       toLocationPrison.items = fieldHelpers.insertInitialOption(
-        prisons.map(fieldHelpers.mapReferenceDataToOption),
+        prisons
+          .filter(referenceDataHelpers.filterDisabled())
+          .map(fieldHelpers.mapReferenceDataToOption),
         'prison'
       )
 

--- a/app/move/controllers/new.move-details.test.js
+++ b/app/move/controllers/new.move-details.test.js
@@ -3,6 +3,7 @@ const FormController = require('hmpo-form-wizard').Controller
 const Controller = require('./new.move-details')
 const filters = require('../../../config/nunjucks/filters')
 const referenceDataService = require('../../../common/services/reference-data')
+const referenceDataHelpers = require('../../../common/helpers/reference-data')
 
 const controller = new Controller({ route: '/' })
 const courtsMock = [
@@ -44,6 +45,9 @@ describe('Move controllers', function () {
 
         beforeEach(async function () {
           sinon.spy(FormController.prototype, 'configure')
+          sinon.stub(referenceDataHelpers, 'filterDisabled').callsFake(() => {
+            return () => true
+          })
           sinon.stub(referenceDataService, 'getLocations').resolves(courtsMock)
           sinon.stub(filters, 'formatDateWithDay').returnsArg(0)
 

--- a/app/move/controllers/new.personal-details.js
+++ b/app/move/controllers/new.personal-details.js
@@ -2,16 +2,19 @@ const FormController = require('./new.form')
 const fieldHelpers = require('../../../common/helpers/field')
 const personService = require('../../../common/services/person')
 const referenceDataService = require('../../../common/services/reference-data')
+const referenceDataHelpers = require('../../../common/helpers/reference-data')
 
 class PersonalDetailsController extends FormController {
   async configure (req, res, next) {
     try {
       const genders = await referenceDataService.getGenders()
       const ethnicities = await referenceDataService.getEthnicities()
-      const genderOptions = genders.map(fieldHelpers.mapReferenceDataToOption)
-      const ethnicityOptions = ethnicities.map(
-        fieldHelpers.mapReferenceDataToOption
-      )
+      const genderOptions = genders
+        .filter(referenceDataHelpers.filterDisabled())
+        .map(fieldHelpers.mapReferenceDataToOption)
+      const ethnicityOptions = ethnicities
+        .filter(referenceDataHelpers.filterDisabled())
+        .map(fieldHelpers.mapReferenceDataToOption)
 
       req.form.options.fields.gender.items = genderOptions
       req.form.options.fields.ethnicity.items = fieldHelpers.insertInitialOption(

--- a/app/move/controllers/new.personal-details.test.js
+++ b/app/move/controllers/new.personal-details.test.js
@@ -3,6 +3,7 @@ const FormController = require('hmpo-form-wizard').Controller
 const Controller = require('./new.personal-details')
 const personService = require('../../../common/services/person')
 const referenceDataService = require('../../../common/services/reference-data')
+const referenceDataHelpers = require('../../../common/helpers/reference-data')
 
 const controller = new Controller({ route: '/' })
 const genderMock = [
@@ -45,6 +46,9 @@ describe('Move controllers', function () {
 
         beforeEach(async function () {
           sinon.spy(FormController.prototype, 'configure')
+          sinon.stub(referenceDataHelpers, 'filterDisabled').callsFake(() => {
+            return () => true
+          })
           sinon.stub(referenceDataService, 'getGenders').resolves(genderMock)
           sinon
             .stub(referenceDataService, 'getEthnicities')

--- a/common/helpers/reference-data.js
+++ b/common/helpers/reference-data.js
@@ -1,0 +1,18 @@
+function filterDisabled ({ currentValue = null, createdOn } = {}) {
+  const createdOnTime = Date.parse(createdOn) || Date.now()
+
+  return function (item) {
+    if (!item.disabled_on) {
+      return true
+    }
+
+    const isDisabled = Date.parse(item.disabled_on) > createdOnTime
+    const isCurrentValue = item.id === currentValue
+
+    return isDisabled || isCurrentValue
+  }
+}
+
+module.exports = {
+  filterDisabled,
+}

--- a/common/helpers/reference-data.test.js
+++ b/common/helpers/reference-data.test.js
@@ -1,0 +1,166 @@
+const { addMonths, subMonths } = require('date-fns')
+
+const { filterDisabled } = require('./reference-data')
+
+const nextMonth = addMonths(new Date(), 1)
+const lastMonth = subMonths(new Date(), 1)
+
+describe('Reference data helpers', function () {
+  describe('#filterDisabled', function () {
+    context('when an option was disabled in the past', function () {
+      beforeEach(function () {
+        this.options = [
+          {
+            id: '1234',
+            name: 'Freds',
+            disabled_on: lastMonth,
+          },
+        ]
+      })
+
+      context('when the option is not the current field value', function () {
+        beforeEach(function () {
+          this.filteredOptions = this.options.filter(
+            filterDisabled({
+              currentValue: '3',
+              createdOn: lastMonth,
+            })
+          )
+        })
+
+        it('should not include the option', function () {
+          expect(this.filteredOptions).to.have.length(0)
+        })
+      })
+
+      context('when the option is the current field value', function () {
+        beforeEach(function () {
+          this.filteredOptions = this.options.filter(
+            filterDisabled({
+              currentValue: '1234',
+              createdOn: lastMonth,
+            })
+          )
+        })
+
+        it('should include the option', function () {
+          expect(this.filteredOptions).to.have.length(1)
+        })
+      })
+
+      context('when there is no current value', function () {
+        beforeEach(function () {
+          this.filteredOptions = this.options.filter(filterDisabled())
+        })
+
+        it('should not include the option', function () {
+          expect(this.filteredOptions).to.have.length(0)
+        })
+      })
+    })
+
+    context('when an option is disabled in the future', function () {
+      beforeEach(function () {
+        this.options = [
+          {
+            id: '1234',
+            name: 'Freds',
+            disabled_on: nextMonth,
+          },
+        ]
+      })
+
+      context('when the option is not the current field value', function () {
+        beforeEach(function () {
+          this.filteredOptions = this.options.filter(
+            filterDisabled({
+              currentValue: '3',
+              createdOn: lastMonth,
+            })
+          )
+        })
+
+        it('should include the option', function () {
+          expect(this.filteredOptions).to.have.length(1)
+        })
+      })
+
+      context('when the option is the current field value', function () {
+        beforeEach(function () {
+          this.filteredOptions = this.options.filter(
+            filterDisabled({
+              currentValue: '1234',
+              createdOn: lastMonth,
+            })
+          )
+        })
+
+        it('should include the option', function () {
+          expect(this.filteredOptions).to.have.length(1)
+        })
+      })
+
+      context('when there is no current value', function () {
+        beforeEach(function () {
+          this.filteredOptions = this.options.filter(filterDisabled())
+        })
+
+        it('should include the option', function () {
+          expect(this.filteredOptions).to.have.length(1)
+        })
+      })
+    })
+
+    context('when an option is not disabled', function () {
+      beforeEach(function () {
+        this.options = [
+          {
+            id: '1234',
+            name: 'Freds',
+            disabled_on: null,
+          },
+        ]
+      })
+
+      context('when the option is not the current field value', function () {
+        beforeEach(function () {
+          this.filteredOptions = this.options.filter(
+            filterDisabled({
+              currentValue: '3',
+              createdOn: lastMonth,
+            })
+          )
+        })
+
+        it('should include the option', function () {
+          expect(this.filteredOptions).to.have.length(1)
+        })
+      })
+
+      context('when the option is the current field value', function () {
+        beforeEach(function () {
+          this.filteredOptions = this.options.filter(
+            filterDisabled({
+              currentValue: '1234',
+              createdOn: lastMonth,
+            })
+          )
+        })
+
+        it('should include the option', function () {
+          expect(this.filteredOptions).to.have.length(1)
+        })
+      })
+
+      context('when there is no current value', function () {
+        beforeEach(function () {
+          this.filteredOptions = this.options.filter(filterDisabled())
+        })
+
+        it('should include the option', function () {
+          expect(this.filteredOptions).to.have.length(1)
+        })
+      })
+    })
+  })
+})

--- a/common/lib/api-client/models.js
+++ b/common/lib/api-client/models.js
@@ -35,42 +35,64 @@ function defineModels (jsonApi) {
     },
   })
 
-  jsonApi.define('gender', {
-    key: '',
-    title: '',
-    description: '',
-  }, {
-    collectionPath: 'reference/genders',
-  })
+  jsonApi.define(
+    'gender',
+    {
+      key: '',
+      title: '',
+      description: '',
+      nomis_code: '',
+      disabled_at: '',
+    },
+    {
+      collectionPath: 'reference/genders',
+    }
+  )
 
-  jsonApi.define('ethnicity', {
-    key: '',
-    title: '',
-    description: '',
-  }, {
-    collectionPath: 'reference/ethnicities',
-  })
+  jsonApi.define(
+    'ethnicity',
+    {
+      key: '',
+      title: '',
+      description: '',
+      nomis_code: '',
+      disabled_at: '',
+    },
+    {
+      collectionPath: 'reference/ethnicities',
+    }
+  )
 
-  jsonApi.define('assessment_question', {
-    created_at: '',
-    expires_at: '',
-    key: '',
-    title: '',
-    category: '',
-    nomis_alert_type: '',
-    nomis_alert_code: '',
-  }, {
-    collectionPath: 'reference/assessment_questions',
-  })
+  jsonApi.define(
+    'assessment_question',
+    {
+      created_at: '',
+      expires_at: '',
+      disabled_at: '',
+      key: '',
+      title: '',
+      category: '',
+      nomis_alert_type: '',
+      nomis_alert_code: '',
+    },
+    {
+      collectionPath: 'reference/assessment_questions',
+    }
+  )
 
-  jsonApi.define('location', {
-    key: '',
-    title: '',
-    location_type: '',
-    location_code: '',
-  }, {
-    collectionPath: 'reference/locations',
-  })
+  jsonApi.define(
+    'location',
+    {
+      key: '',
+      title: '',
+      location_type: '',
+      nomis_agency_id: '',
+      disabled_at: '',
+    },
+    {
+      collectionPath: 'reference/locations',
+    }
+  )
 }
 
 module.exports = defineModels

--- a/test/fixtures/api-client/move.get.deserialized.json
+++ b/test/fixtures/api-client/move.get.deserialized.json
@@ -73,14 +73,14 @@
       "type": "locations",
       "title": "HMP Leeds",
       "location_type": "prison",
-      "location_code": null
+      "nomis_agency_id": null
     },
     "to_location": {
       "id": "c4814e3f-ee9f-4f08-a515-94fc0afe6eb2",
       "type": "locations",
       "title": "Barrow in Furness County Court",
       "location_type": "court",
-      "location_code": null
+      "nomis_agency_id": null
     }
   }
 }

--- a/test/fixtures/api-client/move.get.serialized.json
+++ b/test/fixtures/api-client/move.get.serialized.json
@@ -126,7 +126,7 @@
           "attributes": {
               "title": "HMP Leeds",
               "location_type": "prison",
-              "location_code": null
+              "nomis_agency_id": null
           }
       },
       {
@@ -135,7 +135,7 @@
           "attributes": {
               "title": "Barrow in Furness County Court",
               "location_type": "court",
-              "location_code": null
+              "nomis_agency_id": null
           }
       }
   ]

--- a/test/fixtures/api-client/moves.get.deserialized.json
+++ b/test/fixtures/api-client/moves.get.deserialized.json
@@ -66,7 +66,7 @@
       "key": "hmp_dartmoor",
       "title": "HMP Dartmoor",
       "location_type": "prison",
-      "location_code": null
+      "nomis_agency_id": null
     },
     "to_location": {
       "id": "54714961-3b18-4a01-b65e-93c3991de37a",
@@ -74,7 +74,7 @@
       "key": "axminster_crown_court",
       "title": "Axminster Crown Court",
       "location_type": "court",
-      "location_code": null
+      "nomis_agency_id": null
     }
   }, {
     "id": "271c95bc-359d-4413-ac63-364c4521a67f",
@@ -143,7 +143,7 @@
       "key": "hmp_yoi_bronzefield",
       "title": "HMP/YOI Bronzefield",
       "location_type": "prison",
-      "location_code": null
+      "nomis_agency_id": null
     },
     "to_location": {
       "id": "54714961-3b18-4a01-b65e-93c3991de37a",
@@ -151,7 +151,7 @@
       "key": "axminster_crown_court",
       "title": "Axminster Crown Court",
       "location_type": "court",
-      "location_code": null
+      "nomis_agency_id": null
     }
   }, {
     "id": "2f1ab125-6d5a-4621-affe-c5f1e96e53d6",
@@ -220,7 +220,7 @@
       "key": "hmp_yoi_hewell",
       "title": "HMP/YOI Hewell",
       "location_type": "prison",
-      "location_code": null
+      "nomis_agency_id": null
     },
     "to_location": {
       "id": "54714961-3b18-4a01-b65e-93c3991de37a",
@@ -228,7 +228,7 @@
       "key": "axminster_crown_court",
       "title": "Axminster Crown Court",
       "location_type": "court",
-      "location_code": null
+      "nomis_agency_id": null
     }
   }, {
     "id": "17a7c1cf-e3dd-4d28-8162-d2f54ce477f5",
@@ -297,7 +297,7 @@
       "key": "hmp_yoi_portland",
       "title": "HMP/YOI Portland",
       "location_type": "prison",
-      "location_code": null
+      "nomis_agency_id": null
     },
     "to_location": {
       "id": "54714961-3b18-4a01-b65e-93c3991de37a",
@@ -305,7 +305,7 @@
       "key": "axminster_crown_court",
       "title": "Axminster Crown Court",
       "location_type": "court",
-      "location_code": null
+      "nomis_agency_id": null
     }
   }, {
     "id": "417449a3-8ef2-48e4-9379-7fbbf74ceed4",
@@ -374,7 +374,7 @@
       "key": "hmirc_the_verne",
       "title": "HMIRC The Verne",
       "location_type": "prison",
-      "location_code": null
+      "nomis_agency_id": null
     },
     "to_location": {
       "id": "54714961-3b18-4a01-b65e-93c3991de37a",
@@ -382,7 +382,7 @@
       "key": "axminster_crown_court",
       "title": "Axminster Crown Court",
       "location_type": "court",
-      "location_code": null
+      "nomis_agency_id": null
     }
   }, {
     "id": "20e2495b-e86c-40f1-a066-9fdb79d884e2",
@@ -451,7 +451,7 @@
       "key": "hmp_lindholme",
       "title": "HMP Lindholme",
       "location_type": "prison",
-      "location_code": null
+      "nomis_agency_id": null
     },
     "to_location": {
       "id": "54714961-3b18-4a01-b65e-93c3991de37a",
@@ -459,7 +459,7 @@
       "key": "axminster_crown_court",
       "title": "Axminster Crown Court",
       "location_type": "court",
-      "location_code": null
+      "nomis_agency_id": null
     }
   }, {
     "id": "8fe0a416-4aa9-4b82-ada5-810cec881e42",
@@ -528,7 +528,7 @@
       "key": "hmp_yoi_warren_hill",
       "title": "HMP/YOI Warren Hill",
       "location_type": "prison",
-      "location_code": null
+      "nomis_agency_id": null
     },
     "to_location": {
       "id": "54714961-3b18-4a01-b65e-93c3991de37a",
@@ -536,7 +536,7 @@
       "key": "axminster_crown_court",
       "title": "Axminster Crown Court",
       "location_type": "court",
-      "location_code": null
+      "nomis_agency_id": null
     }
   }, {
     "id": "81a4d40d-a007-4d3a-beb8-c5334ea42b36",
@@ -605,7 +605,7 @@
       "key": "hmp_yoi_sudbury",
       "title": "HMP/YOI Sudbury",
       "location_type": "prison",
-      "location_code": null
+      "nomis_agency_id": null
     },
     "to_location": {
       "id": "54714961-3b18-4a01-b65e-93c3991de37a",
@@ -613,7 +613,7 @@
       "key": "axminster_crown_court",
       "title": "Axminster Crown Court",
       "location_type": "court",
-      "location_code": null
+      "nomis_agency_id": null
     }
   }, {
     "id": "d02a534f-96e7-4fae-8818-3b71cb596f21",
@@ -682,7 +682,7 @@
       "key": "hmp_yoi_altcourse",
       "title": "HMP/YOI Altcourse",
       "location_type": "prison",
-      "location_code": null
+      "nomis_agency_id": null
     },
     "to_location": {
       "id": "54714961-3b18-4a01-b65e-93c3991de37a",
@@ -690,7 +690,7 @@
       "key": "axminster_crown_court",
       "title": "Axminster Crown Court",
       "location_type": "court",
-      "location_code": null
+      "nomis_agency_id": null
     }
   }, {
     "id": "eddc9f3a-4c2f-4853-88ea-b7fa0872fc16",
@@ -759,7 +759,7 @@
       "key": "hmp_long_lartin",
       "title": "HMP Long Lartin",
       "location_type": "prison",
-      "location_code": null
+      "nomis_agency_id": null
     },
     "to_location": {
       "id": "54714961-3b18-4a01-b65e-93c3991de37a",
@@ -767,7 +767,7 @@
       "key": "axminster_crown_court",
       "title": "Axminster Crown Court",
       "location_type": "court",
-      "location_code": null
+      "nomis_agency_id": null
     }
   }, {
     "id": "3959d016-451b-4acd-8698-e84fcbdd6acb",
@@ -836,7 +836,7 @@
       "key": "hmp_coldingley",
       "title": "HMP Coldingley",
       "location_type": "prison",
-      "location_code": null
+      "nomis_agency_id": null
     },
     "to_location": {
       "id": "df72ff9e-e18f-4aff-af2c-91c2840c6083",
@@ -844,7 +844,7 @@
       "key": "barnstaple_magistrates_court",
       "title": "Barnstaple Magistrates Court",
       "location_type": "court",
-      "location_code": null
+      "nomis_agency_id": null
     }
   }, {
     "id": "5a1d17af-5204-4d4b-8126-d4fd0b24b700",
@@ -913,7 +913,7 @@
       "key": "hmp_yoi_belmarsh",
       "title": "HMP/YOI Belmarsh",
       "location_type": "prison",
-      "location_code": null
+      "nomis_agency_id": null
     },
     "to_location": {
       "id": "df72ff9e-e18f-4aff-af2c-91c2840c6083",
@@ -921,7 +921,7 @@
       "key": "barnstaple_magistrates_court",
       "title": "Barnstaple Magistrates Court",
       "location_type": "court",
-      "location_code": null
+      "nomis_agency_id": null
     }
   }, {
     "id": "69eb41e9-3b62-48fb-bd54-e574c0385b25",
@@ -990,7 +990,7 @@
       "key": "hmp_yoi_eastwood_park",
       "title": "HMP/YOI Eastwood Park",
       "location_type": "prison",
-      "location_code": null
+      "nomis_agency_id": null
     },
     "to_location": {
       "id": "df72ff9e-e18f-4aff-af2c-91c2840c6083",
@@ -998,7 +998,7 @@
       "key": "barnstaple_magistrates_court",
       "title": "Barnstaple Magistrates Court",
       "location_type": "court",
-      "location_code": null
+      "nomis_agency_id": null
     }
   }, {
     "id": "f3347cd8-2819-4ed8-a53a-b4464146d35f",
@@ -1067,7 +1067,7 @@
       "key": "hmp_yoi_glen_parva",
       "title": "HMP/YOI Glen Parva",
       "location_type": "prison",
-      "location_code": null
+      "nomis_agency_id": null
     },
     "to_location": {
       "id": "df72ff9e-e18f-4aff-af2c-91c2840c6083",
@@ -1075,7 +1075,7 @@
       "key": "barnstaple_magistrates_court",
       "title": "Barnstaple Magistrates Court",
       "location_type": "court",
-      "location_code": null
+      "nomis_agency_id": null
     }
   }, {
     "id": "f6bc200d-b9a1-4190-a498-7723cff30f08",
@@ -1144,7 +1144,7 @@
       "key": "hmp_camp_hill",
       "title": "HMP Camp Hill",
       "location_type": "prison",
-      "location_code": null
+      "nomis_agency_id": null
     },
     "to_location": {
       "id": "df72ff9e-e18f-4aff-af2c-91c2840c6083",
@@ -1152,7 +1152,7 @@
       "key": "barnstaple_magistrates_court",
       "title": "Barnstaple Magistrates Court",
       "location_type": "court",
-      "location_code": null
+      "nomis_agency_id": null
     }
   }, {
     "id": "270d105e-c0ae-49be-987d-1eb4d74af201",
@@ -1221,7 +1221,7 @@
       "key": "hmp_the_mount",
       "title": "HMP The Mount",
       "location_type": "prison",
-      "location_code": null
+      "nomis_agency_id": null
     },
     "to_location": {
       "id": "031818f0-3b69-4e7a-8b3f-9d51cc964dee",
@@ -1229,7 +1229,7 @@
       "key": "barrow_in_furness_county_court",
       "title": "Barrow in Furness County Court",
       "location_type": "court",
-      "location_code": null
+      "nomis_agency_id": null
     }
   }, {
     "id": "9558f9e3-0b5a-40ef-9c10-28c2dbd45b5a",
@@ -1298,7 +1298,7 @@
       "key": "hmp_kirkham",
       "title": "HMP Kirkham",
       "location_type": "prison",
-      "location_code": null
+      "nomis_agency_id": null
     },
     "to_location": {
       "id": "031818f0-3b69-4e7a-8b3f-9d51cc964dee",
@@ -1306,7 +1306,7 @@
       "key": "barrow_in_furness_county_court",
       "title": "Barrow in Furness County Court",
       "location_type": "court",
-      "location_code": null
+      "nomis_agency_id": null
     }
   }, {
     "id": "c5e82247-f176-492b-a048-fb1c4c661887",
@@ -1375,7 +1375,7 @@
       "key": "hmp_reading",
       "title": "HMP Reading",
       "location_type": "prison",
-      "location_code": null
+      "nomis_agency_id": null
     },
     "to_location": {
       "id": "031818f0-3b69-4e7a-8b3f-9d51cc964dee",
@@ -1383,7 +1383,7 @@
       "key": "barrow_in_furness_county_court",
       "title": "Barrow in Furness County Court",
       "location_type": "court",
-      "location_code": null
+      "nomis_agency_id": null
     }
   }, {
     "id": "fe9e4207-9938-4ba0-98cd-3a36854c45c7",
@@ -1452,7 +1452,7 @@
       "key": "hmp_long_lartin",
       "title": "HMP Long Lartin",
       "location_type": "prison",
-      "location_code": null
+      "nomis_agency_id": null
     },
     "to_location": {
       "id": "031818f0-3b69-4e7a-8b3f-9d51cc964dee",
@@ -1460,7 +1460,7 @@
       "key": "barrow_in_furness_county_court",
       "title": "Barrow in Furness County Court",
       "location_type": "court",
-      "location_code": null
+      "nomis_agency_id": null
     }
   }, {
     "id": "7104c76c-78ba-4f9d-a9b1-1fd7736226dc",
@@ -1529,7 +1529,7 @@
       "key": "hmp_brockhill",
       "title": "HMP Brockhill",
       "location_type": "prison",
-      "location_code": null
+      "nomis_agency_id": null
     },
     "to_location": {
       "id": "031818f0-3b69-4e7a-8b3f-9d51cc964dee",
@@ -1537,7 +1537,7 @@
       "key": "barrow_in_furness_county_court",
       "title": "Barrow in Furness County Court",
       "location_type": "court",
-      "location_code": null
+      "nomis_agency_id": null
     }
   }],
   "meta": {

--- a/test/fixtures/api-client/moves.get.serialized.json
+++ b/test/fixtures/api-client/moves.get.serialized.json
@@ -705,7 +705,7 @@
         "key": "hmp_dartmoor",
         "title": "HMP Dartmoor",
         "location_type": "prison",
-        "location_code": null
+        "nomis_agency_id": null
       }
     },
     {
@@ -715,7 +715,7 @@
         "key": "axminster_crown_court",
         "title": "Axminster Crown Court",
         "location_type": "court",
-        "location_code": null
+        "nomis_agency_id": null
       }
     },
     {
@@ -803,7 +803,7 @@
         "key": "hmp_yoi_bronzefield",
         "title": "HMP/YOI Bronzefield",
         "location_type": "prison",
-        "location_code": null
+        "nomis_agency_id": null
       }
     },
     {
@@ -873,7 +873,7 @@
         "key": "hmp_yoi_hewell",
         "title": "HMP/YOI Hewell",
         "location_type": "prison",
-        "location_code": null
+        "nomis_agency_id": null
       }
     },
     {
@@ -952,7 +952,7 @@
         "key": "hmp_yoi_portland",
         "title": "HMP/YOI Portland",
         "location_type": "prison",
-        "location_code": null
+        "nomis_agency_id": null
       }
     },
     {
@@ -1022,7 +1022,7 @@
         "key": "hmirc_the_verne",
         "title": "HMIRC The Verne",
         "location_type": "prison",
-        "location_code": null
+        "nomis_agency_id": null
       }
     },
     {
@@ -1092,7 +1092,7 @@
         "key": "hmp_lindholme",
         "title": "HMP Lindholme",
         "location_type": "prison",
-        "location_code": null
+        "nomis_agency_id": null
       }
     },
     {
@@ -1171,7 +1171,7 @@
         "key": "hmp_yoi_warren_hill",
         "title": "HMP/YOI Warren Hill",
         "location_type": "prison",
-        "location_code": null
+        "nomis_agency_id": null
       }
     },
     {
@@ -1241,7 +1241,7 @@
         "key": "hmp_yoi_sudbury",
         "title": "HMP/YOI Sudbury",
         "location_type": "prison",
-        "location_code": null
+        "nomis_agency_id": null
       }
     },
     {
@@ -1320,7 +1320,7 @@
         "key": "hmp_yoi_altcourse",
         "title": "HMP/YOI Altcourse",
         "location_type": "prison",
-        "location_code": null
+        "nomis_agency_id": null
       }
     },
     {
@@ -1399,7 +1399,7 @@
         "key": "hmp_long_lartin",
         "title": "HMP Long Lartin",
         "location_type": "prison",
-        "location_code": null
+        "nomis_agency_id": null
       }
     },
     {
@@ -1478,7 +1478,7 @@
         "key": "hmp_coldingley",
         "title": "HMP Coldingley",
         "location_type": "prison",
-        "location_code": null
+        "nomis_agency_id": null
       }
     },
     {
@@ -1488,7 +1488,7 @@
         "key": "barnstaple_magistrates_court",
         "title": "Barnstaple Magistrates Court",
         "location_type": "court",
-        "location_code": null
+        "nomis_agency_id": null
       }
     },
     {
@@ -1567,7 +1567,7 @@
         "key": "hmp_yoi_belmarsh",
         "title": "HMP/YOI Belmarsh",
         "location_type": "prison",
-        "location_code": null
+        "nomis_agency_id": null
       }
     },
     {
@@ -1577,7 +1577,7 @@
         "key": "hmp_yoi_eastwood_park",
         "title": "HMP/YOI Eastwood Park",
         "location_type": "prison",
-        "location_code": null
+        "nomis_agency_id": null
       }
     },
     {
@@ -1656,7 +1656,7 @@
         "key": "hmp_yoi_glen_parva",
         "title": "HMP/YOI Glen Parva",
         "location_type": "prison",
-        "location_code": null
+        "nomis_agency_id": null
       }
     },
     {
@@ -1666,7 +1666,7 @@
         "key": "hmp_camp_hill",
         "title": "HMP Camp Hill",
         "location_type": "prison",
-        "location_code": null
+        "nomis_agency_id": null
       }
     },
     {
@@ -1676,7 +1676,7 @@
         "key": "hmp_the_mount",
         "title": "HMP The Mount",
         "location_type": "prison",
-        "location_code": null
+        "nomis_agency_id": null
       }
     },
     {
@@ -1686,7 +1686,7 @@
         "key": "barrow_in_furness_county_court",
         "title": "Barrow in Furness County Court",
         "location_type": "court",
-        "location_code": null
+        "nomis_agency_id": null
       }
     },
     {
@@ -1756,7 +1756,7 @@
         "key": "hmp_kirkham",
         "title": "HMP Kirkham",
         "location_type": "prison",
-        "location_code": null
+        "nomis_agency_id": null
       }
     },
     {
@@ -1766,7 +1766,7 @@
         "key": "hmp_reading",
         "title": "HMP Reading",
         "location_type": "prison",
-        "location_code": null
+        "nomis_agency_id": null
       }
     },
     {
@@ -1905,7 +1905,7 @@
         "key": "hmp_brockhill",
         "title": "HMP Brockhill",
         "location_type": "prison",
-        "location_code": null
+        "nomis_agency_id": null
       }
     }
   ],

--- a/test/fixtures/api-client/reference.assessment.deserialized.json
+++ b/test/fixtures/api-client/reference.assessment.deserialized.json
@@ -2,6 +2,7 @@
   "data": [{
     "id": "f6e1f57c-7d07-41d2-afee-1662f5103e2d",
     "type": "assessment_questions",
+    "disabled_at": null,
     "category": "risk",
     "key": "violent",
     "title": "Violent",
@@ -11,6 +12,7 @@
   {
     "id": "0c76cf75-95f4-4dee-9854-a35782304647",
     "type": "assessment_questions",
+    "disabled_at": null,
     "category": "risk",
     "key": "escape",
     "title": "Escape",
@@ -20,6 +22,7 @@
   {
     "id": "6b111c00-22f4-416c-a15e-e5f7c0af2518",
     "type": "assessment_questions",
+    "disabled_at": null,
     "key": "self_harm",
     "category": "risk",
     "title": "Self harm",
@@ -29,6 +32,7 @@
   {
     "id": "f4e803f2-08af-4e1c-9578-48be5dd88085",
     "type": "assessment_questions",
+    "disabled_at": null,
     "key": "interpreter",
     "category": "court",
     "title": "Sign or other language interpreter",
@@ -38,6 +42,7 @@
   {
     "id": "b441c760-8190-45ee-b377-e3cd6e17ac7f",
     "type": "assessment_questions",
+    "disabled_at": null,
     "key": "medication",
     "category": "health",
     "title": "Medication",
@@ -47,6 +52,7 @@
   {
     "id": "7360ea7b-f4c2-4a09-88fd-5e3b57de1a47",
     "type": "assessment_questions",
+    "disabled_at": null,
     "key": "health_issue",
     "category": "health",
     "title": "Health issue",

--- a/test/fixtures/api-client/reference.assessment.serialized.json
+++ b/test/fixtures/api-client/reference.assessment.serialized.json
@@ -3,6 +3,7 @@
     "id": "f6e1f57c-7d07-41d2-afee-1662f5103e2d",
     "type": "assessment_questions",
     "attributes": {
+      "disabled_at": null,
       "category": "risk",
       "key": "violent",
       "title": "Violent",
@@ -14,6 +15,7 @@
     "id": "0c76cf75-95f4-4dee-9854-a35782304647",
     "type": "assessment_questions",
     "attributes": {
+      "disabled_at": null,
       "category": "risk",
       "key": "escape",
       "title": "Escape",
@@ -25,44 +27,48 @@
     "id": "6b111c00-22f4-416c-a15e-e5f7c0af2518",
     "type": "assessment_questions",
     "attributes": {
-        "key": "self_harm",
-        "category": "risk",
-        "title": "Self harm",
-        "nomis_alert_type": null,
-        "nomis_alert_code": null
+      "disabled_at": null,
+      "key": "self_harm",
+      "category": "risk",
+      "title": "Self harm",
+      "nomis_alert_type": null,
+      "nomis_alert_code": null
     }
   },
   {
     "id": "f4e803f2-08af-4e1c-9578-48be5dd88085",
     "type": "assessment_questions",
     "attributes": {
-        "key": "interpreter",
-        "category": "court",
-        "title": "Sign or other language interpreter",
-        "nomis_alert_type": null,
-        "nomis_alert_code": null
+      "disabled_at": null,
+      "key": "interpreter",
+      "category": "court",
+      "title": "Sign or other language interpreter",
+      "nomis_alert_type": null,
+      "nomis_alert_code": null
     }
   },
   {
     "id": "b441c760-8190-45ee-b377-e3cd6e17ac7f",
     "type": "assessment_questions",
     "attributes": {
-        "key": "medication",
-        "category": "health",
-        "title": "Medication",
-        "nomis_alert_type": null,
-        "nomis_alert_code": null
+      "disabled_at": null,
+      "key": "medication",
+      "category": "health",
+      "title": "Medication",
+      "nomis_alert_type": null,
+      "nomis_alert_code": null
     }
   },
   {
     "id": "7360ea7b-f4c2-4a09-88fd-5e3b57de1a47",
     "type": "assessment_questions",
     "attributes": {
-        "key": "health_issue",
-        "category": "health",
-        "title": "Health issue",
-        "nomis_alert_type": null,
-        "nomis_alert_code": null
+      "disabled_at": null,
+      "key": "health_issue",
+      "category": "health",
+      "title": "Health issue",
+      "nomis_alert_type": null,
+      "nomis_alert_code": null
     }
   }]
 }

--- a/test/fixtures/api-client/reference.ethnicities.deserialized.json
+++ b/test/fixtures/api-client/reference.ethnicities.deserialized.json
@@ -2,26 +2,34 @@
   "data": [{
     "id": "b95bfb7c-18cd-419d-8119-2dee1506726f",
     "type": "ethnicities",
-    "key": "A1",
+    "disabled_at": null,
+    "key": "a1",
     "title": "Asian or Asian British (Indian)",
-    "description": "A1 - Asian or Asian British (Indian)"
+    "description": "A1 - Asian or Asian British (Indian)",
+    "nomis_code": "A1"
   }, {
     "id": "35660b02-243f-4df2-9337-e3ec49b6d70d",
     "type": "ethnicities",
-    "key": "B1",
+    "disabled_at": "2019-06-11",
+    "key": "b1",
     "title": "Black (Caribbean)",
-    "description": "B1 - Black (Caribbean)"
+    "description": "B1 - Black (Caribbean)",
+    "nomis_code": "B1"
   }, {
     "id": "238bf804-7fc9-4f1f-b834-1d1086b2645d",
     "type": "ethnicities",
-    "key": "O1",
+    "disabled_at": null,
+    "key": "o1",
     "title": "Chinese",
-    "description": "O1 - Chinese"
+    "description": "O1 - Chinese",
+    "nomis_code": "O1"
   }, {
     "id": "c1f81573-8f9f-4a2a-a947-9a8288272c65",
     "type": "ethnicities",
-    "key": "W1",
+    "disabled_at": null,
+    "key": "w1",
     "title": "White (British)",
-    "description": "W1 - White (British)"
+    "description": "W1 - White (British)",
+    "nomis_code": "W1"
   }]
 }

--- a/test/fixtures/api-client/reference.ethnicities.serialized.json
+++ b/test/fixtures/api-client/reference.ethnicities.serialized.json
@@ -3,36 +3,44 @@
     "id": "b95bfb7c-18cd-419d-8119-2dee1506726f",
     "type": "ethnicities",
     "attributes": {
-      "key": "A1",
+      "key": "a1",
       "title": "Asian or Asian British (Indian)",
-      "description": "A1 - Asian or Asian British (Indian)"
+      "description": "A1 - Asian or Asian British (Indian)",
+      "nomis_code": "A1",
+      "disabled_at": null
     }
   },
   {
     "id": "35660b02-243f-4df2-9337-e3ec49b6d70d",
     "type": "ethnicities",
     "attributes": {
-      "key": "B1",
+      "key": "b1",
       "title": "Black (Caribbean)",
-      "description": "B1 - Black (Caribbean)"
+      "description": "B1 - Black (Caribbean)",
+      "nomis_code": "B1",
+      "disabled_at": "2019-06-11"
     }
   },
   {
     "id": "238bf804-7fc9-4f1f-b834-1d1086b2645d",
     "type": "ethnicities",
     "attributes": {
-      "key": "O1",
+      "key": "o1",
       "title": "Chinese",
-      "description": "O1 - Chinese"
+      "description": "O1 - Chinese",
+      "nomis_code": "O1",
+      "disabled_at": null
     }
   },
   {
     "id": "c1f81573-8f9f-4a2a-a947-9a8288272c65",
     "type": "ethnicities",
     "attributes": {
-      "key": "W1",
+      "key": "w1",
       "title": "White (British)",
-      "description": "W1 - White (British)"
+      "description": "W1 - White (British)",
+      "nomis_code": "W1",
+      "disabled_at": null
     }
   }]
 }

--- a/test/fixtures/api-client/reference.genders.deserialized.json
+++ b/test/fixtures/api-client/reference.genders.deserialized.json
@@ -2,20 +2,26 @@
   "data": [{
     "id": "d335715f-c9d1-415c-a7c8-06e830158214",
     "type": "genders",
+    "disabled_at": "2019-06-11",
     "key": "female",
     "title": "Female",
-    "description": null
+    "description": null,
+    "nomis_code": "F"
   }, {
     "id": "4d9e344e-1f89-4ca8-a95f-ac14df3f1a24",
     "type": "genders",
+    "disabled_at": null,
     "key": "male",
     "title": "Male",
-    "description": null
+    "description": null,
+    "nomis_code": "M"
   }, {
     "id": "86c2f34a-987c-4b3a-80ad-0f3af66b1190",
     "type": "genders",
+    "disabled_at": null,
     "key": "transexual",
     "title": "Transexual",
-    "description": null
+    "description": null,
+    "nomis_code": "T"
   }]
 }

--- a/test/fixtures/api-client/reference.genders.serialized.json
+++ b/test/fixtures/api-client/reference.genders.serialized.json
@@ -3,27 +3,33 @@
     "id": "d335715f-c9d1-415c-a7c8-06e830158214",
     "type": "genders",
     "attributes": {
+      "disabled_at": "2019-06-11",
       "key": "female",
       "title": "Female",
-      "description": null
+      "description": null,
+      "nomis_code": "F"
     }
   },
   {
     "id": "4d9e344e-1f89-4ca8-a95f-ac14df3f1a24",
     "type": "genders",
     "attributes": {
+      "disabled_at": null,
       "key": "male",
       "title": "Male",
-      "description": null
+      "description": null,
+      "nomis_code": "M"
     }
   },
   {
     "id": "86c2f34a-987c-4b3a-80ad-0f3af66b1190",
     "type": "genders",
     "attributes": {
+      "disabled_at": null,
       "key": "transexual",
       "title": "Transexual",
-      "description": null
+      "description": null,
+      "nomis_code": "T"
     }
   }]
 }

--- a/test/fixtures/api-client/reference.location.deserialized.json
+++ b/test/fixtures/api-client/reference.location.deserialized.json
@@ -2,9 +2,10 @@
   "data": {
     "id": "2c952ca0-f750-4ac3-ac76-fb631445f974",
     "type": "locations",
+    "disabled_at": null,
     "key": "axminster_crown_court",
     "title": "Axminster Crown Court",
     "location_type": "court",
-    "location_code": null
+    "nomis_agency_id": null
   }
 }

--- a/test/fixtures/api-client/reference.location.serialized.json
+++ b/test/fixtures/api-client/reference.location.serialized.json
@@ -3,10 +3,11 @@
     "id": "2c952ca0-f750-4ac3-ac76-fb631445f974",
     "type": "locations",
     "attributes": {
+      "disabled_at": null,
       "key": "axminster_crown_court",
       "title": "Axminster Crown Court",
       "location_type": "court",
-      "location_code": null
+      "nomis_agency_id": null
     }
   }
 }

--- a/test/fixtures/api-client/reference.locations.deserialized.json
+++ b/test/fixtures/api-client/reference.locations.deserialized.json
@@ -5,377 +5,431 @@
     "key": "axminster_crown_court",
     "title": "Axminster Crown Court",
     "location_type": "court",
-    "location_code": null
+    "nomis_agency_id": null,
+    "disabled_at": null
   }, {
     "id": "9b56ca31-222b-4522-9d65-4ef429f9081e",
     "type": "locations",
     "key": "barnstaple_crown_court",
     "title": "Barnstaple Crown Court",
     "location_type": "court",
-    "location_code": null
+    "nomis_agency_id": null,
+    "disabled_at": null
   }, {
     "id": "d8e9cf86-55cd-4412-83b7-3562b7d1f8b6",
     "type": "locations",
     "key": "barrow_in_furness_magistrates_court",
     "title": "Barrow in Furness Magistrates Court",
     "location_type": "court",
-    "location_code": null
+    "nomis_agency_id": null,
+    "disabled_at": null
   }, {
     "id": "10923762-bc17-4ea1-bae3-68ea709ee23e",
     "type": "locations",
     "key": "basingstoke_county_court",
     "title": "Basingstoke County Court",
     "location_type": "court",
-    "location_code": null
+    "nomis_agency_id": null,
+    "disabled_at": null
   }, {
     "id": "398bca42-2ee6-4d2e-ac08-3e5a4b2deb69",
     "type": "locations",
     "key": "bedford_county_court",
     "title": "Bedford County Court",
     "location_type": "court",
-    "location_code": null
+    "nomis_agency_id": null,
+    "disabled_at": null
   }, {
     "id": "23b1ac5c-04e3-4ff1-94bc-eb4e7fa477d6",
     "type": "locations",
     "key": "blackburn_county_court",
     "title": "Blackburn County Court",
     "location_type": "court",
-    "location_code": null
+    "nomis_agency_id": null,
+    "disabled_at": null
   }, {
     "id": "747b8928-9f5d-45ee-87ca-595d8287ed74",
     "type": "locations",
     "key": "bodmin_magistrates_court",
     "title": "Bodmin Magistrates Court",
     "location_type": "court",
-    "location_code": null
+    "nomis_agency_id": null,
+    "disabled_at": null
   }, {
     "id": "1e95f86c-af05-4f31-9c3c-4a0da0c6da95",
     "type": "locations",
     "key": "brighton_county_court",
     "title": "Brighton County Court",
     "location_type": "court",
-    "location_code": null
+    "nomis_agency_id": null,
+    "disabled_at": null
   }, {
     "id": "05085309-2c99-4f87-b9ab-b285b446974b",
     "type": "locations",
     "key": "bristol_crown_court",
     "title": "Bristol Crown Court",
     "location_type": "court",
-    "location_code": null
+    "nomis_agency_id": null,
+    "disabled_at": null
   }, {
     "id": "73163046-22df-463f-8cc2-f471550e2dc1",
     "type": "locations",
     "key": "bude_county_court",
     "title": "Bude County Court",
     "location_type": "court",
-    "location_code": null
+    "nomis_agency_id": null,
+    "disabled_at": null
   }, {
     "id": "61346c8a-370c-4cbd-9285-cf4e5610bd95",
     "type": "locations",
     "key": "burnley_county_court",
     "title": "Burnley County Court",
     "location_type": "court",
-    "location_code": null
+    "nomis_agency_id": null,
+    "disabled_at": null
   }, {
     "id": "dc08582b-c57c-4053-b691-bf3482a00c59",
     "type": "locations",
     "key": "cambridge_crown_court",
     "title": "Cambridge Crown Court",
     "location_type": "court",
-    "location_code": null
+    "nomis_agency_id": null,
+    "disabled_at": null
   }, {
     "id": "b3707992-da62-4593-896f-983d41315f09",
     "type": "locations",
     "key": "carlisle_county_court",
     "title": "Carlisle County Court",
     "location_type": "court",
-    "location_code": null
+    "nomis_agency_id": null,
+    "disabled_at": null
   }, {
     "id": "5ed150fd-4cc1-4b38-ab10-0ac7b44b8a2b",
     "type": "locations",
     "key": "cheltenham_crown_court",
     "title": "Cheltenham Crown Court",
     "location_type": "court",
-    "location_code": null
+    "nomis_agency_id": null,
+    "disabled_at": null
   }, {
     "id": "fa7f6393-76e9-43f2-9fb7-3fc82956a4c4",
     "type": "locations",
     "key": "chesterfield_crown_court",
     "title": "Chesterfield Crown Court",
     "location_type": "court",
-    "location_code": null
+    "nomis_agency_id": null,
+    "disabled_at": null
   }, {
     "id": "fa1817f6-4d50-4fbb-b491-2ecd95b378ba",
     "type": "locations",
     "key": "colchester_county_court",
     "title": "Colchester County Court",
     "location_type": "court",
-    "location_code": null
+    "nomis_agency_id": null,
+    "disabled_at": null
   }, {
     "id": "a3e4228e-3330-4c64-842e-297af0ab8cc4",
     "type": "locations",
     "key": "croydon_magistrates_court",
     "title": "Croydon Magistrates Court",
     "location_type": "court",
-    "location_code": null
+    "nomis_agency_id": null,
+    "disabled_at": null
   }, {
     "id": "ea949640-cefe-4d1b-8053-600af97be807",
     "type": "locations",
     "key": "darlington_crown_court",
     "title": "Darlington Crown Court",
     "location_type": "court",
-    "location_code": null
+    "nomis_agency_id": null,
+    "disabled_at": null
   }, {
     "id": "8cb9cd00-8e80-4686-b3c3-d14958b8145d",
     "type": "locations",
     "key": "derby_county_court",
     "title": "Derby County Court",
     "location_type": "court",
-    "location_code": null
+    "nomis_agency_id": null,
+    "disabled_at": null
   }, {
     "id": "979fae93-9aae-43ce-81e0-c64d4ee472ff",
     "type": "locations",
     "key": "dover_magistrates_court",
     "title": "Dover Magistrates Court",
     "location_type": "court",
-    "location_code": null
+    "nomis_agency_id": null,
+    "disabled_at": null
   }, {
     "id": "3287b21e-9691-43f7-a5b7-948b1fa72a75",
     "type": "locations",
     "key": "durham_magistrates_court",
     "title": "Durham Magistrates Court",
     "location_type": "court",
-    "location_code": null
+    "nomis_agency_id": null,
+    "disabled_at": null
   }, {
     "id": "2f03c2fc-2fb7-43bd-be40-eaed19cacb5a",
     "type": "locations",
     "key": "exeter_magistrates_court",
     "title": "Exeter Magistrates Court",
     "location_type": "court",
-    "location_code": null
+    "nomis_agency_id": null,
+    "disabled_at": null
   }, {
     "id": "6d6eec6a-3e28-46c5-84ec-269851000ba1",
     "type": "locations",
     "key": "grantham_magistrates_court",
     "title": "Grantham Magistrates Court",
     "location_type": "court",
-    "location_code": null
+    "nomis_agency_id": null,
+    "disabled_at": null
   }, {
     "id": "1015f73d-0f41-4e85-9f34-0cfd5cfb27f4",
     "type": "locations",
     "key": "grimsby_magistrates_court",
     "title": "Grimsby Magistrates Court",
     "location_type": "court",
-    "location_code": null
+    "nomis_agency_id": null,
+    "disabled_at": null
   }, {
     "id": "272a0f54-61f6-4c39-8cd2-7f3937707d85",
     "type": "locations",
     "key": "guildford_county_court",
     "title": "Guildford County Court",
     "location_type": "court",
-    "location_code": null
+    "nomis_agency_id": null,
+    "disabled_at": null
   }, {
     "id": "9d5bbb95-b03e-47a0-a07e-ecacb56abed7",
     "type": "locations",
     "key": "harlow_magistrates_court",
     "title": "Harlow Magistrates Court",
     "location_type": "court",
-    "location_code": null
+    "nomis_agency_id": null,
+    "disabled_at": null
   }, {
     "id": "4eb51a6c-222c-497c-90e0-0e3203443b68",
     "type": "locations",
     "key": "kingston_upon_thames_county_court",
     "title": "Kingston upon Thames County Court",
     "location_type": "court",
-    "location_code": null
+    "nomis_agency_id": null,
+    "disabled_at": null
   }, {
     "id": "c5c5aeb0-7d2e-4168-a7a9-d55746a58318",
     "type": "locations",
     "key": "liverpool_magistrates_court",
     "title": "Liverpool Magistrates Court",
     "location_type": "court",
-    "location_code": null
+    "nomis_agency_id": null,
+    "disabled_at": null
   }, {
     "id": "98905621-0684-4873-9f0c-c428c24933ea",
     "type": "locations",
     "key": "luton_crown_court",
     "title": "Luton Crown Court",
     "location_type": "court",
-    "location_code": null
+    "nomis_agency_id": null,
+    "disabled_at": null
   }, {
     "id": "7d9734a1-81e4-4faf-a4f4-54c84ed3cf85",
     "type": "locations",
     "key": "macclesfield_magistrates_court",
     "title": "Macclesfield Magistrates Court",
     "location_type": "court",
-    "location_code": null
+    "nomis_agency_id": null,
+    "disabled_at": null
   }, {
     "id": "d77fdb81-2a09-4981-a4f2-c6a649768319",
     "type": "locations",
     "key": "maidenhead_magistrates_court",
     "title": "Maidenhead Magistrates Court",
     "location_type": "court",
-    "location_code": null
+    "nomis_agency_id": null,
+    "disabled_at": null
   }, {
     "id": "f11b377e-a19d-4a91-b98d-a26c4b2e4d84",
     "type": "locations",
     "key": "maidstone_crown_court",
     "title": "Maidstone Crown Court",
     "location_type": "court",
-    "location_code": null
+    "nomis_agency_id": null,
+    "disabled_at": null
   }, {
     "id": "881fa099-201c-4b76-9253-df37d6bd1009",
     "type": "locations",
     "key": "manchester_county_court",
     "title": "Manchester County Court",
     "location_type": "court",
-    "location_code": null
+    "nomis_agency_id": null,
+    "disabled_at": null
   }, {
     "id": "ddb11bbb-526b-4769-a9f2-cc82875ca52e",
     "type": "locations",
     "key": "newbury_county_court",
     "title": "Newbury County Court",
     "location_type": "court",
-    "location_code": null
+    "nomis_agency_id": null,
+    "disabled_at": null
   }, {
     "id": "9e51f929-2880-460c-a7c0-1156a4a9dba3",
     "type": "locations",
     "key": "newquay_magistrates_court",
     "title": "Newquay Magistrates Court",
     "location_type": "court",
-    "location_code": null
+    "nomis_agency_id": null,
+    "disabled_at": null
   }, {
     "id": "88fc43ba-50f7-4489-a906-ff78dde3ebcb",
     "type": "locations",
     "key": "norwich_magistrates_court",
     "title": "Norwich Magistrates Court",
     "location_type": "court",
-    "location_code": null
+    "nomis_agency_id": null,
+    "disabled_at": null
   }, {
     "id": "58ec74f4-09c8-4e57-8550-9b460202229b",
     "type": "locations",
     "key": "oldham_crown_court",
     "title": "Oldham Crown Court",
     "location_type": "court",
-    "location_code": null
+    "nomis_agency_id": null,
+    "disabled_at": null
   }, {
     "id": "64983bdd-26e0-4574-9014-8471d66f8437",
     "type": "locations",
     "key": "oxford_magistrates_court",
     "title": "Oxford Magistrates Court",
     "location_type": "court",
-    "location_code": null
+    "nomis_agency_id": null,
+    "disabled_at": null
   }, {
     "id": "b09cc87d-9330-42ef-a9bb-ad32216358a5",
     "type": "locations",
     "key": "penzance_county_court",
     "title": "Penzance County Court",
     "location_type": "court",
-    "location_code": null
+    "nomis_agency_id": null,
+    "disabled_at": null
   }, {
     "id": "c48c8573-134f-4eba-86cf-ef8bff129045",
     "type": "locations",
     "key": "peterborough_crown_court",
     "title": "Peterborough Crown Court",
     "location_type": "court",
-    "location_code": null
+    "nomis_agency_id": null,
+    "disabled_at": null
   }, {
     "id": "f7ef5006-e873-461d-ac32-dccf4a8cabc8",
     "type": "locations",
     "key": "plymouth_county_court",
     "title": "Plymouth County Court",
     "location_type": "court",
-    "location_code": null
+    "nomis_agency_id": null,
+    "disabled_at": null
   }, {
     "id": "bdec4256-ce5a-46bd-8583-6234b535b8c7",
     "type": "locations",
     "key": "preston_crown_court",
     "title": "Preston Crown Court",
     "location_type": "court",
-    "location_code": null
+    "nomis_agency_id": null,
+    "disabled_at": null
   }, {
     "id": "2d80f632-c831-44a8-9285-be2732fe9a64",
     "type": "locations",
     "key": "reading_county_court",
     "title": "Reading County Court",
     "location_type": "court",
-    "location_code": null
+    "nomis_agency_id": null,
+    "disabled_at": null
   }, {
     "id": "2756e2e3-cd61-4a67-9775-417adb3671f4",
     "type": "locations",
     "key": "richmond_crown_court",
     "title": "Richmond Crown Court",
     "location_type": "court",
-    "location_code": null
+    "nomis_agency_id": null,
+    "disabled_at": null
   }, {
     "id": "a288caba-70d2-44a0-bec5-331f8ead9d3f",
     "type": "locations",
     "key": "romford_magistrates_court",
     "title": "Romford Magistrates Court",
     "location_type": "court",
-    "location_code": null
+    "nomis_agency_id": null,
+    "disabled_at": null
   }, {
     "id": "b044ad72-2375-46be-9610-f75c1a539e8a",
     "type": "locations",
     "key": "southall_crown_court",
     "title": "Southall Crown Court",
     "location_type": "court",
-    "location_code": null
+    "nomis_agency_id": null,
+    "disabled_at": null
   }, {
     "id": "6ca4e72a-499b-474d-9267-8ddc055f983a",
     "type": "locations",
     "key": "southampton_county_court",
     "title": "Southampton County Court",
     "location_type": "court",
-    "location_code": null
+    "nomis_agency_id": null,
+    "disabled_at": null
   }, {
     "id": "7db3722d-bef0-4208-8a93-05b70dc0761b",
     "type": "locations",
     "key": "torquay_county_court",
     "title": "Torquay County Court",
     "location_type": "court",
-    "location_code": null
+    "nomis_agency_id": null,
+    "disabled_at": null
   }, {
     "id": "df6d742d-63b3-445f-b748-2653380f28d7",
     "type": "locations",
     "key": "wantage_county_court",
     "title": "Wantage County Court",
     "location_type": "court",
-    "location_code": null
+    "nomis_agency_id": null,
+    "disabled_at": null
   }, {
     "id": "5c82f67f-25f6-44c2-9fdd-a2ba6d71d964",
     "type": "locations",
     "key": "warrington_county_court",
     "title": "Warrington County Court",
     "location_type": "court",
-    "location_code": null
+    "nomis_agency_id": null,
+    "disabled_at": null
   }, {
     "id": "bacd8ed5-378b-4912-a029-bfb789086945",
     "type": "locations",
     "key": "watford_crown_court",
     "title": "Watford Crown Court",
     "location_type": "court",
-    "location_code": null
+    "nomis_agency_id": null,
+    "disabled_at": null
   }, {
     "id": "de136fb8-4491-48ea-be48-8f53f335e338",
     "type": "locations",
     "key": "weymouth_crown_court",
     "title": "Weymouth Crown Court",
     "location_type": "court",
-    "location_code": null
+    "nomis_agency_id": null,
+    "disabled_at": null
   }, {
     "id": "e9f59e9b-afd0-40e7-a1d4-f1786d7a7fc0",
     "type": "locations",
     "key": "wimbledon_magistrates_court",
     "title": "Wimbledon Magistrates Court",
     "location_type": "court",
-    "location_code": null
+    "nomis_agency_id": null,
+    "disabled_at": null
   }, {
     "id": "c6d31f13-ea68-4d47-9260-a2d77b0dbca5",
     "type": "locations",
     "key": "windsor_county_court",
     "title": "Windsor County Court",
     "location_type": "court",
-    "location_code": null
+    "nomis_agency_id": null,
+    "disabled_at": null
   }]
 }

--- a/test/fixtures/api-client/reference.locations.page-1.serialized.json
+++ b/test/fixtures/api-client/reference.locations.page-1.serialized.json
@@ -7,7 +7,8 @@
               "key": "bedford_county_court",
               "title": "Bedford County Court",
               "location_type": "court",
-              "location_code": null
+              "nomis_agency_id": null,
+              "disabled_at": null
           }
       },
       {
@@ -17,7 +18,8 @@
               "key": "luton_crown_court",
               "title": "Luton Crown Court",
               "location_type": "court",
-              "location_code": null
+              "nomis_agency_id": null,
+              "disabled_at": null
           }
       },
       {
@@ -27,7 +29,8 @@
               "key": "maidenhead_magistrates_court",
               "title": "Maidenhead Magistrates Court",
               "location_type": "court",
-              "location_code": null
+              "nomis_agency_id": null,
+              "disabled_at": null
           }
       },
       {
@@ -37,7 +40,8 @@
               "key": "newbury_county_court",
               "title": "Newbury County Court",
               "location_type": "court",
-              "location_code": null
+              "nomis_agency_id": null,
+              "disabled_at": null
           }
       },
       {
@@ -47,7 +51,8 @@
               "key": "reading_county_court",
               "title": "Reading County Court",
               "location_type": "court",
-              "location_code": null
+              "nomis_agency_id": null,
+              "disabled_at": null
           }
       },
       {
@@ -57,7 +62,8 @@
               "key": "windsor_county_court",
               "title": "Windsor County Court",
               "location_type": "court",
-              "location_code": null
+              "nomis_agency_id": null,
+              "disabled_at": null
           }
       },
       {
@@ -67,7 +73,8 @@
               "key": "bristol_crown_court",
               "title": "Bristol Crown Court",
               "location_type": "court",
-              "location_code": null
+              "nomis_agency_id": null,
+              "disabled_at": null
           }
       },
       {
@@ -77,7 +84,8 @@
               "key": "cambridge_crown_court",
               "title": "Cambridge Crown Court",
               "location_type": "court",
-              "location_code": null
+              "nomis_agency_id": null,
+              "disabled_at": null
           }
       },
       {
@@ -87,7 +95,8 @@
               "key": "peterborough_crown_court",
               "title": "Peterborough Crown Court",
               "location_type": "court",
-              "location_code": null
+              "nomis_agency_id": null,
+              "disabled_at": null
           }
       },
       {
@@ -97,7 +106,8 @@
               "key": "macclesfield_magistrates_court",
               "title": "Macclesfield Magistrates Court",
               "location_type": "court",
-              "location_code": null
+              "nomis_agency_id": null,
+              "disabled_at": null
           }
       },
       {
@@ -107,7 +117,8 @@
               "key": "warrington_county_court",
               "title": "Warrington County Court",
               "location_type": "court",
-              "location_code": null
+              "nomis_agency_id": null,
+              "disabled_at": null
           }
       },
       {
@@ -117,7 +128,8 @@
               "key": "bodmin_magistrates_court",
               "title": "Bodmin Magistrates Court",
               "location_type": "court",
-              "location_code": null
+              "nomis_agency_id": null,
+              "disabled_at": null
           }
       },
       {
@@ -127,7 +139,8 @@
               "key": "bude_county_court",
               "title": "Bude County Court",
               "location_type": "court",
-              "location_code": null
+              "nomis_agency_id": null,
+              "disabled_at": null
           }
       },
       {
@@ -137,7 +150,8 @@
               "key": "newquay_magistrates_court",
               "title": "Newquay Magistrates Court",
               "location_type": "court",
-              "location_code": null
+              "nomis_agency_id": null,
+              "disabled_at": null
           }
       },
       {
@@ -147,7 +161,8 @@
               "key": "penzance_county_court",
               "title": "Penzance County Court",
               "location_type": "court",
-              "location_code": null
+              "nomis_agency_id": null,
+              "disabled_at": null
           }
       },
       {
@@ -157,7 +172,8 @@
               "key": "darlington_crown_court",
               "title": "Darlington Crown Court",
               "location_type": "court",
-              "location_code": null
+              "nomis_agency_id": null,
+              "disabled_at": null
           }
       },
       {
@@ -167,7 +183,8 @@
               "key": "durham_magistrates_court",
               "title": "Durham Magistrates Court",
               "location_type": "court",
-              "location_code": null
+              "nomis_agency_id": null,
+              "disabled_at": null
           }
       },
       {
@@ -177,7 +194,8 @@
               "key": "barrow_in_furness_magistrates_court",
               "title": "Barrow in Furness Magistrates Court",
               "location_type": "court",
-              "location_code": null
+              "nomis_agency_id": null,
+              "disabled_at": null
           }
       },
       {
@@ -187,7 +205,8 @@
               "key": "carlisle_county_court",
               "title": "Carlisle County Court",
               "location_type": "court",
-              "location_code": null
+              "nomis_agency_id": null,
+              "disabled_at": null
           }
       },
       {
@@ -197,7 +216,8 @@
               "key": "chesterfield_crown_court",
               "title": "Chesterfield Crown Court",
               "location_type": "court",
-              "location_code": null
+              "nomis_agency_id": null,
+              "disabled_at": null
           }
       },
       {
@@ -207,7 +227,8 @@
               "key": "derby_county_court",
               "title": "Derby County Court",
               "location_type": "court",
-              "location_code": null
+              "nomis_agency_id": null,
+              "disabled_at": null
           }
       },
       {
@@ -217,7 +238,8 @@
               "key": "axminster_crown_court",
               "title": "Axminster Crown Court",
               "location_type": "court",
-              "location_code": null
+              "nomis_agency_id": null,
+              "disabled_at": null
           }
       },
       {
@@ -227,7 +249,8 @@
               "key": "barnstaple_crown_court",
               "title": "Barnstaple Crown Court",
               "location_type": "court",
-              "location_code": null
+              "nomis_agency_id": null,
+              "disabled_at": null
           }
       },
       {
@@ -237,7 +260,8 @@
               "key": "exeter_magistrates_court",
               "title": "Exeter Magistrates Court",
               "location_type": "court",
-              "location_code": null
+              "nomis_agency_id": null,
+              "disabled_at": null
           }
       },
       {
@@ -247,7 +271,8 @@
               "key": "plymouth_county_court",
               "title": "Plymouth County Court",
               "location_type": "court",
-              "location_code": null
+              "nomis_agency_id": null,
+              "disabled_at": null
           }
       },
       {
@@ -257,7 +282,8 @@
               "key": "torquay_county_court",
               "title": "Torquay County Court",
               "location_type": "court",
-              "location_code": null
+              "nomis_agency_id": null,
+              "disabled_at": null
           }
       },
       {
@@ -267,7 +293,8 @@
               "key": "weymouth_crown_court",
               "title": "Weymouth Crown Court",
               "location_type": "court",
-              "location_code": null
+              "nomis_agency_id": null,
+              "disabled_at": null
           }
       },
       {
@@ -277,7 +304,8 @@
               "key": "brighton_county_court",
               "title": "Brighton County Court",
               "location_type": "court",
-              "location_code": null
+              "nomis_agency_id": null,
+              "disabled_at": null
           }
       },
       {
@@ -287,7 +315,8 @@
               "key": "colchester_county_court",
               "title": "Colchester County Court",
               "location_type": "court",
-              "location_code": null
+              "nomis_agency_id": null,
+              "disabled_at": null
           }
       },
       {
@@ -297,7 +326,8 @@
               "key": "harlow_magistrates_court",
               "title": "Harlow Magistrates Court",
               "location_type": "court",
-              "location_code": null
+              "nomis_agency_id": null,
+              "disabled_at": null
           }
       },
       {
@@ -307,7 +337,8 @@
               "key": "romford_magistrates_court",
               "title": "Romford Magistrates Court",
               "location_type": "court",
-              "location_code": null
+              "nomis_agency_id": null,
+              "disabled_at": null
           }
       },
       {
@@ -317,7 +348,8 @@
               "key": "cheltenham_crown_court",
               "title": "Cheltenham Crown Court",
               "location_type": "court",
-              "location_code": null
+              "nomis_agency_id": null,
+              "disabled_at": null
           }
       },
       {
@@ -327,7 +359,8 @@
               "key": "croydon_magistrates_court",
               "title": "Croydon Magistrates Court",
               "location_type": "court",
-              "location_code": null
+              "nomis_agency_id": null,
+              "disabled_at": null
           }
       },
       {
@@ -337,7 +370,8 @@
               "key": "kingston_upon_thames_county_court",
               "title": "Kingston upon Thames County Court",
               "location_type": "court",
-              "location_code": null
+              "nomis_agency_id": null,
+              "disabled_at": null
           }
       },
       {
@@ -347,7 +381,8 @@
               "key": "richmond_crown_court",
               "title": "Richmond Crown Court",
               "location_type": "court",
-              "location_code": null
+              "nomis_agency_id": null,
+              "disabled_at": null
           }
       },
       {
@@ -357,7 +392,8 @@
               "key": "southall_crown_court",
               "title": "Southall Crown Court",
               "location_type": "court",
-              "location_code": null
+              "nomis_agency_id": null,
+              "disabled_at": null
           }
       },
       {
@@ -367,7 +403,8 @@
               "key": "wimbledon_magistrates_court",
               "title": "Wimbledon Magistrates Court",
               "location_type": "court",
-              "location_code": null
+              "nomis_agency_id": null,
+              "disabled_at": null
           }
       },
       {
@@ -377,7 +414,8 @@
               "key": "manchester_county_court",
               "title": "Manchester County Court",
               "location_type": "court",
-              "location_code": null
+              "nomis_agency_id": null,
+              "disabled_at": null
           }
       },
       {
@@ -387,7 +425,8 @@
               "key": "oldham_crown_court",
               "title": "Oldham Crown Court",
               "location_type": "court",
-              "location_code": null
+              "nomis_agency_id": null,
+              "disabled_at": null
           }
       },
       {
@@ -397,7 +436,8 @@
               "key": "basingstoke_county_court",
               "title": "Basingstoke County Court",
               "location_type": "court",
-              "location_code": null
+              "nomis_agency_id": null,
+              "disabled_at": null
           }
       },
       {
@@ -407,7 +447,8 @@
               "key": "southampton_county_court",
               "title": "Southampton County Court",
               "location_type": "court",
-              "location_code": null
+              "nomis_agency_id": null,
+              "disabled_at": null
           }
       },
       {
@@ -417,7 +458,8 @@
               "key": "watford_crown_court",
               "title": "Watford Crown Court",
               "location_type": "court",
-              "location_code": null
+              "nomis_agency_id": null,
+              "disabled_at": null
           }
       },
       {
@@ -427,7 +469,8 @@
               "key": "dover_magistrates_court",
               "title": "Dover Magistrates Court",
               "location_type": "court",
-              "location_code": null
+              "nomis_agency_id": null,
+              "disabled_at": null
           }
       },
       {
@@ -437,7 +480,8 @@
               "key": "maidstone_crown_court",
               "title": "Maidstone Crown Court",
               "location_type": "court",
-              "location_code": null
+              "nomis_agency_id": null,
+              "disabled_at": null
           }
       },
       {
@@ -447,7 +491,8 @@
               "key": "blackburn_county_court",
               "title": "Blackburn County Court",
               "location_type": "court",
-              "location_code": null
+              "nomis_agency_id": null,
+              "disabled_at": null
           }
       },
       {
@@ -457,7 +502,8 @@
               "key": "burnley_county_court",
               "title": "Burnley County Court",
               "location_type": "court",
-              "location_code": null
+              "nomis_agency_id": null,
+              "disabled_at": null
           }
       },
       {
@@ -467,7 +513,8 @@
               "key": "preston_crown_court",
               "title": "Preston Crown Court",
               "location_type": "court",
-              "location_code": null
+              "nomis_agency_id": null,
+              "disabled_at": null
           }
       },
       {
@@ -477,7 +524,8 @@
               "key": "grantham_magistrates_court",
               "title": "Grantham Magistrates Court",
               "location_type": "court",
-              "location_code": null
+              "nomis_agency_id": null,
+              "disabled_at": null
           }
       },
       {
@@ -487,7 +535,8 @@
               "key": "grimsby_magistrates_court",
               "title": "Grimsby Magistrates Court",
               "location_type": "court",
-              "location_code": null
+              "nomis_agency_id": null,
+              "disabled_at": null
           }
       },
       {
@@ -497,7 +546,8 @@
               "key": "liverpool_magistrates_court",
               "title": "Liverpool Magistrates Court",
               "location_type": "court",
-              "location_code": null
+              "nomis_agency_id": null,
+              "disabled_at": null
           }
       }
   ],

--- a/test/fixtures/api-client/reference.locations.page-2.serialized.json
+++ b/test/fixtures/api-client/reference.locations.page-2.serialized.json
@@ -7,7 +7,8 @@
               "key": "norwich_magistrates_court",
               "title": "Norwich Magistrates Court",
               "location_type": "court",
-              "location_code": null
+              "nomis_agency_id": null,
+              "disabled_at": null
           }
       },
       {
@@ -17,7 +18,8 @@
               "key": "oxford_magistrates_court",
               "title": "Oxford Magistrates Court",
               "location_type": "court",
-              "location_code": null
+              "nomis_agency_id": null,
+              "disabled_at": null
           }
       },
       {
@@ -27,7 +29,8 @@
               "key": "wantage_county_court",
               "title": "Wantage County Court",
               "location_type": "court",
-              "location_code": null
+              "nomis_agency_id": null,
+              "disabled_at": null
           }
       },
       {
@@ -37,7 +40,8 @@
               "key": "guildford_county_court",
               "title": "Guildford County Court",
               "location_type": "court",
-              "location_code": null
+              "nomis_agency_id": null,
+              "disabled_at": null
           }
       }
   ],


### PR DESCRIPTION
This removes items that we don't want displayed when creating new moves from the reference data set.

It uses the `disabled_at` property to determine whether these options should be shown or not.