### PR TITLE
Allow reference data service to search for locations by NOMIS agency ID

### DIFF
--- a/app/move/controllers/new.move-details.js
+++ b/app/move/controllers/new.move-details.js
@@ -9,8 +9,13 @@ const referenceDataHelpers = require('../../../common/helpers/reference-data')
 class MoveDetailsController extends FormController {
   async configure(req, res, next) {
     try {
-      const courts = await referenceDataService.getLocations('court')
-      const prisons = await referenceDataService.getLocations('prison')
+      const courts = await referenceDataService.getLocations({
+        type: 'court',
+      })
+      const prisons = await referenceDataService.getLocations({
+        type: 'prison',
+      })
+
       const {
         to_location_court: toLocationCourt,
         to_location_prison: toLocationPrison,

--- a/app/move/controllers/new.move-details.test.js
+++ b/app/move/controllers/new.move-details.test.js
@@ -52,10 +52,10 @@ describe('Move controllers', function() {
           sinon.stub(filters, 'formatDateWithDay').returnsArg(0)
 
           referenceDataService.getLocations
-            .withArgs('court')
+            .withArgs({ type: 'court' })
             .resolves(courtsMock)
           referenceDataService.getLocations
-            .withArgs('prison')
+            .withArgs({ type: 'prison' })
             .resolves(prisonsMock)
 
           req = {

--- a/common/services/reference-data.js
+++ b/common/services/reference-data.js
@@ -18,12 +18,13 @@ function getAssessmentQuestions(category) {
     .then(response => response.data)
 }
 
-function getLocations(type, combinedData, page = 1) {
+function getLocations({ type, nomisAgencyId, combinedData, page = 1 } = {}) {
   return apiClient
     .findAll('location', {
       page,
       per_page: 100,
       'filter[location_type]': type,
+      'filter[nomis_agency_id]': nomisAgencyId,
     })
     .then(response => {
       const { data, links } = response
@@ -35,7 +36,12 @@ function getLocations(type, combinedData, page = 1) {
         return sortBy(locations, 'title')
       }
 
-      return getLocations(type, locations, page + 1)
+      return getLocations({
+        type,
+        nomisAgencyId,
+        combinedData: locations,
+        page: page + 1,
+      })
     })
 }
 

--- a/common/services/reference-data.test.js
+++ b/common/services/reference-data.test.js
@@ -106,30 +106,102 @@ describe('Reference Service', function() {
   })
 
   describe('#getLocations()', function() {
-    context('when request returns 200', function() {
-      let response
+    context('with no parameters', function() {
+      context('when request returns 200', function() {
+        let response
 
-      beforeEach(async function() {
-        nock(API.BASE_URL)
-          .get('/reference/locations')
-          .query({ page: '1', per_page: '100' })
-          .reply(200, locationsPage1Serialized)
+        beforeEach(async function() {
+          nock(API.BASE_URL)
+            .get('/reference/locations')
+            .query({ page: '1', per_page: '100' })
+            .reply(200, locationsPage1Serialized)
 
-        nock(API.BASE_URL)
-          .get('/reference/locations')
-          .query({ page: '2', per_page: '100' })
-          .reply(200, locationsPage2Serialized)
+          nock(API.BASE_URL)
+            .get('/reference/locations')
+            .query({ page: '2', per_page: '100' })
+            .reply(200, locationsPage2Serialized)
 
-        response = await getLocations()
+          response = await getLocations()
+        })
+
+        it('should call API with no filter query parameters', function() {
+          expect(nock.isDone()).to.be.true
+        })
+
+        it('should return a full list of locations', function() {
+          expect(response.length).to.deep.equal(
+            locationsDeserialized.data.length
+          )
+          expect(response).to.deep.equal(locationsDeserialized.data)
+        })
       })
+    })
 
-      it('should call API', function() {
-        expect(nock.isDone()).to.be.true
+    context('with type parameter', function() {
+      context('when request returns 200', function() {
+        let type
+
+        beforeEach(async function() {
+          type = 'police'
+
+          nock(API.BASE_URL)
+            .get('/reference/locations')
+            .query({
+              page: '1',
+              per_page: '100',
+              filter: { location_type: type },
+            })
+            .reply(200, locationsPage1Serialized)
+
+          nock(API.BASE_URL)
+            .get('/reference/locations')
+            .query({
+              page: '2',
+              per_page: '100',
+              filter: { location_type: type },
+            })
+            .reply(200, locationsPage2Serialized)
+
+          await getLocations({ type: type })
+        })
+
+        it('should call API with the type filter query parameter', function() {
+          expect(nock.isDone()).to.be.true
+        })
       })
+    })
 
-      it('should return a full list of locations', function() {
-        expect(response.length).to.deep.equal(locationsDeserialized.data.length)
-        expect(response).to.deep.equal(locationsDeserialized.data)
+    context('with nomisAgencyId parameter', function() {
+      context('when request returns 200', function() {
+        let nomisAgencyId
+
+        beforeEach(async function() {
+          nomisAgencyId = 'TEST'
+
+          nock(API.BASE_URL)
+            .get('/reference/locations')
+            .query({
+              page: '1',
+              per_page: '100',
+              filter: { nomis_agency_id: nomisAgencyId },
+            })
+            .reply(200, locationsPage1Serialized)
+
+          nock(API.BASE_URL)
+            .get('/reference/locations')
+            .query({
+              page: '2',
+              per_page: '100',
+              filter: { nomis_agency_id: nomisAgencyId },
+            })
+            .reply(200, locationsPage2Serialized)
+
+          await getLocations({ nomisAgencyId: nomisAgencyId })
+        })
+
+        it('should call API with the nomis_agency_id filter query parameter', function() {
+          expect(nock.isDone()).to.be.true
+        })
       })
     })
   })


### PR DESCRIPTION
This allows the reference data service to look up locations by both type as currently, and also NOMIS agency ID, as implemented in https://github.com/ministryofjustice/hmpps-book-secure-move-api/pull/95.

This is a pre-requisite to look up locations by agency ID, as supplied by HMPPS SSO.