### PR TITLE
[P4-636] Display cancellation banner on move detail page

### DIFF
--- a/app/move/controllers/cancel.js
+++ b/app/move/controllers/cancel.js
@@ -5,7 +5,7 @@ const moveService = require('../../../common/services/move')
 
 class CancelController extends FormWizardController {
   async successHandler(req, res, next) {
-    const { id: moveId, person } = res.locals.move
+    const { id: moveId } = res.locals.move
 
     try {
       const data = pick(
@@ -20,12 +20,6 @@ class CancelController extends FormWizardController {
 
       req.journeyModel.reset()
       req.sessionModel.reset()
-
-      req.flash('success', {
-        title: req.t('messages::cancel_move.success.title', {
-          name: person.fullname.toUpperCase(),
-        }),
-      })
 
       res.redirect(`/move/${moveId}`)
     } catch (error) {

--- a/app/move/controllers/cancel.test.js
+++ b/app/move/controllers/cancel.test.js
@@ -36,8 +36,6 @@ describe('Move controllers', function() {
           journeyModel: {
             reset: sinon.stub(),
           },
-          flash: sinon.stub(),
-          t: sinon.stub().returnsArg(0),
         }
         res = {
           redirect: sinon.stub(),
@@ -66,21 +64,6 @@ describe('Move controllers', function() {
 
         it('should reset the session', function() {
           expect(req.sessionModel.reset).to.have.been.calledOnce
-        })
-
-        it('should set a success message', function() {
-          expect(req.flash).to.have.been.calledOnceWith('success', {
-            title: 'messages::cancel_move.success.title',
-          })
-        })
-
-        it('should uppercase name in success message', function() {
-          expect(req.t.firstCall).to.have.been.calledWithExactly(
-            'messages::cancel_move.success.title',
-            {
-              name: res.locals.move.person.fullname.toUpperCase(),
-            }
-          )
         })
 
         it('should redirect correctly', function() {

--- a/app/move/controllers/view.js
+++ b/app/move/controllers/view.js
@@ -2,7 +2,11 @@ const presenters = require('../../../common/presenters')
 
 module.exports = function view(req, res) {
   const { move } = res.locals
-  const { person } = move
+  const {
+    person,
+    cancellation_reason: cancellationReason,
+    cancellation_reason_comments: cancellationComments,
+  } = move
   const locals = {
     moveSummary: presenters.moveToMetaListComponent(move),
     personalDetailsSummary: presenters.personToSummaryListComponent(person),
@@ -12,6 +16,15 @@ module.exports = function view(req, res) {
       person.assessment_answers,
       'court'
     ),
+  }
+
+  if (cancellationReason) {
+    const reasonLabel = req.t(
+      `fields::cancellation_reason.items.${cancellationReason}.label`
+    )
+
+    locals.cancellationReason =
+      cancellationReason !== 'other' ? reasonLabel : cancellationComments
   }
 
   res.render('move/views/view', locals)

--- a/app/move/views/view.njk
+++ b/app/move/views/view.njk
@@ -22,6 +22,21 @@
   <a href="javascript:window.print()" class="app-!-float-right app-print--hide govuk-!-margin-top-3">
     {{ t("actions::print_move_detail") }}
   </a>
+
+  {% if move.status == "cancelled" %}
+    {{ appMessage({
+      allowDismiss: false,
+      classes: "app-message--temporary",
+      title: {
+        text: t("moves::cancel.panel.heading")
+      },
+      content: {
+        text: t("moves::cancel.panel.content", {
+          reason: cancellationReason
+        }) if cancellationReason
+      }
+    }) }}
+  {% endif %}
 {% endblock %}
 
 {% block content %}
@@ -55,8 +70,8 @@
 
       {% include "move/views/_includes/assessment.njk" %}
 
-      {% if canAccess('move:cancel') %}
-        <p class="govuk-!-margin-top-9">
+      {% if canAccess("move:cancel") and move.status == "requested" %}
+        <p class="govuk-!-margin-top-9 govuk-!-margin-bottom-0">
           <a href="{{ move.id }}/cancel" class="app-link--destructive">
             {{ t("actions::cancel_move") }}
           </a>

--- a/common/components/message/_message.scss
+++ b/common/components/message/_message.scss
@@ -1,7 +1,10 @@
+$_message-padding: govuk-spacing(3);
+$_message-border-width: 5px;
+
 .app-message {
   background-color: govuk-colour("white");
-  border: 5px solid $govuk-brand-colour;
-  padding: govuk-spacing(3);
+  border: $_message-border-width solid $govuk-brand-colour;
+  padding: $_message-padding;
   position: relative;
 
   @include mq ($from: tablet) {
@@ -34,6 +37,10 @@
 
 .app-message__heading {
   @include govuk-font($size: 24, $weight: bold);
+
+  + * {
+    margin-top: govuk-spacing(2);
+  }
 }
 
 .app-message__content {
@@ -86,4 +93,23 @@
   border-color: govuk-colour("dark-grey");
   border-width: 0 0 0 5px;
   background-color: govuk-colour("light-grey");
+}
+
+.app-message--temporary {
+  background-color: govuk-colour("blue");
+  border-width: 0;
+  color: govuk-colour("white");
+  padding: $_message-padding + $_message-border-width;
+
+  .app-message__heading {
+    @include govuk-font($size: 36, $weight: bold);
+
+    + * {
+      margin-top: govuk-spacing(4);
+    }
+  }
+
+  * {
+    color: govuk-colour("white");
+  }
 }

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -4,10 +4,5 @@
       "title": "Move scheduled",
       "content": "Move for <strong>{{name}}</strong> to <strong>{{location}}</strong> on <strong>{{date}}</strong> has been scheduled."
     }
-  },
-  "cancel_move": {
-    "success": {
-      "title": "Move request cancelled for {{name}}"
-    }
   }
 }

--- a/locales/en/moves.json
+++ b/locales/en/moves.json
@@ -81,7 +81,11 @@
       }
     },
     "page_title": "Cancel move for ‘{{name}}’",
-    "warning": "You must also contact the supplier to cancel the move request for {{name}}"
+    "warning": "You must also contact the supplier to cancel the move request for {{name}}",
+    "panel": {
+      "heading": "Move cancelled",
+      "content": "Reason — {{reason}}"
+    }
   },
   "confirmation": {
     "page_title": "Move scheduled for {{name}}",


### PR DESCRIPTION
If a move has been cancelled it will display a banner to signify
that this move is in a cancelled state.

The banner can be used in the future to show the status of a move and any further
information like reason for cancellation.

🚀 **[DEMO](https://book-a-secure-move.herokuapp.com/)** 🚀 

## What it looks like

![localhost_3000_move_a53fb8f7-3e34-41ca-8f7d-2b97ae89f785](https://user-images.githubusercontent.com/3327997/64334777-3670fe00-cfd1-11e9-9143-b355e4510921.png)
