### PR TITLE
[P4-537] Extra gender information

### DIFF
--- a/app/move/controllers/new.personal-details.js
+++ b/app/move/controllers/new.personal-details.js
@@ -12,6 +12,12 @@ class PersonalDetailsController extends FormController {
       const genderOptions = genders
         .filter(referenceDataHelpers.filterDisabled())
         .map(fieldHelpers.mapReferenceDataToOption)
+        .map(
+          fieldHelpers.insertItemConditional({
+            key: 'trans',
+            field: 'gender_additional_information',
+          })
+        )
       const ethnicityOptions = ethnicities
         .filter(referenceDataHelpers.filterDisabled())
         .map(fieldHelpers.mapReferenceDataToOption)

--- a/app/move/controllers/new.personal-details.test.js
+++ b/app/move/controllers/new.personal-details.test.js
@@ -4,6 +4,7 @@ const Controller = require('./new.personal-details')
 const personService = require('../../../common/services/person')
 const referenceDataService = require('../../../common/services/reference-data')
 const referenceDataHelpers = require('../../../common/helpers/reference-data')
+const fieldHelpers = require('../../../common/helpers/field')
 
 const controller = new Controller({ route: '/' })
 const genderMock = [
@@ -46,10 +47,13 @@ describe('Move controllers', function() {
 
         beforeEach(async function() {
           sinon.spy(FormController.prototype, 'configure')
+          sinon.stub(fieldHelpers, 'insertItemConditional').callsFake(() => {
+            return item => item
+          })
+          sinon.stub(referenceDataService, 'getGenders').resolves(genderMock)
           sinon.stub(referenceDataHelpers, 'filterDisabled').callsFake(() => {
             return () => true
           })
-          sinon.stub(referenceDataService, 'getGenders').resolves(genderMock)
           sinon
             .stub(referenceDataService, 'getEthnicities')
             .resolves(ethnicityMock)
@@ -73,6 +77,15 @@ describe('Move controllers', function() {
             { value: '8888', text: 'Male' },
             { value: '9999', text: 'Female' },
           ])
+        })
+
+        it('should insert trans conditional field', function() {
+          expect(
+            fieldHelpers.insertItemConditional
+          ).to.have.been.calledOnceWithExactly({
+            key: 'trans',
+            field: 'gender_additional_information',
+          })
         })
 
         it('should set list of ethnicities dynamically', function() {

--- a/app/move/fields.js
+++ b/app/move/fields.js
@@ -118,6 +118,21 @@ module.exports = {
     name: 'gender',
     items: [],
   },
+  gender_additional_information: {
+    skip: true,
+    component: 'govukTextarea',
+    name: 'gender_additional_information',
+    classes: 'govuk-input--width-20',
+    rows: 3,
+    label: {
+      text: `fields::gender_additional_information.label`,
+      classes: 'govuk-label--s govuk-input--width-20',
+    },
+    hint: {
+      text: `fields::gender_additional_information.hint`,
+      classes: 'govuk-input--width-20',
+    },
+  },
   ethnicity: {
     validate: 'required',
     component: 'govukSelect',

--- a/app/move/steps.js
+++ b/app/move/steps.js
@@ -24,6 +24,7 @@ module.exports = {
       'date_of_birth',
       'ethnicity',
       'gender',
+      'gender_additional_information',
     ],
   },
   '/move-details': {

--- a/common/helpers/field.js
+++ b/common/helpers/field.js
@@ -147,6 +147,19 @@ function insertInitialOption(items, label = 'option') {
   return [initialOption, ...items]
 }
 
+function insertItemConditional({ key, field }) {
+  return item => {
+    if (item.key !== key) {
+      return item
+    }
+
+    return {
+      ...item,
+      conditional: field,
+    }
+  }
+}
+
 module.exports = {
   mapReferenceDataToOption,
   mapAssessmentQuestionToConditionalField,
@@ -155,4 +168,5 @@ module.exports = {
   setFieldError,
   translateField,
   insertInitialOption,
+  insertItemConditional,
 }

--- a/common/helpers/field.test.js
+++ b/common/helpers/field.test.js
@@ -8,6 +8,7 @@ const {
   setFieldError,
   translateField,
   insertInitialOption,
+  insertItemConditional,
 } = require('./field')
 
 const componentService = require('../services/component')
@@ -780,6 +781,69 @@ describe('Form helpers', function() {
             text: 'Bar',
           },
         ])
+      })
+    })
+  })
+
+  describe('#insertItemConditional()', function() {
+    const conditionalField = 'conditional_field'
+    let response
+
+    context('when key matches item', function() {
+      context('when conditional already exists', function() {
+        const field = {
+          name: 'match',
+          key: 'match',
+          conditional: 'original_conditional_field',
+        }
+        beforeEach(function() {
+          response = insertItemConditional({
+            key: 'match',
+            field: conditionalField,
+          })(field)
+        })
+
+        it('should overwrite conditional field', function() {
+          expect(response).to.deep.equal({
+            name: 'match',
+            key: 'match',
+            conditional: 'conditional_field',
+          })
+        })
+      })
+
+      context('when no conditional exists', function() {
+        const field = { name: 'match', key: 'match' }
+
+        beforeEach(function() {
+          response = insertItemConditional({
+            key: 'match',
+            field: conditionalField,
+          })(field)
+        })
+
+        it('should add conditional field', function() {
+          expect(response).to.deep.equal({
+            name: 'match',
+            key: 'match',
+            conditional: 'conditional_field',
+          })
+        })
+      })
+    })
+
+    context('when key does not match item', function() {
+      const field = { name: 'field', key: 'field' }
+
+      beforeEach(function() {
+        response = insertItemConditional({
+          key: 'no_match',
+          field: conditionalField,
+        })(field)
+      })
+
+      it('should return original item', function() {
+        expect(response).to.deep.equal({ name: 'field', key: 'field' })
       })
     })
   })

--- a/common/lib/api-client/models.js
+++ b/common/lib/api-client/models.js
@@ -25,6 +25,7 @@ function defineModels(jsonApi) {
     date_of_birth: '',
     identifiers: '',
     assessment_answers: '',
+    gender_additional_information: '',
     gender: {
       jsonApi: 'hasOne',
       type: 'genders',

--- a/common/presenters/person-to-summary-list-component.js
+++ b/common/presenters/person-to-summary-list-component.js
@@ -6,10 +6,14 @@ const filters = require('../../config/nunjucks/filters')
 module.exports = function personToSummaryListComponent({
   date_of_birth: dateOfBirth,
   gender,
+  gender_additional_information: genderAdditionalInformation,
   ethnicity,
   identifiers,
 }) {
   const age = `(${i18n.t('age')} ${filters.calculateAge(dateOfBirth)})`
+  const genderExtra = genderAdditionalInformation
+    ? ` — ${genderAdditionalInformation}`
+    : ''
   const pncNumber = find(identifiers, {
     identifier_type: 'police_national_computer',
   })
@@ -35,7 +39,7 @@ module.exports = function personToSummaryListComponent({
         text: i18n.t('fields::gender.label'),
       },
       value: {
-        text: gender ? gender.title : '',
+        text: gender ? `${gender.title}${genderExtra}` : '',
       },
     },
     {

--- a/common/presenters/person-to-summary-list-component.test.js
+++ b/common/presenters/person-to-summary-list-component.test.js
@@ -51,7 +51,9 @@ describe('Presenters', function() {
 
           expect(row).to.deep.equal({
             key: { text: '__translated__' },
-            value: { text: mockMove.person.gender.title },
+            value: {
+              text: `${mockMove.person.gender.title} — ${mockMove.person.gender_additional_information}`,
+            },
           })
         })
 
@@ -141,6 +143,29 @@ describe('Presenters', function() {
           expect(row).to.deep.equal({
             key: { text: '__translated__' },
             value: { text: '' },
+          })
+        })
+      })
+    })
+
+    context('when no additional gender information', function() {
+      let transformedResponse
+
+      beforeEach(function() {
+        transformedResponse = personToSummaryListComponent({
+          gender: {
+            title: 'Male',
+          },
+        })
+      })
+
+      describe('response', function() {
+        it('should return only gender name', function() {
+          const row = transformedResponse.rows[2]
+
+          expect(row).to.deep.equal({
+            key: { text: '__translated__' },
+            value: { text: 'Male' },
           })
         })
       })

--- a/common/templates/form-wizard.njk
+++ b/common/templates/form-wizard.njk
@@ -31,21 +31,25 @@
     </div>
   </header>
 
-  <form method="post">
-    <input type="hidden" name="x-csrf-token" value="{{ getLocal('csrf-token') }}">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <form method="post">
+        <input type="hidden" name="x-csrf-token" value="{{ getLocal('csrf-token') }}">
 
-    {% block beforeFields %}{% endblock %}
+        {% block beforeFields %}{% endblock %}
 
-    {% block fields %}
-      {% for key, fieldsOptions in options.fields %}
-        {% if fieldsOptions.component and not fieldsOptions.skip %}
-          {{ callAsMacro(fieldsOptions.component)(fieldsOptions) }}
-        {% endif %}
-      {% endfor %}
-    {% endblock %}
+        {% block fields %}
+          {% for key, fieldsOptions in options.fields %}
+            {% if fieldsOptions.component and not fieldsOptions.skip %}
+              {{ callAsMacro(fieldsOptions.component)(fieldsOptions) }}
+            {% endif %}
+          {% endfor %}
+        {% endblock %}
 
-    {{ govukButton({
-      text: t(options.buttonText or "actions::continue")
-    }) }}
-  </form>
+        {{ govukButton({
+          text: t(options.buttonText or "actions::continue")
+        }) }}
+      </form>
+    </div>
+  </div>
 {% endblock %}

--- a/locales/en/fields.json
+++ b/locales/en/fields.json
@@ -15,6 +15,10 @@
   "gender": {
     "label": "Gender"
   },
+  "gender_additional_information": {
+    "label": "More information",
+    "hint": "Give more information if this person’s gender identity may put them at risk from others, or pose a risk to others"
+  },
   "ethnicity": {
     "label": "Ethnicity"
   },

--- a/test/fixtures/api-client/move.get.deserialized.json
+++ b/test/fixtures/api-client/move.get.deserialized.json
@@ -13,6 +13,7 @@
       "first_names": "Buffy",
       "last_name": "Thompson",
       "date_of_birth": "1948-04-24",
+      "gender_additional_information": "Additional gender information",
       "assessment_answers": [{
         "key": "concealed_items",
         "title": "Concealed items",

--- a/test/fixtures/api-client/move.get.serialized.json
+++ b/test/fixtures/api-client/move.get.serialized.json
@@ -38,6 +38,7 @@
               "first_names": "Buffy",
               "last_name": "Thompson",
               "date_of_birth": "1948-04-24",
+              "gender_additional_information": "Additional gender information",
               "assessment_answers": [
                   {
                       "key": "concealed_items",


### PR DESCRIPTION
This adds a new field to capture any extra gender information necessary
to transport a detainee/prisoner.

## What it looks like

### Request journey
![image](https://user-images.githubusercontent.com/3327997/62630188-5fe13000-b926-11e9-8659-cf409db0c967.png)

### Move detail

#### With additional information
![image](https://user-images.githubusercontent.com/3327997/62630273-84d5a300-b926-11e9-838a-a3abd6d9e1cb.png)

#### Without additional information
![image](https://user-images.githubusercontent.com/3327997/62630236-71c2d300-b926-11e9-8392-2fe6d7c83cb3.png)

### Checklist

- [x] If adding new environment variables, they have been documented in the [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md)
- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
