### PR TITLE
[P4-260] Increase page limit on moves request

### DIFF
--- a/common/services/move.js
+++ b/common/services/move.js
@@ -13,16 +13,38 @@ function format(data) {
   })
 }
 
-function getRequestedMovesByDateAndLocation(moveDate, locationId) {
+function getMoves({ filter, combinedData = [], page = 1 } = {}) {
   return apiClient
     .findAll('move', {
+      ...filter,
+      page,
       per_page: 100,
+    })
+    .then(response => {
+      const { data, links } = response
+      const items = [...combinedData, ...data]
+
+      if (!links.next) {
+        return items
+      }
+
+      return getMoves({
+        filter,
+        combinedData: items,
+        page: page + 1,
+      })
+    })
+}
+
+function getRequestedMovesByDateAndLocation(moveDate, locationId) {
+  return getMoves({
+    filter: {
       'filter[status]': 'requested',
       'filter[date_from]': moveDate,
       'filter[date_to]': moveDate,
       'filter[from_location_id]': locationId,
-    })
-    .then(response => response.data)
+    },
+  })
 }
 
 function getMoveById(id) {
@@ -48,6 +70,7 @@ function cancel(id) {
 
 module.exports = {
   format,
+  getMoves,
   getRequestedMovesByDateAndLocation,
   getMoveById,
   create,

--- a/common/services/move.js
+++ b/common/services/move.js
@@ -16,6 +16,7 @@ function format(data) {
 function getRequestedMovesByDateAndLocation(moveDate, locationId) {
   return apiClient
     .findAll('move', {
+      per_page: 100,
       'filter[status]': 'requested',
       'filter[date_from]': moveDate,
       'filter[date_to]': moveDate,

--- a/common/services/move.test.js
+++ b/common/services/move.test.js
@@ -119,6 +119,7 @@ describe('Move Service', function() {
         nock(API.BASE_URL)
           .get('/moves')
           .query({
+            per_page: 100,
             filter: {
               status: 'requested',
               date_from: mockDate,

--- a/common/services/move.test.js
+++ b/common/services/move.test.js
@@ -4,6 +4,8 @@ const { API } = require('../../config')
 
 const movesGetDeserialized = require('../../test/fixtures/api-client/moves.get.deserialized.json')
 const movesGetSerialized = require('../../test/fixtures/api-client/moves.get.serialized.json')
+const movesGetPage1Serialized = require('../../test/fixtures/api-client/moves.get.page-1.serialized.json')
+const movesGetPage2Serialized = require('../../test/fixtures/api-client/moves.get.page-2.serialized.json')
 const moveGetDeserialized = require('../../test/fixtures/api-client/move.get.deserialized.json')
 const moveGetSerialized = require('../../test/fixtures/api-client/move.get.serialized.json')
 
@@ -108,6 +110,40 @@ describe('Move Service', function() {
     })
   })
 
+  describe('#getLocations()', function() {
+    context('when request returns 200', function() {
+      let moves
+
+      beforeEach(async function() {
+        nock(API.BASE_URL)
+          .get('/moves')
+          .query({
+            page: 1,
+            per_page: 100,
+          })
+          .reply(200, movesGetPage1Serialized)
+
+        nock(API.BASE_URL)
+          .get('/moves')
+          .query({
+            page: 2,
+            per_page: 100,
+          })
+          .reply(200, movesGetPage2Serialized)
+
+        moves = await moveService.getMoves()
+      })
+
+      it('should get moves from API with current date', function() {
+        expect(nock.isDone()).to.be.true
+      })
+
+      it('should contain moves with correct data', function() {
+        expect(moves.length).to.equal(40)
+      })
+    })
+  })
+
   describe('#getRequestedMovesByDateAndLocation()', function() {
     context('when request returns 200', function() {
       const mockDate = '2017-08-10'
@@ -119,6 +155,7 @@ describe('Move Service', function() {
         nock(API.BASE_URL)
           .get('/moves')
           .query({
+            page: 1,
             per_page: 100,
             filter: {
               status: 'requested',

--- a/test/fixtures/api-client/moves.get.deserialized.json
+++ b/test/fixtures/api-client/moves.get.deserialized.json
@@ -1585,21 +1585,20 @@
   }],
   "meta": {
     "pagination": {
-      "per_page": 20,
-      "total_pages": 25,
-      "total_objects": 500,
+      "per_page": 100,
+      "total_pages": 1,
+      "total_objects": 20,
       "links": {
         "first": "/api/v1/moves?page=1",
-        "last": "/api/v1/moves?page=25",
-        "next": "/api/v1/moves?page=2"
+        "last": "/api/v1/moves?page=1"
       }
     }
   },
   "links": {
-    "self": "http://localhost:5000/api/v1/moves?page%5Bnumber%5D=1&page%5Bsize%5D=20",
-    "first": "http://localhost:5000/api/v1/moves?page%5Bnumber%5D=1&page%5Bsize%5D=20",
+    "self": "http://localhost:5000/api/v1/moves?page%5Bnumber%5D=1&page%5Bsize%5D=100",
+    "first": "http://localhost:5000/api/v1/moves?page%5Bnumber%5D=1&page%5Bsize%5D=100",
     "prev": null,
-    "next": "http://localhost:5000/api/v1/moves?page%5Bnumber%5D=2&page%5Bsize%5D=20",
-    "last": "http://localhost:5000/api/v1/moves?page%5Bnumber%5D=25&page%5Bsize%5D=20"
+    "next": null,
+    "last": "http://localhost:5000/api/v1/moves?page%5Bnumber%5D=1&page%5Bsize%5D=100"
   }
 }

--- a/test/fixtures/api-client/moves.get.page-1.serialized.json
+++ b/test/fixtures/api-client/moves.get.page-1.serialized.json
@@ -1956,17 +1956,18 @@
     "self": "http://localhost:5000/api/v1/moves?page%5Bnumber%5D=1&page%5Bsize%5D=100",
     "first": "http://localhost:5000/api/v1/moves?page%5Bnumber%5D=1&page%5Bsize%5D=100",
     "prev": null,
-    "next": null,
-    "last": "http://localhost:5000/api/v1/moves?page%5Bnumber%5D=1&page%5Bsize%5D=100"
+    "next": "http://localhost:5000/api/v1/moves?page%5Bnumber%5D=2&page%5Bsize%5D=100",
+    "last": "http://localhost:5000/api/v1/moves?page%5Bnumber%5D=2&page%5Bsize%5D=100"
   },
   "meta": {
     "pagination": {
       "per_page": 100,
-      "total_pages": 1,
-      "total_objects": 20,
+      "total_pages": 2,
+      "total_objects": 200,
       "links": {
         "first": "/api/v1/moves?page=1",
-        "last": "/api/v1/moves?page=1"
+        "last": "/api/v1/moves?page=1",
+        "next": "/api/v1/moves?page=2"
       }
     }
   }

--- a/test/fixtures/api-client/moves.get.page-2.serialized.json
+++ b/test/fixtures/api-client/moves.get.page-2.serialized.json
@@ -1953,20 +1953,21 @@
     }
   ],
   "links": {
-    "self": "http://localhost:5000/api/v1/moves?page%5Bnumber%5D=1&page%5Bsize%5D=100",
+    "self": "http://localhost:5000/api/v1/moves?page%5Bnumber%5D=2&page%5Bsize%5D=100",
     "first": "http://localhost:5000/api/v1/moves?page%5Bnumber%5D=1&page%5Bsize%5D=100",
-    "prev": null,
+    "prev": "http://localhost:5000/api/v1/moves?page%5Bnumber%5D=1&page%5Bsize%5D=100",
     "next": null,
-    "last": "http://localhost:5000/api/v1/moves?page%5Bnumber%5D=1&page%5Bsize%5D=100"
+    "last": "http://localhost:5000/api/v1/moves?page%5Bnumber%5D=2&page%5Bsize%5D=100"
   },
   "meta": {
     "pagination": {
       "per_page": 100,
-      "total_pages": 1,
-      "total_objects": 20,
+      "total_pages": 2,
+      "total_objects": 200,
       "links": {
         "first": "/api/v1/moves?page=1",
-        "last": "/api/v1/moves?page=1"
+        "last": "/api/v1/moves?page=1",
+        "prev": "/api/v1/moves?page=1"
       }
     }
   }


### PR DESCRIPTION
This change ensures that we return the maximum number of moves
to the dashboard. At the moment there is no pagination so this
will ensure that no moves are not displayed on the dashboard.

There will be a performance issue with this initially but this
has been accepted for this initial pilot where only small number of
moves are being put through a day.