### PR TITLE
Ensure session is destroyed before redirecting

### DIFF
--- a/app/auth/controllers.js
+++ b/app/auth/controllers.js
@@ -12,7 +12,8 @@ module.exports = {
     const authProviderLogoutUrl =
       AUTH_PROVIDERS[DEFAULT_AUTH_PROVIDER].logout_url
 
-    req.session.destroy()
-    res.redirect(authProviderLogoutUrl)
+    req.session.destroy(() => {
+      res.redirect(authProviderLogoutUrl)
+    })
   },
 }

--- a/app/auth/controllers.test.js
+++ b/app/auth/controllers.test.js
@@ -64,12 +64,13 @@ describe('Authentication app', function() {
       req = {
         query: {},
         session: {
-          destroy: sinon.spy(),
+          destroy: callback => callback(),
         },
       }
       res = {
         redirect: sinon.spy(),
       }
+      sinon.spy(req.session, 'destroy')
 
       controllers.signOut(req, res)
     })


### PR DESCRIPTION
The session destroy method as asynchronous, especially when using
a session store like Redis.

Currently the user is being redirect before the session is actually
destroyed which has led to some inconsistencies when signing out
and back in again in quick succession.

This change calls the redirect in the destroy callback to ensure
it has been destroyed properly.