### PR TITLE
[P4-670] Alert groupings

### DIFF
--- a/app/move/views/_includes/assessment.njk
+++ b/app/move/views/_includes/assessment.njk
@@ -1,34 +1,43 @@
-{% for section in assessment %}
+{% for assessmentCategory in assessment %}
   <h2 class="govuk-heading-m govuk-!-margin-bottom-2 govuk-!-margin-top-7">
-    {{ t("moves::assessment.categories." + section.category + ".heading") }}
+    {{ t("moves::assessment.categories." + assessmentCategory.key + ".heading") }}
   </h2>
 
-  {% for item in section.items %}
+  {% for title, answers in assessmentCategory.answersByTitle %}
     {% call appPanel({
       attributes: {
-        id: item.title
+        id: title | kebabcase
       },
       tag: {
-        text: item.title,
-        classes: section.tagClass
+        text: title,
+        classes: assessmentCategory.tagClass
       }
     }) %}
-      {% set itemHtml %}
-        {{ item.comments if item.comments else '' }}
 
-        {% if item.created_at %}
-          <div class="govuk-!-margin-top-2 govuk-!-font-size-16">
-            {{ item.created_at | formatDateWithDay }}
-          </div>
-        {% endif %}
-      {% endset %}
+      {% set items = [] %}
+      {% for answer in answers %}
+        {% set answerHtml %}
+          {% if answer.nomis_alert_description %}
+            <h4 class="govuk-!-margin-top-0 govuk-!-margin-bottom-2">
+              {{ answer.nomis_alert_description }}
+            </h4>
+          {% endif %}
+
+          {{ answer.comments if answer.comments }}
+
+          {% if answer.created_at %}
+            <div class="govuk-!-margin-top-2 govuk-!-font-size-16">
+              {{ answer.created_at | formatDateWithDay }}
+            </div>
+          {% endif %}
+        {% endset %}
+
+        {% set items = (items.push({ value: { html: answerHtml } }), items) %}
+      {% endfor %}
 
       {{ appMetaList({
-        items: [{
-          value: {
-            html: itemHtml
-          }
-        }]
+        classes: "app-meta-list--divider",
+        items: items
       }) }}
     {% endcall %}
   {% else %}
@@ -36,7 +45,7 @@
       classes: "app-message--muted",
       allowDismiss: false,
       content: {
-        html: t("moves::assessment.categories." + section.category + ".empty")
+        html: t("moves::assessment.categories." + assessmentCategory.key + ".empty")
       }
     }) }}
   {% endfor %}

