### PR TITLE
[P4-367] Cache reference data from API

### DIFF
--- a/common/lib/api-client/index.js
+++ b/common/lib/api-client/index.js
@@ -1,7 +1,7 @@
 const JsonApi = require('devour-client')
 
 const { API, IS_DEV } = require('../../../config')
-const { auth, errors, requestTimeout } = require('./middleware')
+const { auth, errors, request, requestTimeout } = require('./middleware')
 const models = require('./models')
 
 let instance
@@ -17,6 +17,7 @@ module.exports = function() {
   })
 
   instance.replaceMiddleware('errors', errors)
+  instance.replaceMiddleware('axios-request', request(API.CACHE_EXPIRY))
   instance.insertMiddlewareBefore('axios-request', requestTimeout(API.TIMEOUT))
   instance.insertMiddlewareBefore('axios-request', auth)
 

--- a/common/lib/api-client/middleware/index.js
+++ b/common/lib/api-client/middleware/index.js
@@ -1,9 +1,11 @@
 const auth = require('./auth')
 const errors = require('./errors')
+const request = require('./request')
 const requestTimeout = require('./request-timeout')
 
 module.exports = {
   auth,
   errors,
+  request,
   requestTimeout,
 }

--- a/common/lib/api-client/middleware/request.js
+++ b/common/lib/api-client/middleware/request.js
@@ -1,0 +1,46 @@
+const { get } = require('lodash')
+
+const redisStore = require('../../../../config/redis-store')()
+const models = require('../models')
+
+function cacheResponse(key, expiry) {
+  return async response => {
+    await redisStore.client.setexAsync(
+      key,
+      expiry,
+      JSON.stringify(response.data)
+    )
+    return response
+  }
+}
+
+function requestMiddleware(expiry = 60) {
+  return {
+    name: 'axios-request',
+    req: async function req(payload) {
+      const { req, jsonApi } = payload
+      const pathname = new URL(req.url).pathname
+      const searchString = new URLSearchParams(req.params).toString()
+      const key = `cache:${req.method}.${pathname}${
+        searchString ? `?${searchString}` : ''
+      }`
+      const cacheModel = get(models, `${req.model}.options.cache`)
+
+      if (!cacheModel) {
+        return jsonApi.axios(req)
+      }
+
+      return redisStore.client.getAsync(key).then(response => {
+        if (!response) {
+          return jsonApi.axios(req).then(cacheResponse(key, expiry))
+        }
+
+        return {
+          data: JSON.parse(response),
+        }
+      })
+    },
+  }
+}
+
+module.exports = requestMiddleware

