### PR TITLE
[P4-476] [P4-546] No results panel

### DIFF
--- a/app/move/views/_includes/assessment.njk
+++ b/app/move/views/_includes/assessment.njk
@@ -32,9 +32,13 @@
       }) }}
     {% endcall %}
   {% else %}
-    <p>
-      {{ t("moves::assessment.categories." + section.category + ".empty") }}
-    </p>
+    {{ appMessage({
+      classes: "app-message--muted",
+      allowDismiss: false,
+      content: {
+        html: t("moves::assessment.categories." + section.category + ".empty")
+      }
+    }) }}
   {% endfor %}
 {% endfor %}
 
@@ -45,7 +49,11 @@
 {% if courtSummary.rows | length %}
   {{ govukSummaryList(courtSummary) }}
 {% else %}
-  <p>
-    {{ t("moves::assessment.categories.court.empty") }}
-  </p>
+  {{ appMessage({
+    classes: "app-message--muted",
+    allowDismiss: false,
+    content: {
+      html: t("moves::assessment.categories.court.empty")
+    }
+  }) }}
 {% endif %}

--- a/app/move/views/view.njk
+++ b/app/move/views/view.njk
@@ -56,7 +56,7 @@
       {% include "move/views/_includes/assessment.njk" %}
 
       {% if canAccess('move:cancel') %}
-        <p class="app-border-top-1 govuk-!-padding-top-6 govuk-!-margin-top-8">
+        <p class="govuk-!-margin-top-9">
           <a href="{{ move.id }}/cancel" class="app-link--destructive">
             {{ t("actions::cancel_move") }}
           </a>

--- a/app/moves/views/list.njk
+++ b/app/moves/views/list.njk
@@ -56,5 +56,13 @@
         {{ appCard(move) }}
       {% endfor %}
     </div>
+  {% else %}
+    {{ appMessage({
+      classes: "app-message--muted govuk-!-margin-top-7",
+      allowDismiss: false,
+      content: {
+        html: t("moves::dashboard.no_results")
+      }
+    }) }}
   {% endfor %}
 {% endblock %}

--- a/common/components/message/_message.scss
+++ b/common/components/message/_message.scss
@@ -81,3 +81,9 @@
 .app-message--error {
   border-color: $govuk-error-colour;
 }
+
+.app-message--muted {
+  border-color: govuk-colour("grey-1");
+  border-width: 0 0 0 5px;
+  background-color: govuk-colour("grey-4");
+}

--- a/common/components/message/message.yaml
+++ b/common/components/message/message.yaml
@@ -61,3 +61,10 @@ examples:
         html: A message heading
       content:
         html: Containing some <strong>extra content</strong>.
+  - name: without dismiss
+    data:
+      allowDismiss: false
+      title:
+        html: A message heading
+      content:
+        html: Containing some <strong>extra content</strong>.

--- a/common/components/message/template.njk
+++ b/common/components/message/template.njk
@@ -1,6 +1,7 @@
 {% set element = params.element | default('div') %}
+{% set allowDismiss = params.allowDismiss | default(true) %}
 
-<{{ element }} class="app-message{% if params.classes %} {{ params.classes }}{% endif %}" data-module="app-message" tabindex="-1" role="alert">
+<{{ element }} class="app-message{% if params.classes %} {{ params.classes }}{% endif %}"{% if allowDismiss %} data-module="app-message"{% endif %} tabindex="-1" role="alert">
   {% if params.title.html or params.title.text %}
     <h2 class="app-message__heading">
       {{ params.title.html | safe if params.title.html else params.title.text }}

--- a/common/components/message/template.test.js
+++ b/common/components/message/template.test.js
@@ -23,6 +23,10 @@ describe('Message component', function() {
           .trim()
       ).to.equal('Notification message')
     })
+
+    it('should render module data attribute', function() {
+      expect($component.attr('data-module')).to.equal('app-message')
+    })
   })
 
   context('with classes', function() {
@@ -144,6 +148,13 @@ describe('Message component', function() {
         expect($component.html()).to.contain(
           'A message with <strong>bold text</strong>'
         )
+      })
+    })
+
+    context('when dismiss is prevented', function() {
+      it('should render unescaped html', function() {
+        const $ = render('message', examples['without dismiss'])
+        expect($('.app-message').attr('data-module')).to.equal(undefined)
       })
     })
   })

--- a/locales/en/moves.json
+++ b/locales/en/moves.json
@@ -62,7 +62,8 @@
   },
   "dashboard": {
     "upcoming_moves": "Upcoming moves for {{date}}",
-    "move_to": "Move to"
+    "move_to": "Move to",
+    "no_results": "No moves scheduled"
   },
   "detail": {
     "page_title": "Move details for {{name}}"


### PR DESCRIPTION
This change covers 2 tickets which relate to how empty results are displayed both on the move detail page and the move listing page. 

It extends the message component so that it can be used to display the empty results text in the desired way.

## What it looks like

### Move details

#### Before
![localhost_3000_move_1d8dbf06-4d64-4045-8b31-90862d6dcbcd (1)](https://user-images.githubusercontent.com/3327997/62462629-c24bfc00-b77f-11e9-90d7-702f6409c944.png)
![localhost_3000_move_633a32e5-3086-49a7-8a2b-541bc309cb91 (1)](https://user-images.githubusercontent.com/3327997/62462641-cc6dfa80-b77f-11e9-9570-b7f44ffbea42.png)

#### After
![localhost_3000_move_1d8dbf06-4d64-4045-8b31-90862d6dcbcd](https://user-images.githubusercontent.com/3327997/62462516-8add4f80-b77f-11e9-83de-effa9e02d285.png)
![localhost_3000_move_633a32e5-3086-49a7-8a2b-541bc309cb91](https://user-images.githubusercontent.com/3327997/62462539-992b6b80-b77f-11e9-9e62-f23408df405a.png)

### Move listing

#### Before
![localhost_3000_moves_move-date=2019-08-04 (1)](https://user-images.githubusercontent.com/3327997/62462597-b2ccb300-b77f-11e9-9ec4-75ae3ee54aa7.png)

#### After
![localhost_3000_moves_move-date=2019-08-04](https://user-images.githubusercontent.com/3327997/62462573-a6e0f100-b77f-11e9-8923-bb9b2fe34fb4.png)
