### PR TITLE
Fix confirmation page copy

### DIFF
--- a/app/move/views/confirmation.njk
+++ b/app/move/views/confirmation.njk
@@ -32,9 +32,11 @@
           }) | safe }}
       </p>
 
-      <a href="{{ MOVES_URL }}">
-        {{ t("actions::back_to_dashboard") }}
-      </a>
+      <p>
+        <a href="{{ MOVES_URL }}">
+          {{ t("actions::back_to_dashboard") }}
+        </a>
+      </p>
     </div>
   </div>
 {% endblock %}

--- a/locales/en/moves.json
+++ b/locales/en/moves.json
@@ -89,6 +89,6 @@
       "heading": "Move scheduled",
       "content": "Reference number<br><strong>{{moveReference}}</strong>"
     },
-    "detail": "The move for <strong><a href=\"{{href}}\">{{name}}</a></strong> to <strong>{{location}}</strong> on <strong>{{date}}</strong> has been scheduled"
+    "detail": "The move for <strong><a href=\"{{href}}\">{{name}}</a></strong> to <strong>{{location}}</strong> on <strong>{{date}}</strong> has been scheduled."
   }
 }


### PR DESCRIPTION
This adds two small fixes to the confirmation page:

- add missing full stop to end of success sentence
- wrap dashboard link in paragraph so text size matches (the GOV.UK
design system doesn't provide the same font size style for elements
not wrapped in p, ul, etc.)

## Before
![image](https://user-images.githubusercontent.com/3327997/64334583-ba76b600-cfd0-11e9-877a-181b6a1f9fd1.png)

## After
![image](https://user-images.githubusercontent.com/3327997/64334638-daa67500-cfd0-11e9-982f-fba6e4a700a1.png)
