### PR TITLE
Update test undefined syntax

### DIFF
--- a/app/move/controllers/new.form.test.js
+++ b/app/move/controllers/new.form.test.js
@@ -63,7 +63,7 @@ describe('Move controllers', function() {
 
         it('should set cancel url correctly', function() {
           expect(res.locals).to.have.property('cancelUrl')
-          expect(res.locals.cancelUrl).to.equal(undefined)
+          expect(res.locals.cancelUrl).to.be.undefined
         })
 
         it('should call next', function() {

--- a/app/move/controllers/new.form.test.js
+++ b/app/move/controllers/new.form.test.js
@@ -118,7 +118,7 @@ describe('Move controllers', function() {
 
         it('should call next with error', function() {
           expect(nextSpy).to.be.calledOnce
-          expect(nextSpy.args[0][0] instanceof Error).to.be.true
+          expect(nextSpy.args[0][0]).to.be.an('error')
           expect(nextSpy.args[0][0].message).to.equal(
             'Current location is not set in session.'
           )

--- a/common/components/message/template.test.js
+++ b/common/components/message/template.test.js
@@ -154,7 +154,7 @@ describe('Message component', function() {
     context('when dismiss is prevented', function() {
       it('should render unescaped html', function() {
         const $ = render('message', examples['without dismiss'])
-        expect($('.app-message').attr('data-module')).to.equal(undefined)
+        expect($('.app-message').attr('data-module')).to.be.undefined
       })
     })
   })

--- a/common/lib/api-client/middleware/errors.test.js
+++ b/common/lib/api-client/middleware/errors.test.js
@@ -82,7 +82,7 @@ describe('API Client', function() {
             const error = errorMiddleware.error({ response })
 
             expect(error).to.be.an.instanceOf(Error)
-            expect(error.errors).to.equal(undefined)
+            expect(error.errors).to.be.undefined
           })
         })
 

--- a/common/lib/user.test.js
+++ b/common/lib/user.test.js
@@ -17,7 +17,7 @@ describe('User class', function() {
       it('should not set username', function() {
         user = new User()
 
-        expect(user.userName).to.equal(undefined)
+        expect(user.userName).to.be.undefined
       })
     })
 

--- a/common/middleware/errors.test.js
+++ b/common/middleware/errors.test.js
@@ -26,7 +26,7 @@ describe('Error middleware', function() {
 
     it('should call next with an error', function() {
       expect(nextSpy.calledOnce).to.be.true
-      expect(nextSpy.args[0][0] instanceof Error).to.be.true
+      expect(nextSpy.args[0][0]).to.be.an('error')
       expect(nextSpy.args[0][0].message).to.equal('Not Found')
     })
   })

--- a/config/nunjucks/filters.test.js
+++ b/config/nunjucks/filters.test.js
@@ -185,7 +185,7 @@ describe('Nunjucks filters', function() {
     context('when given falsey values', function() {
       it('should return input value', function() {
         const age = filters.formatTime(undefined)
-        expect(age).to.equal(undefined)
+        expect(age).to.be.undefined
       })
 
       it('should return input value', function() {

--- a/config/nunjucks/globals.test.js
+++ b/config/nunjucks/globals.test.js
@@ -111,14 +111,14 @@ describe('Nunjucks globals', function() {
       })
 
       it('should log friendly message', function() {
-        expect(logger.error.args[0][0] instanceof Error).to.be.true
+        expect(logger.error.args[0][0]).to.be.an('error')
         expect(logger.error.args[0][0].message).to.equal(
           'Manifest file is not found. Ensure assets are built.'
         )
       })
 
       it('should log full error', function() {
-        expect(logger.error.args[1][0] instanceof Error).to.be.true
+        expect(logger.error.args[1][0]).to.be.an('error')
         expect(logger.error.args[1][0].message).to.equal(
           "Cannot find module 'path/to/missing/manifest.json'"
         )


### PR DESCRIPTION
A number of tests were using `to.equal(undefined)`. This is the same
as `to.be.undefined` in chai and the latter reads better.

This change makes the change across the test codebase after it was
spotted in another change (#202).