### PR TITLE
Add "Error:" page title prefix to form error pages

### DIFF
--- a/common/templates/form-wizard.njk
+++ b/common/templates/form-wizard.njk
@@ -3,6 +3,9 @@
 {% set additionalContainerClass = "sticky-sidebar-container" %}
 
 {% block pageTitle %}
+  {%- if errors.errorList.length -%}
+  {{ t("validation::page_title_prefix") }}:
+  {%- endif %}
   {{ t(options.pageTitle) }} - {{ t(options.journeyPageTitle) }}
 {% endblock %}
 

--- a/locales/en/validation.json
+++ b/locales/en/validation.json
@@ -1,4 +1,5 @@
 {
+  "page_title_prefix": "Error",
   "summary": {
     "heading": "There is a problem with this page"
   },


### PR DESCRIPTION
The GOV.UK Design System suggests using a prefix in the page title
so that screen readers will read out that there is an error straight
away:
https://design-system.service.gov.uk/components/error-summary/#how-it-works

This also allows us to track error pages separately in analytics
by using the page title as a secondary dimension.