### PR TITLE
[P4-661] Handle invalid move date

### DIFF
--- a/app/moves/controllers/list.js
+++ b/app/moves/controllers/list.js
@@ -4,7 +4,7 @@ const permissions = require('../../../common/middleware/permissions')
 const presenters = require('../../../common/presenters')
 
 module.exports = function list(req, res) {
-  const { cancelledMovesByDate, requestedMovesByDate } = res.locals
+  const { cancelledMovesByDate = [], requestedMovesByDate = [] } = res.locals
   const userPermissions = get(req.session, 'user.permissions')
   const canViewMove = permissions.check('move:view', userPermissions)
   const template = canViewMove ? 'moves/views/list' : 'moves/views/download'

--- a/app/moves/controllers/list.test.js
+++ b/app/moves/controllers/list.test.js
@@ -24,41 +24,61 @@ describe('Moves controllers', function() {
         .callsFake(() => moveToCardComponentMapStub)
       req = {}
       res = {
-        locals: {
-          requestedMovesByDate: mockRequestedMovesByDate,
-          cancelledMovesByDate: mockCancelledMovesByDate,
-        },
+        locals: {},
         render: sinon.spy(),
       }
     })
 
     describe('template params', function() {
-      beforeEach(function() {
-        controller(req, res)
-      })
+      context('with moves', function() {
+        beforeEach(function() {
+          res.locals.requestedMovesByDate = mockRequestedMovesByDate
+          res.locals.cancelledMovesByDate = mockCancelledMovesByDate
 
-      it('should contain a page title', function() {
-        expect(res.render.args[0][1]).to.have.property('pageTitle')
-      })
-
-      it('should call movesByToLocation presenter', function() {
-        expect(presenters.movesByToLocation).to.be.calledOnceWithExactly(
-          mockRequestedMovesByDate
-        )
-      })
-
-      it('should call moveToCardComponent presenter', function() {
-        expect(presenters.moveToCardComponent).to.be.calledOnceWithExactly({
-          showMeta: false,
-          showTags: false,
+          controller(req, res)
         })
-        expect(moveToCardComponentMapStub).to.be.calledTwice
+
+        it('should contain a page title', function() {
+          expect(res.render.args[0][1]).to.have.property('pageTitle')
+        })
+
+        it('should call movesByToLocation presenter', function() {
+          expect(presenters.movesByToLocation).to.be.calledOnceWithExactly(
+            mockRequestedMovesByDate
+          )
+        })
+
+        it('should call moveToCardComponent presenter', function() {
+          expect(presenters.moveToCardComponent).to.be.calledOnceWithExactly({
+            showMeta: false,
+            showTags: false,
+          })
+          expect(moveToCardComponentMapStub).to.be.calledTwice
+        })
+
+        it('should contain destinations property', function() {
+          const params = res.render.args[0][1]
+          expect(params).to.have.property('destinations')
+          expect(params.destinations).to.deep.equal(mockRequestedMovesByDate)
+        })
       })
 
-      it('should contain destinations property', function() {
-        const params = res.render.args[0][1]
-        expect(params).to.have.property('destinations')
-        expect(params.destinations).to.deep.equal(mockRequestedMovesByDate)
+      context('without moves', function() {
+        beforeEach(function() {
+          controller(req, res)
+        })
+
+        it('should call movesByToLocation presenter', function() {
+          expect(presenters.movesByToLocation).to.be.calledOnceWithExactly([])
+        })
+
+        it('should call moveToCardComponent presenter', function() {
+          expect(presenters.moveToCardComponent).to.be.calledOnceWithExactly({
+            showMeta: false,
+            showTags: false,
+          })
+          expect(moveToCardComponentMapStub).not.to.be.called
+        })
       })
     })
 

--- a/app/moves/middleware.js
+++ b/app/moves/middleware.js
@@ -1,5 +1,11 @@
 const queryString = require('query-string')
-const { format, addDays, subDays } = require('date-fns')
+const {
+  format,
+  addDays,
+  subDays,
+  isValid: isValidDate,
+  parse: parseDate,
+} = require('date-fns')
 const { find, get } = require('lodash')
 
 const { getQueryString } = require('../../common/lib/request')
@@ -35,8 +41,14 @@ module.exports = {
     next()
   },
   setMoveDate: (req, res, next) => {
-    res.locals.moveDate =
-      req.query['move-date'] || format(new Date(), moveDateFormat)
+    const date = parseDate(req.query['move-date'] || new Date())
+    const validDate = isValidDate(date)
+
+    if (!validDate) {
+      return res.redirect(req.baseUrl)
+    }
+
+    res.locals.moveDate = format(date, moveDateFormat)
 
     next()
   },

--- a/app/moves/middleware.test.js
+++ b/app/moves/middleware.test.js
@@ -190,7 +190,10 @@ describe('Moves middleware', function() {
     let req, res, nextSpy
 
     beforeEach(function() {
-      res = { locals: {} }
+      res = {
+        locals: {},
+        redirect: sinon.stub(),
+      }
       nextSpy = sinon.spy()
     })
 
@@ -220,23 +223,50 @@ describe('Moves middleware', function() {
     })
 
     context('when move date exists in query', function() {
-      beforeEach(function() {
-        req = {
-          query: {
-            'move-date': '2019-10-10',
-          },
-        }
+      context('with valid move date', function() {
+        beforeEach(function() {
+          req = {
+            query: {
+              'move-date': '2019-10-10',
+            },
+          }
 
-        middleware.setMoveDate(req, res, nextSpy)
+          middleware.setMoveDate(req, res, nextSpy)
+        })
+
+        it('should set move date to query value', function() {
+          expect(res.locals).to.have.property('moveDate')
+          expect(res.locals.moveDate).to.equal('2019-10-10')
+        })
+
+        it('should call next', function() {
+          expect(nextSpy).to.be.calledOnceWithExactly()
+        })
       })
 
-      it('should set move date to query value', function() {
-        expect(res.locals).to.have.property('moveDate')
-        expect(res.locals.moveDate).to.equal('2019-10-10')
-      })
+      context('with invalid move date', function() {
+        beforeEach(function() {
+          req = {
+            baseUrl: '/req-base',
+            query: {
+              'move-date': 'Invalid date',
+            },
+          }
 
-      it('should call next', function() {
-        expect(nextSpy).to.be.calledOnceWithExactly()
+          middleware.setMoveDate(req, res, nextSpy)
+        })
+
+        it('should redirect to base url', function() {
+          expect(res.redirect).to.be.calledOnceWithExactly('/req-base')
+        })
+
+        it('should not set move date', function() {
+          expect(res.locals).not.to.have.property('moveDate')
+        })
+
+        it('should not call next', function() {
+          expect(nextSpy).not.to.be.called
+        })
       })
     })
   })

--- a/app/moves/views/list.njk
+++ b/app/moves/views/list.njk
@@ -1,11 +1,5 @@
 {% extends "./_layout.njk" %}
 
-{% block pageTitle %}
-  {{ t(pageTitle, {
-    date: moveDate | formatDateAsRelativeDay
-  }) }}
-{% endblock %}
-
 {% block headerActions %}
   {% if canAccess('move:create') %}
     {{ govukButton({


### PR DESCRIPTION
This ensures a move date is valid before doing anything else with it.

In the instance that a move date is not valid it will redirect back
to the base URL of the moves app so that the user is redirected to
the default dashboard.