### PR TITLE
[P4-505] Display username in header

### DIFF
--- a/common/components/internal-header/template.njk
+++ b/common/components/internal-header/template.njk
@@ -62,6 +62,10 @@
                 {{ item.text }}
               </a>
             </li>
+          {% elif item.text %}
+            <li class="app-header__navigation-item">
+              {{ item.text }}
+            </li>
           {% endif %}
         {% endfor %}
       </ul>

--- a/common/components/internal-header/template.test.js
+++ b/common/components/internal-header/template.test.js
@@ -106,6 +106,31 @@ describe('Internal header component', function() {
         'my-attribute-2'
       )
     })
+
+    it('renders navigation items with text only', function() {
+      const $ = render('internal-header', {
+        navigation: [
+          {
+            text: 'Item 1',
+          },
+          {
+            text: 'Item 2',
+          },
+        ],
+      })
+
+      const $component = $('.app-header')
+      const $list = $component.find('ul.app-header__navigation')
+      const $firstItem = $list.find('li.app-header__navigation-item').first()
+      const $lastItem = $list.find('li.app-header__navigation-item').last()
+
+      expect($firstItem.html().trim()).to.equal('Item 1')
+      expect($firstItem.find('a').length).to.equal(0)
+
+      expect($lastItem.html().trim()).to.equal('Item 2')
+      expect($lastItem.find('a').length).to.equal(0)
+    })
+
     describe('menu button', function() {
       it('has an explicit type="button" so it does not act as a submit button', function() {
         const $ = render('internal-header', examples['with navigation'])

--- a/common/templates/layouts/base.njk
+++ b/common/templates/layouts/base.njk
@@ -65,6 +65,9 @@
     containerClasses: "govuk-width-container",
     navigation: [
       {
+        text: USER.userName
+      },
+      {
         href: "/auth/sign-out",
         text: t("actions::sign_out")
       }


### PR DESCRIPTION
## Feature
Add user name into the internal header.

## ToDo
The `user.username` is currently only available via the `access_token` further work needs to be created to query the api to get the `user.name` which is easier on the eye. This was felt out of scope for this work.

## Screenshots

### Large screen
![Screenshot 2019-08-20 at 17 10 22](https://user-images.githubusercontent.com/2305016/63365059-c0349080-c36e-11e9-862e-607492357cca.png)

### Small screen
![Screenshot 2019-08-20 at 17 14 31](https://user-images.githubusercontent.com/2305016/63365060-c0349080-c36e-11e9-9544-fdd96705a693.png)

