### PR TITLE
Update move service calls to always return data

### DIFF
--- a/app/move/middleware.js
+++ b/app/move/middleware.js
@@ -7,10 +7,7 @@ module.exports = {
     }
 
     try {
-      const move = await moveService.getMoveById(moveId)
-
-      res.locals.move = move.data
-
+      res.locals.move = await moveService.getMoveById(moveId)
       next()
     } catch (error) {
       next(error)

--- a/app/move/middleware.test.js
+++ b/app/move/middleware.test.js
@@ -2,9 +2,7 @@ const moveService = require('../../common/services/move')
 
 const middleware = require('./middleware')
 
-const moveStub = {
-  data: [{ foo: 'bar' }, { fizz: 'buzz' }],
-}
+const moveStub = [{ foo: 'bar' }, { fizz: 'buzz' }]
 const mockMoveId = '6904dea1-017f-48d8-a5ad-2723dee9d146'
 const errorStub = new Error('Problem')
 
@@ -54,7 +52,7 @@ describe('Move middleware', function() {
 
         it('should set response data to locals object', function() {
           expect(res.locals).to.have.property('move')
-          expect(res.locals.move).to.equal(moveStub.data)
+          expect(res.locals.move).to.equal(moveStub)
         })
 
         it('should call next with no argument', function() {

--- a/common/services/move.js
+++ b/common/services/move.js
@@ -48,7 +48,7 @@ function getRequestedMovesByDateAndLocation(moveDate, locationId) {
 }
 
 function getMoveById(id) {
-  return apiClient.find('move', id)
+  return apiClient.find('move', id).then(response => response.data)
 }
 
 function create(data) {

--- a/common/services/move.test.js
+++ b/common/services/move.test.js
@@ -199,7 +199,7 @@ describe('Move Service', function() {
       })
 
       it('should contain move with correct data', function() {
-        expect(move.data).to.deep.equal(moveGetDeserialized.data)
+        expect(move).to.deep.equal(moveGetDeserialized.data)
       })
     })
   })


### PR DESCRIPTION
Previously the call would return the response from the JSON API
client library which would include unnecessary properties.

This change replicates the other methods in the service and extracts
the deserialized data from the response and returns that rather
than the full response object.