### PR TITLE
[P4-504] Add sticky sidebar to move detail page

### DIFF
--- a/app/move/views/view.njk
+++ b/app/move/views/view.njk
@@ -45,7 +45,7 @@
     {% endif %}
   </header>
 
-  <div class="govuk-grid-row">
+  <div class="govuk-grid-row sticky-sidebar-container">
     <div class="govuk-grid-column-two-thirds">
       <h2 class="govuk-heading-m">
         {{ t("moves::steps.personal_details.heading") }}
@@ -65,10 +65,12 @@
     </div>
 
     <div class="govuk-grid-column-one-third">
-      <div class="app-border-top-2 app-border--blue govuk-!-padding-top-4">
-        <h3 class="govuk-heading-m">{{ fullname | upper }}</h3>
+      <div class="sticky-sidebar">
+        <div class="sticky-sidebar__inner">
+          <h3 class="govuk-heading-m app-border-top-2 app-border--blue govuk-!-padding-top-4">{{ fullname | upper }}</h3>
 
-        {{ appMetaList(moveSummary) }}
+          {{ appMetaList(moveSummary) }}
+        </div>
       </div>
     </div>
   </div>

--- a/common/assets/javascripts/application.js
+++ b/common/assets/javascripts/application.js
@@ -9,6 +9,7 @@ import '../images/hmpps-apple-touch-icon-180x180.png'
 import { nodeListForEach } from './utils'
 import { initAll } from 'govuk-frontend'
 import accessibleAutocomplete from 'accessible-autocomplete'
+import StickySidebar from 'sticky-sidebar/dist/sticky-sidebar'
 import Message from '../../components/message/message'
 import Header from '../../components/internal-header/internal-header'
 
@@ -32,3 +33,14 @@ nodeListForEach($autocompletes, function($autocomplete) {
     defaultValue: '',
   })
 })
+
+var $stickySidebars = document.querySelectorAll('.sticky-sidebar')
+if ($stickySidebars.length) {
+  // eslint-disable-next-line no-new
+  new StickySidebar('.sticky-sidebar', {
+    topSpacing: 20,
+    bottomSpacing: 20,
+    containerSelector: '.sticky-sidebar-container',
+    innerWrapperSelector: '.sticky-sidebar__inner',
+  })
+}

--- a/common/assets/scss/components/_all.scss
+++ b/common/assets/scss/components/_all.scss
@@ -1,5 +1,6 @@
 @import "autocomplete";
 @import "stack-trace";
+@import "sticky-sidebar";
 
 // Load components from the shared components folder
 @import "card/card";

--- a/common/assets/scss/components/_sticky-sidebar.scss
+++ b/common/assets/scss/components/_sticky-sidebar.scss
@@ -1,0 +1,9 @@
+.sticky-sidebar {
+  will-change: min-height;
+}
+
+.sticky-sidebar__inner {
+  transform: translate(0, 0); /* For browsers don't support translate3d. */
+  transform: translate3d(0, 0, 0);
+  will-change: position, transform;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -11292,6 +11292,11 @@
         "readable-stream": "^2.0.1"
       }
     },
+    "sticky-sidebar": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/sticky-sidebar/-/sticky-sidebar-3.3.1.tgz",
+      "integrity": "sha1-FCv2tkwrQW5LcH6/jwm4taUEOHc="
+    },
     "stream-browserify": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "query-string": "6.7.0",
     "serve-favicon": "2.5.0",
     "slashify": "1.0.0",
+    "sticky-sidebar": "3.3.1",
     "winston": "3.2.1"
   },
   "devDependencies": {


### PR DESCRIPTION
This adds some client side JS to pin the right hand panel
on the move detail page to the top of the window on scroll.

This allows the user to keep the context of the person they
are moving and where they are moving as they scroll the page.

## What it looks like (on scroll)

![image](https://user-images.githubusercontent.com/3327997/63717326-dbf0d880-c83f-11e9-84a6-c78351f62c09.png)
