### PR TITLE
Add page title to form wizard

### DIFF
--- a/app/move/index.js
+++ b/app/move/index.js
@@ -13,6 +13,7 @@ const wizardConfig = {
   controller: Form,
   name: 'new-move',
   journeyName: 'new-move',
+  journeyPageTitle: 'actions::create_move',
   template: 'form-wizard',
 }
 

--- a/app/move/steps.js
+++ b/app/move/steps.js
@@ -15,7 +15,7 @@ module.exports = {
   '/personal-details': {
     controller: PersonalDetails,
     backLink: null,
-    heading: 'moves::steps.personal_details.heading',
+    pageTitle: 'moves::steps.personal_details.heading',
     next: 'move-details',
     fields: [
       'police_national_computer',
@@ -29,7 +29,7 @@ module.exports = {
   '/move-details': {
     controller: MoveDetails,
     template: 'move/views/new/move-details',
-    heading: 'moves::steps.move_details.heading',
+    pageTitle: 'moves::steps.move_details.heading',
     next: [
       { field: 'to_location_type', value: 'court', next: 'court-information' },
       'risk-information',
@@ -47,7 +47,7 @@ module.exports = {
   },
   '/court-information': {
     controller: Assessment,
-    heading: 'moves::steps.court_information.heading',
+    pageTitle: 'moves::steps.court_information.heading',
     next: 'risk-information',
     fields: [
       'court',
@@ -58,7 +58,7 @@ module.exports = {
   },
   '/risk-information': {
     controller: Assessment,
-    heading: 'moves::steps.risk_information.heading',
+    pageTitle: 'moves::steps.risk_information.heading',
     next: 'health-information',
     fields: [
       'risk',
@@ -73,7 +73,7 @@ module.exports = {
   '/health-information': {
     controller: Assessment,
     next: 'save',
-    heading: 'moves::steps.health_information.heading',
+    pageTitle: 'moves::steps.health_information.heading',
     buttonText: 'actions::schedule_move',
     fields: [
       'health',

--- a/common/templates/form-wizard.njk
+++ b/common/templates/form-wizard.njk
@@ -1,5 +1,9 @@
 {% extends "layouts/govuk.njk" %}
 
+{% block pageTitle %}
+  {{ t(options.pageTitle) }} - {{ t(options.journeyPageTitle) }}
+{% endblock %}
+
 {% block beforeContent %}
   {{ super() }}
 
@@ -22,7 +26,7 @@
   <header class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-xl">
-        {{ t(options.heading) }}
+        {{ t(options.pageTitle) }}
       </h1>
     </div>
   </header>


### PR DESCRIPTION
This change sets the page title for form wizard steps. At the moment
the form wizard falls back to the default page title.

This change adds a new property to the wizard settings to use as
the page title. It also renames the `heading` property for each step
to be more consistent.

## Before
![image](https://user-images.githubusercontent.com/3327997/62056320-4a2c8600-b215-11e9-9fd3-79bc60965fbd.png)

## After
![image](https://user-images.githubusercontent.com/3327997/62056379-67f9eb00-b215-11e9-9c78-3b0eb7ed4184.png)

