### PR TITLE
Disable coveralls coverage upload

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -147,11 +147,11 @@ jobs:
           command: |
             npm run circle:coverage
           when: always
-      - run:
-          name: upload coverage to coveralls
-          command: |
-            npm run circle:coveralls
-          when: always
+      # - run:
+      #     name: upload coverage to coveralls
+      #     command: |
+      #       npm run circle:coveralls
+      #     when: always
       - run:
           name: upload coverage to code climate
           command: |


### PR DESCRIPTION
This Coveralls service has been down for sometime and is causing
the unit test build to fail.

This change removes that from the unit_test job on CI so that
it doesn't prevent successful builds until Coveralls fix the issue.

## Coveralls status

![image](https://user-images.githubusercontent.com/3327997/62943544-9f9a9280-bdd2-11e9-9cbf-b78c60aacd49.png)

## Repo page

![image](https://user-images.githubusercontent.com/3327997/62943557-ac1eeb00-bdd2-11e9-808d-34da8075351c.png)


### Checklist

- [x] If adding new environment variables, they have been documented in the [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md)
- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
