### PR TITLE
[P4-634] Show cancelled moves on the dashboard

### DIFF
--- a/app/move/middleware.js
+++ b/app/move/middleware.js
@@ -7,7 +7,7 @@ module.exports = {
     }
 
     try {
-      res.locals.move = await moveService.getMoveById(moveId)
+      res.locals.move = await moveService.getById(moveId)
       next()
     } catch (error) {
       next(error)

--- a/app/move/middleware.test.js
+++ b/app/move/middleware.test.js
@@ -12,7 +12,7 @@ describe('Move middleware', function() {
       let res, nextSpy
 
       beforeEach(async function() {
-        sinon.stub(moveService, 'getMoveById').resolves(moveStub)
+        sinon.stub(moveService, 'getById').resolves(moveStub)
 
         res = { locals: {} }
         nextSpy = sinon.spy()
@@ -25,7 +25,7 @@ describe('Move middleware', function() {
       })
 
       it('should not call API with move ID', function() {
-        expect(moveService.getMoveById).not.to.be.called
+        expect(moveService.getById).not.to.be.called
       })
 
       it('should not set response data to locals object', function() {
@@ -38,7 +38,7 @@ describe('Move middleware', function() {
         let res, nextSpy
 
         beforeEach(async function() {
-          sinon.stub(moveService, 'getMoveById').resolves(moveStub)
+          sinon.stub(moveService, 'getById').resolves(moveStub)
 
           res = { locals: {} }
           nextSpy = sinon.spy()
@@ -47,7 +47,7 @@ describe('Move middleware', function() {
         })
 
         it('should call API with move ID', function() {
-          expect(moveService.getMoveById).to.be.calledWith(mockMoveId)
+          expect(moveService.getById).to.be.calledWith(mockMoveId)
         })
 
         it('should set response data to locals object', function() {
@@ -64,7 +64,7 @@ describe('Move middleware', function() {
         let res, nextSpy
 
         beforeEach(async function() {
-          sinon.stub(moveService, 'getMoveById').throws(errorStub)
+          sinon.stub(moveService, 'getById').throws(errorStub)
 
           res = { locals: {} }
           nextSpy = sinon.spy()

--- a/app/moves/controllers/download.js
+++ b/app/moves/controllers/download.js
@@ -4,7 +4,7 @@ const presenters = require('../../../common/presenters')
 
 module.exports = function download(req, res, next) {
   const { extension } = req.params
-  const { moveDate, movesByDate } = res.locals
+  const { moveDate, requestedMovesByDate } = res.locals
   const currentTimestamp = format(new Date(), 'YYYY-MM-DD HH:mm:ss')
   const filename = req.t('moves::download_filename', {
     date: moveDate,
@@ -21,12 +21,12 @@ module.exports = function download(req, res, next) {
   )
 
   if (extension === 'json') {
-    return res.json(movesByDate)
+    return res.json(requestedMovesByDate)
   }
 
   if (extension === 'csv') {
     return presenters
-      .movesToCSV(movesByDate)
+      .movesToCSV(requestedMovesByDate)
       .then(csv => {
         res.setHeader('Content-Type', 'text/csv')
         res.send(csv)

--- a/app/moves/controllers/download.test.js
+++ b/app/moves/controllers/download.test.js
@@ -25,7 +25,7 @@ describe('Moves controllers', function() {
         setHeader: sinon.stub(),
         locals: {
           moveDate: mockMoveDate,
-          movesByDate: movesStub,
+          requestedMovesByDate: movesStub,
         },
       }
       nextSpy = sinon.spy()

--- a/app/moves/controllers/list.js
+++ b/app/moves/controllers/list.js
@@ -6,7 +6,7 @@ const permissions = require('../../../common/middleware/permissions')
 const presenters = require('../../../common/presenters')
 
 module.exports = function list(req, res) {
-  const { moveDate, requestedMovesByDate } = res.locals
+  const { moveDate, cancelledMovesByDate, requestedMovesByDate } = res.locals
   const today = format(new Date(), 'YYYY-MM-DD')
   const previousDay = format(subDays(moveDate, 1), 'YYYY-MM-DD')
   const nextDay = format(addDays(moveDate, 1), 'YYYY-MM-DD')
@@ -18,6 +18,12 @@ module.exports = function list(req, res) {
   const locals = {
     pageTitle: 'moves::dashboard.upcoming_moves',
     destinations: presenters.movesByToLocation(requestedMovesByDate),
+    cancelledMoves: cancelledMovesByDate.map(
+      presenters.moveToCardComponent({
+        showMeta: false,
+        showTags: false,
+      })
+    ),
     pagination: {
       todayUrl: getQueryString(req.query, {
         'move-date': today,

--- a/app/moves/controllers/list.js
+++ b/app/moves/controllers/list.js
@@ -6,7 +6,7 @@ const permissions = require('../../../common/middleware/permissions')
 const presenters = require('../../../common/presenters')
 
 module.exports = function list(req, res) {
-  const { moveDate, movesByDate } = res.locals
+  const { moveDate, requestedMovesByDate } = res.locals
   const today = format(new Date(), 'YYYY-MM-DD')
   const previousDay = format(subDays(moveDate, 1), 'YYYY-MM-DD')
   const nextDay = format(addDays(moveDate, 1), 'YYYY-MM-DD')
@@ -17,7 +17,7 @@ module.exports = function list(req, res) {
   const template = canViewMove ? 'moves/views/list' : 'moves/views/download'
   const locals = {
     pageTitle: 'moves::dashboard.upcoming_moves',
-    destinations: presenters.movesByToLocation(movesByDate),
+    destinations: presenters.movesByToLocation(requestedMovesByDate),
     pagination: {
       todayUrl: getQueryString(req.query, {
         'move-date': today,

--- a/app/moves/controllers/list.test.js
+++ b/app/moves/controllers/list.test.js
@@ -7,20 +7,29 @@ const mockRequestedMovesByDate = [
   { foo: 'bar', status: 'requested' },
   { fizz: 'buzz', status: 'requested' },
 ]
+const mockCancelledMovesByDate = [
+  { foo: 'bar', status: 'cancelled' },
+  { fizz: 'buzz', status: 'cancelled' },
+]
 
 describe('Moves controllers', function() {
   describe('#list()', function() {
     const mockMoveDate = '2019-10-10'
-    let req, res
+    let req, res, moveToCardComponentMapStub
 
     beforeEach(function() {
+      moveToCardComponentMapStub = sinon.stub().returnsArg(0)
       this.clock = sinon.useFakeTimers(new Date(mockMoveDate).getTime())
       sinon.stub(presenters, 'movesByToLocation').returnsArg(0)
+      sinon
+        .stub(presenters, 'moveToCardComponent')
+        .callsFake(() => moveToCardComponentMapStub)
       req = { query: {} }
       res = {
         locals: {
           moveDate: mockMoveDate,
           requestedMovesByDate: mockRequestedMovesByDate,
+          cancelledMovesByDate: mockCancelledMovesByDate,
         },
         render: sinon.spy(),
       }
@@ -51,6 +60,14 @@ describe('Moves controllers', function() {
         expect(presenters.movesByToLocation).to.be.calledOnceWithExactly(
           mockRequestedMovesByDate
         )
+      })
+
+      it('should call moveToCardComponent presenter', function() {
+        expect(presenters.moveToCardComponent).to.be.calledOnceWithExactly({
+          showMeta: false,
+          showTags: false,
+        })
+        expect(moveToCardComponentMapStub).to.be.calledTwice
       })
 
       it('should contain destinations property', function() {

--- a/app/moves/controllers/list.test.js
+++ b/app/moves/controllers/list.test.js
@@ -3,7 +3,10 @@ const permissions = require('../../../common/middleware/permissions')
 
 const controller = require('./list')
 
-const mockMovesByDate = [{ foo: 'bar' }, { fizz: 'buzz' }]
+const mockRequestedMovesByDate = [
+  { foo: 'bar', status: 'requested' },
+  { fizz: 'buzz', status: 'requested' },
+]
 
 describe('Moves controllers', function() {
   describe('#list()', function() {
@@ -17,7 +20,7 @@ describe('Moves controllers', function() {
       res = {
         locals: {
           moveDate: mockMoveDate,
-          movesByDate: mockMovesByDate,
+          requestedMovesByDate: mockRequestedMovesByDate,
         },
         render: sinon.spy(),
       }
@@ -46,14 +49,14 @@ describe('Moves controllers', function() {
 
       it('should call movesByToLocation presenter', function() {
         expect(presenters.movesByToLocation).to.be.calledOnceWithExactly(
-          mockMovesByDate
+          mockRequestedMovesByDate
         )
       })
 
       it('should contain destinations property', function() {
         const params = res.render.args[0][1]
         expect(params).to.have.property('destinations')
-        expect(params.destinations).to.deep.equal(mockMovesByDate)
+        expect(params.destinations).to.deep.equal(mockRequestedMovesByDate)
       })
     })
 

--- a/app/moves/middleware.js
+++ b/app/moves/middleware.js
@@ -49,7 +49,7 @@ module.exports = {
     }
 
     try {
-      res.locals.movesByDate = await moveService.getRequestedMovesByDateAndLocation(
+      res.locals.movesByDate = await moveService.getRequestedByDateAndLocation(
         moveDate,
         res.locals.fromLocationId
       )

--- a/app/moves/middleware.js
+++ b/app/moves/middleware.js
@@ -42,17 +42,20 @@ module.exports = {
     next()
   },
   setMovesByDate: async (req, res, next) => {
-    const { moveDate } = res.locals
+    const { moveDate, fromLocationId } = res.locals
 
     if (!moveDate) {
       return next()
     }
 
     try {
-      res.locals.movesByDate = await moveService.getRequestedByDateAndLocation(
-        moveDate,
-        res.locals.fromLocationId
-      )
+      const [requestedMoves, cancelledMoves] = await Promise.all([
+        moveService.getRequested({ moveDate, fromLocationId }),
+        moveService.getCancelled({ moveDate, fromLocationId }),
+      ])
+
+      res.locals.requestedMovesByDate = requestedMoves
+      res.locals.cancelledMovesByDate = cancelledMoves
 
       next()
     } catch (error) {

--- a/app/moves/middleware.test.js
+++ b/app/moves/middleware.test.js
@@ -264,7 +264,7 @@ describe('Moves middleware', function() {
     const mockCurrentLocation = '5555'
 
     beforeEach(async function() {
-      sinon.stub(moveService, 'getRequestedMovesByDateAndLocation')
+      sinon.stub(moveService, 'getRequestedByDateAndLocation')
       nextSpy = sinon.spy()
       res = { locals: {} }
     })
@@ -279,7 +279,7 @@ describe('Moves middleware', function() {
       })
 
       it('should not call API with move date', function() {
-        expect(moveService.getRequestedMovesByDateAndLocation).not.to.be.called
+        expect(moveService.getRequestedByDateAndLocation).not.to.be.called
       })
 
       it('should not set response data to locals object', function() {
@@ -299,13 +299,13 @@ describe('Moves middleware', function() {
 
       context('when API call returns succesfully', function() {
         beforeEach(async function() {
-          moveService.getRequestedMovesByDateAndLocation.resolves(movesStub)
+          moveService.getRequestedByDateAndLocation.resolves(movesStub)
           await middleware.setMovesByDate({}, res, nextSpy)
         })
 
         it('should call API with move date and location ID', function() {
           expect(
-            moveService.getRequestedMovesByDateAndLocation
+            moveService.getRequestedByDateAndLocation
           ).to.be.calledOnceWithExactly(
             res.locals.moveDate,
             res.locals.fromLocationId
@@ -324,7 +324,7 @@ describe('Moves middleware', function() {
 
       context('when API call returns an error', function() {
         beforeEach(async function() {
-          moveService.getRequestedMovesByDateAndLocation.throws(errorStub)
+          moveService.getRequestedByDateAndLocation.throws(errorStub)
           await middleware.setMovesByDate({}, res, nextSpy)
         })
 

--- a/app/moves/views/list.njk
+++ b/app/moves/views/list.njk
@@ -66,4 +66,21 @@
       }
     }) }}
   {% endfor %}
+
+  {% if cancelledMoves.length %}
+    <div class="govuk-!-margin-top-9">
+      {% set cancelledMovesHtml %}
+        {% for cancelledMove in cancelledMoves %}
+          {{ appCard(cancelledMove) }}
+        {% endfor %}
+      {% endset %}
+
+      {{ govukDetails({
+        html: cancelledMovesHtml,
+        summaryText: t("moves::dashboard.cancelled_moves", {
+          count: cancelledMoves.length
+        })
+      }) }}
+    </div>
+  {% endif %}
 {% endblock %}

--- a/common/assets/scss/application.scss
+++ b/common/assets/scss/application.scss
@@ -15,6 +15,7 @@ $govuk-font-family: "Inter", system-ui, sans-serif;
 @import "govuk-frontend/govuk/components/back-link/back-link.scss";
 @import "govuk-frontend/govuk/components/button/button.scss";
 @import "govuk-frontend/govuk/components/checkboxes/checkboxes.scss";
+@import "govuk-frontend/govuk/components/details/details.scss";
 @import "govuk-frontend/govuk/components/error-summary/error-summary.scss";
 @import "govuk-frontend/govuk/components/footer/footer.scss";
 @import "govuk-frontend/govuk/components/header/header.scss";

--- a/common/presenters/move-to-card-component.test.js
+++ b/common/presenters/move-to-card-component.test.js
@@ -39,108 +39,114 @@ const mockMove = {
 
 describe('Presenters', function() {
   describe('#moveToCardComponent()', function() {
+    let transformedResponse
+
     beforeEach(function() {
       sinon.stub(i18n, 't').returns('__translated__')
       sinon.stub(filters, 'formatDate').returns('18 Jun 1960')
       sinon.stub(filters, 'calculateAge').returns(50)
     })
 
-    context('when provided with a mock move object', function() {
-      let transformedResponse
-
-      beforeEach(function() {
-        transformedResponse = moveToCardComponent(mockMove)
-      })
-
-      describe('response', function() {
-        it('should contain a href', function() {
-          expect(transformedResponse).to.have.property('href')
-          expect(transformedResponse.href).to.equal('/move/12345')
+    context('with default options', function() {
+      context('with mock move', function() {
+        beforeEach(function() {
+          transformedResponse = moveToCardComponent()(mockMove)
         })
 
-        it('should contain a title', function() {
-          expect(transformedResponse).to.have.property('title')
-          expect(transformedResponse.title).to.deep.equal({
-            text: mockMove.person.fullname.toUpperCase(),
+        describe('response', function() {
+          it('should contain a href', function() {
+            expect(transformedResponse).to.have.property('href')
+            expect(transformedResponse.href).to.equal('/move/12345')
+          })
+
+          it('should contain a title', function() {
+            expect(transformedResponse).to.have.property('title')
+            expect(transformedResponse.title).to.deep.equal({
+              text: mockMove.person.fullname.toUpperCase(),
+            })
+          })
+
+          it('should contain a caption', function() {
+            expect(transformedResponse).to.have.property('caption')
+            expect(transformedResponse.caption).to.deep.equal({
+              text: `__translated__`,
+            })
+          })
+
+          it('should contain correct meta data', function() {
+            expect(transformedResponse).to.have.property('meta')
+            expect(transformedResponse.meta).to.deep.equal({
+              items: [
+                {
+                  label: '__translated__',
+                  text: '__translated__',
+                },
+                {
+                  label: '__translated__',
+                  text: mockMove.person.gender.title,
+                },
+              ],
+            })
+          })
+
+          it('should contain correct tags', function() {
+            expect(transformedResponse).to.have.property('tags')
+            expect(transformedResponse.tags).to.deep.equal({
+              items: [
+                {
+                  href: '/move/12345#concealed_items',
+                  text: 'Concealed items',
+                  classes: 'app-tag--destructive',
+                  sortOrder: 1,
+                },
+                {
+                  href: '/move/12345#other_risks',
+                  text: 'Any other risks',
+                  classes: 'app-tag--destructive',
+                  sortOrder: 1,
+                },
+                {
+                  href: '/move/12345#health_issue',
+                  text: 'Health issue',
+                  classes: '',
+                  sortOrder: 2,
+                },
+              ],
+            })
           })
         })
 
-        it('should contain a caption', function() {
-          expect(transformedResponse).to.have.property('caption')
-          expect(transformedResponse.caption).to.deep.equal({
-            text: `__translated__`,
+        describe('translations', function() {
+          it('should translate age label', function() {
+            expect(i18n.t.getCall(0)).to.be.calledWithExactly('age', {
+              context: 'with_date_of_birth',
+              age: 50,
+              date_of_birth: '18 Jun 1960',
+            })
           })
-        })
 
-        it('should contain correct meta data', function() {
-          expect(transformedResponse).to.have.property('meta')
-          expect(transformedResponse.meta).to.deep.equal({
-            items: [
-              {
-                label: '__translated__',
-                html: '18 Jun 1960 (__translated__ 50)',
-              },
-              {
-                label: '__translated__',
-                text: mockMove.person.gender.title,
-              },
-            ],
+          it('should translate date of birth label', function() {
+            expect(i18n.t.getCall(1)).to.be.calledWithExactly(
+              'fields::date_of_birth.label'
+            )
           })
-        })
 
-        it('should contain correct tags', function() {
-          expect(transformedResponse).to.have.property('tags')
-          expect(transformedResponse.tags).to.deep.equal({
-            items: [
-              {
-                href: '/move/12345#concealed_items',
-                text: 'Concealed items',
-                classes: 'app-tag--destructive',
-                sortOrder: 1,
-              },
-              {
-                href: '/move/12345#other_risks',
-                text: 'Any other risks',
-                classes: 'app-tag--destructive',
-                sortOrder: 1,
-              },
-              {
-                href: '/move/12345#health_issue',
-                text: 'Health issue',
-                classes: '',
-                sortOrder: 2,
-              },
-            ],
+          it('should translate gender label', function() {
+            expect(i18n.t.getCall(2)).to.be.calledWithExactly(
+              'fields::gender.label'
+            )
           })
-        })
-      })
 
-      describe('translations', function() {
-        it('should translate age label', function() {
-          expect(i18n.t.firstCall).to.be.calledWithExactly('age')
-        })
+          it('should translate move reference', function() {
+            expect(i18n.t.getCall(3)).to.be.calledWithExactly(
+              'moves::move_reference',
+              { reference: 'AB12FS45' }
+            )
+          })
 
-        it('should translate date of birth label', function() {
-          expect(i18n.t.secondCall).to.be.calledWithExactly(
-            'fields::date_of_birth.label'
-          )
-        })
-
-        it('should translate gender label', function() {
-          expect(i18n.t.thirdCall).to.be.calledWithExactly(
-            'fields::gender.label'
-          )
-        })
-
-        it('should translate move reference', function() {
-          expect(i18n.t.getCall(3)).to.be.calledWithExactly(
-            'moves::move_reference',
-            { reference: 'AB12FS45' }
-          )
-        })
-
-        it('should translate correct number of times', function() {
-          expect(i18n.t).to.be.callCount(4)
+          it('should translate correct number of times', function() {
+            expect(i18n.t).to.be.callCount(4)
+          })
         })
       })
 
@@ -148,7 +154,7 @@ describe('Presenters', function() {
         let transformedResponse
 
         beforeEach(function() {
-          transformedResponse = moveToCardComponent({
+          transformedResponse = moveToCardComponent()({
             person: {
               last_name: 'Jones',
               first_names: 'Steve',
@@ -170,7 +176,7 @@ describe('Presenters', function() {
         let transformedResponse
 
         beforeEach(function() {
-          transformedResponse = moveToCardComponent({
+          transformedResponse = moveToCardComponent()({
             person: {
               last_name: 'Jones',
               first_names: 'Steve',
@@ -281,7 +287,7 @@ describe('Presenters', function() {
             },
           }
 
-          transformedResponse = moveToCardComponent(mockMove)
+          transformedResponse = moveToCardComponent()(mockMove)
         })
 
         it('should correctly filter', function() {
@@ -323,6 +329,66 @@ describe('Presenters', function() {
             },
           ])
         })
+      })
+    })
+
+    context('with meta disabled', function() {
+      beforeEach(function() {
+        transformedResponse = moveToCardComponent({
+          showMeta: false,
+        })(mockMove)
+      })
+
+      it('should not contain meta items', function() {
+        expect(transformedResponse).to.have.property('meta')
+        expect(transformedResponse.meta.items).to.be.undefined
+      })
+
+      it('should contain href', function() {
+        expect(transformedResponse).to.have.property('href')
+      })
+
+      it('should contain title', function() {
+        expect(transformedResponse).to.have.property('title')
+      })
+
+      it('should contain caption', function() {
+        expect(transformedResponse).to.have.property('caption')
+      })
+
+      it('should contain tags', function() {
+        expect(transformedResponse).to.have.property('tags')
+        expect(transformedResponse.tags.items.length).to.equal(3)
+      })
+    })
+
+    context('with tag disabled', function() {
+      beforeEach(function() {
+        transformedResponse = moveToCardComponent({
+          showTags: false,
+        })(mockMove)
+      })
+
+      it('should not contain tags items', function() {
+        expect(transformedResponse).to.have.property('tags')
+        expect(transformedResponse.tags.items).to.be.undefined
+      })
+
+      it('should contain href', function() {
+        expect(transformedResponse).to.have.property('href')
+      })
+
+      it('should contain title', function() {
+        expect(transformedResponse).to.have.property('title')
+      })
+
+      it('should contain caption', function() {
+        expect(transformedResponse).to.have.property('caption')
+      })
+
+      it('should contain meta', function() {
+        expect(transformedResponse).to.have.property('meta')
+        expect(transformedResponse.meta.items.length).to.equal(2)
       })
     })
   })

--- a/common/presenters/moves-by-to-location.js
+++ b/common/presenters/moves-by-to-location.js
@@ -29,7 +29,7 @@ module.exports = function movesByToLocation(data) {
 
   Object.entries(groupedByLocation).forEach(([locationId, moves]) => {
     locations.push({
-      items: moves.map(moveToCardComponent),
+      items: moves.map(moveToCardComponent()),
       location: get(moves[0], 'to_location.title'),
     })
   })

--- a/common/presenters/moves-by-to-location.test.js
+++ b/common/presenters/moves-by-to-location.test.js
@@ -2,7 +2,9 @@ const proxyquire = require('proxyquire')
 
 const i18n = require('../../config/i18n')
 const movesByToLocation = proxyquire('./moves-by-to-location', {
-  './move-to-card-component': sinon.stub().returnsArg(0),
+  './move-to-card-component': sinon
+    .stub()
+    .callsFake(() => sinon.stub().returnsArg(0)),
 })
 const mockMoves = require('../../test/fixtures/moves.json')
 

--- a/common/services/move.js
+++ b/common/services/move.js
@@ -15,7 +15,7 @@ const moveService = {
     })
   },
 
-  getMoves({ filter, combinedData = [], page = 1 } = {}) {
+  getAll({ filter, combinedData = [], page = 1 } = {}) {
     return apiClient
       .findAll('move', {
         ...filter,
@@ -33,7 +33,7 @@ const moveService = {
           }))
         }
 
-        return moveService.getMoves({
+        return moveService.getAll({
           filter,
           combinedData: moves,
           page: page + 1,
@@ -41,8 +41,8 @@ const moveService = {
       })
   },
 
-  getRequestedMovesByDateAndLocation(moveDate, locationId) {
-    return moveService.getMoves({
+  getRequestedByDateAndLocation(moveDate, locationId) {
+    return moveService.getAll({
       filter: {
         'filter[status]': 'requested',
         'filter[date_from]': moveDate,
@@ -52,7 +52,7 @@ const moveService = {
     })
   },
 
-  getMoveById(id) {
+  getById(id) {
     if (!id) {
       return Promise.reject(new Error('No move ID supplied'))
     }

--- a/common/services/move.js
+++ b/common/services/move.js
@@ -41,13 +41,26 @@ const moveService = {
       })
   },
 
-  getRequestedByDateAndLocation(moveDate, locationId) {
+  getRequested({ moveDate, fromLocationId, toLocationId } = {}) {
     return moveService.getAll({
       filter: {
         'filter[status]': 'requested',
         'filter[date_from]': moveDate,
         'filter[date_to]': moveDate,
-        'filter[from_location_id]': locationId,
+        'filter[from_location_id]': fromLocationId,
+        'filter[to_location_id]': toLocationId,
+      },
+    })
+  },
+
+  getCancelled({ moveDate, fromLocationId, toLocationId } = {}) {
+    return moveService.getAll({
+      filter: {
+        'filter[status]': 'cancelled',
+        'filter[date_from]': moveDate,
+        'filter[date_to]': moveDate,
+        'filter[from_location_id]': fromLocationId,
+        'filter[to_location_id]': toLocationId,
       },
     })
   },

--- a/common/services/move.test.js
+++ b/common/services/move.test.js
@@ -263,7 +263,7 @@ describe('Move Service', function() {
     })
   })
 
-  describe('#getRequestedByDateAndLocation()', function() {
+  describe('#getRequested()', function() {
     const mockResponse = []
     let moves
 
@@ -273,91 +273,114 @@ describe('Move Service', function() {
 
     context('without arguments', function() {
       beforeEach(async function() {
-        moves = await moveService.getRequestedByDateAndLocation()
+        moves = await moveService.getRequested()
       })
 
       it('should call getAll methods', function() {
-        expect(moveService.getAll).to.be.calledOnce
+        expect(moveService.getAll).to.be.calledOnceWithExactly({
+          filter: {
+            'filter[status]': 'requested',
+            'filter[date_from]': undefined,
+            'filter[date_to]': undefined,
+            'filter[from_location_id]': undefined,
+            'filter[to_location_id]': undefined,
+          },
+        })
       })
 
       it('should return moves', function() {
         expect(moves).to.deep.equal(mockResponse)
-      })
-
-      describe('filters', function() {
-        let filters
-
-        beforeEach(function() {
-          filters = moveService.getAll.args[0][0].filter
-        })
-
-        it('should set status filter to "requested"', function() {
-          expect(filters).to.contain.property('filter[status]')
-          expect(filters['filter[status]']).to.equal('requested')
-        })
-
-        it('should set date_from filter to undefined', function() {
-          expect(filters).to.contain.property('filter[date_from]')
-          expect(filters['filter[date_from]']).to.equal(undefined)
-        })
-
-        it('should set date_to filter to undefined', function() {
-          expect(filters).to.contain.property('filter[date_to]')
-          expect(filters['filter[date_to]']).to.equal(undefined)
-        })
-
-        it('should set from_location_id filter to undefined', function() {
-          expect(filters).to.contain.property('filter[from_location_id]')
-          expect(filters['filter[from_location_id]']).to.equal(undefined)
-        })
       })
     })
 
     context('with arguments', function() {
       const mockMoveDate = '2019-10-10'
-      const mockLocationId = 'b695d0f0-af8e-4b97-891e-92020d6820b9'
+      const mockFromLocationId = 'b695d0f0-af8e-4b97-891e-92020d6820b9'
+      const mockToLocationId = 'b195d0f0-df8e-4b97-891e-92020d6820b9'
 
       beforeEach(async function() {
-        moves = await moveService.getRequestedByDateAndLocation(
-          mockMoveDate,
-          mockLocationId
-        )
+        moves = await moveService.getRequested({
+          moveDate: mockMoveDate,
+          fromLocationId: mockFromLocationId,
+          toLocationId: mockToLocationId,
+        })
       })
 
-      it('should call getAll methods', function() {
-        expect(moveService.getAll).to.be.calledOnce
+      it('should call getAll with correct filter', function() {
+        expect(moveService.getAll).to.be.calledOnceWithExactly({
+          filter: {
+            'filter[status]': 'requested',
+            'filter[date_from]': mockMoveDate,
+            'filter[date_to]': mockMoveDate,
+            'filter[from_location_id]': mockFromLocationId,
+            'filter[to_location_id]': mockToLocationId,
+          },
+        })
       })
 
       it('should return moves', function() {
         expect(moves).to.deep.equal(mockResponse)
       })
+    })
+  })
 
-      describe('filters', function() {
-        let filters
+  describe('#getCancelled()', function() {
+    const mockResponse = []
+    let moves
 
-        beforeEach(function() {
-          filters = moveService.getAll.args[0][0].filter
+    beforeEach(async function() {
+      sinon.stub(moveService, 'getAll').resolves(mockResponse)
+    })
+
+    context('without arguments', function() {
+      beforeEach(async function() {
+        moves = await moveService.getCancelled()
+      })
+
+      it('should call getAll methods', function() {
+        expect(moveService.getAll).to.be.calledOnceWithExactly({
+          filter: {
+            'filter[status]': 'cancelled',
+            'filter[date_from]': undefined,
+            'filter[date_to]': undefined,
+            'filter[from_location_id]': undefined,
+            'filter[to_location_id]': undefined,
+          },
         })
+      })
 
-        it('should set status filter to "requested"', function() {
-          expect(filters).to.contain.property('filter[status]')
-          expect(filters['filter[status]']).to.equal('requested')
-        })
+      it('should return moves', function() {
+        expect(moves).to.deep.equal(mockResponse)
+      })
+    })
 
-        it('should set date_from filter to move date', function() {
-          expect(filters).to.contain.property('filter[date_from]')
-          expect(filters['filter[date_from]']).to.equal(mockMoveDate)
-        })
+    context('with arguments', function() {
+      const mockMoveDate = '2019-10-10'
+      const mockFromLocationId = 'b695d0f0-af8e-4b97-891e-92020d6820b9'
+      const mockToLocationId = 'c195d0f0-df8e-4b97-891e-92020d6820b9'
 
-        it('should set date_to filter to move date', function() {
-          expect(filters).to.contain.property('filter[date_to]')
-          expect(filters['filter[date_to]']).to.equal(mockMoveDate)
+      beforeEach(async function() {
+        moves = await moveService.getCancelled({
+          moveDate: mockMoveDate,
+          fromLocationId: mockFromLocationId,
+          toLocationId: mockToLocationId,
         })
+      })
 
-        it('should set from_location_id filter to location ID', function() {
-          expect(filters).to.contain.property('filter[from_location_id]')
-          expect(filters['filter[from_location_id]']).to.equal(mockLocationId)
+      it('should call getAll methods', function() {
+        expect(moveService.getAll).to.be.calledOnceWithExactly({
+          filter: {
+            'filter[status]': 'cancelled',
+            'filter[date_from]': mockMoveDate,
+            'filter[date_to]': mockMoveDate,
+            'filter[from_location_id]': mockFromLocationId,
+            'filter[to_location_id]': mockToLocationId,
+          },
         })
+      })
+
+      it('should return moves', function() {
+        expect(moves).to.deep.equal(mockResponse)
       })
     })
   })

--- a/common/services/move.test.js
+++ b/common/services/move.test.js
@@ -129,7 +129,7 @@ describe('Move Service', function() {
     })
   })
 
-  describe('#getLocations()', function() {
+  describe('#getAll()', function() {
     const mockResponse = {
       data: mockMoves,
       links: {},
@@ -156,7 +156,7 @@ describe('Move Service', function() {
 
       context('by default', function() {
         beforeEach(async function() {
-          moves = await moveService.getMoves()
+          moves = await moveService.getAll()
         })
 
         it('should call the API client once', function() {
@@ -181,7 +181,7 @@ describe('Move Service', function() {
 
       context('with filter', function() {
         beforeEach(async function() {
-          moves = await moveService.getMoves({
+          moves = await moveService.getAll({
             filter: mockFilter,
           })
         })
@@ -207,7 +207,7 @@ describe('Move Service', function() {
 
       context('by default', function() {
         beforeEach(async function() {
-          moves = await moveService.getMoves()
+          moves = await moveService.getAll()
         })
 
         it('should call the API client twice', function() {
@@ -239,7 +239,7 @@ describe('Move Service', function() {
 
       context('with filter', function() {
         beforeEach(async function() {
-          moves = await moveService.getMoves({
+          moves = await moveService.getAll({
             filter: mockFilter,
           })
         })
@@ -263,21 +263,21 @@ describe('Move Service', function() {
     })
   })
 
-  describe('#getRequestedMovesByDateAndLocation()', function() {
+  describe('#getRequestedByDateAndLocation()', function() {
     const mockResponse = []
     let moves
 
     beforeEach(async function() {
-      sinon.stub(moveService, 'getMoves').resolves(mockResponse)
+      sinon.stub(moveService, 'getAll').resolves(mockResponse)
     })
 
     context('without arguments', function() {
       beforeEach(async function() {
-        moves = await moveService.getRequestedMovesByDateAndLocation()
+        moves = await moveService.getRequestedByDateAndLocation()
       })
 
-      it('should call getMoves methods', function() {
-        expect(moveService.getMoves).to.be.calledOnce
+      it('should call getAll methods', function() {
+        expect(moveService.getAll).to.be.calledOnce
       })
 
       it('should return moves', function() {
@@ -288,7 +288,7 @@ describe('Move Service', function() {
         let filters
 
         beforeEach(function() {
-          filters = moveService.getMoves.args[0][0].filter
+          filters = moveService.getAll.args[0][0].filter
         })
 
         it('should set status filter to "requested"', function() {
@@ -318,14 +318,14 @@ describe('Move Service', function() {
       const mockLocationId = 'b695d0f0-af8e-4b97-891e-92020d6820b9'
 
       beforeEach(async function() {
-        moves = await moveService.getRequestedMovesByDateAndLocation(
+        moves = await moveService.getRequestedByDateAndLocation(
           mockMoveDate,
           mockLocationId
         )
       })
 
-      it('should call getMoves methods', function() {
-        expect(moveService.getMoves).to.be.calledOnce
+      it('should call getAll methods', function() {
+        expect(moveService.getAll).to.be.calledOnce
       })
 
       it('should return moves', function() {
@@ -336,7 +336,7 @@ describe('Move Service', function() {
         let filters
 
         beforeEach(function() {
-          filters = moveService.getMoves.args[0][0].filter
+          filters = moveService.getAll.args[0][0].filter
         })
 
         it('should set status filter to "requested"', function() {
@@ -362,10 +362,10 @@ describe('Move Service', function() {
     })
   })
 
-  describe('#getMoveById()', function() {
+  describe('#getById()', function() {
     context('without move ID', function() {
       it('should reject with error', function() {
-        return expect(moveService.getMoveById()).to.be.rejectedWith(
+        return expect(moveService.getById()).to.be.rejectedWith(
           'No move ID supplied'
         )
       })
@@ -381,7 +381,7 @@ describe('Move Service', function() {
       beforeEach(async function() {
         sinon.stub(apiClient, 'find').resolves(mockResponse)
 
-        move = await moveService.getMoveById(mockId)
+        move = await moveService.getById(mockId)
       })
 
       it('should call update method with data', function() {

--- a/common/services/reference-data.test.js
+++ b/common/services/reference-data.test.js
@@ -361,7 +361,7 @@ describe('Reference Data Service', function() {
         locations = await referenceDataService.getLocationByNomisAgencyId()
       })
 
-      it('should call getMoves methods', function() {
+      it('should call getLocations methods', function() {
         expect(referenceDataService.getLocations).to.be.calledOnce
       })
 
@@ -392,7 +392,7 @@ describe('Reference Data Service', function() {
         )
       })
 
-      it('should call getMoves methods', function() {
+      it('should call getLocations methods', function() {
         expect(referenceDataService.getLocations).to.be.calledOnce
       })
 

--- a/common/templates/layouts/base.njk
+++ b/common/templates/layouts/base.njk
@@ -4,6 +4,7 @@
 {% from "govuk/components/back-link/macro.njk"         import govukBackLink %}
 {% from "govuk/components/button/macro.njk"            import govukButton %}
 {% from "govuk/components/checkboxes/macro.njk"        import govukCheckboxes %}
+{% from "govuk/components/details/macro.njk"           import govukDetails %}
 {% from "govuk/components/error-summary/macro.njk"     import govukErrorSummary %}
 {% from "govuk/components/input/macro.njk"             import govukInput %}
 {% from "govuk/components/panel/macro.njk"             import govukPanel %}

--- a/locales/en/default.json
+++ b/locales/en/default.json
@@ -1,5 +1,6 @@
 {
   "phase_banner": "This is a new service",
   "phase_banner_with_feedback": "This is a new service – your <a class=\"govuk-link\" href=\"{{url}}\">feedback</a> will help us to improve it.",
-  "age": "Age"
+  "age": "Age",
+  "age_with_date_of_birth": "{{date_of_birth}} (Age {{age}})"
 }

--- a/locales/en/moves.json
+++ b/locales/en/moves.json
@@ -68,6 +68,7 @@
   },
   "dashboard": {
     "upcoming_moves": "Upcoming moves for {{date}}",
+    "cancelled_moves": "{{count}} cancelled moves",
     "move_to": "Move to",
     "no_results": "No moves scheduled"
   },


### PR DESCRIPTION
This set of changes includes cancelled moves on the dashboard so that a user can still see and view the details of cancelled moves.

## What it looks like

### With requested and cancelled moves
![localhost_3000_moves_move-date=2019-09-06 (2)](https://user-images.githubusercontent.com/3327997/64438108-6991bb00-d0bf-11e9-8d4f-0ea2033078aa.png)
![localhost_3000_moves_move-date=2019-09-06 (3)](https://user-images.githubusercontent.com/3327997/64438135-731b2300-d0bf-11e9-8a39-157ef600cf86.png)

### With only cancelled moves
![localhost_3000_moves_move-date=2019-09-07 (1)](https://user-images.githubusercontent.com/3327997/64438181-8f1ec480-d0bf-11e9-8431-de7e3d600ae7.png)

### With only requested moves
![localhost_3000_moves_move-date=2019-09-08](https://user-images.githubusercontent.com/3327997/64438240-ad84c000-d0bf-11e9-980b-15d9924a3564.png)
