### PR TITLE
Ensure form wizard template is using translations

### DIFF
--- a/common/templates/form-wizard.njk
+++ b/common/templates/form-wizard.njk
@@ -18,7 +18,7 @@
 {% block content %}
   {% if errors.errorList.length %}
     {{ govukErrorSummary({
-      titleText: "There is a problem with this page",
+      titleText: t("validation::summary.heading"),
       errorList: errors.errorList
     }) }}
   {% endif %}
@@ -51,7 +51,9 @@
         }) }}
 
         {% if cancelUrl %}
-          <a href="{{ cancelUrl }}" class="govuk-button govuk-button--text">Cancel</a>
+          <a href="{{ cancelUrl }}" class="govuk-button govuk-button--text">
+            {{ t("actions::cancel") }}
+          </a>
         {% endif %}
       </form>
     </div>

--- a/locales/en/actions.json
+++ b/locales/en/actions.json
@@ -9,6 +9,7 @@
   "schedule_move": "Schedule move",
   "continue": "Continue",
   "restart": "Restart",
+  "cancel": "Cancel",
   "cancel_move": "Cancel this move",
   "cancel_move_confirmation": "Cancel move",
   "download": "Download moves",

--- a/locales/en/validation.json
+++ b/locales/en/validation.json
@@ -1,4 +1,7 @@
 {
+  "summary": {
+    "heading": "There is a problem with this page"
+  },
   "required": "cannot be blank",
   "numeric": "can only contain numbers",
   "date": "must be a valid date",


### PR DESCRIPTION
This amends the form wizard template to make sure it is making
use of the i18n library to translate any content.