--- a/common/lib/api-client/middleware/request.test.js
+++ b/common/lib/api-client/middleware/request.test.js
@@ -1,0 +1,183 @@
+const proxyquire = require('proxyquire')
+
+const mockModels = {
+  cachedModel: {
+    options: {
+      cache: true,
+    },
+  },
+  nonCachedModel: {
+    options: {
+      cache: false,
+    },
+  },
+}
+const mockResponse = {
+  data: {
+    foo: 'bar',
+  },
+}
+
+describe('API Client', function() {
+  describe('Request middleware', function() {
+    let getAsyncStub
+    let setexAsyncStub
+    let payload
+    let response
+    let requestMiddleware
+
+    beforeEach(function() {
+      getAsyncStub = sinon.stub()
+      setexAsyncStub = sinon.stub()
+      payload = {
+        jsonApi: {
+          axios: sinon.stub().resolves(mockResponse),
+        },
+        req: {
+          url: 'http://localhost:3030/path/to/endpoint',
+          method: 'GET',
+          params: {},
+        },
+      }
+      requestMiddleware = proxyquire('./request', {
+        '../../../../config/redis-store': () => {
+          return {
+            client: {
+              getAsync: getAsyncStub,
+              setexAsync: setexAsyncStub,
+            },
+          }
+        },
+        '../models': mockModels,
+      })
+    })
+
+    context('when model should not be cached', function() {
+      beforeEach(async function() {
+        payload.req.model = 'nonCachedModel'
+        response = await requestMiddleware().req(payload)
+      })
+
+      it('should make request using axios library with payload', function() {
+        expect(payload.jsonApi.axios).to.be.calledOnceWithExactly(payload.req)
+      })
+
+      it('should not call redis client', function() {
+        expect(getAsyncStub).not.to.be.called
+        expect(setexAsyncStub).not.to.be.called
+      })
+
+      it('should return a request', function() {
+        expect(response).to.deep.equal(mockResponse)
+      })
+    })
+
+    context('when model should be cached', function() {
+      beforeEach(function() {
+        payload.req.model = 'cachedModel'
+      })
+
+      context('when result exists in Redis', function() {
+        const mockRedisResponse = JSON.stringify(mockResponse.data)
+
+        beforeEach(async function() {
+          getAsyncStub.resolves(mockRedisResponse)
+          response = await requestMiddleware().req(payload)
+        })
+
+        it('should attempt to get key from redis', function() {
+          expect(getAsyncStub).to.be.calledOnceWithExactly(
+            'cache:GET./path/to/endpoint'
+          )
+        })
+
+        it('should not make request using axios library', function() {
+          expect(payload.jsonApi.axios).not.to.be.called
+        })
+
+        it('should return a request', function() {
+          expect(response).to.deep.equal(mockResponse)
+        })
+      })
+
+      context('when result does not exist in Redis', function() {
+        beforeEach(async function() {
+          getAsyncStub.resolves(null)
+          setexAsyncStub.resolves(true)
+          response = await requestMiddleware().req(payload)
+        })
+
+        it('should attempt to get key from redis', function() {
+          expect(getAsyncStub).to.be.calledOnceWithExactly(
+            'cache:GET./path/to/endpoint'
+          )
+        })
+
+        it('should make request using axios library', function() {
+          expect(payload.jsonApi.axios).to.be.calledOnceWithExactly(payload.req)
+        })
+
+        it('should set response data in redis', function() {
+          expect(setexAsyncStub).to.be.calledOnceWithExactly(
+            'cache:GET./path/to/endpoint',
+            60,
+            JSON.stringify(mockResponse.data)
+          )
+        })
+
+        it('should return a request', function() {
+          expect(response).to.deep.equal(mockResponse)
+        })
+      })
+
+      context('when request contains params', function() {
+        beforeEach(async function() {
+          getAsyncStub.resolves(null)
+          payload.req.params = {
+            name: 'John',
+            page: 5,
+            per_page: 100,
+          }
+          response = await requestMiddleware().req(payload)
+        })
+
+        it('should append search to key', function() {
+          expect(getAsyncStub).to.be.calledOnceWithExactly(
+            'cache:GET./path/to/endpoint?name=John&page=5&per_page=100'
+          )
+        })
+
+        it('should return a request', function() {
+          expect(response).to.deep.equal(mockResponse)
+        })
+      })
+
+      describe('options', function() {
+        beforeEach(async function() {
+          getAsyncStub.resolves(null)
+          setexAsyncStub.resolves(true)
+        })
+
+        context('without expiry argument', function() {
+          beforeEach(async function() {
+            response = await requestMiddleware().req(payload)
+          })
+
+          it('should use default value', function() {
+            expect(setexAsyncStub.args[0][1]).to.equal(60)
+          })
+        })
+
+        context('with expiry argument', function() {
+          beforeEach(async function() {
+            response = await requestMiddleware(1000).req(payload)
+          })
+
+          it('should use argument value', function() {
+            expect(setexAsyncStub.args[0][1]).to.equal(1000)
+          })
+        })
+      })
+    })
+  })
+})

--- a/common/lib/api-client/models.js
+++ b/common/lib/api-client/models.js
@@ -51,6 +51,7 @@ module.exports = {
       disabled_at: '',
     },
     options: {
+      cache: true,
       collectionPath: 'reference/genders',
     },
   },
@@ -63,6 +64,7 @@ module.exports = {
       disabled_at: '',
     },
     options: {
+      cache: true,
       collectionPath: 'reference/ethnicities',
     },
   },
@@ -76,6 +78,7 @@ module.exports = {
       nomis_alert_code: '',
     },
     options: {
+      cache: true,
       collectionPath: 'reference/assessment_questions',
     },
   },
@@ -88,6 +91,7 @@ module.exports = {
       disabled_at: '',
     },
     options: {
+      cache: true,
       collectionPath: 'reference/locations',
     },
   },

--- a/common/lib/api-client/models.test.js
+++ b/common/lib/api-client/models.test.js
@@ -74,6 +74,7 @@ const client = proxyquire('./', {
   '../../../config': mockConfig,
   './middleware': {
     auth: sinon.stub(),
+    request: sinon.stub().returns({}),
   },
 })()
 

