### PR TITLE
Handle journey prereq error

### DIFF
--- a/common/controllers/form-wizard.js
+++ b/common/controllers/form-wizard.js
@@ -26,9 +26,11 @@ class FormController extends Controller {
       return res.redirect(err.redirect)
     }
 
-    if (err.code === 'SESSION_TIMEOUT') {
-      return res.render('form-wizard-timeout', {
+    if (err.code === 'SESSION_TIMEOUT' || err.code === 'MISSING_PREREQ') {
+      return res.render('form-wizard-error', {
+        journeyName: req.form.options.journeyName.replace('-', '_'),
         journeyBaseUrl: req.baseUrl,
+        errorKey: err.code.toLowerCase(),
       })
     }
 

--- a/common/controllers/form-wizard.test.js
+++ b/common/controllers/form-wizard.test.js
@@ -97,7 +97,7 @@ describe('Move controllers', function() {
           controller.errorHandler(errorMock, {}, resMock)
         })
 
-        it('redirect to specificed value', function() {
+        it('redirect to specified value', function() {
           expect(resMock.redirect).to.be.calledWith(errorMock.redirect)
         })
 
@@ -113,18 +113,59 @@ describe('Move controllers', function() {
           errorMock.code = 'SESSION_TIMEOUT'
           reqMock = {
             baseUrl: '/journey-base-url',
+            form: {
+              options: {
+                journeyName: 'mock-journey',
+              },
+            },
           }
 
           controller.errorHandler(errorMock, reqMock, resMock)
         })
 
         it('should render the timeout template', function() {
-          expect(resMock.render.args[0][0]).to.equal('form-wizard-timeout')
+          expect(resMock.render.args[0][0]).to.equal('form-wizard-error')
         })
 
         it('should pass the correct data to the view', function() {
           expect(resMock.render.args[0][1]).to.deep.equal({
             journeyBaseUrl: reqMock.baseUrl,
+            errorKey: errorMock.code.toLowerCase(),
+            journeyName: 'mock_journey',
+          })
+        })
+
+        it('should not call parent error handler', function() {
+          expect(FormController.prototype.errorHandler).not.to.be.called
+        })
+      })
+
+      context('when it returns missing prereq error', function() {
+        let reqMock
+
+        beforeEach(function() {
+          errorMock.code = 'MISSING_PREREQ'
+          reqMock = {
+            baseUrl: '/journey-base-url-other',
+            form: {
+              options: {
+                journeyName: 'mock-journey',
+              },
+            },
+          }
+
+          controller.errorHandler(errorMock, reqMock, resMock)
+        })
+
+        it('should render the timeout template', function() {
+          expect(resMock.render.args[0][0]).to.equal('form-wizard-error')
+        })
+
+        it('should pass the correct data to the view', function() {
+          expect(resMock.render.args[0][1]).to.deep.equal({
+            journeyBaseUrl: reqMock.baseUrl,
+            errorKey: errorMock.code.toLowerCase(),
+            journeyName: 'mock_journey',
           })
         })
 

--- a/common/templates/form-wizard-error.njk
+++ b/common/templates/form-wizard-error.njk
@@ -4,18 +4,23 @@
   <header class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-xl">
-        {{ t("errors::timeout.heading") }}
+        {{ t("errors::" + errorKey + ".heading", { context: journeyName }) }}
       </h1>
     </div>
   </header>
-
   <p>
-    {{ t("errors::timeout.content") }}
+    {{ t("errors::" + errorKey + ".content", { context: journeyName }) }}
   </p>
 
   <p>
+  {% if errorKey == "missing_prereq" %}
+    <a href="/moves">
+      {{ t("actions::back_to_dashboard") }}
+    </a>
+  {% else %}
     <a href="{{ journeyBaseUrl }}" class="govuk-button">
       {{ t("actions::restart") }}
     </a>
+  {% endif %}
   </p>
 {% endblock %}

--- a/locales/en/errors.json
+++ b/locales/en/errors.json
@@ -3,13 +3,19 @@
     "heading": "Page unavailable",
     "content": "We are experiencing technical problems and the error has been reported. Try again in a few moments."
   },
-  "timeout": {
+  "session_timeout": {
     "heading": "Session timeout",
     "content": "Your session has timed out due to a long period of inactivity."
   },
   "not_found": {
     "heading": "Page not found",
     "content": "If you entered a web address check it was correct."
+  },
+  "missing_prereq": {
+    "heading": "Journey expired",
+    "heading_create_move": "This move has been scheduled",
+    "content": "Your journey has been completed.",
+    "content_create_move": "You can view upcoming moves or create a new move from the dashboard."
   },
   "tampered_with": {
     "heading": "This form has been tampered with",


### PR DESCRIPTION
## Feature
If a journeys session model has been reset or destroyed then
an error with the code `MISSING_PREREQ` is thrown. This work handles
this error and displays a page with a user-friendly message

## Of Note
@lmoney-moj is sending final copy over at present this is just placeholder copy

### Screenshot
`SESSION_TIMEOUT`
![screencapture-localhost-3000-move-new-health-information-2019-09-04-14_30_13](https://user-images.githubusercontent.com/2305016/64259405-e8042680-cf20-11e9-842c-bc8ab9343d75.png)

`MISSING_PREREQ`
![screencapture-localhost-3000-move-new-health-information-2019-09-04-14_29_18](https://user-images.githubusercontent.com/2305016/64259419-ecc8da80-cf20-11e9-8b26-6330619b40d3.png)