### PR TITLE
Extract API client auth

### DIFF
--- a/common/lib/api-client/auth.js
+++ b/common/lib/api-client/auth.js
@@ -1,0 +1,58 @@
+const axios = require('axios')
+
+function getTimestamp() {
+  return Math.floor(new Date() / 1000)
+}
+
+function Auth({ timeout = 10000, authUrl, username, password } = {}) {
+  this.accessToken = null
+  this.tokenExpiresAt = null
+  this.config = {
+    timeout,
+    authUrl,
+    username,
+    password,
+  }
+}
+
+Auth.prototype = {
+  async getAccessToken() {
+    if (this.isExpired()) {
+      return this.refreshAccessToken().then(data => {
+        this.accessToken = data.access_token
+        this.tokenExpiresAt = data.expires_in + getTimestamp()
+
+        return this.accessToken
+      })
+    }
+
+    return Promise.resolve(this.accessToken)
+  },
+
+  refreshAccessToken() {
+    const data = {
+      grant_type: 'client_credentials',
+    }
+    const config = {
+      timeout: this.config.timeout,
+      auth: {
+        username: this.config.username,
+        password: this.config.password,
+      },
+    }
+
+    return axios
+      .post(this.config.authUrl, data, config)
+      .then(response => response.data)
+  },
+
+  isExpired() {
+    if (!this.accessToken || !this.tokenExpiresAt) {
+      return true
+    }
+
+    return this.tokenExpiresAt <= getTimestamp()
+  },
+}
+
+module.exports = Auth

--- a/common/lib/api-client/auth.test.js
+++ b/common/lib/api-client/auth.test.js
@@ -1,0 +1,180 @@
+const axios = require('axios')
+
+const Auth = require('./auth')
+
+describe('API Client', function() {
+  describe('Auth library', function() {
+    let auth
+    const mockOptions = {
+      timeout: 1000,
+      authUrl: 'http://auth-url.com/token',
+      username: 'user-id',
+      password: 'asecret',
+    }
+    const mockTokenResponse = {
+      access_token: 'newMockToken',
+      expires_in: 60,
+    }
+
+    describe('when instantiated', function() {
+      context('with options', function() {
+        beforeEach(function() {
+          auth = new Auth(mockOptions)
+        })
+
+        it('should set options as config', function() {
+          expect(auth.config).to.deep.equal(mockOptions)
+        })
+      })
+
+      context('without options', function() {
+        beforeEach(function() {
+          auth = new Auth()
+        })
+
+        it('should set default config', function() {
+          expect(auth.config).to.deep.equal({
+            timeout: 10000,
+            authUrl: undefined,
+            username: undefined,
+            password: undefined,
+          })
+        })
+      })
+    })
+
+    describe('#getAccessToken()', function() {
+      let accessToken
+
+      beforeEach(function() {
+        auth = new Auth()
+        auth.accessToken = 'mockToken'
+        auth.isExpired = sinon.stub()
+        auth.refreshAccessToken = sinon.stub()
+      })
+
+      context('when expired', function() {
+        beforeEach(async function() {
+          auth.refreshAccessToken.resolves(mockTokenResponse)
+          auth.isExpired.returns(true)
+
+          accessToken = await auth.getAccessToken()
+        })
+
+        it('should refresh the token', function() {
+          expect(auth.refreshAccessToken).to.be.calledOnce
+        })
+
+        it('should set the access token', function() {
+          expect(auth.accessToken).to.be.equal('newMockToken')
+        })
+
+        it('should return access token', function() {
+          expect(accessToken).to.equal('newMockToken')
+        })
+      })
+
+      context('when not expired', function() {
+        beforeEach(async function() {
+          auth.isExpired.returns(false)
+          accessToken = await auth.getAccessToken()
+        })
+
+        it('should not refresh access token', function() {
+          expect(auth.refreshAccessToken).not.to.be.called
+        })
+
+        it('should return access token', function() {
+          expect(accessToken).to.equal('mockToken')
+        })
+      })
+    })
+
+    describe('#refreshAccessToken()', function() {
+      let refreshedToken
+      const mockResponse = {
+        data: mockTokenResponse,
+      }
+
+      beforeEach(async function() {
+        sinon.stub(axios, 'post').resolves(mockResponse)
+
+        auth = new Auth(mockOptions)
+        refreshedToken = await auth.refreshAccessToken()
+      })
+
+      it('should correctly post to auth token endpoint', function() {
+        expect(axios.post).to.be.calledOnceWithExactly(
+          mockOptions.authUrl,
+          {
+            grant_type: 'client_credentials',
+          },
+          {
+            timeout: mockOptions.timeout,
+            auth: {
+              username: mockOptions.username,
+              password: mockOptions.password,
+            },
+          }
+        )
+      })
+
+      it('should return response data', function() {
+        expect(refreshedToken).to.deep.equal(mockTokenResponse)
+      })
+    })
+
+    describe('#isExpired()', function() {
+      beforeEach(function() {
+        auth = new Auth()
+      })
+
+      context('when no access token is set', function() {
+        it('should return true', function() {
+          expect(auth.isExpired()).to.be.true
+        })
+      })
+
+      context('when no token expiry is set', function() {
+        it('should return true', function() {
+          expect(auth.isExpired()).to.be.true
+        })
+      })
+
+      context('when token expiry is set', function() {
+        beforeEach(function() {
+          auth.accessToken = 'token'
+          auth.tokenExpiresAt = new Date('2017-08-09').getTime() / 1000
+        })
+
+        context('when token is out of date', function() {
+          beforeEach(function() {
+            this.clock = sinon.useFakeTimers(new Date('2017-08-10').getTime())
+          })
+
+          afterEach(function() {
+            this.clock.restore()
+          })
+
+          it('should return true', function() {
+            expect(auth.isExpired()).to.be.true
+          })
+        })
+
+        context('when token is not out of date', function() {
+          beforeEach(function() {
+            this.clock = sinon.useFakeTimers(new Date('2017-08-08').getTime())
+          })
+
+          afterEach(function() {
+            this.clock.restore()
+          })
+
+          it('should return false', function() {
+            expect(auth.isExpired()).to.be.false
+          })
+        })
+      })
+    })
+  })
+})

