### PR TITLE
[P4-650] Ensure a user can only see locations they have access to

### DIFF
--- a/app/moves/controllers/list.js
+++ b/app/moves/controllers/list.js
@@ -1,19 +1,12 @@
-const { format, addDays, subDays } = require('date-fns')
 const { get } = require('lodash')
 
-const { getQueryString } = require('../../../common/lib/request')
 const permissions = require('../../../common/middleware/permissions')
 const presenters = require('../../../common/presenters')
 
 module.exports = function list(req, res) {
-  const { moveDate, cancelledMovesByDate, requestedMovesByDate } = res.locals
-  const today = format(new Date(), 'YYYY-MM-DD')
-  const previousDay = format(subDays(moveDate, 1), 'YYYY-MM-DD')
-  const nextDay = format(addDays(moveDate, 1), 'YYYY-MM-DD')
-  const canViewMove = permissions.check(
-    'move:view',
-    get(req.session, 'user.permissions')
-  )
+  const { cancelledMovesByDate, requestedMovesByDate } = res.locals
+  const userPermissions = get(req.session, 'user.permissions')
+  const canViewMove = permissions.check('move:view', userPermissions)
   const template = canViewMove ? 'moves/views/list' : 'moves/views/download'
   const locals = {
     pageTitle: 'moves::dashboard.upcoming_moves',
@@ -24,17 +17,6 @@ module.exports = function list(req, res) {
         showTags: false,
       })
     ),
-    pagination: {
-      todayUrl: getQueryString(req.query, {
-        'move-date': today,
-      }),
-      nextUrl: getQueryString(req.query, {
-        'move-date': nextDay,
-      }),
-      prevUrl: getQueryString(req.query, {
-        'move-date': previousDay,
-      }),
-    },
   }
 
   res.render(template, locals)

