### PR TITLE
[P4-317] Store listing state

### DIFF
--- a/app/move/views/view.njk
+++ b/app/move/views/view.njk
@@ -16,7 +16,7 @@
   {{ govukBackLink({
     text: t("actions::back_to_dashboard"),
     classes: "app-print--hide",
-    href: "/moves"
+    href: MOVES_URL
   }) }}
 
   <a href="javascript:window.print()" class="app-!-float-right app-print--hide govuk-!-margin-top-3">

--- a/app/moves/index.js
+++ b/app/moves/index.js
@@ -6,6 +6,7 @@ const { protectRoute } = require('../../common/middleware/permissions')
 const { download, list } = require('./controllers')
 const {
   redirectUsers,
+  storeQuery,
   setMoveDate,
   setFromLocation,
   setMovesByDate,
@@ -18,6 +19,7 @@ const uuidRegex =
 router.param('locationId', setFromLocation)
 
 // Define routes
+router.use(storeQuery)
 router.use(setMoveDate)
 router.get(
   '/',

--- a/app/moves/middleware.js
+++ b/app/moves/middleware.js
@@ -1,3 +1,4 @@
+const queryString = require('query-string')
 const { format } = require('date-fns')
 const { get } = require('lodash')
 
@@ -8,6 +9,7 @@ module.exports = {
   redirectUsers: (req, res, next) => {
     const userPermissions = get(req.session, 'user.permissions')
     const currentLocation = get(req.session, 'currentLocation.id')
+    const search = queryString.stringify(req.query)
 
     if (permissions.check('moves:view:all', userPermissions)) {
       return next()
@@ -17,7 +19,9 @@ module.exports = {
       permissions.check('moves:view:by_location', userPermissions) &&
       currentLocation
     ) {
-      return res.redirect(`/moves/${currentLocation}`)
+      return res.redirect(
+        `${req.baseUrl}/${currentLocation}${search ? `?${search}` : ''}`
+      )
     }
 
     next()

--- a/app/moves/middleware.js
+++ b/app/moves/middleware.js
@@ -22,6 +22,11 @@ module.exports = {
 
     next()
   },
+  storeQuery: (req, res, next) => {
+    req.session.movesQuery = req.query
+
+    next()
+  },
   setMoveDate: (req, res, next) => {
     res.locals.moveDate =
       req.query['move-date'] || format(new Date(), 'YYYY-MM-DD')

--- a/app/moves/middleware.test.js
+++ b/app/moves/middleware.test.js
@@ -13,7 +13,9 @@ describe('Moves middleware', function() {
     beforeEach(function() {
       sinon.stub(permissions, 'check')
       nextSpy = sinon.spy()
-      req = {}
+      req = {
+        baseUrl: '/moves',
+      }
       res = {
         redirect: sinon.stub(),
       }
@@ -59,17 +61,41 @@ describe('Moves middleware', function() {
           req.session.currentLocation = {
             id: mockLocationId,
           }
-          middleware.redirectUsers(req, res, nextSpy)
         })
 
-        it('should redirect to moves by location', function() {
-          expect(res.redirect).to.have.been.calledOnceWithExactly(
-            `/moves/${mockLocationId}`
-          )
+        context('when current request contains search', function() {
+          beforeEach(function() {
+            req.query = {
+              'move-date': '2019-10-10',
+            }
+            middleware.redirectUsers(req, res, nextSpy)
+          })
+
+          it('should redirect to moves by location', function() {
+            expect(res.redirect).to.have.been.calledOnceWithExactly(
+              `/moves/${mockLocationId}?move-date=2019-10-10`
+            )
+          })
+
+          it('should not call next', function() {
+            expect(nextSpy).not.to.have.been.called
+          })
         })
 
-        it('should not call next', function() {
-          expect(nextSpy).not.to.have.been.called
+        context('when current request does not contain search', function() {
+          beforeEach(function() {
+            middleware.redirectUsers(req, res, nextSpy)
+          })
+
+          it('should redirect to moves by location', function() {
+            expect(res.redirect).to.have.been.calledOnceWithExactly(
+              `/moves/${mockLocationId}`
+            )
+          })
+
+          it('should not call next', function() {
+            expect(nextSpy).not.to.have.been.called
+          })
         })
       })
 

--- a/app/moves/middleware.test.js
+++ b/app/moves/middleware.test.js
@@ -103,6 +103,56 @@ describe('Moves middleware', function() {
     })
   })
 
+  describe('#storeQuery()', function() {
+    let req, nextSpy
+
+    context('with empty request query', function() {
+      beforeEach(function() {
+        req = {
+          query: {},
+          session: {},
+        }
+        nextSpy = sinon.spy()
+
+        middleware.storeQuery(req, {}, nextSpy)
+      })
+
+      it('should update session correctly', function() {
+        expect(req.session).to.have.property('movesQuery')
+        expect(req.session.movesQuery).to.deep.equal({})
+      })
+
+      it('should call next', function() {
+        expect(nextSpy).to.be.calledOnceWithExactly()
+      })
+    })
+
+    context('with non empty request query', function() {
+      beforeEach(function() {
+        req = {
+          query: {
+            'move-date': '2019-10-10',
+          },
+          session: {},
+        }
+        nextSpy = sinon.spy()
+
+        middleware.storeQuery(req, {}, nextSpy)
+      })
+
+      it('should update session correctly', function() {
+        expect(req.session).to.have.property('movesQuery')
+        expect(req.session.movesQuery).to.deep.equal({
+          'move-date': '2019-10-10',
+        })
+      })
+
+      it('should call next', function() {
+        expect(nextSpy).to.be.calledOnceWithExactly()
+      })
+    })
+  })
+
   describe('#setMoveDate()', function() {
     let req, res, nextSpy
 

--- a/common/middleware/locals.js
+++ b/common/middleware/locals.js
@@ -1,3 +1,4 @@
+const queryString = require('query-string')
 const { get } = require('lodash')
 const { startOfTomorrow } = require('date-fns')
 
@@ -6,12 +7,14 @@ const { check } = require('./permissions')
 module.exports = function setLocals(req, res, next) {
   const protocol = req.encrypted ? 'https' : req.protocol
   const baseUrl = `${protocol}://${req.get('host')}`
+  const movesSearch = queryString.stringify(req.session.movesQuery)
   const locals = {
     CANONICAL_URL: baseUrl + req.path,
     TODAY: new Date(),
     TOMORROW: startOfTomorrow(),
     REQUEST_PATH: req.path,
     CURRENT_LOCATION: req.session.currentLocation,
+    MOVES_URL: movesSearch ? `/moves?${movesSearch}` : '/moves',
     getLocal: key => res.locals[key],
     getMessages: () => req.flash(),
     canAccess: permission => {


### PR DESCRIPTION
Currently the link back to the dashboard will go back to a non-filtered view.

If a user changes the date and navigates to a move the current date will be lost and they will return to the default dashboard view for "today" on clicking the back to dashboard link.

This change will persist the current filter so that it can be used to go back to the correctly filtered version of the dashboard.