### PR TITLE
Use correct property name for disabled filter

### DIFF
--- a/common/helpers/reference-data.js
+++ b/common/helpers/reference-data.js
@@ -2,11 +2,11 @@ function filterDisabled ({ currentValue = null, createdOn } = {}) {
   const createdOnTime = Date.parse(createdOn) || Date.now()
 
   return function (item) {
-    if (!item.disabled_on) {
+    if (!item.disabled_at) {
       return true
     }
 
-    const isDisabled = Date.parse(item.disabled_on) > createdOnTime
+    const isDisabled = Date.parse(item.disabled_at) > createdOnTime
     const isCurrentValue = item.id === currentValue
 
     return isDisabled || isCurrentValue

--- a/common/helpers/reference-data.test.js
+++ b/common/helpers/reference-data.test.js
@@ -13,7 +13,7 @@ describe('Reference data helpers', function () {
           {
             id: '1234',
             name: 'Freds',
-            disabled_on: lastMonth,
+            disabled_at: lastMonth,
           },
         ]
       })
@@ -65,7 +65,7 @@ describe('Reference data helpers', function () {
           {
             id: '1234',
             name: 'Freds',
-            disabled_on: nextMonth,
+            disabled_at: nextMonth,
           },
         ]
       })
@@ -117,7 +117,7 @@ describe('Reference data helpers', function () {
           {
             id: '1234',
             name: 'Freds',
-            disabled_on: null,
+            disabled_at: null,
           },
         ]
       })


### PR DESCRIPTION
The reference data disabled filter was using the wrong property name.

This change updates it to use the correct one.