### PR TITLE
Ensure API auth call includes timeout

### DIFF
--- a/common/lib/api-client/middleware/auth.js
+++ b/common/lib/api-client/middleware/auth.js
@@ -28,6 +28,7 @@ async function refreshAccessToken() {
     API.AUTH_URL,
     {},
     {
+      timeout: API.TIMEOUT,
       params: {
         grant_type: 'client_credentials',
       },

--- a/common/lib/api-client/middleware/auth.test.js
+++ b/common/lib/api-client/middleware/auth.test.js
@@ -5,6 +5,7 @@ const mockConfig = {
   AUTH_URL: 'http://baseurl.com/oauth/token',
   CLIENT_ID: 'clientid',
   SECRET: 'secret',
+  TIMEOUT: 10000,
 }
 const auth = proxyquire('./auth', {
   '../../../../config': {


### PR DESCRIPTION
A timeout was added to all regular API client calls but the
separate auth call was missed.

This change adds the setting to the auth middleware to ensure it
receives the same timeout. This is an initial fix to prevent
the frontend from hanging.

In future it might also be better to make use of the axios instance
on the jsonApi object. But that can come as part of a refactor to the
way [the API client is currently tested and used within the app](https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/issues/82).

Fixes #189

### Checklist

- [x] If adding new environment variables, they have been documented in the [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md)
- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
