### PR TITLE
[P4-627] Add completed page create journey

### DIFF
--- a/app/move/controllers/confirmation.js
+++ b/app/move/controllers/confirmation.js
@@ -1,0 +1,14 @@
+function confirmation(req, res) {
+  const { move_type: moveType, to_location: toLocation } = res.locals.move
+
+  const locals = {
+    location:
+      moveType === 'prison_recall'
+        ? req.t('fields::move_type.items.prison_recall.label')
+        : toLocation.title,
+  }
+
+  res.render('move/views/confirmation', locals)
+}
+
+module.exports = confirmation

--- a/app/move/controllers/confirmation.test.js
+++ b/app/move/controllers/confirmation.test.js
@@ -1,0 +1,77 @@
+const controller = require('./confirmation')
+
+const mockMove = {
+  move_type: 'court_appearance',
+  to_location: {
+    title: 'Axminster Crown Court',
+  },
+}
+
+describe('Move controllers', function() {
+  describe('#confirmation()', function() {
+    describe('with move_type "court_appearance"', function() {
+      let req, res
+
+      beforeEach(function() {
+        req = {}
+        res = {
+          render: sinon.spy(),
+          locals: {
+            move: mockMove,
+          },
+        }
+
+        controller(req, res)
+      })
+
+      it('should render confirmation template', function() {
+        const template = res.render.args[0][0]
+
+        expect(res.render.calledOnce).to.be.true
+        expect(template).to.equal('move/views/confirmation')
+      })
+
+      it('should contain a location param', function() {
+        const params = res.render.args[0][1]
+        expect(params).to.have.property('location')
+        expect(params.location).to.equal(mockMove.to_location.title)
+      })
+    })
+
+    describe('with move_type "prison_recall"', function() {
+      let req, res
+
+      beforeEach(function() {
+        req = {
+          t: sinon.stub().returnsArg(0),
+        }
+        res = {
+          render: sinon.spy(),
+          locals: {
+            move: {
+              ...mockMove,
+              move_type: 'prison_recall',
+            },
+          },
+        }
+
+        controller(req, res)
+      })
+
+      it('should render confirmation template', function() {
+        const template = res.render.args[0][0]
+
+        expect(res.render.calledOnce).to.be.true
+        expect(template).to.equal('move/views/confirmation')
+      })
+
+      it('should pass correct values to location translation', function() {
+        const params = res.render.args[0][1]
+        expect(params).to.have.property('location')
+        expect(req.t.firstCall).to.have.been.calledWithExactly(
+          'fields::move_type.items.prison_recall.label'
+        )
+      })
+    })
+  })
+})

--- a/app/move/controllers/create/save.js
+++ b/app/move/controllers/create/save.js
@@ -1,10 +1,8 @@
 const { omit } = require('lodash')
 
 const CreateBaseController = require('./base')
-const { mountpath: movesUrl } = require('../../../moves')
 const moveService = require('../../../../common/services/move')
 const personService = require('../../../../common/services/person')
-const filters = require('../../../../config/nunjucks/filters')
 
 class SaveController extends CreateBaseController {
   async saveValues(req, res, next) {
@@ -14,7 +12,6 @@ class SaveController extends CreateBaseController {
         'errors',
         'errorValues',
       ])
-
       const move = await moveService.create(data)
       await personService.update(data.person)
 
@@ -27,31 +24,12 @@ class SaveController extends CreateBaseController {
   }
 
   successHandler(req, res) {
-    const {
-      date,
-      person,
-      move_type: moveType,
-      to_location: toLocation,
-    } = req.sessionModel.get('move')
+    const { id } = req.sessionModel.get('move')
 
     req.journeyModel.reset()
-    req.journeyModel.destroy()
     req.sessionModel.reset()
-    req.sessionModel.destroy()
 
-    req.flash('success', {
-      title: req.t('messages::create_move.success.title'),
-      content: req.t('messages::create_move.success.content', {
-        name: person.fullname,
-        location:
-          moveType === 'prison_recall'
-            ? req.t('fields::move_type.items.prison_recall.label')
-            : toLocation.title,
-        date: filters.formatDateWithDay(date),
-      }),
-    })
-
-    res.redirect(`${movesUrl}?move-date=${date}`)
+    res.redirect(`/move/${id}/confirmation`)
   }
 }
 

