### PR TITLE
Refactor API model definitions

### DIFF
--- a/common/lib/api-client/json-api.js
+++ b/common/lib/api-client/json-api.js
@@ -3,7 +3,7 @@ const JsonApi = require('devour-client')
 const { API, IS_DEV } = require('../../../config')
 const { errors, requestTimeout } = require('./middleware')
 const { devourAuthMiddleware } = require('./middleware/auth')
-const defineModels = require('./models')
+const models = require('./models')
 
 const jsonApi = new JsonApi({
   apiUrl: API.BASE_URL,
@@ -14,6 +14,9 @@ jsonApi.replaceMiddleware('errors', errors)
 jsonApi.insertMiddlewareBefore('axios-request', requestTimeout(API.TIMEOUT))
 jsonApi.insertMiddlewareBefore('axios-request', devourAuthMiddleware)
 
-defineModels(jsonApi)
+// define models
+Object.entries(models).forEach(([modelName, model]) => {
+  jsonApi.define(modelName, model.attributes, model.options)
+})
 
 module.exports = jsonApi

--- a/common/lib/api-client/models.js
+++ b/common/lib/api-client/models.js
@@ -1,74 +1,71 @@
-function defineModels(jsonApi) {
-  jsonApi.define('move', {
-    reference: '',
-    status: '',
-    move_type: '',
-    additional_information: '',
-    updated_at: '',
-    time_due: '',
-    date: '',
-    person: {
-      jsonApi: 'hasOne',
-      type: 'people',
+module.exports = {
+  move: {
+    attributes: {
+      reference: '',
+      status: '',
+      move_type: '',
+      additional_information: '',
+      updated_at: '',
+      time_due: '',
+      date: '',
+      person: {
+        jsonApi: 'hasOne',
+        type: 'people',
+      },
+      from_location: {
+        jsonApi: 'hasOne',
+        type: 'locations',
+      },
+      to_location: {
+        jsonApi: 'hasOne',
+        type: 'locations',
+      },
     },
-    from_location: {
-      jsonApi: 'hasOne',
-      type: 'locations',
+  },
+  person: {
+    attributes: {
+      first_names: '',
+      last_name: '',
+      date_of_birth: '',
+      identifiers: '',
+      assessment_answers: '',
+      gender_additional_information: '',
+      gender: {
+        jsonApi: 'hasOne',
+        type: 'genders',
+      },
+      ethnicity: {
+        jsonApi: 'hasOne',
+        type: 'ethnicities',
+      },
     },
-    to_location: {
-      jsonApi: 'hasOne',
-      type: 'locations',
-    },
-  })
-
-  jsonApi.define('person', {
-    first_names: '',
-    last_name: '',
-    date_of_birth: '',
-    identifiers: '',
-    assessment_answers: '',
-    gender_additional_information: '',
-    gender: {
-      jsonApi: 'hasOne',
-      type: 'genders',
-    },
-    ethnicity: {
-      jsonApi: 'hasOne',
-      type: 'ethnicities',
-    },
-  })
-
-  jsonApi.define(
-    'gender',
-    {
+  },
+  gender: {
+    attributes: {
       key: '',
       title: '',
       description: '',
       nomis_code: '',
       disabled_at: '',
     },
-    {
+    options: {
       collectionPath: 'reference/genders',
-    }
-  )
-
-  jsonApi.define(
-    'ethnicity',
-    {
+    },
+  },
+  ethnicity: {
+    attributes: {
       key: '',
       title: '',
       description: '',
       nomis_code: '',
       disabled_at: '',
     },
-    {
+    options: {
       collectionPath: 'reference/ethnicities',
-    }
-  )
-
-  jsonApi.define(
-    'assessment_question',
-    {
+    },
+  },
+  assessment_question: {
+    attributes: {
       created_at: '',
       expires_at: '',
       disabled_at: '',
@@ -78,24 +75,20 @@ function defineModels(jsonApi) {
       nomis_alert_type: '',
       nomis_alert_code: '',
     },
-    {
+    options: {
       collectionPath: 'reference/assessment_questions',
-    }
-  )
-
-  jsonApi.define(
-    'location',
-    {
+    },
+  },
+  location: {
+    attributes: {
       key: '',
       title: '',
       location_type: '',
       nomis_agency_id: '',
       disabled_at: '',
     },
-    {
+    options: {
       collectionPath: 'reference/locations',
-    }
-  )
+    },
+  },
 }
-
-module.exports = defineModels


### PR DESCRIPTION
This change exports the model objects rather than a function that
defines each model on the API client.

This will allow the model and its attributes to be used in other
parts of the app like services to ensure when formatting they follow
the same property structure as the API model.