### PR TITLE
Fix for locations

### DIFF
--- a/app/move/controllers/create/move-details.js
+++ b/app/move/controllers/create/move-details.js
@@ -15,14 +15,6 @@ class MoveDetailsController extends CreateBaseController {
           'filter[location_type]': 'court',
         },
       })
-      const prisons = await referenceDataService.getLocations({
-        type: 'prison',
-      })
-
-      const {
-        to_location_prison_recall: toLocationPrison,
-        date_type: dateType,
-      } = req.form.options.fields
 
       const { date_type: dateType } = req.form.options.fields
       const courtItems = fieldHelpers.insertInitialOption(
@@ -31,11 +23,6 @@ class MoveDetailsController extends CreateBaseController {
           .map(fieldHelpers.mapReferenceDataToOption),
         'court'
       )
-      toLocationPrison.items = fieldHelpers.insertInitialOption(
-        prisons
-          .filter(referenceDataHelpers.filterDisabled())
-          .map(fieldHelpers.mapReferenceDataToOption),
-        'prison'
 
       set(
         req,

--- a/app/move/controllers/create/move-details.js
+++ b/app/move/controllers/create/move-details.js
@@ -10,11 +10,9 @@ const referenceDataHelpers = require('../../../../common/helpers/reference-data'
 class MoveDetailsController extends CreateBaseController {
   async configure(req, res, next) {
     try {
-      const courtLocations = await referenceDataService.getLocations({
-        filter: {
-          'filter[location_type]': 'court',
-        },
-      })
+      const courtLocations = await referenceDataService.getLocationsByType(
+        'court'
+      )
 
       const { date_type: dateType } = req.form.options.fields
       const courtItems = fieldHelpers.insertInitialOption(

--- a/app/move/controllers/create/move-details.js
+++ b/app/move/controllers/create/move-details.js
@@ -9,8 +9,10 @@ const referenceDataHelpers = require('../../../../common/helpers/reference-data'
 class MoveDetailsController extends CreateBaseController {
   async configure(req, res, next) {
     try {
-      const courts = await referenceDataService.getLocations({
-        type: 'court',
+      const courtLocations = await referenceDataService.getLocations({
+        filter: {
+          'filter[location_type]': 'court',
+        },
       })
       const prisons = await referenceDataService.getLocations({
         type: 'prison',

--- a/app/move/controllers/create/move-details.js
+++ b/app/move/controllers/create/move-details.js
@@ -1,3 +1,4 @@
+const { set } = require('lodash')
 const dateFns = require('date-fns')
 
 const CreateBaseController = require('./base')
@@ -19,13 +20,13 @@ class MoveDetailsController extends CreateBaseController {
       })
 
       const {
-        to_location_court_appearance: toLocationCourt,
         to_location_prison_recall: toLocationPrison,
         date_type: dateType,
       } = req.form.options.fields
 
-      toLocationCourt.items = fieldHelpers.insertInitialOption(
-        courts
+      const { date_type: dateType } = req.form.options.fields
+      const courtItems = fieldHelpers.insertInitialOption(
+        courtLocations
           .filter(referenceDataHelpers.filterDisabled())
           .map(fieldHelpers.mapReferenceDataToOption),
         'court'
@@ -35,6 +36,11 @@ class MoveDetailsController extends CreateBaseController {
           .filter(referenceDataHelpers.filterDisabled())
           .map(fieldHelpers.mapReferenceDataToOption),
         'prison'
+
+      set(
+        req,
+        'form.options.fields.to_location_court_appearance.items',
+        courtItems
       )
 
       // translate date type options early to cater for date injection

--- a/app/move/controllers/create/move-details.test.js
+++ b/app/move/controllers/create/move-details.test.js
@@ -38,16 +38,11 @@ describe('Move controllers', function() {
           sinon.stub(referenceDataHelpers, 'filterDisabled').callsFake(() => {
             return () => true
           })
-          sinon.stub(referenceDataService, 'getLocations').resolves(courtsMock)
-          sinon.stub(filters, 'formatDateWithDay').returnsArg(0)
-
-          referenceDataService.getLocations
-            .withArgs({
-              filter: {
-                'filter[location_type]': 'court',
-              },
-            })
+          sinon
+            .stub(referenceDataService, 'getLocationsByType')
+            .withArgs('court')
             .resolves(courtsMock)
+          sinon.stub(filters, 'formatDateWithDay').returnsArg(0)
 
           req = {
             t: sinon.stub().returns('__translated__'),

--- a/app/move/controllers/create/move-details.test.js
+++ b/app/move/controllers/create/move-details.test.js
@@ -16,16 +16,6 @@ const courtsMock = [
     title: 'Court 9999',
   },
 ]
-const prisonsMock = [
-  {
-    id: '3333',
-    title: 'Prison 3333',
-  },
-  {
-    id: '4444',
-    title: 'Prison 4444',
-  },
-]
 const mockCurrentLocation = {
   id: '5555',
   title: 'Prison 5555',
@@ -58,9 +48,6 @@ describe('Move controllers', function() {
               },
             })
             .resolves(courtsMock)
-          referenceDataService.getLocations
-            .withArgs({ type: 'prison' })
-            .resolves(prisonsMock)
 
           req = {
             t: sinon.stub().returns('__translated__'),
@@ -107,16 +94,6 @@ describe('Move controllers', function() {
             { text: '--- Choose court ---' },
             { value: '8888', text: 'Court 8888' },
             { value: '9999', text: 'Court 9999' },
-          ])
-        })
-
-        it('should set list of prison dynamically', function() {
-          expect(
-            req.form.options.fields.to_location_prison_recall.items
-          ).to.deep.equal([
-            { text: '--- Choose prison ---' },
-            { value: '3333', text: 'Prison 3333' },
-            { value: '4444', text: 'Prison 4444' },
           ])
         })
 

--- a/app/move/controllers/create/move-details.test.js
+++ b/app/move/controllers/create/move-details.test.js
@@ -52,7 +52,11 @@ describe('Move controllers', function() {
           sinon.stub(filters, 'formatDateWithDay').returnsArg(0)
 
           referenceDataService.getLocations
-            .withArgs({ type: 'court' })
+            .withArgs({
+              filter: {
+                'filter[location_type]': 'court',
+              },
+            })
             .resolves(courtsMock)
           referenceDataService.getLocations
             .withArgs({ type: 'prison' })

--- a/common/services/reference-data.js
+++ b/common/services/reference-data.js
@@ -69,6 +69,14 @@ const referenceDataService = {
     )
   },
 
+  getLocationsByType(type) {
+    return referenceDataService.getLocations({
+      filter: {
+        'filter[location_type]': type,
+      },
+    })
+  },
+
   mapLocationIdsToLocations(ids, callback) {
     const locationPromises = ids.map(id => {
       return callback(id).catch(() => false)

--- a/common/services/reference-data.test.js
+++ b/common/services/reference-data.test.js
@@ -485,4 +485,69 @@ describe('Reference Data Service', function() {
       })
     })
   })
+
+  describe('#getLocationsByType()', function() {
+    const mockResponse = mockLocations
+    let locations
+
+    beforeEach(async function() {
+      sinon.stub(referenceDataService, 'getLocations').resolves(mockResponse)
+    })
+
+    context('without type', function() {
+      beforeEach(async function() {
+        locations = await referenceDataService.getLocationsByType()
+      })
+
+      it('should call getMoves methods', function() {
+        expect(referenceDataService.getLocations).to.be.calledOnce
+      })
+
+      it('should return first result', function() {
+        expect(locations).to.deep.equal(mockResponse)
+      })
+
+      describe('filters', function() {
+        let filters
+
+        beforeEach(function() {
+          filters = referenceDataService.getLocations.args[0][0].filter
+        })
+
+        it('should set location_type filter to undefined', function() {
+          expect(filters).to.contain.property('filter[location_type]')
+          expect(filters['filter[location_type]']).to.equal(undefined)
+        })
+      })
+    })
+
+    context('with type', function() {
+      const mockType = 'court'
+
+      beforeEach(async function() {
+        locations = await referenceDataService.getLocationsByType(mockType)
+      })
+
+      it('should call getMoves methods', function() {
+        expect(referenceDataService.getLocations).to.be.calledOnce
+      })
+
+      it('should return first result', function() {
+        expect(locations).to.deep.equal(mockResponse)
+      })
+
+      describe('filters', function() {
+        let filters
+
+        beforeEach(function() {
+          filters = referenceDataService.getLocations.args[0][0].filter
+        })
+
+        it('should set location_type filter to agency ID', function() {
+          expect(filters).to.contain.property('filter[location_type]')
+          expect(filters['filter[location_type]']).to.equal(mockType)
+        })
+      })
+    })
+  })
 })


### PR DESCRIPTION
### Fix

Previously the call to `referenceDataService.getLocations` was bringing back all `location_type` rather than a specific type. This work fixes that.

## Of Note
This work also removes the call to get `prison` locations as the form on this page no longer requires them
