### PR TITLE
Return error when user has no locations set

### DIFF
--- a/app/move/controllers/new.form.js
+++ b/app/move/controllers/new.form.js
@@ -22,9 +22,7 @@ class FormController extends Controller {
 
   checkCurrentLocation(req, res, next) {
     if (!req.session.currentLocation) {
-      const error = new Error(
-        'Current location is not set. Check environment variable is correctly set.'
-      )
+      const error = new Error('Current location is not set.')
       return next(error)
     }
 

--- a/app/move/controllers/new.form.test.js
+++ b/app/move/controllers/new.form.test.js
@@ -120,7 +120,7 @@ describe('Move controllers', function() {
           expect(nextSpy).to.be.calledOnce
           expect(nextSpy.args[0][0] instanceof Error).to.be.true
           expect(nextSpy.args[0][0].message).to.equal(
-            'Current location is not set. Check environment variable is correctly set.'
+            'Current location is not set.'
           )
         })
       })

--- a/common/lib/user.js
+++ b/common/lib/user.js
@@ -1,5 +1,6 @@
 function User({ name, roles = [], locations = [] } = {}) {
   this.userName = name
+  this.roles = roles
   this.permissions = this.getPermissions(roles)
   this.locations = locations
 }

--- a/common/lib/user.test.js
+++ b/common/lib/user.test.js
@@ -27,6 +27,11 @@ describe('User class', function() {
         roles = ['ROLE_PECS_SUPPLIER']
       })
 
+      it('should set roles', function() {
+        user = new User({ name: 'USERNAME', roles })
+        expect(user.roles).to.deep.equal(roles)
+      })
+
       it('should set permissions', function() {
         user = new User({ name: 'USERNAME', roles })
         expect(Array.isArray(user.permissions)).to.be.true
@@ -38,6 +43,12 @@ describe('User class', function() {
         user = new User()
 
         expect(user.permissions).to.deep.equal([])
+      })
+
+      it('should set roles to empty array', function() {
+        user = new User()
+
+        expect(user.roles).to.deep.equal([])
       })
     })
 

--- a/common/middleware/ensure-user-location.js
+++ b/common/middleware/ensure-user-location.js
@@ -1,0 +1,18 @@
+const { get } = require('lodash')
+
+module.exports = function ensureUserLocation(req, res, next) {
+  const userLocations = get(req.session, 'user.locations')
+  const userRoles = get(req.session, 'user.roles')
+
+  if (
+    (Array.isArray(userLocations) && userLocations.length) ||
+    (Array.isArray(userRoles) && userRoles.includes('PECS_ROLE_SUPPLIER'))
+  ) {
+    return next()
+  }
+
+  const error = new Error(`No locations found for user`)
+  error.statusCode = 403
+
+  next(error)
+}

--- a/common/middleware/ensure-user-location.test.js
+++ b/common/middleware/ensure-user-location.test.js
@@ -1,0 +1,78 @@
+const ensureUserLocation = require('./ensure-user-location')
+
+describe('Location middleware', function() {
+  describe('#ensureUserLocation()', function() {
+    let req, nextSpy
+
+    beforeEach(function() {
+      nextSpy = sinon.spy()
+      req = {
+        session: {
+          user: {},
+        },
+      }
+    })
+
+    context('when no user in session', function() {
+      it('should call next with 403 error', function() {
+        ensureUserLocation(req, {}, nextSpy)
+
+        const error = nextSpy.args[0][0]
+        expect(nextSpy).to.be.calledOnce
+        expect(error).to.be.an.instanceOf(Error)
+        expect(error.message).to.equal('No locations found for user')
+        expect(error.statusCode).to.equal(403)
+      })
+    })
+
+    context('when user has no locations', function() {
+      context('when the user has role PECS_ROLE_SUPPLIER', function() {
+        beforeEach(function() {
+          req.session.user = {
+            locations: [],
+            roles: ['PECS_ROLE_SUPPLIER'],
+          }
+
+          ensureUserLocation(req, {}, nextSpy)
+        })
+
+        it('should call next without error', function() {
+          expect(nextSpy).to.be.calledOnceWithExactly()
+        })
+      })
+
+      context('when the user has role PECS_ROLE_POLICE', function() {
+        beforeEach(function() {
+          req.session.user = {
+            locations: [],
+            roles: ['PECS_ROLE_POLICE'],
+          }
+
+          ensureUserLocation(req, {}, nextSpy)
+        })
+
+        it('should call next with 403 error', function() {
+          const error = nextSpy.args[0][0]
+          expect(nextSpy).to.be.calledOnce
+          expect(error).to.be.an.instanceOf(Error)
+          expect(error.message).to.equal('No locations found for user')
+          expect(error.statusCode).to.equal(403)
+        })
+      })
+    })
+
+    context('when user has a location', function() {
+      beforeEach(function() {
+        req.session.user = {
+          locations: [{ id: 'test' }],
+        }
+
+        ensureUserLocation(req, {}, nextSpy)
+      })
+
+      it('should call next without error', function() {
+        expect(nextSpy).to.be.calledOnceWithExactly()
+      })
+    })
+  })
+})

--- a/server.js
+++ b/server.js
@@ -23,6 +23,7 @@ const logger = require('./config/logger')
 const i18n = require('./config/i18n')
 const nunjucks = require('./config/nunjucks')
 const redisStore = require('./config/redis-store')
+const ensureUserLocation = require('./common/middleware/ensure-user-location')
 const setCurrentLocation = require('./common/middleware/set-current-location')
 const errorHandlers = require('./common/middleware/errors')
 const checkSession = require('./common/middleware/check-session')
@@ -122,6 +123,7 @@ app.use(
     whitelist: config.AUTH_WHITELIST_URLS,
   })
 )
+app.use(ensureUserLocation)
 app.use(setCurrentLocation)
 app.use(helmet())
 


### PR DESCRIPTION
This shows a more meaningful error message when the user has no locations set, e.g. when they have no groups assigned, or no matching location is found in the back end API.

![Screenshot 2019-08-18 at 15 08 09](https://user-images.githubusercontent.com/408371/63225671-82970280-c1ca-11e9-9457-27344a0cdb3b.png)