--- a/common/lib/api-client/index.js
+++ b/common/lib/api-client/index.js
@@ -1,8 +1,7 @@
 const JsonApi = require('devour-client')
 
 const { API, IS_DEV } = require('../../../config')
-const { errors, requestTimeout } = require('./middleware')
-const { devourAuthMiddleware } = require('./middleware/auth')
+const { auth, errors, requestTimeout } = require('./middleware')
 const models = require('./models')
 
 let instance
@@ -19,7 +18,7 @@ module.exports = function() {
 
   instance.replaceMiddleware('errors', errors)
   instance.insertMiddlewareBefore('axios-request', requestTimeout(API.TIMEOUT))
-  instance.insertMiddlewareBefore('axios-request', devourAuthMiddleware)
+  instance.insertMiddlewareBefore('axios-request', auth)
 
   // define models
   Object.entries(models).forEach(([modelName, model]) => {

--- a/common/lib/api-client/index.test.js
+++ b/common/lib/api-client/index.test.js
@@ -163,37 +163,4 @@ describe('Back-end API client', function() {
       })
     })
   })
-
-  describe('#find', function() {
-    let apiMock
-
-    beforeEach(async function() {
-      const client = proxyquire('./', {
-        '../../../config': mockConfig,
-      })()
-
-      const accessToken = 'foo'
-      const path = 'tests'
-      const id = 123
-
-      sinon.stub(auth, 'getAccessToken').returns(accessToken)
-      sinon
-        .stub(auth, 'getAccessTokenExpiry')
-        .returns(Math.floor(new Date() / 1000) + 100)
-
-      apiMock = nock(mockConfig.API.BASE_URL, {
-        reqheaders: {
-          authorization: `Bearer ${accessToken}`,
-        },
-      })
-        .get(`/${path}/${id}`)
-        .reply(200)
-
-      await client.find(path, id)
-    })
-
-    it('adds the access token to the headers of the request', function() {
-      expect(apiMock.isDone()).to.be.true
-    })
-  })
 })

--- a/common/lib/api-client/middleware/auth.js
+++ b/common/lib/api-client/middleware/auth.js
@@ -1,66 +1,20 @@
-const axios = require('axios')
-
 const { API } = require('../../../../config')
+const Auth = require('../auth')
 
-let accessToken = null
-let accessTokenExpiry = null
+const auth = new Auth({
+  timeout: API.TIMEOUT,
+  authUrl: API.AUTH_URL,
+  username: API.CLIENT_ID,
+  password: API.SECRET,
+})
 
-function getCurrentTime() {
-  return Math.floor(new Date() / 1000)
-}
-
-function isAuthExpired() {
-  const expiry = module.exports.getAccessTokenExpiry()
-  const token = module.exports.getAccessToken()
-  return !token || !expiry || expiry <= getCurrentTime()
-}
-
-function getAccessToken() {
-  return accessToken
-}
-
-function getAccessTokenExpiry() {
-  return accessTokenExpiry
-}
-
-async function refreshAccessToken() {
-  const response = await axios.post(
-    API.AUTH_URL,
-    {},
-    {
-      timeout: API.TIMEOUT,
-      params: {
-        grant_type: 'client_credentials',
-      },
-      auth: {
-        username: API.CLIENT_ID,
-        password: API.SECRET,
-      },
-    }
-  )
-
-  accessToken = response.data.access_token
-  accessTokenExpiry = response.data.expires_in + getCurrentTime()
-
-  return true
-}
-
-const devourAuthMiddleware = {
+module.exports = {
   name: 'oauth-client-credentials',
   req: async function(payload) {
-    if (isAuthExpired()) {
-      await refreshAccessToken()
-    }
+    const token = await auth.getAccessToken()
 
-    const token = module.exports.getAccessToken()
     payload.req.headers.authorization = `Bearer ${token}`
 
     return payload
   },
-}
-
-module.exports = {
-  getAccessToken,
-  getAccessTokenExpiry,
-  devourAuthMiddleware,
 }

--- a/common/lib/api-client/models.test.js
+++ b/common/lib/api-client/models.test.js
@@ -1,4 +1,4 @@
-const proxyquire = require('proxyquire').noCallThru()
+const proxyquire = require('proxyquire')
 const pluralize = require('pluralize')
 const { forEach, flatten, get, startCase } = require('lodash')
 
@@ -72,8 +72,8 @@ const testCases = {
 
 const client = proxyquire('./', {
   '../../../config': mockConfig,
-  './middleware/auth': {
-    devourAuthMiddleware: sinon.stub(),
+  './middleware': {
+    auth: sinon.stub(),
   },
 })()
 


### PR DESCRIPTION
This change refactors the way the  auth token is retrieved and set to connect to the backend API.

It refactors most of the logic from the middleware into a self-contained library that handles getting the token which makes the middleware a lot simpler and easier to test/mock elsewhere.