### PR TITLE
Update the error message for checking current location

### DIFF
--- a/app/move/controllers/new.form.js
+++ b/app/move/controllers/new.form.js
@@ -22,9 +22,7 @@ class FormController extends Controller {
 
   checkCurrentLocation(req, res, next) {
     if (!req.session.currentLocation) {
-      const error = new Error(
-        'Current location is not set. Check environment variable is correctly set.'
-      )
+      const error = new Error('Current location is not set in session.')
       return next(error)
     }
 

--- a/app/move/controllers/new.form.test.js
+++ b/app/move/controllers/new.form.test.js
@@ -120,7 +120,7 @@ describe('Move controllers', function() {
           expect(nextSpy).to.be.calledOnce
           expect(nextSpy.args[0][0] instanceof Error).to.be.true
           expect(nextSpy.args[0][0].message).to.equal(
-            'Current location is not set. Check environment variable is correctly set.'
+            'Current location is not set in session.'
           )
         })
       })


### PR DESCRIPTION
The current location is no longer set via environment variable.

This change updates the error message that is thrown when the
create journey is started without a current location.