### PR TITLE
[P4-495] [P4-496] Header tweaks

### DIFF
--- a/common/assets/javascripts/application.js
+++ b/common/assets/javascripts/application.js
@@ -10,8 +10,12 @@ import { nodeListForEach } from './utils'
 import { initAll } from 'govuk-frontend'
 import accessibleAutocomplete from 'accessible-autocomplete'
 import Message from '../../components/message/message'
+import Header from '../../components/internal-header/internal-header'
 
 initAll()
+
+var $toggleButton = document.querySelector('[data-module="header"]')
+new Header($toggleButton).init()
 
 var $messages = document.querySelectorAll('[data-module="app-message"]')
 nodeListForEach($messages, function ($message) {

--- a/common/components/internal-header/_internal-header.scss
+++ b/common/components/internal-header/_internal-header.scss
@@ -91,9 +91,13 @@ $govuk-header-nav-item-border-color: #2e3133;
   // in Firefox
   @include govuk-font($size: false, $weight: bold);
 
-  display: inline-block;
+  display: inline;
   font-size: 30px; // We don't have a mixin that produces 30px font size
-  line-height: 30px;
+  line-height: 1;
+
+  @include mq ($from: desktop) {
+    display: inline-block;
+  }
 
   &:link,
   &:visited {
@@ -107,6 +111,12 @@ $govuk-header-nav-item-border-color: #2e3133;
     // Omitting colour will use default value of currentColor – if we
     // specified currentColor explicitly IE8 would ignore this rule.
     border-bottom: 1px solid;
+  }
+
+  // Remove any borders that show when focused and hovered.
+  &:focus {
+    margin-bottom: 0;
+    border-bottom: 0;
   }
 }
 
@@ -122,7 +132,8 @@ $govuk-header-nav-item-border-color: #2e3133;
 }
 
 .app-header__logo {
-  @include govuk-responsive-margin(2, "bottom");
+  padding-bottom: govuk-spacing(2);
+  padding-right: govuk-spacing(9);
 
   @include mq ($from: desktop) {
     width: 50%;

--- a/common/components/internal-header/_internal-header.scss
+++ b/common/components/internal-header/_internal-header.scss
@@ -192,7 +192,10 @@ $govuk-header-nav-item-border-color: #2e3133;
   margin: 0;
   padding: 0;
   list-style: none;
-  float: right;
+
+  @include mq ($from: desktop) {
+    float: right;
+  }
 }
 
 .js-enabled {

--- a/common/components/internal-header/internal-header.js
+++ b/common/components/internal-header/internal-header.js
@@ -1,0 +1,62 @@
+function Header ($module) {
+  this.$module = $module
+}
+
+Header.prototype.init = function () {
+  // Check for module
+  var $module = this.$module
+  if (!$module) {
+    return
+  }
+
+  // Check for button
+  var $toggleButton = $module.querySelector('.js-header-toggle')
+  if (!$toggleButton) {
+    return
+  }
+
+  // Handle $toggleButton click events
+  $toggleButton.addEventListener('click', this.handleClick.bind(this))
+}
+
+/**
+ * Toggle class
+ * @param {object} node element
+ * @param {string} className to toggle
+ */
+Header.prototype.toggleClass = function (node, className) {
+  if (node.className.indexOf(className) > 0) {
+    node.className = node.className.replace(' ' + className, '')
+  } else {
+    node.className += ' ' + className
+  }
+}
+
+/**
+ * An event handler for click event on $toggleButton
+ * @param {object} event event
+ */
+Header.prototype.handleClick = function (event) {
+  var $module = this.$module
+  var $toggleButton = event.target || event.srcElement
+  var $target = $module.querySelector(
+    '#' + $toggleButton.getAttribute('aria-controls')
+  )
+
+  // If a button with aria-controls, handle click
+  if ($toggleButton && $target) {
+    this.toggleClass($target, 'app-header__navigation--open')
+    this.toggleClass($toggleButton, 'app-header__menu-button--open')
+
+    $toggleButton.setAttribute(
+      'aria-expanded',
+      $toggleButton.getAttribute('aria-expanded') !== 'true'
+    )
+    $target.setAttribute(
+      'aria-hidden',
+      $target.getAttribute('aria-hidden') === 'false'
+    )
+  }
+}
+
+module.exports = Header


### PR DESCRIPTION
This PR includes:
- an update to the style of the header to fix the missing padding on mobile layout
- fix for showing/hiding the menu on mobile (JS needed was taken from [header component](https://github.com/alphagov/govuk-frontend/tree/master/src/govuk/components/header) in GOV.UK Design System)

## What it looks like

### Before

![image](https://user-images.githubusercontent.com/3327997/61810740-ce5ac400-ae37-11e9-9af1-f7630b8cc05b.png)

### After

![image](https://user-images.githubusercontent.com/3327997/61810713-bedb7b00-ae37-11e9-8ceb-c4170f5f1802.png)
