### PR TITLE
[P4-437] - Use translations for assessment questions

### DIFF
--- a/app/move/controllers/create/assessment.js
+++ b/app/move/controllers/create/assessment.js
@@ -24,6 +24,7 @@ class AssessmentController extends CreateBaseController {
               field.items = response
                 .filter(referenceDataHelpers.filterDisabled())
                 .map(fieldHelpers.mapAssessmentQuestionToConditionalField)
+                .map(fieldHelpers.mapAssessmentQuestionToTranslation)
                 .map(fieldHelpers.mapReferenceDataToOption)
             })
         })

--- a/common/helpers/field.js
+++ b/common/helpers/field.js
@@ -1,11 +1,16 @@
 const { cloneDeep, fromPairs, get, set } = require('lodash')
 
 const componentService = require('../services/component')
+const i18n = require('../../config/i18n')
 
-function mapReferenceDataToOption({ id, title, key, conditional }) {
+function mapReferenceDataToOption({ id, title, key, conditional, hint }) {
   const option = {
     value: id,
     text: title,
+  }
+
+  if (hint) {
+    option.hint = { text: hint }
   }
 
   if (key) {
@@ -17,6 +22,18 @@ function mapReferenceDataToOption({ id, title, key, conditional }) {
   }
 
   return option
+}
+
+function mapAssessmentQuestionToTranslation(item) {
+  const { category, key, title } = item
+  const hintKey = `fields::${category}.items.${key}.hint`
+  const labelKey = `fields::${category}.items.${key}.label`
+
+  return {
+    ...item,
+    hint: i18n.exists(hintKey) ? hintKey : undefined,
+    title: i18n.exists(labelKey) ? labelKey : title,
+  }
 }
 
 function mapAssessmentQuestionToConditionalField(item) {
@@ -161,6 +178,7 @@ function insertItemConditional({ key, field }) {
 }
 
 module.exports = {
+  mapAssessmentQuestionToTranslation,
   mapReferenceDataToOption,
   mapAssessmentQuestionToConditionalField,
   renderConditionalFields,

--- a/common/helpers/field.test.js
+++ b/common/helpers/field.test.js
@@ -1,6 +1,7 @@
 const { cloneDeep, set } = require('lodash')
 
 const {
+  mapAssessmentQuestionToTranslation,
   mapReferenceDataToOption,
   mapAssessmentQuestionToConditionalField,
   renderConditionalFields,
@@ -12,6 +13,7 @@ const {
 } = require('./field')
 
 const componentService = require('../services/component')
+const i18n = require('../../config/i18n')
 
 describe('Form helpers', function() {
   describe('#mapReferenceDataToOption()', function() {
@@ -57,6 +59,69 @@ describe('Form helpers', function() {
           key: 'unique_key',
           value: '416badc8-e3ac-47d7-b116-ae3f5b2e4697',
           text: 'Foo',
+        })
+      })
+    })
+
+    context('with hint property', function() {
+      it('should return correctly formatted option', function() {
+        const option = mapReferenceDataToOption({
+          key: 'unique_key',
+          id: '416badc8-e3ac-47d7-b116-ae3f5b2e4697',
+          title: 'Foo',
+          hint: 'eat more vegetables',
+        })
+
+        expect(option).to.deep.equal({
+          key: 'unique_key',
+          value: '416badc8-e3ac-47d7-b116-ae3f5b2e4697',
+          text: 'Foo',
+          hint: {
+            text: 'eat more vegetables',
+          },
+        })
+      })
+    })
+  })
+
+  describe('#mapAssessmentQuestionToTranslation()', function() {
+    const mockItem = {
+      title: 'example title',
+      category: 'mock-category',
+      key: 'mock-key',
+      hint: 'mock hint',
+    }
+
+    context('without available translations', function() {
+      beforeEach(function() {
+        sinon.stub(i18n, 'exists').returns(false)
+      })
+
+      it('should return unchanged item', function() {
+        const option = mapAssessmentQuestionToTranslation(mockItem)
+
+        expect(option).to.deep.equal({
+          title: 'example title',
+          category: 'mock-category',
+          hint: undefined,
+          key: 'mock-key',
+        })
+      })
+    })
+
+    context('with available translations', function() {
+      beforeEach(function() {
+        sinon.stub(i18n, 'exists').returns(true)
+      })
+
+      it('should return item with translation strings', function() {
+        const option = mapAssessmentQuestionToTranslation(mockItem)
+
+        expect(option).to.deep.equal({
+          title: 'fields::mock-category.items.mock-key.label',
+          category: 'mock-category',
+          hint: 'fields::mock-category.items.mock-key.hint',
+          key: 'mock-key',
         })
       })
     })


### PR DESCRIPTION
## Feature

If translations are available in our locales file then use these in the application. This means we can provide:
- form options `hint`locale translations
- override `title` text sent from the `BE` `API` with `label` locale translations

## Screenshots

### Before
![Screenshot 2019-09-10 at 17 38 52](https://user-images.githubusercontent.com/2305016/64633471-299a4300-d3f3-11e9-91d3-b9c575f48f5f.png)

### After
![Screenshot 2019-09-10 at 17 38 24](https://user-images.githubusercontent.com/2305016/64633504-3454d800-d3f3-11e9-8ec5-648e61a3b48c.png)

