### PR TITLE
[P4-638] Fix moves permissions with no locations case

### DIFF
--- a/common/middleware/ensure-current-location.js
+++ b/common/middleware/ensure-current-location.js
@@ -1,9 +1,14 @@
 function ensureCurrentLocation({ locationsMountpath, whitelist = [] } = {}) {
   return (req, res, next) => {
+    const { permissions = [], locations = [] } = req.session.user || {}
+    const canViewAllMovesWithoutLocations =
+      permissions.includes('moves:view:all') && !locations.length
+
     if (
       req.session.currentLocation ||
       whitelist.includes(req.url) ||
-      req.url.includes(locationsMountpath)
+      req.url.includes(locationsMountpath) ||
+      canViewAllMovesWithoutLocations
     ) {
       return next()
     }

--- a/common/middleware/ensure-current-location.test.js
+++ b/common/middleware/ensure-current-location.test.js
@@ -86,4 +86,69 @@ describe('Ensure current location middleware', function() {
       expect(res.redirect).to.be.calledOnceWithExactly(locationsMountpath)
     })
   })
+
+  context('when user has view all moves permission', function() {
+    beforeEach(function() {
+      req.session.user = {
+        permissions: ['moves:view:all'],
+      }
+    })
+
+    context('when user locations contains items', function() {
+      beforeEach(function() {
+        req.session.user.locations = [
+          {
+            id: '1',
+            name: 'Location one',
+          },
+        ]
+
+        ensureCurrentLocation({
+          locationsMountpath,
+        })(req, res, nextSpy)
+      })
+
+      it('should not call next', function() {
+        expect(nextSpy).not.to.be.called
+      })
+
+      it('should redirect to locations mountpath', function() {
+        expect(res.redirect).to.be.calledOnceWithExactly(locationsMountpath)
+      })
+    })
+
+    context('when user locations is empty list', function() {
+      beforeEach(function() {
+        req.session.user.locations = []
+
+        ensureCurrentLocation({
+          locationsMountpath,
+        })(req, res, nextSpy)
+      })
+
+      it('should call next', function() {
+        expect(nextSpy).to.be.calledOnceWithExactly()
+      })
+
+      it('should not redirect', function() {
+        expect(res.redirect).not.to.be.called
+      })
+    })
+
+    context('when user locations does not exist', function() {
+      beforeEach(function() {
+        ensureCurrentLocation({
+          locationsMountpath,
+        })(req, res, nextSpy)
+      })
+
+      it('should call next', function() {
+        expect(nextSpy).to.be.calledOnceWithExactly()
+      })
+
+      it('should not redirect', function() {
+        expect(res.redirect).not.to.be.called
+      })
+    })
+  })
 })


### PR DESCRIPTION
If a user has permission to view all moves, regardless of location,
they should be able to view moves even if their user does not currently
have any available locations.

This is currently the case for suppliers. Without this change a
supplier user is only greeted with the no locations message and cannot
view any other parts of the app.