### PR TITLE
[P4-539] Update phase banner to "Beta"

### DIFF
--- a/common/templates/layouts/govuk.njk
+++ b/common/templates/layouts/govuk.njk
@@ -60,7 +60,7 @@
 {% block beforeContent %}
   {{ govukPhaseBanner({
     tag: {
-      text: "alpha"
+      text: "Beta"
     },
     html: t("phase_banner", {
       context: "with_feedback" if FEEDBACK_URL,


### PR DESCRIPTION
The service is moving in private beta so this change updates the
phase banner to match.

## Before

![image](https://user-images.githubusercontent.com/3327997/61790961-7f4d6880-ae10-11e9-8b8b-6a5c0bf66195.png)

## After

![image](https://user-images.githubusercontent.com/3327997/61790937-72c91000-ae10-11e9-887c-41f2020a1633.png)
