### PR TITLE
Redirect user back to that day after save

### DIFF
--- a/app/move/controllers/new.save.js
+++ b/app/move/controllers/new.save.js
@@ -44,7 +44,7 @@ class SaveController extends FormController {
       }),
     })
 
-    res.redirect('/moves')
+    res.redirect(`/moves?move-date=${date}`)
   }
 }
 

--- a/app/move/controllers/new.save.test.js
+++ b/app/move/controllers/new.save.test.js
@@ -167,7 +167,9 @@ describe('Move controllers', function() {
 
       it('should redirect correctly', function() {
         expect(res.redirect).to.have.been.calledOnce
-        expect(res.redirect).to.have.been.calledWith('/moves')
+        expect(res.redirect).to.have.been.calledWith(
+          `/moves?move-date=${moveMock.date}`
+        )
       })
     })
   })


### PR DESCRIPTION
This change redirects the user back to the date they created the move
for on the dashboard.

This makes more sense than always redirecting the user back to the
default day (today) where they won't see the move they just created.