--- a/app/move/controllers/create/save.test.js
+++ b/app/move/controllers/create/save.test.js
@@ -126,14 +126,10 @@ describe('Move controllers', function() {
           sessionModel: {
             get: sinon.stub(),
             reset: sinon.stub(),
-            destroy: sinon.stub(),
           },
           journeyModel: {
             reset: sinon.stub(),
-            destroy: sinon.stub(),
           },
-          flash: sinon.stub(),
-          t: sinon.stub().returnsArg(0),
         }
         res = {
           redirect: sinon.stub(),
@@ -148,72 +144,18 @@ describe('Move controllers', function() {
           controller.successHandler(req, res)
         })
 
-        it('should set a success message', function() {
-          expect(req.flash).to.have.been.calledOnceWith('success', {
-            title: 'messages::create_move.success.title',
-            content: 'messages::create_move.success.content',
-          })
-        })
-
-        it('should pass correct values to success content translation', function() {
-          expect(req.t.secondCall).to.have.been.calledWithExactly(
-            'messages::create_move.success.content',
-            {
-              name: mockMove.person.fullname,
-              location: mockMove.to_location.title,
-              date: mockMove.date,
-            }
-          )
-        })
-
         it('should reset the journey', function() {
           expect(req.journeyModel.reset).to.have.been.calledOnce
-          expect(req.journeyModel.destroy).to.have.been.calledOnce
         })
 
         it('should reset the session', function() {
           expect(req.sessionModel.reset).to.have.been.calledOnce
-          expect(req.sessionModel.destroy).to.have.been.calledOnce
         })
 
         it('should redirect correctly', function() {
           expect(res.redirect).to.have.been.calledOnce
           expect(res.redirect).to.have.been.calledWith(
-            `/moves?move-date=${mockMove.date}`
-          )
-        })
-      })
-
-      context('with prison recall move type', function() {
-        beforeEach(function() {
-          req.sessionModel.get.withArgs('move').returns({
-            ...mockMove,
-            move_type: 'prison_recall',
-          })
-          controller.successHandler(req, res)
-        })
-
-        it('should set a success message', function() {
-          expect(req.flash).to.have.been.calledOnceWith('success', {
-            title: 'messages::create_move.success.title',
-            content: 'messages::create_move.success.content',
-          })
-        })
-
-        it('should translate prison recall title', function() {
-          expect(req.t.secondCall).to.have.been.calledWithExactly(
-            'fields::move_type.items.prison_recall.label'
-          )
-        })
-
-        it('should pass correct values to success content translation', function() {
-          expect(req.t.thirdCall).to.have.been.calledWithExactly(
-            'messages::create_move.success.content',
-            {
-              name: mockMove.person.fullname,
-              location: 'fields::move_type.items.prison_recall.label',
-              date: mockMove.date,
-            }
+            `/move/${mockMove.id}/confirmation`
           )
         })
       })

--- a/app/move/controllers/index.js
+++ b/app/move/controllers/index.js
@@ -1,9 +1,11 @@
 const cancel = require('./cancel')
 const create = require('./create')
 const view = require('./view')
+const confirmation = require('./confirmation')
 
 module.exports = {
   cancel,
   create,
   view,
+  confirmation,
 }

--- a/app/move/index.js
+++ b/app/move/index.js
@@ -7,7 +7,7 @@ const FormWizardController = require('../../common/controllers/form-wizard')
 const { protectRoute } = require('../../common/middleware/permissions')
 const { create: createSteps } = require('./steps')
 const { create: createFields } = require('./fields')
