### PR TITLE
[P4-503] Create cancel option

### DIFF
--- a/app/move/controllers/new.form.js
+++ b/app/move/controllers/new.form.js
@@ -10,6 +10,16 @@ class FormController extends Controller {
     this.use(this.checkCurrentLocation)
   }
 
+  middlewareLocals() {
+    super.middlewareLocals()
+    this.use(this.setCancelUrl)
+  }
+
+  setCancelUrl(req, res, next) {
+    res.locals.cancelUrl = res.locals.MOVES_URL
+    next()
+  }
+
   checkCurrentLocation(req, res, next) {
     if (!req.session.currentLocation) {
       const error = new Error(

--- a/app/move/controllers/new.form.test.js
+++ b/app/move/controllers/new.form.test.js
@@ -28,6 +28,66 @@ describe('Move controllers', function() {
       })
     })
 
+    describe('#middlewareLocals()', function() {
+      beforeEach(function() {
+        sinon.stub(FormController.prototype, 'middlewareLocals')
+        sinon.stub(controller, 'use')
+
+        controller.middlewareLocals()
+      })
+
+      it('should call parent method', function() {
+        expect(FormController.prototype.middlewareLocals).to.have.been
+          .calledOnce
+      })
+
+      it('should call set cancel url method', function() {
+        expect(controller.use).to.have.been.calledWith(controller.setCancelUrl)
+      })
+    })
+
+    describe('#setCancelUrl()', function() {
+      let res, nextSpy
+
+      beforeEach(function() {
+        nextSpy = sinon.spy()
+        res = {
+          locals: {},
+        }
+      })
+
+      context('with no moves url local', function() {
+        beforeEach(function() {
+          controller.setCancelUrl({}, res, nextSpy)
+        })
+
+        it('should set cancel url correctly', function() {
+          expect(res.locals).to.have.property('cancelUrl')
+          expect(res.locals.cancelUrl).to.equal(undefined)
+        })
+
+        it('should call next', function() {
+          expect(nextSpy).to.be.calledOnceWithExactly()
+        })
+      })
+
+      context('with moves url local', function() {
+        beforeEach(function() {
+          res.locals.MOVES_URL = '/moves?move-date=2019-10-10'
+          controller.setCancelUrl({}, res, nextSpy)
+        })
+
+        it('should set cancel url moves url', function() {
+          expect(res.locals).to.have.property('cancelUrl')
+          expect(res.locals.cancelUrl).to.equal('/moves?move-date=2019-10-10')
+        })
+
+        it('should call next', function() {
+          expect(nextSpy).to.be.calledOnceWithExactly()
+        })
+      })
+    })
+
     describe('#checkCurrentLocation()', function() {
       let req, nextSpy
 

--- a/common/assets/scss/overrides/_all.scss
+++ b/common/assets/scss/overrides/_all.scss
@@ -1,2 +1,3 @@
+@import "buttons";
 @import "font-corrections";
 @import "positioning";

--- a/common/assets/scss/overrides/_buttons.scss
+++ b/common/assets/scss/overrides/_buttons.scss
@@ -1,0 +1,28 @@
+.govuk-button--text {
+  background: none;
+  box-shadow: none;
+  color: $govuk-link-colour;
+  text-align: left;
+  text-decoration: underline;
+
+  &:link,
+  &:visited {
+    color: $govuk-link-colour;
+    text-decoration: underline;
+  }
+
+  &:active {
+    color: $govuk-link-active-colour;
+    top: 0;
+  }
+
+  &:hover {
+    color: $govuk-link-hover-colour;
+    text-decoration: underline;
+  }
+
+  &:hover,
+  &:focus {
+    background: none;
+  }
+}

--- a/common/templates/form-wizard.njk
+++ b/common/templates/form-wizard.njk
@@ -49,6 +49,10 @@
         {{ govukButton({
           text: t(options.buttonText or "actions::continue")
         }) }}
+
+        {% if cancelUrl %}
+          <a href="{{ cancelUrl }}" class="govuk-button govuk-button--text">Cancel</a>
+        {% endif %}
       </form>
     </div>
   </div>


### PR DESCRIPTION
This adds a cancel button that can be used by the user to cancel the current create journey.

## What it looks like

![localhost_3000_move_new_personal-details](https://user-images.githubusercontent.com/3327997/62482840-28e80e80-b7ae-11e9-9dd3-4334cbe8bb1c.png)