--- a/app/move/views/_includes/assessment.njk
+++ b/app/move/views/_includes/assessment.njk
@@ -6,7 +6,7 @@
   {% for item in section.items %}
     {% call appPanel({
       attributes: {
-        id: item.key
+        id: item.title
       },
       tag: {
         text: item.title,

--- a/common/components/meta-list/_meta-list.scss
+++ b/common/components/meta-list/_meta-list.scss
@@ -10,6 +10,13 @@
   }
 }
 
+.app-meta-list--divider {
+  .app-meta-list__item + .app-meta-list__item {
+    border-top: 1px solid $govuk-border-colour;
+    padding-top: govuk-spacing(3);
+  }
+}
+
 .app-meta-list__key,
 .app-meta-list__value {
   display: block;

--- a/common/presenters/assessment-answer-to-tag.js
+++ b/common/presenters/assessment-answer-to-tag.js
@@ -1,11 +1,12 @@
+const { kebabCase } = require('lodash')
 const { TAG_CATEGORY_WHITELIST } = require('../../config')
 
 module.exports = function assessmentAnswerToTag(hrefPrefix = '') {
-  return function map({ key, title, category }) {
+  return function buildTag({ title, category }) {
     const whitelisted = TAG_CATEGORY_WHITELIST[category]
 
     return {
-      href: `${hrefPrefix}#${key}`,
+      href: `${hrefPrefix}#${kebabCase(title)}`,
       text: title,
       classes: whitelisted ? whitelisted.tagClass : 'app-tag--inactive',
       sortOrder: whitelisted ? whitelisted.sortOrder : null,

--- a/common/presenters/assessment-answer-to-tag.test.js
+++ b/common/presenters/assessment-answer-to-tag.test.js
@@ -1,4 +1,5 @@
 const proxyquire = require('proxyquire')
+const { kebabCase } = require('lodash')
 
 const assessmentAnswerToTag = proxyquire('./assessment-answer-to-tag', {
   '../../config': {
@@ -20,14 +21,13 @@ describe('Presenters', function() {
     context('when category is in whitelist', function() {
       it('should return correct properties', function() {
         const mockAnswer = {
-          key: 'concealed_items',
           title: 'Concealed items',
           category: 'risk',
         }
         const transformedResponse = assessmentAnswerToTag()(mockAnswer)
 
         expect(transformedResponse).to.deep.equal({
-          href: `#${mockAnswer.key}`,
+          href: `#${kebabCase(mockAnswer.title)}`,
           text: mockAnswer.title,
           classes: 'app-tag--destructive',
           sortOrder: 1,
@@ -36,14 +36,13 @@ describe('Presenters', function() {
 
       it('should return correct properties', function() {
         const mockAnswer = {
-          key: 'health_issue',
           title: 'Health issue',
           category: 'health',
         }
         const transformedResponse = assessmentAnswerToTag()(mockAnswer)
 
         expect(transformedResponse).to.deep.equal({
-          href: `#${mockAnswer.key}`,
+          href: `#${kebabCase(mockAnswer.title)}`,
           text: mockAnswer.title,
           classes: '',
           sortOrder: 2,
@@ -56,7 +55,6 @@ describe('Presenters', function() {
 
       beforeEach(function() {
         mockAnswer = {
-          key: 'food_allergy',
           title: 'Food allergy',
           category: 'invalid',
         }
@@ -66,7 +64,7 @@ describe('Presenters', function() {
 
       it('should return property defaults', function() {
         expect(transformedResponse).to.deep.equal({
-          href: `#${mockAnswer.key}`,
+          href: `#${kebabCase(mockAnswer.title)}`,
           text: mockAnswer.title,
           classes: 'app-tag--inactive',
           sortOrder: null,
@@ -79,7 +77,6 @@ describe('Presenters', function() {
 
       beforeEach(function() {
         mockAnswer = {
-          key: 'food_allergy',
           title: 'Food allergy',
           category: 'invalid',
         }
@@ -88,7 +85,9 @@ describe('Presenters', function() {
       })
 
       it('should not return a href prefix', function() {
-        expect(transformedResponse.href).to.equal(`#${mockAnswer.key}`)
+        expect(transformedResponse.href).to.equal(
+          `#${kebabCase(mockAnswer.title)}`
+        )
       })
     })
 
@@ -98,7 +97,6 @@ describe('Presenters', function() {
       beforeEach(function() {
         mockPrefix = '/move/123456789'
         mockAnswer = {
-          key: 'food_allergy',
           title: 'Food allergy',
           category: 'invalid',
         }
@@ -108,7 +106,7 @@ describe('Presenters', function() {
 
       it('should return a href prefix', function() {
         expect(transformedResponse.href).to.equal(
-          `${mockPrefix}#${mockAnswer.key}`
+          `${mockPrefix}#${kebabCase(mockAnswer.title)}`
         )
       })
     })

--- a/common/presenters/assessment-by-category.js
+++ b/common/presenters/assessment-by-category.js
@@ -1,11 +1,15 @@
+const { filter, groupBy, sortBy, mapValues } = require('lodash')
+
 const { TAG_CATEGORY_WHITELIST } = require('../../config')
-const { filter, sortBy, mapValues } = require('lodash')
 
 module.exports = function assessmentByCategory(assessment) {
   const mapped = mapValues(TAG_CATEGORY_WHITELIST, (params, category) => {
-    params.category = category
-    params.items = filter(assessment, { category })
-    return params
+    const answers = filter(assessment, { category })
+    return {
+      ...params,
+      key: category,
+      answersByTitle: groupBy(answers, 'title'),
+    }
   })
 
   return sortBy(mapped, 'sortOrder')

--- a/common/presenters/assessment-by-category.test.js
+++ b/common/presenters/assessment-by-category.test.js
@@ -34,16 +34,96 @@ describe('Presenters', function() {
       })
 
       it('should correctly order categories', function() {
-        expect(transformedResponse[0].category).to.equal('risk')
+        expect(transformedResponse[0].key).to.equal('risk')
       })
 
       it('should correctly order categories', function() {
-        expect(transformedResponse[1].category).to.equal('health')
+        expect(transformedResponse[1].key).to.equal('health')
       })
 
-      it('should contain correct number of items', function() {
-        expect(transformedResponse[0].items.length).to.equal(3)
-        expect(transformedResponse[1].items.length).to.equal(3)
+      it('should contain correct number of types', function() {
+        expect(
+          Object.keys(transformedResponse[0].answersByTitle)
+        ).to.have.length(3)
+        expect(
+          Object.keys(transformedResponse[1].answersByTitle)
+        ).to.have.length(3)
+      })
+
+      it('should group risk answers correctly', function() {
+        expect(transformedResponse[0].answersByTitle).to.deep.equal({
+          Violent: [
+            {
+              title: 'Violent',
+              comments: 'Karate black belt',
+              date: null,
+              expiry_date: null,
+              assessment_question_id: '7448fb0c-d10e-4cab-9354-1732a4d17a30',
+              category: 'risk',
+              key: 'violent',
+            },
+          ],
+          Escape: [
+            {
+              title: 'Escape',
+              comments: 'Large poster in cell',
+              date: null,
+              expiry_date: null,
+              assessment_question_id: 'd61c0068-cdb0-43de-88e5-c0a09adbf726',
+              category: 'risk',
+              key: 'escape',
+            },
+          ],
+          'Must be held separately': [
+            {
+              title: 'Must be held separately',
+              comments: 'Incitement to riot',
+              date: null,
+              expiry_date: null,
+              assessment_question_id: '745a50e8-ea8d-4667-8ba0-c09c62ee3fc5',
+              category: 'risk',
+              key: 'hold_separately',
+            },
+          ],
+        })
+      })
+
+      it('should group health answers correctly', function() {
+        expect(transformedResponse[1].answersByTitle).to.deep.equal({
+          'Special diet or allergy': [
+            {
+              title: 'Special diet or allergy',
+              comments: 'Vegan',
+              date: null,
+              expiry_date: null,
+              assessment_question_id: 'ff77c212-1244-4b2b-a441-81922d5c2ed8',
+              category: 'health',
+              key: 'special_diet_or_allergy',
+            },
+          ],
+          'Health issue': [
+            {
+              title: 'Health issue',
+              comments: 'Claustophobic',
+              date: null,
+              expiry_date: null,
+              assessment_question_id: 'c1c8e0c1-4376-4f80-8515-dfb7d454a95c',
+              category: 'health',
+              key: 'health_issue',
+            },
+          ],
+          Medication: [
+            {
+              title: 'Medication',
+              comments: 'Heart medication needed twice daily',
+              date: null,
+              expiry_date: null,
+              assessment_question_id: '044cca13-b632-4f65-8111-8902e4913cfe',
+              category: 'health',
+              key: 'medication',
+            },
+          ],
+        })
       })
     })
 
@@ -59,16 +139,20 @@ describe('Presenters', function() {
       })
 
       it('should correctly order categories', function() {
-        expect(transformedResponse[0].category).to.equal('risk')
+        expect(transformedResponse[0].key).to.equal('risk')
       })
 
       it('should correctly order categories', function() {
-        expect(transformedResponse[1].category).to.equal('health')
+        expect(transformedResponse[1].key).to.equal('health')
       })
 
-      it('should contain correct number of items', function() {
-        expect(transformedResponse[0].items.length).to.equal(0)
-        expect(transformedResponse[1].items.length).to.equal(0)
+      it('should contain correct number of types', function() {
+        expect(
+          Object.keys(transformedResponse[0].answersByTitle)
+        ).to.have.length(0)
+        expect(
+          Object.keys(transformedResponse[1].answersByTitle)
+        ).to.have.length(0)
       })
     })
   })

--- a/common/presenters/assessment-to-tag-list.js
+++ b/common/presenters/assessment-to-tag-list.js
@@ -1,10 +1,10 @@
-const { sortBy } = require('lodash')
+const { sortBy, uniqBy } = require('lodash')
 
 const { TAG_CATEGORY_WHITELIST } = require('../../config')
 const assessmentAnswerToTag = require('./assessment-answer-to-tag')
 
 module.exports = function assessmentToTagList(answers, hrefPrefix = '') {
-  const tags = answers
+  const tags = uniqBy(answers, 'title')
     .filter(answer => TAG_CATEGORY_WHITELIST[answer.category])
     .map(assessmentAnswerToTag(hrefPrefix))
 

--- a/common/presenters/assessment-to-tag-list.test.js
+++ b/common/presenters/assessment-to-tag-list.test.js
@@ -54,6 +54,51 @@ describe('Presenters', function() {
 
         expect(response).to.deep.equal(mockAnswers)
       })
+
+      it('should remove duplicate titles', function() {
+        const mockAnswers = [
+          {
+            key: 'escape',
+            title: 'Escape risk',
+            assessment_question_id: '195d3f05-4d25-43ef-8e7e-6d3a0e742888',
+            category: 'whitelisted_other',
+          },
+          {
+            key: 'escape',
+            title: 'Escape risk',
+            assessment_question_id: '195d3f05-4d25-43ef-8e7e-6d3a0e742888',
+            category: 'whitelisted_other',
+          },
+          {
+            key: 'health_issue',
+            title: 'Health issue',
+            assessment_question_id: '394d3f05-4d25-43ef-8e7e-6d3a0e742888',
+            category: 'whitelisted',
+          },
+          {
+            key: 'escape',
+            title: 'Escape risk',
+            assessment_question_id: '195d3f05-4d25-43ef-8e7e-6d3a0e742888',
+            category: 'whitelisted_other',
+          },
+        ]
+        const response = assessmentToTagList(mockAnswers)
+
+        expect(response).to.deep.equal([
+          {
+            key: 'escape',
+            title: 'Escape risk',
+            assessment_question_id: '195d3f05-4d25-43ef-8e7e-6d3a0e742888',
+            category: 'whitelisted_other',
+          },
+          {
+            key: 'health_issue',
+            title: 'Health issue',
+            assessment_question_id: '394d3f05-4d25-43ef-8e7e-6d3a0e742888',
+            category: 'whitelisted',
+          },
+        ])
+      })
     })
 
     context('when category is not whitelist', function() {

--- a/common/presenters/move-to-card-component.test.js
+++ b/common/presenters/move-to-card-component.test.js
@@ -94,19 +94,19 @@ describe('Presenters', function() {
             expect(transformedResponse.tags).to.deep.equal({
               items: [
                 {
-                  href: '/move/12345#concealed_items',
+                  href: '/move/12345#concealed-items',
                   text: 'Concealed items',
                   classes: 'app-tag--destructive',
                   sortOrder: 1,
                 },
                 {
-                  href: '/move/12345#other_risks',
+                  href: '/move/12345#any-other-risks',
                   text: 'Any other risks',
                   classes: 'app-tag--destructive',
                   sortOrder: 1,
                 },
                 {
-                  href: '/move/12345#health_issue',
+                  href: '/move/12345#health-issue',
                   text: 'Health issue',
                   classes: '',
                   sortOrder: 2,
@@ -298,13 +298,13 @@ describe('Presenters', function() {
         it('should correctly map and sort', function() {
           expect(transformedResponse.tags.items).to.deep.equal([
             {
-              href: `/move/${mockMove.id}#concealed_items`,
+              href: `/move/${mockMove.id}#concealed-items`,
               text: 'Concealed items',
               classes: 'app-tag--destructive',
               sortOrder: 1,
             },
             {
-              href: `/move/${mockMove.id}#other_risks`,
+              href: `/move/${mockMove.id}#any-other-risks`,
               text: 'Any other risks',
               classes: 'app-tag--destructive',
               sortOrder: 1,
@@ -316,13 +316,13 @@ describe('Presenters', function() {
               sortOrder: 1,
             },
             {
-              href: `/move/${mockMove.id}#health_issue`,
+              href: `/move/${mockMove.id}#health-issue`,
               text: 'Health issue',
               classes: '',
               sortOrder: 2,
             },
             {
-              href: `/move/${mockMove.id}#diet_allergy`,
+              href: `/move/${mockMove.id}#special-diet-or-allergy`,
               text: 'Special diet or allergy',
               classes: '',
               sortOrder: 2,

--- a/config/nunjucks/filters.js
+++ b/config/nunjucks/filters.js
@@ -7,6 +7,7 @@ const {
   parse: parseDate,
   isValid: isValidDate,
 } = require('date-fns')
+const { kebabCase } = require('lodash')
 
 const { DATE_FORMATS } = require('../index')
 
@@ -126,4 +127,5 @@ module.exports = {
   formatDateAsRelativeDay,
   calculateAge,
   formatTime,
+  kebabcase: kebabCase,
 }


### PR DESCRIPTION
This change groups the flags to avoid duplicates being shown in the summaries.

This is particularly necessary for the way alerts are being pulled in from NOMIS.

## What it looks like

### Before
![localhost_3000_moves_b8dec44a-fd67-4969-a4ff-046e862609c7 (1)](https://user-images.githubusercontent.com/3327997/64804253-62b6ec80-d586-11e9-977e-3edff050bd8d.png)

![localhost_3000_move_42e141d1-14a2-4f6f-9303-c12fea85870c (1)](https://user-images.githubusercontent.com/3327997/64804722-3c458100-d587-11e9-838f-64d03b9048ed.png)

### After
![localhost_3000_moves_b8dec44a-fd67-4969-a4ff-046e862609c7 (2)](https://user-images.githubusercontent.com/3327997/64804391-a90c4b80-d586-11e9-97d3-aedc7cb045e6.png)

![localhost_3000_move_42e141d1-14a2-4f6f-9303-c12fea85870c](https://user-images.githubusercontent.com/3327997/64804557-ec66ba00-d586-11e9-9aeb-e2e5c67e5019.png)
