### PR TITLE
Fix for prison recall selection

### DIFF
--- a/app/move/controllers/create/move-details.test.js
+++ b/app/move/controllers/create/move-details.test.js
@@ -50,7 +50,6 @@ describe('Move controllers', function() {
               options: {
                 fields: {
                   to_location_court_appearance: {},
-                  to_location_prison_recall: {},
                   date_type: {
                     items: [
                       {
@@ -279,14 +278,13 @@ describe('Move controllers', function() {
           req.form.values = {
             move_type: 'prison_recall',
             to_location: '',
-            to_location_prison_recall: '67890',
           }
 
           controller.process(req, {}, nextSpy)
         })
 
         it('should set to_location based on location type', function() {
-          expect(req.form.values.to_location).to.equal('67890')
+          expect(req.form.values.to_location).to.be.undefined
         })
 
         it('should call next without error', function() {

--- a/app/move/fields/create.js
+++ b/app/move/fields/create.js
@@ -178,7 +178,6 @@ module.exports = {
   to_location_court_appearance: toLocationType('court_appearance', {
     validate: 'required',
   }),
-  to_location_prison_recall: toLocationType('prison_recall'),
   additional_information: {
     skip: true,
     rows: 3,

--- a/app/move/steps/create.js
+++ b/app/move/steps/create.js
@@ -45,7 +45,6 @@ module.exports = {
       'to_location',
       'move_type',
       'to_location_court_appearance',
-      'to_location_prison_recall',
       'additional_information',
       'date',
       'date_type',

--- a/locales/en/fields.json
+++ b/locales/en/fields.json
@@ -41,9 +41,6 @@
       }
     }
   },
-  "to_location_prison_recall": {
-    "label": "Name of prison"
-  },
   "to_location_court_appearance": {
     "label": "Name of court"
   },


### PR DESCRIPTION
The move details form errors out because it is looking for a value that was being set by the recently removed prison recall select.

This work removes the need for a value from the prison recall select and
update tests where required.
