### PR TITLE
Locations lookup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,7 @@ AUTH_PROVIDER_KEY=
 AUTH_PROVIDER_SECRET=
 AUTH_PROVIDER_URL=
 SERVER_HOST=localhost:3000
+NOMIS_ELITE2_API_URL=https://gateway.t3.nomis-api.hmpps.dsd.io/elite2api
 
 ## Development only
 # BYPASS_SSO=true

--- a/README.md
+++ b/README.md
@@ -128,9 +128,9 @@ npm run lint
 | AUTH_PROVIDER_KEY **(required)** | Client key provided by the OAuth2 provider for user authentication | |
 | AUTH_PROVIDER_SECRET **(required)** | Client secret provided by the OAuth2 provider for user authentication | |
 | AUTH_PROVIDER_URL **(required)** | Base URL for the auth provider server | |
+| NOMIS_ELITE2_API_URL **(required)** | Base URL for the NOMIS Elite 2 API, without trailing slash | |
 | SERVER_HOST **(required)** | The (accessible) hostname (and port) of the listening web server. Used by [Grant](https://github.com/simov/grant) to construct redirect URLs after OAuth authentication. For example `localhost:3000` | |
 | FEEDBACK_URL | URL for the feedback link in the phase banner at the top of the page. If empty, the link will not be displayed. | |
-| CURRENT_LOCATION_UUID **(TEMPORARY)** | UUID of the current location to list and create moves for | |
 | SENTRY_KEY | Sentry key | |
 | SENTRY_PROJECT | Sentry project ID | |
 | GOOGLE_ANALYTICS_ID | Google analytics tracking ID to use for the environment | |

--- a/app/auth/index.js
+++ b/app/auth/index.js
@@ -4,11 +4,10 @@ const router = require('express').Router()
 // Local dependencies
 const { redirect, signOut } = require('./controllers')
 const { processAuthResponse } = require('./middleware')
-const { CURRENT_LOCATION_UUID } = require('../../config')
 
 // Define routes
 router.get('/', redirect)
-router.get('/callback', processAuthResponse([CURRENT_LOCATION_UUID]), redirect)
+router.get('/callback', processAuthResponse(), redirect)
 router.get('/sign-out', signOut)
 
 // Export

--- a/app/healthcheck/dependencies.js
+++ b/app/healthcheck/dependencies.js
@@ -1,33 +1,44 @@
 const axios = require('axios')
 
-const { AUTH_PROVIDERS, DEFAULT_AUTH_PROVIDER, API } = require('../../config')
+const {
+  AUTH_PROVIDERS,
+  DEFAULT_AUTH_PROVIDER,
+  API,
+  NOMIS_ELITE2_API,
+} = require('../../config')
+
 const redisStore = require('../../config/redis-store')
 
 const timeout = 5000
+
+function _checkApiDependency(url) {
+  return new Promise((resolve, reject) => {
+    axios
+      .get(url, { timeout })
+      .then(() => resolve('OK'))
+      .catch(reject)
+  })
+}
 
 module.exports = [
   {
     name: 'API',
     healthcheck: () => {
-      return new Promise((resolve, reject) => {
-        axios
-          .get(API.HEALTHCHECK_URL, { timeout })
-          .then(() => resolve('OK'))
-          .catch(reject)
-      })
+      return _checkApiDependency(API.HEALTHCHECK_URL)
     },
   },
   {
     name: 'HMPPS SSO',
     healthcheck: () => {
-      return new Promise((resolve, reject) => {
-        axios
-          .get(AUTH_PROVIDERS[DEFAULT_AUTH_PROVIDER].healthcheck_url, {
-            timeout,
-          })
-          .then(() => resolve('OK'))
-          .catch(reject)
-      })
+      return _checkApiDependency(
+        AUTH_PROVIDERS[DEFAULT_AUTH_PROVIDER].healthcheck_url
+      )
+    },
+  },
+  {
+    name: 'HMPPS Elite2 API',
+    healthcheck: () => {
+      return _checkApiDependency(NOMIS_ELITE2_API.healthcheck_url)
     },
   },
   {

--- a/common/lib/access-token.js
+++ b/common/lib/access-token.js
@@ -1,0 +1,6 @@
+module.exports = {
+  decodeAccessToken(token) {
+    const payload = token.split('.')[1]
+    return JSON.parse(Buffer.from(payload, 'base64').toString('utf8'))
+  },
+}

--- a/common/lib/access-token.test.js
+++ b/common/lib/access-token.test.js
@@ -1,0 +1,17 @@
+const { decodeAccessToken } = require('./access-token')
+
+describe('Access token library', function() {
+  describe('#decodeAccessToken', function() {
+    context('supplied with a properly encoded token', function() {
+      it('returns a Javascript object of the token payload', function() {
+        const payload = { test: 'test' }
+        const encodedPayload = Buffer.from(JSON.stringify(payload)).toString(
+          'base64'
+        )
+        const token = `test.${encodedPayload}.test`
+
+        expect(decodeAccessToken(token)).to.deep.equal(payload)
+      })
+    })
+  })
+})

--- a/common/lib/user.js
+++ b/common/lib/user.js
@@ -1,14 +1,14 @@
-function User(token = {}) {
-  this.userName = token.user_name
-  this.locations = token.locations || []
-  this.permissions = this.getPermissions(token.authorities)
+function User({ name, roles = [], locations = [] } = {}) {
+  this.userName = name
+  this.permissions = this.getPermissions(roles)
+  this.locations = locations
 }
 
 User.prototype = {
-  getPermissions(authorities = []) {
+  getPermissions(roles = []) {
     const permissions = []
 
-    if (authorities.includes('ROLE_PECS_POLICE')) {
+    if (roles.includes('ROLE_PECS_POLICE')) {
       permissions.push(
         ...[
           'moves:view:by_location',
@@ -20,7 +20,7 @@ User.prototype = {
       )
     }
 
-    if (authorities.includes('ROLE_PECS_SUPPLIER')) {
+    if (roles.includes('ROLE_PECS_SUPPLIER')) {
       permissions.push(...['moves:view:all', 'moves:download:all'])
     }
 

--- a/common/lib/user.test.js
+++ b/common/lib/user.test.js
@@ -2,15 +2,14 @@ const User = require('./user')
 
 describe('User class', function() {
   describe('when instantiated', function() {
-    let user
+    let user, userName, roles, locations
 
     context('with username', function() {
       it('should set username', function() {
-        user = new User({
-          user_name: 'USERNAME',
-        })
+        userName = 'USERNAME'
+        user = new User({ name: userName })
 
-        expect(user.userName).to.equal('USERNAME')
+        expect(user.userName).to.equal(userName)
       })
     })
 
@@ -22,22 +21,20 @@ describe('User class', function() {
       })
     })
 
-    context('with authorities', function() {
+    context('with roles', function() {
       beforeEach(function() {
         sinon.stub(User.prototype, 'getPermissions').returnsArg(0)
+        roles = ['ROLE_PECS_SUPPLIER']
       })
 
       it('should set permissions', function() {
-        user = new User({
-          authorities: ['ROLE_SUPPLIER'],
-        })
-
-        expect(user.permissions).to.deep.equal(['ROLE_SUPPLIER'])
+        user = new User({ name: 'USERNAME', roles })
+        expect(Array.isArray(user.permissions)).to.be.true
       })
     })
 
-    context('without authorities', function() {
-      it('should not set permissions to empty array', function() {
+    context('without roles', function() {
+      it('should set permissions to empty array', function() {
         user = new User()
 
         expect(user.permissions).to.deep.equal([])
@@ -45,12 +42,13 @@ describe('User class', function() {
     })
 
     context('with locations', function() {
-      it('should set locations', function() {
-        user = new User({
-          locations: ['111', '222'],
-        })
+      beforeEach(function() {
+        locations = ['PECS_TEST']
+      })
 
-        expect(user.locations).to.deep.equal(['111', '222'])
+      it('should set locations', function() {
+        user = new User({ name: 'USERNAME', roles: [], locations })
+        expect(user.locations).to.deep.equal(locations)
       })
     })
 
@@ -70,7 +68,7 @@ describe('User class', function() {
       user = new User()
     })
 
-    context('when user has no authorities', function() {
+    context('when user has no roles', function() {
       beforeEach(function() {
         permissions = user.getPermissions()
       })

--- a/common/services/reference-data.js
+++ b/common/services/reference-data.js
@@ -49,11 +49,22 @@ function getLocationById(id) {
   return apiClient.find('location', id).then(response => response.data)
 }
 
-function getLocationsById(locations = []) {
-  const locationPromises = locations.map(locationId => {
-    return getLocationById(locationId).catch(() => false)
-  })
+function getLocationByNomisAgencyId(nomisAgencyId) {
+  return getLocations({ nomisAgencyId }).then(results => results[0])
+}
 
+function getLocationsById(ids = []) {
+  return _mapLocationIdsToLocations(ids, getLocationById)
+}
+
+function getLocationsByNomisAgencyId(ids = []) {
+  return _mapLocationIdsToLocations(ids, getLocationByNomisAgencyId)
+}
+
+function _mapLocationIdsToLocations(ids, callback) {
+  const locationPromises = ids.map(id => {
+    return callback(id).catch(() => false)
+  })
   return Promise.all(locationPromises).then(locations =>
     locations.filter(Boolean)
   )
@@ -66,4 +77,6 @@ module.exports = {
   getLocations,
   getLocationById,
   getLocationsById,
+  getLocationByNomisAgencyId,
+  getLocationsByNomisAgencyId,
 }

--- a/common/services/user-locations.js
+++ b/common/services/user-locations.js
@@ -1,0 +1,55 @@
+const axios = require('axios')
+const { map } = require('lodash')
+
+const { AUTH_PROVIDERS, NOMIS_ELITE2_API } = require('../../config')
+const { decodeAccessToken } = require('../lib/access-token')
+const referenceDataService = require('./reference-data')
+
+function getUserLocations(token) {
+  return _getAgencies(token).then(agencies =>
+    referenceDataService.getLocationsByNomisAgencyId(agencies)
+  )
+}
+
+function _getAgencies(token) {
+  const { auth_source: source } = decodeAccessToken(token)
+
+  switch (source) {
+    case 'auth':
+      return _getAuthAgencies(token)
+    case 'nomis':
+      return _getNomisAgencies(token)
+    default:
+      return Promise.resolve([])
+  }
+}
+
+function _getAuthAgencies(token) {
+  const tokenData = decodeAccessToken(token)
+
+  return axios
+    .get(AUTH_PROVIDERS.hmpps.groups_url(tokenData.user_name), {
+      headers: _getAuthHeaders(token),
+    })
+    .then(response => response.data)
+    .then(data => data.map(group => group.groupCode.replace(/^PECS_/, '')))
+}
+
+function _getNomisAgencies(token) {
+  return axios
+    .get(NOMIS_ELITE2_API.user_caseloads_url, {
+      headers: _getAuthHeaders(token),
+    })
+    .then(response => response.data)
+    .then(data => map(data, 'caseLoadId'))
+}
+
+function _getAuthHeaders(token) {
+  return {
+    Authorization: `Bearer ${token}`,
+  }
+}
+
+module.exports = {
+  getUserLocations,
+}

--- a/common/services/user-locations.test.js
+++ b/common/services/user-locations.test.js
@@ -1,0 +1,120 @@
+const proxyquire = require('proxyquire')
+
+const referenceDataStub = {
+  getLocationsByNomisAgencyId: sinon.spy(args => {
+    return Promise.resolve([{ id: 'test' }])
+  }),
+}
+
+const configStub = {
+  AUTH_PROVIDERS: {
+    hmpps: { groups_url: () => 'http://test/' },
+  },
+  NOMIS_ELITE2_API: {
+    user_caseloads_url: 'http://test/',
+  },
+}
+
+const userLocationsService = proxyquire('./user-locations', {
+  './reference-data': referenceDataStub,
+  '../../config': configStub,
+})
+
+function _encodeToken(data) {
+  return `test.${Buffer.from(JSON.stringify(data), 'utf8').toString(
+    'base64'
+  )}.test`
+}
+
+const authGroups = [
+  {
+    groupCode: 'PECS_TEST',
+    groupName: 'Test Group',
+  },
+]
+
+const userCaseloads = [
+  {
+    currentlyActive: false,
+    caseLoadId: 'TEST',
+    description: 'Test',
+    type: 'INST',
+    caseloadFunction: 'GENERAL',
+  },
+]
+
+describe('User locations service', function() {
+  describe('#getUserLocations()', function() {
+    let tokenData, token, result
+
+    context('with valid bearer token', function() {
+      context('User authenticated from HMPPS SSO', function() {
+        beforeEach(async function() {
+          tokenData = {
+            user_name: 'test',
+            auth_source: 'auth',
+          }
+
+          token = _encodeToken(tokenData)
+
+          nock(configStub.AUTH_PROVIDERS.hmpps.groups_url('test'))
+            .get('/')
+            .reply(200, JSON.stringify(authGroups))
+
+          result = await userLocationsService.getUserLocations(token)
+        })
+
+        it("requests the user's groups from HMPPS SSO", function() {
+          expect(nock.isDone()).to.be.true
+        })
+
+        it('returns an Array of location objects', function() {
+          expect(result).to.deep.equal([{ id: 'test' }])
+        })
+      })
+
+      context('User authenticated from NOMIS', function() {
+        beforeEach(async function() {
+          tokenData = {
+            user_name: 'test',
+            auth_source: 'nomis',
+          }
+
+          token = _encodeToken(tokenData)
+
+          nock(configStub.NOMIS_ELITE2_API.user_caseloads_url)
+            .get('/')
+            .reply(200, JSON.stringify(userCaseloads))
+
+          result = await userLocationsService.getUserLocations(token)
+        })
+
+        it("requests the user's caseloads from the NOMIS Elite 2 API", function() {
+          expect(nock.isDone()).to.be.true
+        })
+
+        it('returns an Array of location objects', function() {
+          expect(result).to.deep.equal([{ id: 'test' }])
+        })
+      })
+
+      context('User authentication source indeterminate', function() {
+        beforeEach(async function() {
+          tokenData = {
+            user_name: 'test',
+          }
+
+          token = _encodeToken(tokenData)
+
+          result = await userLocationsService.getUserLocations(token)
+        })
+
+        it('defaults to an empty list of locations', function() {
+          expect(
+            referenceDataStub.getLocationsByNomisAgencyId
+          ).to.be.calledWith([])
+        })
+      })
+    })
+  })
+})

--- a/config/index.js
+++ b/config/index.js
@@ -7,6 +7,7 @@ const SERVER_HOST = process.env.SERVER_HOST
 const BASE_URL = `${IS_PRODUCTION ? 'https' : 'http'}://${SERVER_HOST}`
 const AUTH_BASE_URL = process.env.AUTH_PROVIDER_URL
 const AUTH_KEY = process.env.AUTH_PROVIDER_KEY
+const NOMIS_ELITE2_API_BASE_URL = process.env.NOMIS_ELITE2_API_URL
 const SESSION = {
   NAME: process.env.SESSION_NAME || 'book-secure-move.sid',
   SECRET: process.env.SESSION_SECRET,
@@ -30,7 +31,6 @@ module.exports = {
   BUILD_DATE: process.env.APP_BUILD_DATE,
   BUILD_BRANCH: process.env.APP_BUILD_TAG,
   GIT_SHA: process.env.APP_GIT_COMMIT,
-  CURRENT_LOCATION_UUID: process.env.CURRENT_LOCATION_UUID,
   API: {
     BASE_URL: process.env.API_BASE_URL || 'http://localhost:3000/api/v1',
     HEALTHCHECK_URL: process.env.API_HEALTHCHECK_URL,
@@ -81,11 +81,18 @@ module.exports = {
       logout_url: _authUrl(
         `/auth/logout?client_id=${AUTH_KEY}&redirect_uri=${BASE_URL}`
       ),
+      groups_url: userName => {
+        return _authUrl(`/auth/api/authuser/${userName}/groups`)
+      },
       key: AUTH_KEY,
       secret: process.env.AUTH_PROVIDER_SECRET,
     },
   },
   DEFAULT_AUTH_PROVIDER: 'hmpps',
+  NOMIS_ELITE2_API: {
+    user_caseloads_url: `${NOMIS_ELITE2_API_BASE_URL}/api/users/me/caseLoads`,
+    healthcheck_url: `${NOMIS_ELITE2_API_BASE_URL}/ping`,
+  },
   ANALYTICS: {
     GA_ID: process.env.GOOGLE_ANALYTICS_ID,
   },

--- a/config/index.test.js
+++ b/config/index.test.js
@@ -1,0 +1,12 @@
+const config = require('./index')
+
+describe('App Config', function() {
+  describe('AUTH_PROVIDERS.hmpps.groups_url', function() {
+    let url
+
+    it('constructs a path using the userName parameter', function() {
+      url = config.AUTH_PROVIDERS.hmpps.groups_url('test')
+      expect(new URL(url).pathname).to.equal('/auth/api/authuser/test/groups')
+    })
+  })
+})

--- a/test/fixtures/api-client/reference.locations.serialized.json
+++ b/test/fixtures/api-client/reference.locations.serialized.json
@@ -1,0 +1,572 @@
+{
+  "data": [
+      {
+          "id": "398bca42-2ee6-4d2e-ac08-3e5a4b2deb69",
+          "type": "locations",
+          "attributes": {
+              "key": "bedford_county_court",
+              "title": "Bedford County Court",
+              "location_type": "court",
+              "nomis_agency_id": null,
+              "disabled_at": null
+          }
+      },
+      {
+          "id": "98905621-0684-4873-9f0c-c428c24933ea",
+          "type": "locations",
+          "attributes": {
+              "key": "luton_crown_court",
+              "title": "Luton Crown Court",
+              "location_type": "court",
+              "nomis_agency_id": null,
+              "disabled_at": null
+          }
+      },
+      {
+          "id": "d77fdb81-2a09-4981-a4f2-c6a649768319",
+          "type": "locations",
+          "attributes": {
+              "key": "maidenhead_magistrates_court",
+              "title": "Maidenhead Magistrates Court",
+              "location_type": "court",
+              "nomis_agency_id": null,
+              "disabled_at": null
+          }
+      },
+      {
+          "id": "ddb11bbb-526b-4769-a9f2-cc82875ca52e",
+          "type": "locations",
+          "attributes": {
+              "key": "newbury_county_court",
+              "title": "Newbury County Court",
+              "location_type": "court",
+              "nomis_agency_id": null,
+              "disabled_at": null
+          }
+      },
+      {
+          "id": "2d80f632-c831-44a8-9285-be2732fe9a64",
+          "type": "locations",
+          "attributes": {
+              "key": "reading_county_court",
+              "title": "Reading County Court",
+              "location_type": "court",
+              "nomis_agency_id": null,
+              "disabled_at": null
+          }
+      },
+      {
+          "id": "c6d31f13-ea68-4d47-9260-a2d77b0dbca5",
+          "type": "locations",
+          "attributes": {
+              "key": "windsor_county_court",
+              "title": "Windsor County Court",
+              "location_type": "court",
+              "nomis_agency_id": null,
+              "disabled_at": null
+          }
+      },
+      {
+          "id": "05085309-2c99-4f87-b9ab-b285b446974b",
+          "type": "locations",
+          "attributes": {
+              "key": "bristol_crown_court",
+              "title": "Bristol Crown Court",
+              "location_type": "court",
+              "nomis_agency_id": null,
+              "disabled_at": null
+          }
+      },
+      {
+          "id": "dc08582b-c57c-4053-b691-bf3482a00c59",
+          "type": "locations",
+          "attributes": {
+              "key": "cambridge_crown_court",
+              "title": "Cambridge Crown Court",
+              "location_type": "court",
+              "nomis_agency_id": null,
+              "disabled_at": null
+          }
+      },
+      {
+          "id": "c48c8573-134f-4eba-86cf-ef8bff129045",
+          "type": "locations",
+          "attributes": {
+              "key": "peterborough_crown_court",
+              "title": "Peterborough Crown Court",
+              "location_type": "court",
+              "nomis_agency_id": null,
+              "disabled_at": null
+          }
+      },
+      {
+          "id": "7d9734a1-81e4-4faf-a4f4-54c84ed3cf85",
+          "type": "locations",
+          "attributes": {
+              "key": "macclesfield_magistrates_court",
+              "title": "Macclesfield Magistrates Court",
+              "location_type": "court",
+              "nomis_agency_id": null,
+              "disabled_at": null
+          }
+      },
+      {
+          "id": "5c82f67f-25f6-44c2-9fdd-a2ba6d71d964",
+          "type": "locations",
+          "attributes": {
+              "key": "warrington_county_court",
+              "title": "Warrington County Court",
+              "location_type": "court",
+              "nomis_agency_id": null,
+              "disabled_at": null
+          }
+      },
+      {
+          "id": "747b8928-9f5d-45ee-87ca-595d8287ed74",
+          "type": "locations",
+          "attributes": {
+              "key": "bodmin_magistrates_court",
+              "title": "Bodmin Magistrates Court",
+              "location_type": "court",
+              "nomis_agency_id": null,
+              "disabled_at": null
+          }
+      },
+      {
+          "id": "73163046-22df-463f-8cc2-f471550e2dc1",
+          "type": "locations",
+          "attributes": {
+              "key": "bude_county_court",
+              "title": "Bude County Court",
+              "location_type": "court",
+              "nomis_agency_id": null,
+              "disabled_at": null
+          }
+      },
+      {
+          "id": "9e51f929-2880-460c-a7c0-1156a4a9dba3",
+          "type": "locations",
+          "attributes": {
+              "key": "newquay_magistrates_court",
+              "title": "Newquay Magistrates Court",
+              "location_type": "court",
+              "nomis_agency_id": null,
+              "disabled_at": null
+          }
+      },
+      {
+          "id": "b09cc87d-9330-42ef-a9bb-ad32216358a5",
+          "type": "locations",
+          "attributes": {
+              "key": "penzance_county_court",
+              "title": "Penzance County Court",
+              "location_type": "court",
+              "nomis_agency_id": null,
+              "disabled_at": null
+          }
+      },
+      {
+          "id": "ea949640-cefe-4d1b-8053-600af97be807",
+          "type": "locations",
+          "attributes": {
+              "key": "darlington_crown_court",
+              "title": "Darlington Crown Court",
+              "location_type": "court",
+              "nomis_agency_id": null,
+              "disabled_at": null
+          }
+      },
+      {
+          "id": "3287b21e-9691-43f7-a5b7-948b1fa72a75",
+          "type": "locations",
+          "attributes": {
+              "key": "durham_magistrates_court",
+              "title": "Durham Magistrates Court",
+              "location_type": "court",
+              "nomis_agency_id": null,
+              "disabled_at": null
+          }
+      },
+      {
+          "id": "d8e9cf86-55cd-4412-83b7-3562b7d1f8b6",
+          "type": "locations",
+          "attributes": {
+              "key": "barrow_in_furness_magistrates_court",
+              "title": "Barrow in Furness Magistrates Court",
+              "location_type": "court",
+              "nomis_agency_id": null,
+              "disabled_at": null
+          }
+      },
+      {
+          "id": "b3707992-da62-4593-896f-983d41315f09",
+          "type": "locations",
+          "attributes": {
+              "key": "carlisle_county_court",
+              "title": "Carlisle County Court",
+              "location_type": "court",
+              "nomis_agency_id": null,
+              "disabled_at": null
+          }
+      },
+      {
+          "id": "fa7f6393-76e9-43f2-9fb7-3fc82956a4c4",
+          "type": "locations",
+          "attributes": {
+              "key": "chesterfield_crown_court",
+              "title": "Chesterfield Crown Court",
+              "location_type": "court",
+              "nomis_agency_id": null,
+              "disabled_at": null
+          }
+      },
+      {
+          "id": "8cb9cd00-8e80-4686-b3c3-d14958b8145d",
+          "type": "locations",
+          "attributes": {
+              "key": "derby_county_court",
+              "title": "Derby County Court",
+              "location_type": "court",
+              "nomis_agency_id": null,
+              "disabled_at": null
+          }
+      },
+      {
+          "id": "2c952ca0-f750-4ac3-ac76-fb631445f974",
+          "type": "locations",
+          "attributes": {
+              "key": "axminster_crown_court",
+              "title": "Axminster Crown Court",
+              "location_type": "court",
+              "nomis_agency_id": null,
+              "disabled_at": null
+          }
+      },
+      {
+          "id": "9b56ca31-222b-4522-9d65-4ef429f9081e",
+          "type": "locations",
+          "attributes": {
+              "key": "barnstaple_crown_court",
+              "title": "Barnstaple Crown Court",
+              "location_type": "court",
+              "nomis_agency_id": null,
+              "disabled_at": null
+          }
+      },
+      {
+          "id": "2f03c2fc-2fb7-43bd-be40-eaed19cacb5a",
+          "type": "locations",
+          "attributes": {
+              "key": "exeter_magistrates_court",
+              "title": "Exeter Magistrates Court",
+              "location_type": "court",
+              "nomis_agency_id": null,
+              "disabled_at": null
+          }
+      },
+      {
+          "id": "f7ef5006-e873-461d-ac32-dccf4a8cabc8",
+          "type": "locations",
+          "attributes": {
+              "key": "plymouth_county_court",
+              "title": "Plymouth County Court",
+              "location_type": "court",
+              "nomis_agency_id": null,
+              "disabled_at": null
+          }
+      },
+      {
+          "id": "7db3722d-bef0-4208-8a93-05b70dc0761b",
+          "type": "locations",
+          "attributes": {
+              "key": "torquay_county_court",
+              "title": "Torquay County Court",
+              "location_type": "court",
+              "nomis_agency_id": null,
+              "disabled_at": null
+          }
+      },
+      {
+          "id": "de136fb8-4491-48ea-be48-8f53f335e338",
+          "type": "locations",
+          "attributes": {
+              "key": "weymouth_crown_court",
+              "title": "Weymouth Crown Court",
+              "location_type": "court",
+              "nomis_agency_id": null,
+              "disabled_at": null
+          }
+      },
+      {
+          "id": "1e95f86c-af05-4f31-9c3c-4a0da0c6da95",
+          "type": "locations",
+          "attributes": {
+              "key": "brighton_county_court",
+              "title": "Brighton County Court",
+              "location_type": "court",
+              "nomis_agency_id": null,
+              "disabled_at": null
+          }
+      },
+      {
+          "id": "fa1817f6-4d50-4fbb-b491-2ecd95b378ba",
+          "type": "locations",
+          "attributes": {
+              "key": "colchester_county_court",
+              "title": "Colchester County Court",
+              "location_type": "court",
+              "nomis_agency_id": null,
+              "disabled_at": null
+          }
+      },
+      {
+          "id": "9d5bbb95-b03e-47a0-a07e-ecacb56abed7",
+          "type": "locations",
+          "attributes": {
+              "key": "harlow_magistrates_court",
+              "title": "Harlow Magistrates Court",
+              "location_type": "court",
+              "nomis_agency_id": null,
+              "disabled_at": null
+          }
+      },
+      {
+          "id": "a288caba-70d2-44a0-bec5-331f8ead9d3f",
+          "type": "locations",
+          "attributes": {
+              "key": "romford_magistrates_court",
+              "title": "Romford Magistrates Court",
+              "location_type": "court",
+              "nomis_agency_id": null,
+              "disabled_at": null
+          }
+      },
+      {
+          "id": "5ed150fd-4cc1-4b38-ab10-0ac7b44b8a2b",
+          "type": "locations",
+          "attributes": {
+              "key": "cheltenham_crown_court",
+              "title": "Cheltenham Crown Court",
+              "location_type": "court",
+              "nomis_agency_id": null,
+              "disabled_at": null
+          }
+      },
+      {
+          "id": "a3e4228e-3330-4c64-842e-297af0ab8cc4",
+          "type": "locations",
+          "attributes": {
+              "key": "croydon_magistrates_court",
+              "title": "Croydon Magistrates Court",
+              "location_type": "court",
+              "nomis_agency_id": null,
+              "disabled_at": null
+          }
+      },
+      {
+          "id": "4eb51a6c-222c-497c-90e0-0e3203443b68",
+          "type": "locations",
+          "attributes": {
+              "key": "kingston_upon_thames_county_court",
+              "title": "Kingston upon Thames County Court",
+              "location_type": "court",
+              "nomis_agency_id": null,
+              "disabled_at": null
+          }
+      },
+      {
+          "id": "2756e2e3-cd61-4a67-9775-417adb3671f4",
+          "type": "locations",
+          "attributes": {
+              "key": "richmond_crown_court",
+              "title": "Richmond Crown Court",
+              "location_type": "court",
+              "nomis_agency_id": null,
+              "disabled_at": null
+          }
+      },
+      {
+          "id": "b044ad72-2375-46be-9610-f75c1a539e8a",
+          "type": "locations",
+          "attributes": {
+              "key": "southall_crown_court",
+              "title": "Southall Crown Court",
+              "location_type": "court",
+              "nomis_agency_id": null,
+              "disabled_at": null
+          }
+      },
+      {
+          "id": "e9f59e9b-afd0-40e7-a1d4-f1786d7a7fc0",
+          "type": "locations",
+          "attributes": {
+              "key": "wimbledon_magistrates_court",
+              "title": "Wimbledon Magistrates Court",
+              "location_type": "court",
+              "nomis_agency_id": null,
+              "disabled_at": null
+          }
+      },
+      {
+          "id": "881fa099-201c-4b76-9253-df37d6bd1009",
+          "type": "locations",
+          "attributes": {
+              "key": "manchester_county_court",
+              "title": "Manchester County Court",
+              "location_type": "court",
+              "nomis_agency_id": null,
+              "disabled_at": null
+          }
+      },
+      {
+          "id": "58ec74f4-09c8-4e57-8550-9b460202229b",
+          "type": "locations",
+          "attributes": {
+              "key": "oldham_crown_court",
+              "title": "Oldham Crown Court",
+              "location_type": "court",
+              "nomis_agency_id": null,
+              "disabled_at": null
+          }
+      },
+      {
+          "id": "10923762-bc17-4ea1-bae3-68ea709ee23e",
+          "type": "locations",
+          "attributes": {
+              "key": "basingstoke_county_court",
+              "title": "Basingstoke County Court",
+              "location_type": "court",
+              "nomis_agency_id": null,
+              "disabled_at": null
+          }
+      },
+      {
+          "id": "6ca4e72a-499b-474d-9267-8ddc055f983a",
+          "type": "locations",
+          "attributes": {
+              "key": "southampton_county_court",
+              "title": "Southampton County Court",
+              "location_type": "court",
+              "nomis_agency_id": null,
+              "disabled_at": null
+          }
+      },
+      {
+          "id": "bacd8ed5-378b-4912-a029-bfb789086945",
+          "type": "locations",
+          "attributes": {
+              "key": "watford_crown_court",
+              "title": "Watford Crown Court",
+              "location_type": "court",
+              "nomis_agency_id": null,
+              "disabled_at": null
+          }
+      },
+      {
+          "id": "979fae93-9aae-43ce-81e0-c64d4ee472ff",
+          "type": "locations",
+          "attributes": {
+              "key": "dover_magistrates_court",
+              "title": "Dover Magistrates Court",
+              "location_type": "court",
+              "nomis_agency_id": null,
+              "disabled_at": null
+          }
+      },
+      {
+          "id": "f11b377e-a19d-4a91-b98d-a26c4b2e4d84",
+          "type": "locations",
+          "attributes": {
+              "key": "maidstone_crown_court",
+              "title": "Maidstone Crown Court",
+              "location_type": "court",
+              "nomis_agency_id": null,
+              "disabled_at": null
+          }
+      },
+      {
+          "id": "23b1ac5c-04e3-4ff1-94bc-eb4e7fa477d6",
+          "type": "locations",
+          "attributes": {
+              "key": "blackburn_county_court",
+              "title": "Blackburn County Court",
+              "location_type": "court",
+              "nomis_agency_id": null,
+              "disabled_at": null
+          }
+      },
+      {
+          "id": "61346c8a-370c-4cbd-9285-cf4e5610bd95",
+          "type": "locations",
+          "attributes": {
+              "key": "burnley_county_court",
+              "title": "Burnley County Court",
+              "location_type": "court",
+              "nomis_agency_id": null,
+              "disabled_at": null
+          }
+      },
+      {
+          "id": "bdec4256-ce5a-46bd-8583-6234b535b8c7",
+          "type": "locations",
+          "attributes": {
+              "key": "preston_crown_court",
+              "title": "Preston Crown Court",
+              "location_type": "court",
+              "nomis_agency_id": null,
+              "disabled_at": null
+          }
+      },
+      {
+          "id": "6d6eec6a-3e28-46c5-84ec-269851000ba1",
+          "type": "locations",
+          "attributes": {
+              "key": "grantham_magistrates_court",
+              "title": "Grantham Magistrates Court",
+              "location_type": "court",
+              "nomis_agency_id": null,
+              "disabled_at": null
+          }
+      },
+      {
+          "id": "1015f73d-0f41-4e85-9f34-0cfd5cfb27f4",
+          "type": "locations",
+          "attributes": {
+              "key": "grimsby_magistrates_court",
+              "title": "Grimsby Magistrates Court",
+              "location_type": "court",
+              "nomis_agency_id": null,
+              "disabled_at": null
+          }
+      },
+      {
+          "id": "c5c5aeb0-7d2e-4168-a7a9-d55746a58318",
+          "type": "locations",
+          "attributes": {
+              "key": "liverpool_magistrates_court",
+              "title": "Liverpool Magistrates Court",
+              "location_type": "court",
+              "nomis_agency_id": null,
+              "disabled_at": null
+          }
+      }
+  ],
+  "links": {
+      "self": "http://localhost:5000/api/v1/reference/locations?filter%5Blocation_type%5D=court&page%5Bnumber%5D=1&page%5Bsize%5D=50&per_page=50",
+      "first": "http://localhost:5000/api/v1/reference/locations?filter%5Blocation_type%5D=court&page%5Bnumber%5D=1&page%5Bsize%5D=50&per_page=50",
+      "prev": null,
+      "next": null,
+      "last": "http://localhost:5000/api/v1/reference/locations?filter%5Blocation_type%5D=court&page%5Bnumber%5D=2&page%5Bsize%5D=50&per_page=50"
+  },
+  "meta": {
+      "pagination": {
+          "per_page": 50,
+          "total_pages": 1,
+          "total_objects": 50,
+          "links": {
+              "first": "/api/v1/reference/locations?filter%5Blocation_type%5D=court&page=1&per_page=50",
+              "last": "/api/v1/reference/locations?filter%5Blocation_type%5D=court&page=2&per_page=50"
+          }
+      }
+  }
+}


### PR DESCRIPTION
This allows the frontend to look up the user's locations either on HMPPS SSO or NOMIS depending on the type of user, and resolves those to the IDs represented in the API. This will allow us to implement location switching.