--- a/app/moves/controllers/list.test.js
+++ b/app/moves/controllers/list.test.js
@@ -14,29 +14,22 @@ const mockCancelledMovesByDate = [
 
 describe('Moves controllers', function() {
   describe('#list()', function() {
-    const mockMoveDate = '2019-10-10'
     let req, res, moveToCardComponentMapStub
 
     beforeEach(function() {
       moveToCardComponentMapStub = sinon.stub().returnsArg(0)
-      this.clock = sinon.useFakeTimers(new Date(mockMoveDate).getTime())
       sinon.stub(presenters, 'movesByToLocation').returnsArg(0)
       sinon
         .stub(presenters, 'moveToCardComponent')
         .callsFake(() => moveToCardComponentMapStub)
-      req = { query: {} }
+      req = {}
       res = {
         locals: {
-          moveDate: mockMoveDate,
           requestedMovesByDate: mockRequestedMovesByDate,
           cancelledMovesByDate: mockCancelledMovesByDate,
         },
         render: sinon.spy(),
       }
-    })
-
-    afterEach(function() {
-      this.clock.restore()
     })
 
     describe('template params', function() {
@@ -46,14 +39,6 @@ describe('Moves controllers', function() {
 
       it('should contain a page title', function() {
         expect(res.render.args[0][1]).to.have.property('pageTitle')
-      })
-
-      it('should contain pagination with correct links', function() {
-        const params = res.render.args[0][1]
-        expect(params).to.have.property('pagination')
-        expect(params.pagination.todayUrl).to.equal('?move-date=2019-10-10')
-        expect(params.pagination.nextUrl).to.equal('?move-date=2019-10-11')
-        expect(params.pagination.prevUrl).to.equal('?move-date=2019-10-09')
       })
 
       it('should call movesByToLocation presenter', function() {

--- a/app/moves/index.js
+++ b/app/moves/index.js
@@ -9,6 +9,7 @@ const {
   storeQuery,
   setMoveDate,
   setFromLocation,
+  setPagination,
   setMovesByDate,
 } = require('./middleware')
 
@@ -26,12 +27,14 @@ router.get(
   redirectUsers,
   protectRoute('moves:view:all'),
   setMovesByDate,
+  setPagination,
   list
 )
 router.get(
   `/:locationId(${uuidRegex})`,
   protectRoute('moves:view:by_location'),
   setMovesByDate,
+  setPagination,
   list
 )
 router.get(

--- a/app/moves/middleware.js
+++ b/app/moves/middleware.js
@@ -1,6 +1,6 @@
 const queryString = require('query-string')
 const { format, addDays, subDays } = require('date-fns')
-const { get } = require('lodash')
+const { find, get } = require('lodash')
 
 const { getQueryString } = require('../../common/lib/request')
 const moveService = require('../../common/services/move')
@@ -41,6 +41,16 @@ module.exports = {
     next()
   },
   setFromLocation: (req, res, next, locationId) => {
+    const userLocations = get(req.session, 'user.locations')
+    const location = find(userLocations, { id: locationId })
+
+    if (!location) {
+      const error = new Error('Location not found')
+      error.statusCode = 404
+
+      return next(error)
+    }
+
     res.locals.fromLocationId = locationId
     next()
   },

--- a/app/moves/middleware.js
+++ b/app/moves/middleware.js
@@ -1,9 +1,12 @@
 const queryString = require('query-string')
-const { format } = require('date-fns')
+const { format, addDays, subDays } = require('date-fns')
 const { get } = require('lodash')
 
+const { getQueryString } = require('../../common/lib/request')
 const moveService = require('../../common/services/move')
 const permissions = require('../../common/middleware/permissions')
+
+const moveDateFormat = 'YYYY-MM-DD'
 
 module.exports = {
   redirectUsers: (req, res, next) => {
@@ -33,12 +36,26 @@ module.exports = {
   },
   setMoveDate: (req, res, next) => {
     res.locals.moveDate =
-      req.query['move-date'] || format(new Date(), 'YYYY-MM-DD')
+      req.query['move-date'] || format(new Date(), moveDateFormat)
 
     next()
   },
   setFromLocation: (req, res, next, locationId) => {
     res.locals.fromLocationId = locationId
+    next()
+  },
+  setPagination: (req, res, next) => {
+    const { moveDate } = res.locals
+    const today = format(new Date(), moveDateFormat)
+    const previousDay = format(subDays(moveDate, 1), moveDateFormat)
+    const nextDay = format(addDays(moveDate, 1), moveDateFormat)
+
+    res.locals.pagination = {
+      todayUrl: getQueryString(req.query, { 'move-date': today }),
+      nextUrl: getQueryString(req.query, { 'move-date': nextDay }),
+      prevUrl: getQueryString(req.query, { 'move-date': previousDay }),
+    }
+
     next()
   },
   setMovesByDate: async (req, res, next) => {

--- a/app/moves/middleware.test.js
+++ b/app/moves/middleware.test.js
@@ -266,6 +266,79 @@ describe('Moves middleware', function() {
     })
   })
 
+  describe('#setPagination()', function() {
+    const mockMoveDate = '2019-10-10'
+    let req, res, nextSpy
+
+    beforeEach(function() {
+      this.clock = sinon.useFakeTimers(new Date(mockMoveDate).getTime())
+      res = {
+        locals: {
+          moveDate: mockMoveDate,
+        },
+      }
+      req = {
+        query: {},
+      }
+      nextSpy = sinon.spy()
+    })
+
+    afterEach(function() {
+      this.clock.restore()
+    })
+
+    context('with empty query', function() {
+      beforeEach(function() {
+        middleware.setPagination(req, res, nextSpy)
+      })
+
+      it('should contain pagination on locals', function() {
+        expect(res.locals).to.have.property('pagination')
+      })
+
+      it('should contain correct pagination links', function() {
+        const pagination = res.locals.pagination
+        expect(pagination.todayUrl).to.equal('?move-date=2019-10-10')
+        expect(pagination.nextUrl).to.equal('?move-date=2019-10-11')
+        expect(pagination.prevUrl).to.equal('?move-date=2019-10-09')
+      })
+
+      it('should call next', function() {
+        expect(nextSpy).to.be.calledOnceWithExactly()
+      })
+    })
+
+    context('with existing query', function() {
+      beforeEach(function() {
+        req.query = {
+          location: '12345',
+        }
+        middleware.setPagination(req, res, nextSpy)
+      })
+
+      it('should contain pagination on locals', function() {
+        expect(res.locals).to.have.property('pagination')
+      })
+
+      it('should contain correct pagination links', function() {
+        const pagination = res.locals.pagination
+        expect(pagination.todayUrl).to.equal(
+          '?location=12345&move-date=2019-10-10'
+        )
+        expect(pagination.nextUrl).to.equal(
+          '?location=12345&move-date=2019-10-11'
+        )
+        expect(pagination.prevUrl).to.equal(
+          '?location=12345&move-date=2019-10-09'
+        )
+      })
+
+      it('should call next', function() {
+        expect(nextSpy).to.be.calledOnceWithExactly()
+      })
+    })
+  })
+
   describe('#setMovesByDate()', function() {
     let res, nextSpy
     const mockCurrentLocation = '5555'


### PR DESCRIPTION
This change amends the location middleware to check that the user
can see this location before displaying the view.

Previously if a user knew the UUID of a location that they didn't have
access to they would've still been able to see that location's moves.

Now if a user accesses a UUID that is not found in their list of
permitted locations it will return a `404`.

**Note:** This change also includes a small refactor to the list controller.