-const { cancel, view } = require('./controllers')
+const { cancel, view, confirmation } = require('./controllers')
 const { setMove } = require('./middleware')
 
 const createWizardConfig = {
@@ -32,6 +32,7 @@ router
   .route('/:moveId/cancel')
   .get(protectRoute('move:cancel'), cancel.get)
   .post(protectRoute('move:cancel'), cancel.post)
+router.get('/:moveId/confirmation', protectRoute('move:create'), confirmation)
 
 // Export
 module.exports = {

--- a/app/move/steps/create.js
+++ b/app/move/steps/create.js
@@ -8,6 +8,7 @@ const {
 module.exports = {
   '/': {
     entryPoint: true,
+    reset: true,
     resetJourney: true,
     skip: true,
     next: 'personal-details',

--- a/app/move/views/confirmation.njk
+++ b/app/move/views/confirmation.njk
@@ -1,0 +1,40 @@
+{% extends "layouts/base.njk" %}
+
+{% block customGtagConfig %}
+  gtag('set', {'page_title': 'Move scheduled'});
+{% endblock %}
+
+{% block pageTitle %}
+  {{ t("moves::confirmation.page_title", { name: move.person.fullname | upper }) }}
+{% endblock %}
+
+{% block beforeContent %}
+  {{ super() }}
+{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      {{ govukPanel({
+        classes: "govuk-!-margin-bottom-7",
+        titleText: t("moves::confirmation.panel.heading"),
+        html: t("moves::confirmation.panel.content", {
+          moveReference: move.reference
+        })
+      }) }}
+
+      <p>{{ t("moves::confirmation.detail", {
+          href: "/move/" + move.id,
+          name: move.person.fullname | upper,
+          location: location,
+          date: move.date | formatDateWithDay
+          }) | safe }}
+      </p>
+
+      <a href="{{ MOVES_URL }}">
+        {{ t("actions::back_to_dashboard") }}
+      </a>
+    </div>
+  </div>
+{% endblock %}

--- a/common/assets/scss/application.scss
+++ b/common/assets/scss/application.scss
@@ -25,6 +25,7 @@ $govuk-font-family: "Inter", system-ui, sans-serif;
 @import "govuk-frontend/govuk/components/skip-link/skip-link.scss";
 @import "govuk-frontend/govuk/components/summary-list/summary-list.scss";
 @import "govuk-frontend/govuk/components/textarea/textarea.scss";
+@import "govuk-frontend/govuk/components/panel/panel.scss";
 
 @import "govuk-frontend/govuk/utilities/all";
 @import "govuk-frontend/govuk/overrides/all";

--- a/common/templates/layouts/base.njk
+++ b/common/templates/layouts/base.njk
@@ -11,6 +11,7 @@
 {% from "govuk/components/select/macro.njk"            import govukSelect %}
 {% from "govuk/components/summary-list/macro.njk"      import govukSummaryList %}
 {% from "govuk/components/textarea/macro.njk"          import govukTextarea %}
+{% from "govuk/components/panel/macro.njk"             import govukPanel %}
 
 {% from "moj/components/organisation-switcher/macro.njk" import mojOrganisationSwitcher %}
 

--- a/locales/en/moves.json
+++ b/locales/en/moves.json
@@ -80,5 +80,13 @@
       "confirmation": "Are you sure you want to cancel the move for <strong>{{name}}</strong> to <strong>{{location}}</strong>?",
       "warning": "This will delete this move request."
     }
+  },
+  "confirmation": {
+    "page_title": "Move scheduled for {{name}}",
+    "panel": {
+      "heading": "Move scheduled",
+      "content": "Reference number<br><strong>{{moveReference}}</strong>"
+    },
+    "detail": "The move for <strong><a href=\"{{href}}\">{{name}}</a></strong> to <strong>{{location}}</strong> on <strong>{{date}}</strong> has been scheduled"
   }
 }


### PR DESCRIPTION
## Feature
Add a Move completed page to the create journey

### Of Note
- If a user uses the browser back button whilst on the confirmation page it will redirect them to `/moves`
- Users can go to `move/<move_id>/confirmation` to see individual confirmations


### Screenshot
![screencapture-1](https://user-images.githubusercontent.com/2305016/64245891-b4ff6a00-cf03-11e9-818b-196351ef074f.png)

### Journey
![confirmation-2](https://user-images.githubusercontent.com/2305016/64245863-aa44d500-cf03-11e9-8bdd-ed6cb5b31fd8.gif)




