### PR TITLE
[P4-552] CircleCI production build/deploy steps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,6 +26,73 @@ references:
         environment:
           GITHUB_TEAM_NAME_SLUG: pecs
 
+commands:
+  build_for_k8s:
+    description: "Builds a Docker image for staging/production and pushes to ECR"
+    parameters:
+      env:
+        type: string
+    steps:
+      - checkout
+
+      - setup_remote_docker:
+          docker_layer_caching: true
+
+      - run:
+          name: build docker image
+          command: |
+            export BUILD_DATE=$(date -Is) >> $BASH_ENV
+            source $BASH_ENV
+
+            docker build \
+              --label build.git.sha=${CIRCLE_SHA1} \
+              --label build.git.branch=${CIRCLE_BRANCH} \
+              --label build.date=${BUILD_DATE} \
+              --build-arg APP_BUILD_DATE=${BUILD_DATE} \
+              --build-arg APP_BUILD_TAG=${CIRCLE_BRANCH} \
+              --build-arg APP_GIT_COMMIT=${CIRCLE_SHA1} \
+              -t app .
+
+      - run:
+          name: push docker image
+          command: |
+            login="$(aws ecr get-login --region ${AWS_DEFAULT_REGION} --no-include-email)"
+            ${login}
+
+            docker tag app "${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${CIRCLE_PROJECT_REPONAME}:${CIRCLE_SHA1}"
+            docker push "${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${CIRCLE_PROJECT_REPONAME}:${CIRCLE_SHA1}"
+
+            docker tag app "${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${CIRCLE_PROJECT_REPONAME}:<< parameters.env >>.latest"
+            docker push "${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${CIRCLE_PROJECT_REPONAME}:<< parameters.env >>.latest"
+
+  deploy_to_k8s:
+    description: "Deploys a previously built Docker image to staging/production k8s environment"
+    parameters:
+      env:
+        type: string
+    steps:
+      - checkout
+
+      - run:
+          name: kubectl use context
+          command: |
+            setup-kube-auth
+            kubectl config use-context << parameters.env >>
+
+      - deploy:
+          name: rolling update image to << parameters.env >>
+          command: |
+            export BUILD_DATE=$(date -Is) >> $BASH_ENV
+            source $BASH_ENV
+
+            kubectl set image -n hmpps-book-secure-move-frontend-<< parameters.env >> \
+                    deployment/hmpps-book-secure-move-frontend-deployment-<< parameters.env >> \
+                    webapp="${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${CIRCLE_PROJECT_REPONAME}:${CIRCLE_SHA1}"
+
+            kubectl annotate -n hmpps-book-secure-move-frontend-<< parameters.env >> \
+                    deployment/hmpps-book-secure-move-frontend-deployment-<< parameters.env >> \
+                    kubernetes.io/change-cause="${BUILD_DATE} set image ${CIRCLE_PROJECT_REPONAME}:${CIRCLE_SHA1} via CircleCI"
+
 jobs:
   build:
     docker:
@@ -96,65 +163,30 @@ jobs:
           path: ./reports/mocha/test-results.xml
       - store_artifacts:
           path: coverage
+
   build_staging:
     <<: *cloud_container
     steps:
-      - checkout
-
-      - setup_remote_docker:
-          docker_layer_caching: true
-
-      - run:
-          name: build docker image
-          command: |
-            export BUILD_DATE=$(date -Is) >> $BASH_ENV
-            source $BASH_ENV
-
-            docker build \
-              --label build.git.sha=${CIRCLE_SHA1} \
-              --label build.git.branch=${CIRCLE_BRANCH} \
-              --label build.date=${BUILD_DATE} \
-              --build-arg APP_BUILD_DATE=${BUILD_DATE} \
-              --build-arg APP_BUILD_TAG=${CIRCLE_BRANCH} \
-              --build-arg APP_GIT_COMMIT=${CIRCLE_SHA1} \
-              -t app .
-
-      - run:
-          name: push docker image
-          command: |
-            login="$(aws ecr get-login --region ${AWS_DEFAULT_REGION} --no-include-email)"
-            ${login}
-
-            docker tag app "${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${CIRCLE_PROJECT_REPONAME}:${CIRCLE_SHA1}"
-            docker push "${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${CIRCLE_PROJECT_REPONAME}:${CIRCLE_SHA1}"
-
-            docker tag app "${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${CIRCLE_PROJECT_REPONAME}:staging.latest"
-            docker push "${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${CIRCLE_PROJECT_REPONAME}:staging.latest"
+      - build_for_k8s:
+         env: "staging"
 
   deploy_staging:
     <<: *cloud_container
     steps:
-      - checkout
+      - deploy_to_k8s:
+         env: "staging"
 
-      - run:
-          name: kubectl use context
-          command: |
-            setup-kube-auth
-            kubectl config use-context staging
+  build_production:
+    <<: *cloud_container
+    steps:
+      - build_for_k8s:
+         env: "production"
 
-      - deploy:
-          name: rolling update image to staging
-          command: |
-            export BUILD_DATE=$(date -Is) >> $BASH_ENV
-            source $BASH_ENV
-
-            kubectl set image -n hmpps-book-secure-move-frontend-staging \
-                    deployment/hmpps-book-secure-move-frontend-deployment-staging \
-                    webapp="${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${CIRCLE_PROJECT_REPONAME}:${CIRCLE_SHA1}"
-
-            kubectl annotate -n hmpps-book-secure-move-frontend-staging \
-                    deployment/hmpps-book-secure-move-frontend-deployment-staging \
-                    kubernetes.io/change-cause="${BUILD_DATE} set image ${CIRCLE_PROJECT_REPONAME}:${CIRCLE_SHA1} via CircleCI"
+  deploy_production:
+    <<: *cloud_container
+    steps:
+      - deploy_to_k8s:
+         env: "production"
 
 workflows:
   pecs-frontend:
@@ -173,3 +205,18 @@ workflows:
       - deploy_staging:
           requires:
             - build_staging
+      - hold_production:
+          type: approval
+          requires:
+            - build
+            - lint
+            - unit_test
+          filters:
+            branches:
+              only: master
+      - build_production:
+          requires:
+            - hold_production
+      - deploy_production:
+          requires:
+            - build_production


### PR DESCRIPTION
Kick off a production build and deploy after a successful test on `master` subject to an Approval step. Mirrors https://github.com/ministryofjustice/hmpps-book-secure-move-api/pull/85

I've already added the 4 `KUBE_ENV_PRODUCTION_*` environment variables to the CircleCI config, (https://user-guide.cloud-platform.service.justice.gov.uk/tasks.html#add-variables-to-circleci)