--- a/config/index.js
+++ b/config/index.js
@@ -39,6 +39,7 @@ module.exports = {
     CLIENT_ID: process.env.API_CLIENT_ID,
     SECRET: process.env.API_SECRET,
     TIMEOUT: 30000, // in milliseconds
+    CACHE_EXPIRY: 60 * 60 * 24 * 7, // in seconds (7 days)
   },
   DATE_FORMATS: {
     SHORT: 'd M yyyy',

--- a/config/redis-store.js
+++ b/config/redis-store.js
@@ -1,6 +1,7 @@
 const redis = require('redis')
 const session = require('express-session')
 const RedisStore = require('connect-redis')(session)
+const bluebird = require('bluebird')
 
 let store
 
@@ -14,6 +15,8 @@ module.exports = function redisStore(options) {
   }
 
   const client = redis.createClient(options)
+  bluebird.promisifyAll(client)
+
   store = new RedisStore({ client })
 
   return store

--- a/config/redis-store.test.js
+++ b/config/redis-store.test.js
@@ -1,3 +1,4 @@
+const bluebird = require('bluebird')
 const proxyquire = require('proxyquire')
 
 function MockRedisStore(opts = {}) {
@@ -31,6 +32,7 @@ describe('Redis store', function() {
 
     beforeEach(function() {
       sinon.spy(MockRedisStore.prototype, 'init')
+      sinon.stub(bluebird, 'promisifyAll')
     })
 
     context('with first call', function() {
@@ -56,6 +58,9 @@ describe('Redis store', function() {
         it('should create a new store', function() {
           expect(mockRedisClient.createClient).to.be.calledOnceWithExactly(
             mockOptions
+          )
+          expect(bluebird.promisifyAll).to.be.calledOnceWithExactly(
+            'mockClient'
           )
           expect(MockRedisStore.prototype.init).to.be.calledOnceWithExactly(
             mockStoreOptions

--- a/package-lock.json
+++ b/package-lock.json
@@ -10938,6 +10938,15 @@
         }
       }
     },
+    "response-time": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/response-time/-/response-time-2.3.2.tgz",
+      "integrity": "sha1-/6cbq5UtYvfB1Jt0NDVfvGjf/Fo=",
+      "requires": {
+        "depd": "~1.1.0",
+        "on-headers": "~1.0.1"
+      }
+    },
     "restore-cursor": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1879,8 +1879,7 @@
     "bluebird": {
       "version": "3.5.5",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.5.tgz",
-      "integrity": "sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w==",
-      "dev": true
+      "integrity": "sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w=="
     },
     "bn.js": {
       "version": "4.11.8",

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "pluralize": "8.0.0",
     "query-string": "6.8.3",
     "redis": "2.8.0",
+    "response-time": "2.3.2",
     "serve-favicon": "2.5.0",
     "slashify": "1.0.0",
     "sticky-sidebar": "3.3.1",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "@sentry/node": "5.6.2",
     "accessible-autocomplete": "1.6.2",
     "axios": "0.19.0",
+    "bluebird": "3.5.5",
     "body-parser": "1.19.0",
     "chrono-node": "1.3.11",
     "compression": "1.7.4",

--- a/server.js
+++ b/server.js
@@ -22,7 +22,10 @@ const configPaths = require('./config/paths')
 const logger = require('./config/logger')
 const i18n = require('./config/i18n')
 const nunjucks = require('./config/nunjucks')
-const redisStore = require('./config/redis-store')
+const redisStore = require('./config/redis-store')({
+  ...config.REDIS.SESSION,
+  logErrors: error => logger.error(error),
+})
 const ensureCurrentLocation = require('./common/middleware/ensure-current-location')
 const errorHandlers = require('./common/middleware/errors')
 const checkSession = require('./common/middleware/check-session')
@@ -84,10 +87,7 @@ app.use(cookieParser())
 app.use(bodyParser.urlencoded({ extended: true, limit: '1mb' }))
 app.use(
   session({
-    store: redisStore({
-      ...config.REDIS.SESSION,
-      logErrors: error => logger.error(error),
-    }),
+    store: redisStore,
     secret: config.SESSION.SECRET,
     name: config.SESSION.NAME,
     saveUninitialized: false,

--- a/server.js
+++ b/server.js
@@ -12,6 +12,7 @@ const session = require('express-session')
 const grant = require('grant-express')
 const flash = require('connect-flash')
 const favicon = require('serve-favicon')
+const responseTime = require('response-time')
 const slashify = require('slashify')
 const i18nMiddleware = require('i18next-express-middleware')
 const Sentry = require('@sentry/node')
@@ -85,6 +86,7 @@ app.use(express.json())
 app.use(express.urlencoded({ extended: false }))
 app.use(cookieParser())
 app.use(bodyParser.urlencoded({ extended: true, limit: '1mb' }))
+app.use(responseTime())
 app.use(
   session({
     store: redisStore,


### PR DESCRIPTION
This change allows API models to be cached rather than serving from the API each time.

This is useful for reference data that doesn't change very often.

### Questions

- Is this the best place to cache this data? 
  - Could we use a caching layer in between rather than using the frontend Redis instance?
- What's a reasonable time to cache this data? 
  - 24 hours?
  - 7 days?