### PR TITLE
[P4-629] Capture cancellation reason

### DIFF
--- a/app/move/controllers/cancel.test.js
+++ b/app/move/controllers/cancel.test.js
@@ -1,107 +1,114 @@
+const CancelController = require('./cancel')
 const moveService = require('../../../common/services/move')
 
-const controller = require('./cancel')
-
+const controller = new CancelController({ route: '/' })
 const mockMove = {
-  to_location: {
-    title: 'To location',
-  },
+  id: '123456789',
   person: {
     fullname: 'Full name',
   },
 }
+const mockValues = {
+  cancellation_reason: 'error',
+  cancellation_reason_comment: 'Request was made in error',
+}
 
 describe('Move controllers', function() {
-  describe('#cancel.post()', function() {
-    let req, res, nextSpy
+  describe('Cancel controller', function() {
+    describe('#successHandler()', function() {
+      let req, res, nextSpy
 
-    beforeEach(function() {
-      req = {
-        flash: sinon.stub(),
-        t: sinon.stub().returnsArg(0),
-      }
-      res = {
-        redirect: sinon.stub(),
-        locals: {
-          MOVES_URL: '/moves',
-          move: mockMove,
-        },
-      }
-      nextSpy = sinon.spy()
-    })
-
-    context('when move cancel is successful', function() {
-      beforeEach(async function() {
-        sinon.stub(moveService, 'cancel').resolves(mockMove)
-        await controller.post(req, res, nextSpy)
+      beforeEach(function() {
+        nextSpy = sinon.spy()
+        req = {
+          form: {
+            options: {
+              allFields: {
+                cancellation_reason: {},
+                cancellation_reason_comment: {},
+              },
+            },
+          },
+          sessionModel: {
+            reset: sinon.stub(),
+            toJSON: () => mockValues,
+          },
+          journeyModel: {
+            reset: sinon.stub(),
+          },
+          flash: sinon.stub(),
+          t: sinon.stub().returnsArg(0),
+        }
+        res = {
+          redirect: sinon.stub(),
+          locals: {
+            move: mockMove,
+          },
+        }
       })
 
-      it('should set a success message', function() {
-        expect(req.flash).to.have.been.calledOnceWith('success', {
-          title: 'messages::cancel_move.success.title',
-          content: 'messages::cancel_move.success.content',
+      context('when move save is successful', function() {
+        beforeEach(async function() {
+          sinon.stub(moveService, 'cancel').resolves({})
+          await controller.successHandler(req, res, nextSpy)
+        })
+
+        it('should cancel move', function() {
+          expect(moveService.cancel).to.be.calledWith(mockMove.id, {
+            reason: mockValues.cancellation_reason,
+            comment: mockValues.cancellation_reason_comment,
+          })
+        })
+
+        it('should reset the journey', function() {
+          expect(req.journeyModel.reset).to.have.been.calledOnce
+        })
+
+        it('should reset the session', function() {
+          expect(req.sessionModel.reset).to.have.been.calledOnce
+        })
+
+        it('should set a success message', function() {
+          expect(req.flash).to.have.been.calledOnceWith('success', {
+            title: 'messages::cancel_move.success.title',
+          })
+        })
+
+        it('should uppercase name in success message', function() {
+          expect(req.t.firstCall).to.have.been.calledWithExactly(
+            'messages::cancel_move.success.title',
+            {
+              name: res.locals.move.person.fullname.toUpperCase(),
+            }
+          )
+        })
+
+        it('should redirect correctly', function() {
+          expect(res.redirect).to.have.been.calledOnce
+          expect(res.redirect).to.have.been.calledWith('/move/123456789')
         })
       })
 
-      it('should pass correct values to success content translation', function() {
-        expect(req.t.secondCall).to.have.been.calledWithExactly(
-          'messages::cancel_move.success.content',
-          {
-            name: mockMove.person.fullname,
-            location: mockMove.to_location.title,
-          }
-        )
+      context('when save fails', function() {
+        const errorMock = new Error('Problem')
+
+        beforeEach(async function() {
+          sinon.stub(moveService, 'cancel').throws(errorMock)
+          await controller.successHandler(req, res, nextSpy)
+        })
+
+        it('should call next with the error', function() {
+          expect(nextSpy).to.be.calledWith(errorMock)
+        })
+
+        it('should call next once', function() {
+          expect(nextSpy).to.be.calledOnce
+        })
+
+        it('should not redirect', function() {
+          expect(res.redirect).not.to.have.been.called
+        })
       })
-
-      it('should call move service cancel with move id', function() {
-        expect(moveService.cancel).to.be.calledOnceWithExactly(
-          res.locals.move.id
-        )
-      })
-
-      it('should redirect correctly', function() {
-        expect(res.redirect).to.be.calledOnceWithExactly('/moves')
-      })
-
-      it('should not call next', function() {
-        expect(nextSpy).not.to.be.called
-      })
-    })
-
-    context('when update fails', function() {
-      const errorMock = new Error('Problem')
-
-      beforeEach(async function() {
-        sinon.stub(moveService, 'cancel').throws(errorMock)
-        await controller.post(req, res, nextSpy)
-      })
-
-      it('should call next with the error', function() {
-        expect(nextSpy).to.be.calledOnceWithExactly(errorMock)
-      })
-
-      it('should not set flash message', function() {
-        expect(req.flash).not.to.called
-      })
-
-      it('should not redirect', function() {
-        expect(res.redirect).not.to.called
-      })
-    })
-  })
-
-  describe('#cancel.get()', function() {
-    let res
-
-    beforeEach(function() {
-      res = {
-        render: sinon.stub(),
-      }
-      controller.get({}, res)
-    })
-
-    it('should render a template', function() {
-      expect(res.render.calledOnce).to.be.true
     })
   })
 })

--- a/app/move/controllers/index.js
+++ b/app/move/controllers/index.js
@@ -1,10 +1,10 @@
-const cancel = require('./cancel')
+const Cancel = require('./cancel')
 const create = require('./create')
 const view = require('./view')
 const confirmation = require('./confirmation')
 
 module.exports = {
-  cancel,
+  Cancel,
   create,
   view,
   confirmation,

--- a/app/move/fields/cancel.js
+++ b/app/move/fields/cancel.js
@@ -1,0 +1,52 @@
+module.exports = {
+  cancellation_reason: {
+    validate: 'required',
+    component: 'govukRadios',
+    name: 'cancellation_reason',
+    fieldset: {
+      legend: {
+        text: 'fields::cancellation_reason.label',
+        classes: 'govuk-fieldset__legend--m',
+      },
+    },
+    items: [
+      {
+        id: 'cancellation_reason',
+        value: 'made_in_error',
+        text: 'fields::cancellation_reason.items.made_in_error.label',
+        hint: {
+          text: 'fields::cancellation_reason.items.made_in_error.hint',
+        },
+      },
+      {
+        value: 'supplier_declined_to_move',
+        text:
+          'fields::cancellation_reason.items.supplier_declined_to_move.label',
+        hint: {
+          text:
+            'fields::cancellation_reason.items.supplier_declined_to_move.hint',
+        },
+      },
+      {
+        value: 'other',
+        text: 'fields::cancellation_reason.items.other.label',
+        conditional: 'cancellation_reason_comment',
+      },
+    ],
+  },
+  cancellation_reason_comment: {
+    validate: 'required',
+    skip: true,
+    rows: 3,
+    component: 'govukTextarea',
+    classes: 'govuk-input--width-20',
+    label: {
+      text: `fields::cancellation_reason_comment.label`,
+      classes: 'govuk-label--s',
+    },
+    dependent: {
+      field: 'cancellation_reason',
+      value: 'other',
+    },
+  },
+}

--- a/app/move/fields/index.js
+++ b/app/move/fields/index.js
@@ -1,5 +1,7 @@
+const cancel = require('./cancel')
 const create = require('./create')
 
 module.exports = {
+  cancel,
   create,
 }

--- a/app/move/index.js
+++ b/app/move/index.js
@@ -5,17 +5,25 @@ const wizard = require('hmpo-form-wizard')
 // Local dependencies
 const FormWizardController = require('../../common/controllers/form-wizard')
 const { protectRoute } = require('../../common/middleware/permissions')
-const { create: createSteps } = require('./steps')
-const { create: createFields } = require('./fields')
-const { cancel, view, confirmation } = require('./controllers')
+const { cancel: cancelSteps, create: createSteps } = require('./steps')
+const { cancel: cancelFields, create: createFields } = require('./fields')
+const { confirmation, view } = require('./controllers')
 const { setMove } = require('./middleware')
 
-const createWizardConfig = {
+const wizardConfig = {
   controller: FormWizardController,
+  template: 'form-wizard',
+}
+const createConfig = {
+  ...wizardConfig,
   name: 'create-move',
   journeyName: 'create-move',
   journeyPageTitle: 'actions::create_move',
-  template: 'form-wizard',
+}
+const cancelConfig = {
+  ...wizardConfig,
+  name: 'cancel-move',
+  journeyName: 'cancel-move',
 }
 
 // Define param middleware
@@ -25,14 +33,15 @@ router.param('moveId', setMove)
 router.use(
   '/new',
   protectRoute('move:create'),
-  wizard(createSteps, createFields, createWizardConfig)
+  wizard(createSteps, createFields, createConfig)
 )
 router.get('/:moveId', protectRoute('move:view'), view)
-router
-  .route('/:moveId/cancel')
-  .get(protectRoute('move:cancel'), cancel.get)
-  .post(protectRoute('move:cancel'), cancel.post)
 router.get('/:moveId/confirmation', protectRoute('move:create'), confirmation)
+router.use(
+  '/:moveId/cancel',
+  protectRoute('move:cancel'),
+  wizard(cancelSteps, cancelFields, cancelConfig)
+)
 
 // Export
 module.exports = {

--- a/app/move/steps/cancel.js
+++ b/app/move/steps/cancel.js
@@ -1,0 +1,19 @@
+const { Cancel } = require('../controllers')
+
+module.exports = {
+  '/': {
+    entryPoint: true,
+    resetJourney: true,
+    skip: true,
+    next: 'reason',
+  },
+  '/reason': {
+    backLink: null,
+    template: 'move/views/cancel',
+    pageTitle: 'moves::cancel.steps.reason.heading',
+    buttonText: 'actions::cancel_move_confirmation',
+    buttonClasses: 'govuk-button--warning',
+    fields: ['cancellation_reason', 'cancellation_reason_comment'],
+    controller: Cancel,
+  },
+}

--- a/app/move/steps/index.js
+++ b/app/move/steps/index.js
@@ -1,5 +1,7 @@
+const cancel = require('./cancel')
 const create = require('./create')
 
 module.exports = {
+  cancel,
   create,
 }

--- a/app/move/views/cancel.njk
+++ b/app/move/views/cancel.njk
@@ -1,4 +1,4 @@
-{% extends "layouts/base.njk" %}
+{% extends "form-wizard.njk" %}
 
 {% block customGtagConfig %}
   gtag('set', {'page_title': 'Cancel move'});
@@ -17,32 +17,13 @@
   }) }}
 {% endblock %}
 
-{% block content %}
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      <header class="govuk-!-margin-bottom-8">
-        <h1 class="govuk-heading-xl govuk-!-margin-bottom-0">
-          {{ t("moves::cancel.page_title", { name: move.person.fullname | upper }) }}
-        </h1>
-      </header>
+{% block formActions %}
+  {{ govukWarningText({
+    text: t("moves::cancel.warning", {
+      name: move.person.fullname | upper
+    }),
+    iconFallbackText: "Warning"
+  }) }}
 
-      <form method="post">
-        <p>
-          {{ t("moves::cancel.content.confirmation", {
-            name: move.person.fullname | upper,
-            location: move.to_location.title
-          }) | safe }}
-        </p>
-
-        <p>
-          {{ t("moves::cancel.content.warning") }}
-        </p>
-
-        {{ govukButton({
-          text: t("actions::cancel_move_confirmation"),
-          classes: "govuk-button--warning"
-        }) }}
-      </form>
-    </div>
-  </div>
+  {{ super() }}
 {% endblock %}

--- a/common/assets/scss/application.scss
+++ b/common/assets/scss/application.scss
@@ -19,13 +19,14 @@ $govuk-font-family: "Inter", system-ui, sans-serif;
 @import "govuk-frontend/govuk/components/footer/footer.scss";
 @import "govuk-frontend/govuk/components/header/header.scss";
 @import "govuk-frontend/govuk/components/input/input.scss";
+@import "govuk-frontend/govuk/components/panel/panel.scss";
 @import "govuk-frontend/govuk/components/phase-banner/phase-banner.scss";
 @import "govuk-frontend/govuk/components/radios/radios.scss";
 @import "govuk-frontend/govuk/components/select/select.scss";
 @import "govuk-frontend/govuk/components/skip-link/skip-link.scss";
 @import "govuk-frontend/govuk/components/summary-list/summary-list.scss";
 @import "govuk-frontend/govuk/components/textarea/textarea.scss";
-@import "govuk-frontend/govuk/components/panel/panel.scss";
+@import "govuk-frontend/govuk/components/warning-text/warning-text.scss";
 
 @import "govuk-frontend/govuk/utilities/all";
 @import "govuk-frontend/govuk/overrides/all";

--- a/common/lib/api-client/models.js
+++ b/common/lib/api-client/models.js
@@ -4,6 +4,8 @@ module.exports = {
       reference: '',
       status: '',
       move_type: '',
+      cancellation_reason: '',
+      cancellation_reason_comment: '',
       additional_information: '',
       updated_at: '',
       time_due: '',

--- a/common/services/move.js
+++ b/common/services/move.js
@@ -76,7 +76,7 @@ const moveService = {
       }))
   },
 
-  cancel(id) {
+  cancel(id, { reason, comment } = {}) {
     if (!id) {
       return Promise.reject(new Error('No move ID supplied'))
     }
@@ -85,6 +85,8 @@ const moveService = {
       .update('move', {
         id,
         status: 'cancelled',
+        cancellation_reason: reason,
+        cancellation_reason_comment: comment,
       })
       .then(response => response.data)
   },

--- a/common/services/move.test.js
+++ b/common/services/move.test.js
@@ -456,19 +456,47 @@ describe('Move Service', function() {
 
       beforeEach(async function() {
         sinon.stub(apiClient, 'update').resolves(mockResponse)
-
-        move = await moveService.cancel(mockId)
       })
 
-      it('should call update method with data', function() {
-        expect(apiClient.update).to.be.calledOnceWithExactly('move', {
-          id: mockId,
-          status: 'cancelled',
+      context('without data args', function() {
+        beforeEach(async function() {
+          move = await moveService.cancel(mockId)
+        })
+
+        it('should call update method with data', function() {
+          expect(apiClient.update).to.be.calledOnceWithExactly('move', {
+            id: mockId,
+            status: 'cancelled',
+            cancellation_reason: undefined,
+            cancellation_reason_comment: undefined,
+          })
+        })
+
+        it('should return move', function() {
+          expect(move).to.deep.equal(mockResponse.data)
         })
       })
 
-      it('should return move', function() {
-        expect(move).to.deep.equal(mockResponse.data)
+      context('with data args', function() {
+        beforeEach(async function() {
+          move = await moveService.cancel(mockId, {
+            reason: 'other',
+            comment: 'Reason for cancelling',
+          })
+        })
+
+        it('should call update method with data', function() {
+          expect(apiClient.update).to.be.calledOnceWithExactly('move', {
+            id: mockId,
+            status: 'cancelled',
+            cancellation_reason: 'other',
+            cancellation_reason_comment: 'Reason for cancelling',
+          })
+        })
+
+        it('should return move', function() {
+          expect(move).to.deep.equal(mockResponse.data)
+        })
       })
     })
   })

--- a/common/templates/form-wizard.njk
+++ b/common/templates/form-wizard.njk
@@ -46,15 +46,18 @@
           {% endfor %}
         {% endblock %}
 
-        {{ govukButton({
-          text: t(options.buttonText or "actions::continue")
-        }) }}
+        {% block formActions %}
+          {{ govukButton({
+            text: t(options.buttonText or "actions::continue"),
+            classes: options.buttonClasses
+          }) }}
 
-        {% if cancelUrl %}
-          <a href="{{ cancelUrl }}" class="govuk-button govuk-button--text">
-            {{ t("actions::cancel") }}
-          </a>
-        {% endif %}
+          {% if cancelUrl %}
+            <a href="{{ cancelUrl }}" class="govuk-button govuk-button--text">
+              {{ t("actions::cancel") }}
+            </a>
+          {% endif %}
+        {% endblock %}
       </form>
     </div>
   </div>

--- a/common/templates/layouts/base.njk
+++ b/common/templates/layouts/base.njk
@@ -6,12 +6,13 @@
 {% from "govuk/components/checkboxes/macro.njk"        import govukCheckboxes %}
 {% from "govuk/components/error-summary/macro.njk"     import govukErrorSummary %}
 {% from "govuk/components/input/macro.njk"             import govukInput %}
+{% from "govuk/components/panel/macro.njk"             import govukPanel %}
 {% from "govuk/components/phase-banner/macro.njk"      import govukPhaseBanner %}
 {% from "govuk/components/radios/macro.njk"            import govukRadios %}
 {% from "govuk/components/select/macro.njk"            import govukSelect %}
 {% from "govuk/components/summary-list/macro.njk"      import govukSummaryList %}
 {% from "govuk/components/textarea/macro.njk"          import govukTextarea %}
-{% from "govuk/components/panel/macro.njk"             import govukPanel %}
+{% from "govuk/components/warning-text/macro.njk"      import govukWarningText %}
 
 {% from "moj/components/organisation-switcher/macro.njk" import mojOrganisationSwitcher %}
 

--- a/locales/en/fields.json
+++ b/locales/en/fields.json
@@ -86,5 +86,24 @@
   "assessment_comment": {
     "required": "Give details",
     "optional": "Give details (optional)"
+  },
+  "cancellation_reason": {
+    "label": "Why are you cancelling this move request?",
+    "items": {
+      "made_in_error": {
+        "label": "Made in error",
+        "hint": "For example, there’s a mistake or the person no longer needs to move"
+      },
+      "supplier_declined_to_move": {
+        "label": "Supplier declined to move this person",
+        "hint": "For example, the request was made late"
+      },
+      "other": {
+        "label": "Another reason"
+      }
+    }
+  },
+  "cancellation_reason_comment": {
+    "label": "Give details"
   }
 }

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -7,8 +7,7 @@
   },
   "cancel_move": {
     "success": {
-      "title": "Move cancelled",
-      "content": "Move for <strong>{{name}}</strong> to <strong>{{location}}</strong> has been cancelled."
+      "title": "Move request cancelled for {{name}}"
     }
   }
 }

--- a/locales/en/moves.json
+++ b/locales/en/moves.json
@@ -81,10 +81,7 @@
       }
     },
     "page_title": "Cancel move for ‘{{name}}’",
-    "content": {
-      "confirmation": "Are you sure you want to cancel the move for <strong>{{name}}</strong> to <strong>{{location}}</strong>?",
-      "warning": "This will delete this move request."
-    }
+    "warning": "You must also contact the supplier to cancel the move request for {{name}}"
   },
   "confirmation": {
     "page_title": "Move scheduled for {{name}}",

--- a/locales/en/moves.json
+++ b/locales/en/moves.json
@@ -75,6 +75,11 @@
     "page_title": "Move details for {{name}}"
   },
   "cancel": {
+    "steps": {
+      "reason": {
+        "heading": "Cancel this move request"
+      }
+    },
     "page_title": "Cancel move for ‘{{name}}’",
     "content": {
       "confirmation": "Are you sure you want to cancel the move for <strong>{{name}}</strong> to <strong>{{location}}</strong>?",

--- a/test/fixtures/api-client/move.find.json
+++ b/test/fixtures/api-client/move.find.json
@@ -5,6 +5,8 @@
     "attributes": {
       "reference": "KVU1456M",
       "status": "requested",
+      "cancellation_reason": "error",
+      "cancellation_reason_comment": "",
       "updated_at": "2019-08-26T19:31:43+01:00",
       "time_due": "2019-09-06T14:00:00+01:00",
       "date": "2019-09-06",

--- a/test/fixtures/api-client/move.findAll.json
+++ b/test/fixtures/api-client/move.findAll.json
@@ -6,6 +6,8 @@
       "attributes": {
         "reference": "KVU1456M",
         "status": "requested",
+        "cancellation_reason": "error",
+        "cancellation_reason_comment": "",
         "updated_at": "2019-08-26T19:31:43+01:00",
         "time_due": "2019-09-06T14:00:00+01:00",
         "date": "2019-09-06",
@@ -39,6 +41,8 @@
       "attributes": {
         "reference": "YWP9684U",
         "status": "requested",
+        "cancellation_reason": "other",
+        "cancellation_reason_comment": "A different reason",
         "updated_at": "2019-08-26T19:31:43+01:00",
         "time_due": "2019-09-07T09:00:00+01:00",
         "date": "2019-09-07",
@@ -72,6 +76,8 @@
       "attributes": {
         "reference": "NJK3748P",
         "status": "requested",
+        "cancellation_reason": "supplier_cannot_move",
+        "cancellation_reason_comment": "",
         "updated_at": "2019-08-26T19:31:43+01:00",
         "time_due": "2019-09-14T09:00:00+01:00",
         "date": "2019-09-14",
@@ -105,6 +111,8 @@
       "attributes": {
         "reference": "NHY8941P",
         "status": "requested",
+        "cancellation_reason": "error",
+        "cancellation_reason_comment": "",
         "updated_at": "2019-08-26T19:31:42+01:00",
         "time_due": "2019-09-12T14:00:00+01:00",
         "date": "2019-09-12",
@@ -138,6 +146,8 @@
       "attributes": {
         "reference": "UVP2359J",
         "status": "requested",
+        "cancellation_reason": "error",
+        "cancellation_reason_comment": "",
         "updated_at": "2019-08-26T19:31:43+01:00",
         "time_due": "2019-08-30T09:00:00+01:00",
         "date": "2019-08-30",
@@ -171,6 +181,8 @@
       "attributes": {
         "reference": "CRW6738U",
         "status": "requested",
+        "cancellation_reason": "error",
+        "cancellation_reason_comment": "",
         "updated_at": "2019-08-26T19:31:44+01:00",
         "time_due": "2019-08-27T14:00:00+01:00",
         "date": "2019-08-27",
@@ -204,6 +216,8 @@
       "attributes": {
         "reference": "UTF2634R",
         "status": "requested",
+        "cancellation_reason": "error",
+        "cancellation_reason_comment": "",
         "updated_at": "2019-08-26T19:31:43+01:00",
         "time_due": "2019-08-18T14:00:00+01:00",
         "date": "2019-08-18",
@@ -237,6 +251,8 @@
       "attributes": {
         "reference": "JXH4965W",
         "status": "requested",
+        "cancellation_reason": "error",
+        "cancellation_reason_comment": "",
         "updated_at": "2019-08-26T19:31:43+01:00",
         "time_due": "2019-08-17T12:00:00+01:00",
         "date": "2019-08-17",
@@ -270,6 +286,8 @@
       "attributes": {
         "reference": "MNF1954P",
         "status": "requested",
+        "cancellation_reason": "error",
+        "cancellation_reason_comment": "",
         "updated_at": "2019-08-26T19:31:42+01:00",
         "time_due": "2019-09-13T09:00:00+01:00",
         "date": "2019-09-13",
@@ -303,6 +321,8 @@
       "attributes": {
         "reference": "WNU7982N",
         "status": "requested",
+        "cancellation_reason": "error",
+        "cancellation_reason_comment": "",
         "updated_at": "2019-08-26T19:31:44+01:00",
         "time_due": "2019-08-19T14:00:00+01:00",
         "date": "2019-08-19",
@@ -336,6 +356,8 @@
       "attributes": {
         "reference": "RWP6381H",
         "status": "requested",
+        "cancellation_reason": "error",
+        "cancellation_reason_comment": "",
         "updated_at": "2019-08-26T19:31:42+01:00",
         "time_due": "2019-09-13T12:00:00+01:00",
         "date": "2019-09-13",
@@ -369,6 +391,8 @@
       "attributes": {
         "reference": "CWA4568V",
         "status": "requested",
+        "cancellation_reason": "error",
+        "cancellation_reason_comment": "",
         "updated_at": "2019-08-26T19:31:44+01:00",
         "time_due": "2019-09-05T12:00:00+01:00",
         "date": "2019-09-05",
@@ -402,6 +426,8 @@
       "attributes": {
         "reference": "RWU3289A",
         "status": "requested",
+        "cancellation_reason": "error",
+        "cancellation_reason_comment": "",
         "updated_at": "2019-08-26T19:31:43+01:00",
         "time_due": "2019-08-19T09:00:00+01:00",
         "date": "2019-08-19",
@@ -435,6 +461,8 @@
       "attributes": {
         "reference": "YXT7896K",
         "status": "requested",
+        "cancellation_reason": "error",
+        "cancellation_reason_comment": "",
         "updated_at": "2019-08-26T19:31:44+01:00",
         "time_due": "2019-08-18T12:00:00+01:00",
         "date": "2019-08-18",
@@ -468,6 +496,8 @@
       "attributes": {
         "reference": "RXJ2913R",
         "status": "requested",
+        "cancellation_reason": "supplier_cannot_move",
+        "cancellation_reason_comment": "",
         "updated_at": "2019-08-26T19:31:44+01:00",
         "time_due": "2019-09-14T09:00:00+01:00",
         "date": "2019-09-14",
@@ -501,6 +531,8 @@
       "attributes": {
         "reference": "VPR3175W",
         "status": "requested",
+        "cancellation_reason": "error",
+        "cancellation_reason_comment": "",
         "updated_at": "2019-08-26T19:31:43+01:00",
         "time_due": "2019-08-23T14:00:00+01:00",
         "date": "2019-08-23",
@@ -534,6 +566,8 @@
       "attributes": {
         "reference": "WMJ8413V",
         "status": "requested",
+        "cancellation_reason": "error",
+        "cancellation_reason_comment": "",
         "updated_at": "2019-08-26T19:31:43+01:00",
         "time_due": "2019-09-04T14:00:00+01:00",
         "date": "2019-09-04",
@@ -567,6 +601,8 @@
       "attributes": {
         "reference": "RKM4587R",
         "status": "requested",
+        "cancellation_reason": "error",
+        "cancellation_reason_comment": "",
         "updated_at": "2019-08-26T19:31:42+01:00",
         "time_due": "2019-08-29T14:00:00+01:00",
         "date": "2019-08-29",
@@ -600,6 +636,8 @@
       "attributes": {
         "reference": "KXU2359Y",
         "status": "requested",
+        "cancellation_reason": "error",
+        "cancellation_reason_comment": "",
         "updated_at": "2019-08-26T19:31:43+01:00",
         "time_due": "2019-08-25T14:00:00+01:00",
         "date": "2019-08-25",
@@ -633,6 +671,8 @@
       "attributes": {
         "reference": "ETJ9765F",
         "status": "requested",
+        "cancellation_reason": "other",
+        "cancellation_reason_comment": "The person didn't want to move",
         "updated_at": "2019-08-26T19:31:43+01:00",
         "time_due": "2019-09-04T09:00:00+01:00",
         "date": "2019-09-04",


### PR DESCRIPTION
This change adds the initial journey to capture reasons for cancelling a move request.

It makes use of the existing form wizard library to capture form inputs and handle
validation of particular fields.

## What it looks like

![localhost_3000_move_00ddf148-f3b8-4189-82ff-7ef26fe611d9_cancel_reason (2)](https://user-images.githubusercontent.com/3327997/64128633-62ad3480-cdaf-11e9-866b-0b94bf0e267a.png)

![localhost_3000_move_00ddf148-f3b8-4189-82ff-7ef26fe611d9_cancel_reason (3)](https://user-images.githubusercontent.com/3327997/64128637-6476f800-cdaf-11e9-8059-a8bf18065013.png)

![localhost_3000_moves](https://user-images.githubusercontent.com/3327997/64123742-1a851680-cd9d-11e9-9b56-9d0fc4daf7d6.png)
