### PR TITLE
Update move reference style

### DIFF
--- a/app/move/views/view.njk
+++ b/app/move/views/view.njk
@@ -22,13 +22,15 @@
 
 {% block content %}
   <header class="govuk-!-margin-bottom-8">
-    <span class="govuk-caption-xl">
-      {{ move.reference }}
-    </span>
-
-    <h1 class="govuk-heading-xl govuk-!-margin-bottom-0">
+    <h1 class="govuk-heading-xl govuk-!-margin-bottom-1">
       {{ fullname | upper }}
     </h1>
+
+    <span class="govuk-caption-xl">
+      {{ t("moves::move_reference", {
+        reference: move.reference
+      }) }}
+    </span>
 
     {% if tagList | length %}
       <div class="govuk-!-margin-top-2">

--- a/common/components/card/_card.scss
+++ b/common/components/card/_card.scss
@@ -20,17 +20,13 @@
 }
 
 .app-card__caption {
-  @include govuk-font($size: 19);
+  @include govuk-font($size: 16);
+  color: govuk-colour("grey-1");
 }
 
 .app-card__title {
   @include govuk-font($size: 19, $weight: bold);
   margin: 0;
-
-  @include mq ($from: desktop) {
-    margin-right: govuk-spacing(2);
-    float: left;
-  }
 }
 
 .app-card__content {

--- a/common/presenters/move-to-card-component.js
+++ b/common/presenters/move-to-card-component.js
@@ -21,7 +21,6 @@ module.exports = function moveToCardComponent ({ id, reference, person }) {
   const meta = [
     {
       label: i18n.t('fields::date_of_birth.label'),
-      hideLabel: true,
       html: person.date_of_birth
         ? `${filters.formatDate(person.date_of_birth)} (${i18n.t(
           'age'
@@ -30,13 +29,7 @@ module.exports = function moveToCardComponent ({ id, reference, person }) {
     },
     {
       label: i18n.t('fields::gender.label'),
-      hideLabel: true,
       text: person.gender ? person.gender.title : '',
-    },
-    {
-      label: i18n.t('fields::ethnicity.label'),
-      hideLabel: true,
-      text: person.ethnicity ? person.ethnicity.title : '',
     },
   ]
 
@@ -46,7 +39,9 @@ module.exports = function moveToCardComponent ({ id, reference, person }) {
       text: personService.getFullname(person).toUpperCase(),
     },
     caption: {
-      text: reference,
+      text: i18n.t('moves::move_reference', {
+        reference,
+      }),
     },
     meta: {
       items: _removeEmpty(meta, ['text', 'html']),

--- a/common/presenters/move-to-card-component.test.js
+++ b/common/presenters/move-to-card-component.test.js
@@ -41,7 +41,7 @@ describe('Presenters', function () {
         it('should contain a caption', function () {
           expect(transformedResponse).to.have.property('caption')
           expect(transformedResponse.caption).to.deep.equal({
-            text: mockMove.reference,
+            text: `__translated__`,
           })
         })
 
@@ -50,19 +50,12 @@ describe('Presenters', function () {
           expect(transformedResponse.meta).to.deep.equal({
             items: [
               {
-                hideLabel: true,
                 label: '__translated__',
                 html: '18 Jun 1960 (__translated__ 50)',
               },
               {
-                hideLabel: true,
                 label: '__translated__',
                 text: mockMove.person.gender.title,
-              },
-              {
-                hideLabel: true,
-                label: '__translated__',
-                text: mockMove.person.ethnicity.title,
               },
             ],
           })
@@ -113,9 +106,10 @@ describe('Presenters', function () {
           )
         })
 
-        it('should translate ethnicity label', function () {
+        it('should translate move reference', function () {
           expect(i18n.t.getCall(3)).to.be.calledWithExactly(
-            'fields::ethnicity.label'
+            'moves::move_reference',
+            { reference: mockMove.reference }
           )
         })
 
@@ -168,7 +162,6 @@ describe('Presenters', function () {
           expect(transformedResponse.meta).to.deep.equal({
             items: [
               {
-                hideLabel: true,
                 label: '__translated__',
                 text: mockMove.person.gender.title,
               },

--- a/locales/en/moves.json
+++ b/locales/en/moves.json
@@ -1,5 +1,6 @@
 {
   "download_filename": "Moves on {{date}} (Downloaded {{timestamp}})",
+  "move_reference": "Move reference: {{reference}}",
   "assessment": {
     "categories": {
       "risk": {


### PR DESCRIPTION
This change updates how the move reference is displayed on the
move listing and move detail pages.

## Dashboard
### Before
![image](https://user-images.githubusercontent.com/3327997/62085126-ba0d3180-b252-11e9-9d36-8f15f40de303.png)
### After
![image](https://user-images.githubusercontent.com/3327997/62085198-e5901c00-b252-11e9-94fc-ad6868dac7b7.png)

## Move detail
### Before
![image](https://user-images.githubusercontent.com/3327997/62085140-c5605d00-b252-11e9-8518-644e92eaf069.png)

## After
![image](https://user-images.githubusercontent.com/3327997/62085177-d6a96980-b252-11e9-83fb-996970ea3185.png)
