### PR TITLE
Ensure person service transforms the response

### DIFF
--- a/common/services/person.js
+++ b/common/services/person.js
@@ -55,6 +55,7 @@ const personService = {
     return apiClient
       .create('person', personService.format(data))
       .then(response => response.data)
+      .then(person => personService.transform(person))
   },
 
   update(data) {
@@ -65,6 +66,7 @@ const personService = {
     return apiClient
       .update('person', personService.format(data))
       .then(response => response.data)
+      .then(person => personService.transform(person))
   },
 }
 

--- a/common/services/person.test.js
+++ b/common/services/person.test.js
@@ -356,6 +356,7 @@ describe('Person Service', function() {
 
     beforeEach(async function() {
       sinon.stub(apiClient, 'create').resolves(mockResponse)
+      sinon.stub(personService, 'transform').returnsArg(0)
       sinon.stub(personService, 'format').returnsArg(0)
 
       person = await personService.create(mockData)
@@ -367,6 +368,12 @@ describe('Person Service', function() {
 
     it('should format data', function() {
       expect(personService.format).to.be.calledOnceWithExactly(mockData)
+    })
+
+    it('should transform response data', function() {
+      expect(personService.transform).to.be.calledOnceWithExactly(
+        mockResponse.data
+      )
     })
 
     it('should return data property', function() {
@@ -386,6 +393,7 @@ describe('Person Service', function() {
 
     beforeEach(async function() {
       sinon.stub(apiClient, 'update').resolves(mockResponse)
+      sinon.stub(personService, 'transform').returnsArg(0)
       sinon.stub(personService, 'format').returnsArg(0)
     })
 
@@ -414,6 +422,12 @@ describe('Person Service', function() {
 
       it('should format data', function() {
         expect(personService.format).to.be.calledOnceWithExactly(mockData)
+      })
+
+      it('should transform response data', function() {
+        expect(personService.transform).to.be.calledOnceWithExactly(
+          mockResponse.data
+        )
       })
 
       it('should return data property', function() {


### PR DESCRIPTION
The transformation of the person model response was moved to a
shared place so that we can do common things with each Person.

This was added to the Move service where a person exists on a move
but it wasn't added to the Person service.

This change ensure that all responses from the API regarding creating
or updating a person transform the response in the same way.

This relates to #211 