### PR TITLE
[P4-538] Fix pagination alignment

### DIFF
--- a/common/components/pagination/_pagination.scss
+++ b/common/components/pagination/_pagination.scss
@@ -17,6 +17,7 @@
 .app-pagination__link {
   display: block;
   padding: govuk-spacing(3);
+  text-decoration: none;
 
   &:link,
   &:visited,
@@ -37,7 +38,7 @@
 }
 
 .app-pagination__link-text {
-  display: inline-block;
+  display: inline;
   text-decoration: none;
 
   .app-pagination__list-item--prev &,
@@ -70,11 +71,11 @@
 // Modifiers
 .app-pagination--inline {
   .app-pagination__list-item {
-    display: inline;
+    display: inline-block;
   }
 
   .app-pagination__link {
-    display: inline-block;
+    display: block;
   }
 
   .app-pagination__link-text {


### PR DESCRIPTION
The inline variation of the pagination component wasn't being
displayed correctly on certain browser (Safari) due to the position
the inner elements were being given.

The text element was being `display: inline-block` which caused the
text deocration not to be inherited which concealed the alignment
issue.

This change displays the elements as inline and sets the text decoration
styles on the correct element (the parent anchor).

## Inline
### Before
![image](https://user-images.githubusercontent.com/3327997/62635685-0847c200-b930-11e9-9595-37f406c8c85f.png)

### After
![image](https://user-images.githubusercontent.com/3327997/62635714-1b5a9200-b930-11e9-8506-58fe9dc86144.png)

## Stacked
### Before
![image](https://user-images.githubusercontent.com/3327997/62635694-0f6ed000-b930-11e9-97ae-3035599d96dd.png)

### After
![image](https://user-images.githubusercontent.com/3327997/62635721-201f4600-b930-11e9-9ff9-d3d581b4ec79.png)

### Checklist

- [x] If adding new environment variables, they have been documented in the [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md)
- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
