### PR TITLE
Show user's location in header

### DIFF
--- a/common/assets/scss/application.scss
+++ b/common/assets/scss/application.scss
@@ -29,6 +29,9 @@ $govuk-font-family: "Inter", system-ui, sans-serif;
 @import "govuk-frontend/govuk/utilities/all";
 @import "govuk-frontend/govuk/overrides/all";
 
+// Import MoJ Frontend Components
+@import "@ministryofjustice/frontend/moj/components/organisation-switcher/_organisation-switcher.scss";
+
 // Import app settings/tools/helpers
 @import "helpers/all";
 

--- a/common/assets/scss/overrides/_font-corrections.scss
+++ b/common/assets/scss/overrides/_font-corrections.scss
@@ -8,3 +8,11 @@
   padding-top: 4px;
   padding-bottom: 4px;
 }
+
+.moj-organisation-nav {
+  margin: 0;
+  padding: 10px 0;
+}
+.moj-organisation-nav__link {
+  padding-top: 2px;
+}

--- a/common/templates/layouts/base.njk
+++ b/common/templates/layouts/base.njk
@@ -12,6 +12,8 @@
 {% from "govuk/components/summary-list/macro.njk"      import govukSummaryList %}
 {% from "govuk/components/textarea/macro.njk"          import govukTextarea %}
 
+{% from "moj/components/organisation-switcher/macro.njk" import mojOrganisationSwitcher %}
+
 {# App level components #}
 {% from "card/macro.njk"              import appCard %}
 {% from "data/macro.njk"              import appData %}
@@ -80,6 +82,12 @@
       url: FEEDBACK_URL
     })
   }) }}
+
+  {% if CURRENT_LOCATION %}
+    {{ mojOrganisationSwitcher({
+      text: CURRENT_LOCATION.title
+    }) }}
+  {% endif %}
 
   {% include "includes/messages.njk" %}
 {% endblock %}

--- a/config/nunjucks/index.js
+++ b/config/nunjucks/index.js
@@ -6,6 +6,7 @@ const filters = require('./filters')
 module.exports = (app, { IS_DEV, NO_CACHE }, paths) => {
   const views = [
     `${paths.root}/node_modules/govuk-frontend`,
+    `${paths.root}/node_modules/@ministryofjustice/frontend`,
     paths.templates,
     paths.components,
     paths.app,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pecs-frontend",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -762,6 +762,21 @@
         "esutils": "^2.0.2",
         "lodash": "^4.17.11",
         "to-fast-properties": "^2.0.0"
+      }
+    },
+    "@ministryofjustice/frontend": {
+      "version": "0.0.10-alpha",
+      "resolved": "https://registry.npmjs.org/@ministryofjustice/frontend/-/frontend-0.0.10-alpha.tgz",
+      "integrity": "sha512-XCuruEDVjlxDxzATn92d+WMriUMSTFrQblisR/NrWeXbP0+fHw+GowdEvtjVU8dh1M6vWqWDZUcjjrCKnhvM9A==",
+      "requires": {
+        "moment": "^2.22.2"
+      },
+      "dependencies": {
+        "moment": {
+          "version": "2.24.0",
+          "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
+          "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
+        }
       }
     },
     "@sentry/core": {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "pecs"
   ],
   "dependencies": {
+    "@ministryofjustice/frontend": "0.0.10-alpha",
     "@sentry/node": "^5.5.0",
     "accessible-autocomplete": "^1.6.2",
     "axios": "^0.19.0",

--- a/server.js
+++ b/server.js
@@ -67,6 +67,9 @@ app.use(
   '/assets',
   express.static(
     path.join(__dirname, '/node_modules/govuk-frontend/govuk/assets')
+  ),
+  express.static(
+    path.join(__dirname, '/node_modules/@ministryofjustice/frontend/assets')
   )
 )
 


### PR DESCRIPTION
This shows the user's current location on the page header, using the [MoJ organisation switcher](https://moj-design-system.herokuapp.com/components/organisation-switcher) component. This can then be extended in a subsequent PR to allow the user to switch their location.

## What it looks like

![Screenshot 2019-08-18 at 14 24 34](https://user-images.githubusercontent.com/408371/63225045-537d9280-c1c4-11e9-9e7d-6b28fac5be05.png)
