### PR TITLE
[P4-629] Set persons fullname in shared middleware

### DIFF
--- a/app/move/controllers/cancel.js
+++ b/app/move/controllers/cancel.js
@@ -1,4 +1,3 @@
-const personService = require('../../../common/services/person')
 const moveService = require('../../../common/services/move')
 
 module.exports = {
@@ -11,7 +10,7 @@ module.exports = {
       req.flash('success', {
         title: req.t('messages::cancel_move.success.title'),
         content: req.t('messages::cancel_move.success.content', {
-          name: personService.getFullname(move.person),
+          name: move.person.fullname,
           location: move.to_location.title,
         }),
       })
@@ -21,12 +20,5 @@ module.exports = {
       next(error)
     }
   },
-  get: (req, res) => {
-    const { move } = res.locals
-    const locals = {
-      fullname: personService.getFullname(move.person),
-    }
-
-    res.render('move/views/cancel', locals)
-  },
+  get: (req, res) => res.render('move/views/cancel'),
 }

--- a/app/move/controllers/cancel.test.js
+++ b/app/move/controllers/cancel.test.js
@@ -1,12 +1,15 @@
-const personService = require('../../../common/services/person')
 const moveService = require('../../../common/services/move')
 
 const controller = require('./cancel')
 
-const {
-  data: mockMove,
-} = require('../../../test/fixtures/api-client/move.get.deserialized.json')
-const fullname = `${mockMove.person.last_name}, ${mockMove.person.first_names}`
+const mockMove = {
+  to_location: {
+    title: 'To location',
+  },
+  person: {
+    fullname: 'Full name',
+  },
+}
 
 describe('Move controllers', function() {
   describe('#cancel.post()', function() {
@@ -44,7 +47,7 @@ describe('Move controllers', function() {
         expect(req.t.secondCall).to.have.been.calledWithExactly(
           'messages::cancel_move.success.content',
           {
-            name: fullname,
+            name: mockMove.person.fullname,
             location: mockMove.to_location.title,
           }
         )
@@ -91,33 +94,14 @@ describe('Move controllers', function() {
     let res
 
     beforeEach(function() {
-      sinon.stub(personService, 'getFullname')
       res = {
         render: sinon.stub(),
-        locals: {
-          move: {
-            person: {
-              first_names: 'Steve',
-              last_name: 'Jones',
-            },
-          },
-        },
       }
       controller.get({}, res)
     })
 
     it('should render a template', function() {
       expect(res.render.calledOnce).to.be.true
-    })
-
-    describe('template params', function() {
-      it('should contain a fullname', function() {
-        expect(personService.getFullname).to.be.calledOnceWithExactly({
-          first_names: 'Steve',
-          last_name: 'Jones',
-        })
-        expect(res.render.args[0][1]).to.have.property('fullname')
-      })
     })
   })
 })

--- a/app/move/controllers/create/save.js
+++ b/app/move/controllers/create/save.js
@@ -42,7 +42,7 @@ class SaveController extends CreateBaseController {
     req.flash('success', {
       title: req.t('messages::create_move.success.title'),
       content: req.t('messages::create_move.success.content', {
-        name: personService.getFullname(person),
+        name: person.fullname,
         location:
           moveType === 'prison_recall'
             ? req.t('fields::move_type.items.prison_recall.label')

--- a/app/move/controllers/create/save.test.js
+++ b/app/move/controllers/create/save.test.js
@@ -12,12 +12,17 @@ const filters = require('../../../../config/nunjucks/filters')
 
 const controller = new Controller({ route: '/' })
 
-const {
-  data: moveMock,
-} = require('../../../../test/fixtures/api-client/move.get.deserialized.json')
-const fullname = `${moveMock.person.last_name}, ${moveMock.person.first_names}`
 const mockPerson = {
   id: '3333',
+  fullname: 'Full name',
+}
+const mockMove = {
+  id: '4444',
+  date: '2019-10-10',
+  to_location: {
+    title: 'To location',
+  },
+  person: mockPerson,
 }
 const valuesMock = {
   'csrf-secret': 'secret',
@@ -57,7 +62,7 @@ describe('Move controllers', function() {
       context('when move save is successful', function() {
         beforeEach(async function() {
           sinon.spy(FormController.prototype, 'configure')
-          sinon.stub(moveService, 'create').resolves(moveMock)
+          sinon.stub(moveService, 'create').resolves(mockMove)
           sinon.stub(personService, 'update').resolves(mockPerson)
           await controller.saveValues(req, {}, nextSpy)
         })
@@ -79,7 +84,7 @@ describe('Move controllers', function() {
         })
 
         it('should set response to session model', function() {
-          expect(req.sessionModel.set).to.be.calledWith('move', moveMock)
+          expect(req.sessionModel.set).to.be.calledWith('move', mockMove)
         })
 
         it('should not throw an error', function() {
@@ -134,13 +139,12 @@ describe('Move controllers', function() {
           redirect: sinon.stub(),
         }
 
-        sinon.stub(personService, 'getFullname').returns(fullname)
         sinon.stub(filters, 'formatDateWithDay').returnsArg(0)
       })
 
       context('by default', function() {
         beforeEach(function() {
-          req.sessionModel.get.withArgs('move').returns(moveMock)
+          req.sessionModel.get.withArgs('move').returns(mockMove)
           controller.successHandler(req, res)
         })
 
@@ -155,9 +159,9 @@ describe('Move controllers', function() {
           expect(req.t.secondCall).to.have.been.calledWithExactly(
             'messages::create_move.success.content',
             {
-              name: fullname,
-              location: moveMock.to_location.title,
-              date: moveMock.date,
+              name: mockMove.person.fullname,
+              location: mockMove.to_location.title,
+              date: mockMove.date,
             }
           )
         })
@@ -175,7 +179,7 @@ describe('Move controllers', function() {
         it('should redirect correctly', function() {
           expect(res.redirect).to.have.been.calledOnce
           expect(res.redirect).to.have.been.calledWith(
-            `/moves?move-date=${moveMock.date}`
+            `/moves?move-date=${mockMove.date}`
           )
         })
       })
@@ -183,7 +187,7 @@ describe('Move controllers', function() {
       context('with prison recall move type', function() {
         beforeEach(function() {
           req.sessionModel.get.withArgs('move').returns({
-            ...moveMock,
+            ...mockMove,
             move_type: 'prison_recall',
           })
           controller.successHandler(req, res)
@@ -206,9 +210,9 @@ describe('Move controllers', function() {
           expect(req.t.thirdCall).to.have.been.calledWithExactly(
             'messages::create_move.success.content',
             {
-              name: fullname,
+              name: mockMove.person.fullname,
               location: 'fields::move_type.items.prison_recall.label',
-              date: moveMock.date,
+              date: mockMove.date,
             }
           )
         })

--- a/app/move/controllers/view.js
+++ b/app/move/controllers/view.js
@@ -1,11 +1,9 @@
-const personService = require('../../../common/services/person')
 const presenters = require('../../../common/presenters')
 
 module.exports = function view(req, res) {
   const { move } = res.locals
   const { person } = move
   const locals = {
-    fullname: personService.getFullname(person),
     moveSummary: presenters.moveToMetaListComponent(move),
     personalDetailsSummary: presenters.personToSummaryListComponent(person),
     tagList: presenters.assessmentToTagList(person.assessment_answers),

--- a/app/move/controllers/view.test.js
+++ b/app/move/controllers/view.test.js
@@ -1,4 +1,3 @@
-const personService = require('../../../common/services/person')
 const presenters = require('../../../common/presenters')
 
 const controller = require('./view')
@@ -6,14 +5,12 @@ const controller = require('./view')
 const {
   data: mockMove,
 } = require('../../../test/fixtures/api-client/move.get.deserialized.json')
-const fullname = `${mockMove.person.last_name}, ${mockMove.person.first_names}`
 
 describe('Move controllers', function() {
   describe('#view()', function() {
     let req, res
 
     beforeEach(function() {
-      sinon.stub(personService, 'getFullname').returns(fullname)
       sinon.stub(presenters, 'moveToMetaListComponent').returnsArg(0)
       sinon.stub(presenters, 'personToSummaryListComponent').returnsArg(0)
       sinon.stub(presenters, 'assessmentToTagList').returnsArg(0)
@@ -33,12 +30,6 @@ describe('Move controllers', function() {
 
     it('should render a template', function() {
       expect(res.render.calledOnce).to.be.true
-    })
-
-    it('should contain fullname param', function() {
-      const params = res.render.args[0][1]
-      expect(params).to.have.property('fullname')
-      expect(params.fullname).to.equal(fullname)
     })
 
     it('should call moveToMetaListComponent presenter with correct args', function() {

--- a/app/move/views/cancel.njk
+++ b/app/move/views/cancel.njk
@@ -5,7 +5,7 @@
 {% endblock %}
 
 {% block pageTitle %}
-  {{ t("moves::cancel.page_title", { name: fullname | upper }) }}
+  {{ t("moves::cancel.page_title", { name: move.person.fullname | upper }) }}
 {% endblock %}
 
 {% block beforeContent %}
@@ -22,14 +22,14 @@
     <div class="govuk-grid-column-two-thirds">
       <header class="govuk-!-margin-bottom-8">
         <h1 class="govuk-heading-xl govuk-!-margin-bottom-0">
-          {{ t("moves::cancel.page_title", { name: fullname | upper }) }}
+          {{ t("moves::cancel.page_title", { name: move.person.fullname | upper }) }}
         </h1>
       </header>
 
       <form method="post">
         <p>
           {{ t("moves::cancel.content.confirmation", {
-            name: fullname | upper,
+            name: move.person.fullname | upper,
             location: move.to_location.title
           }) | safe }}
         </p>

--- a/app/move/views/view.njk
+++ b/app/move/views/view.njk
@@ -6,7 +6,7 @@
 
 {% block pageTitle %}
   {{ t("moves::detail.page_title", {
-    name: fullname | upper
+    name: move.person.fullname | upper
   }) }}
 {% endblock %}
 
@@ -27,7 +27,7 @@
 {% block content %}
   <header class="govuk-!-margin-bottom-8">
     <h1 class="govuk-heading-xl govuk-!-margin-bottom-1">
-      {{ fullname | upper }}
+      {{ move.person.fullname | upper }}
     </h1>
 
     <span class="govuk-caption-xl">
@@ -67,7 +67,9 @@
     <div class="govuk-grid-column-one-third">
       <div class="sticky-sidebar">
         <div class="sticky-sidebar__inner">
-          <h3 class="govuk-heading-m app-border-top-2 app-border--blue govuk-!-padding-top-4">{{ fullname | upper }}</h3>
+          <h3 class="govuk-heading-m app-border-top-2 app-border--blue govuk-!-padding-top-4">
+            {{ move.person.fullname | upper }}
+          </h3>
 
           {{ appMetaList(moveSummary) }}
         </div>

--- a/common/presenters/move-to-card-component.js
+++ b/common/presenters/move-to-card-component.js
@@ -1,5 +1,4 @@
 const assessmentToTagList = require('./assessment-to-tag-list')
-const personService = require('../services/person')
 const i18n = require('../../config/i18n')
 const filters = require('../../config/nunjucks/filters')
 
@@ -35,7 +34,7 @@ module.exports = function moveToCardComponent({ id, reference, person }) {
   return {
     href: `/move/${id}`,
     title: {
-      text: personService.getFullname(person).toUpperCase(),
+      text: person.fullname ? person.fullname.toUpperCase() : '',
     },
     caption: {
       text: i18n.t('moves::move_reference', {

--- a/common/presenters/move-to-card-component.test.js
+++ b/common/presenters/move-to-card-component.test.js
@@ -2,12 +2,17 @@ const moveToCardComponent = require('./move-to-card-component')
 
 const i18n = require('../../config/i18n')
 const filters = require('../../config/nunjucks/filters')
-const personService = require('../services/person')
-
 const {
-  data: mockMove,
+  data,
 } = require('../../test/fixtures/api-client/move.get.deserialized.json')
-const fullname = `${mockMove.person.last_name}, ${mockMove.person.first_names}`
+
+const mockMove = {
+  ...data,
+  person: {
+    ...data.person,
+    fullname: `${data.person.last_name}, ${data.person.first_names}`,
+  },
+}
 
 describe('Presenters', function() {
   describe('#moveToCardComponent()', function() {
@@ -15,7 +20,6 @@ describe('Presenters', function() {
       sinon.stub(i18n, 't').returns('__translated__')
       sinon.stub(filters, 'formatDate').returns('18 Jun 1960')
       sinon.stub(filters, 'calculateAge').returns(50)
-      sinon.stub(personService, 'getFullname').returns(fullname)
     })
 
     context('when provided with a mock move object', function() {
@@ -34,7 +38,7 @@ describe('Presenters', function() {
         it('should contain a title', function() {
           expect(transformedResponse).to.have.property('title')
           expect(transformedResponse.title).to.deep.equal({
-            text: fullname.toUpperCase(),
+            text: mockMove.person.fullname.toUpperCase(),
           })
         })
 

--- a/common/services/move.js
+++ b/common/services/move.js
@@ -1,6 +1,7 @@
 const { mapValues, pickBy } = require('lodash')
 
 const apiClient = require('../lib/api-client')
+const personService = require('../services/person')
 
 function format(data) {
   const relationships = ['to_location', 'from_location']
@@ -22,15 +23,18 @@ function getMoves({ filter, combinedData = [], page = 1 } = {}) {
     })
     .then(response => {
       const { data, links } = response
-      const items = [...combinedData, ...data]
+      const moves = [...combinedData, ...data]
 
       if (!links.next) {
-        return items
+        return moves.map(move => ({
+          ...move,
+          person: personService.transform(move.person),
+        }))
       }
 
       return getMoves({
         filter,
-        combinedData: items,
+        combinedData: moves,
         page: page + 1,
       })
     })
@@ -48,11 +52,23 @@ function getRequestedMovesByDateAndLocation(moveDate, locationId) {
 }
 
 function getMoveById(id) {
-  return apiClient.find('move', id).then(response => response.data)
+  return apiClient
+    .find('move', id)
+    .then(response => response.data)
+    .then(move => ({
+      ...move,
+      person: personService.transform(move.person),
+    }))
 }
 
 function create(data) {
-  return apiClient.create('move', format(data)).then(response => response.data)
+  return apiClient
+    .create('move', format(data))
+    .then(response => response.data)
+    .then(move => ({
+      ...move,
+      person: personService.transform(move.person),
+    }))
 }
 
 function cancel(id) {

--- a/common/services/move.test.js
+++ b/common/services/move.test.js
@@ -1,4 +1,5 @@
 const moveService = require('./move')
+const personService = require('./person')
 const auth = require('../lib/api-client/middleware/auth')
 const { API } = require('../../config')
 
@@ -11,6 +12,7 @@ const moveGetSerialized = require('../../test/fixtures/api-client/move.get.seria
 
 describe('Move Service', function() {
   beforeEach(function() {
+    sinon.stub(personService, 'transform').returnsArg(0)
     sinon.stub(auth, 'getAccessToken').returns('test')
     sinon
       .stub(auth, 'getAccessTokenExpiry')

--- a/common/services/person.js
+++ b/common/services/person.js
@@ -2,14 +2,10 @@ const { mapValues, uniqBy } = require('lodash')
 
 const apiClient = require('../lib/api-client')
 
-function getFullname({ first_names: firstNames, last_name: lastName }) {
-  return `${lastName}, ${firstNames}`
-}
-
-function transform(person) {
+function transform(person = {}) {
   return {
     ...person,
-    fullname: getFullname(person),
+    fullname: [person.last_name, person.first_names].filter(Boolean).join(', '),
   }
 }
 
@@ -69,7 +65,6 @@ function update(data) {
 }
 
 module.exports = {
-  getFullname,
   transform,
   format,
   create,

--- a/common/services/person.js
+++ b/common/services/person.js
@@ -6,6 +6,13 @@ function getFullname({ first_names: firstNames, last_name: lastName }) {
   return `${lastName}, ${firstNames}`
 }
 
+function transform(person) {
+  return {
+    ...person,
+    fullname: getFullname(person),
+  }
+}
+
 function format(data) {
   const existingIdentifiers = data.identifiers || []
   const relationshipKeys = ['gender', 'ethnicity']
@@ -63,6 +70,7 @@ function update(data) {
 
 module.exports = {
   getFullname,
+  transform,
   format,
   create,
   update,

--- a/common/services/person.test.js
+++ b/common/services/person.test.js
@@ -1,3 +1,5 @@
+const { forEach } = require('lodash')
+
 const personService = require('./person')
 const { API } = require('../../config')
 const auth = require('../lib/api-client/middleware/auth')
@@ -26,6 +28,28 @@ describe('Person Service', function() {
       })
 
       expect(fullname).to.equal(`${lastName}, ${firstNames}`)
+    })
+  })
+
+  describe('#transform()', function() {
+    let transformed
+
+    beforeEach(async function() {
+      transformed = await personService.transform(personPostDeserialized.data)
+    })
+
+    it('should set full name', function() {
+      expect(transformed).to.contain.property('fullname')
+      expect(transformed.fullname).to.equal(
+        `${personPostDeserialized.data.last_name}, ${personPostDeserialized.data.first_names}`
+      )
+    })
+
+    it('should contain original properties', function() {
+      forEach(personPostDeserialized.data, (value, key) => {
+        expect(transformed).to.contain.property(key)
+        expect(transformed[key]).to.equal(value)
+      })
     })
   })
 

--- a/common/services/person.test.js
+++ b/common/services/person.test.js
@@ -18,37 +18,63 @@ describe('Person Service', function() {
       .returns(Math.floor(new Date() / 1000) + 100)
   })
 
-  describe('#getFullname()', function() {
-    it('should format full name', function() {
-      const firstNames = 'Firstnames middlename'
-      const lastName = 'Lastname'
-      const fullname = personService.getFullname({
-        first_names: firstNames,
-        last_name: lastName,
-      })
-
-      expect(fullname).to.equal(`${lastName}, ${firstNames}`)
-    })
-  })
-
   describe('#transform()', function() {
     let transformed
 
-    beforeEach(async function() {
-      transformed = await personService.transform(personPostDeserialized.data)
+    context('with first name and last name', function() {
+      beforeEach(async function() {
+        transformed = await personService.transform(personPostDeserialized.data)
+      })
+
+      it('should set full name', function() {
+        expect(transformed).to.contain.property('fullname')
+        expect(transformed.fullname).to.equal(
+          `${personPostDeserialized.data.last_name}, ${personPostDeserialized.data.first_names}`
+        )
+      })
+
+      it('should contain original properties', function() {
+        forEach(personPostDeserialized.data, (value, key) => {
+          expect(transformed).to.contain.property(key)
+          expect(transformed[key]).to.equal(value)
+        })
+      })
     })
 
-    it('should set full name', function() {
-      expect(transformed).to.contain.property('fullname')
-      expect(transformed.fullname).to.equal(
-        `${personPostDeserialized.data.last_name}, ${personPostDeserialized.data.first_names}`
-      )
+    context('with no first name', function() {
+      beforeEach(async function() {
+        transformed = await personService.transform({
+          last_name: 'Last',
+        })
+      })
+
+      it('should return only last name for full name', function() {
+        expect(transformed).to.contain.property('fullname')
+        expect(transformed.fullname).to.equal('Last')
+      })
     })
 
-    it('should contain original properties', function() {
-      forEach(personPostDeserialized.data, (value, key) => {
-        expect(transformed).to.contain.property(key)
-        expect(transformed[key]).to.equal(value)
+    context('with no last name', function() {
+      beforeEach(async function() {
+        transformed = await personService.transform({
+          first_names: 'Firstname',
+        })
+      })
+
+      it('should return only last name for full name', function() {
+        expect(transformed).to.contain.property('fullname')
+        expect(transformed.fullname).to.equal('Firstname')
+      })
+    })
+
+    context('with no first name or last name', function() {
+      beforeEach(async function() {
+        transformed = await personService.transform()
+      })
+
+      it('should return only last name for full name', function() {
+        expect(transformed).to.contain.property('fullname')
+        expect(transformed.fullname).to.equal('')
       })
     })
   })


### PR DESCRIPTION
This extracts the logic for setting the persons fullname into the
shared middleware so that it can be used by all views that deal
with a person on a move model.