### PR TITLE
Display other identifiers in person details

### DIFF
--- a/common/presenters/person-to-summary-list-component.js
+++ b/common/presenters/person-to-summary-list-component.js
@@ -1,31 +1,31 @@
-const { find } = require('lodash')
-
 const i18n = require('../../config/i18n')
 const filters = require('../../config/nunjucks/filters')
 
+function mapIdentifier({ value, identifier_type: type }) {
+  return {
+    key: {
+      text: i18n.t(`fields::${type}.label`),
+    },
+    value: {
+      text: value,
+    },
+  }
+}
+
 module.exports = function personToSummaryListComponent({
-  date_of_birth: dateOfBirth,
   gender,
-  gender_additional_information: genderAdditionalInformation,
   ethnicity,
-  identifiers,
+  identifiers = [],
+  date_of_birth: dateOfBirth,
+  gender_additional_information: genderAdditionalInformation,
 }) {
   const age = `(${i18n.t('age')} ${filters.calculateAge(dateOfBirth)})`
   const genderExtra = genderAdditionalInformation
     ? ` — ${genderAdditionalInformation}`
     : ''
-  const pncNumber = find(identifiers, {
-    identifier_type: 'police_national_computer',
-  })
+
   const rows = [
-    {
-      key: {
-        text: i18n.t('fields::police_national_computer.label'),
-      },
-      value: {
-        text: pncNumber ? pncNumber.value : '',
-      },
-    },
+    ...identifiers.map(mapIdentifier),
     {
       key: {
         text: i18n.t('fields::date_of_birth.label'),

--- a/common/presenters/person-to-summary-list-component.test.js
+++ b/common/presenters/person-to-summary-list-component.test.js
@@ -11,6 +11,14 @@ const mockPerson = {
       identifier_type: 'police_national_computer',
       value: '11009922',
     },
+    {
+      identifier_type: 'prison_number',
+      value: 'AA/183716',
+    },
+    {
+      identifier_type: 'criminal_records_office',
+      value: 'JS901873',
+    },
   ],
   ethnicity: {
     title: 'Mixed (White and Black Caribbean)',
@@ -38,20 +46,30 @@ describe('Presenters', function() {
       describe('response', function() {
         it('should contain rows property', function() {
           expect(transformedResponse).to.have.property('rows')
-          expect(transformedResponse.rows.length).to.equal(4)
+          expect(transformedResponse.rows.length).to.equal(6)
         })
 
-        it('should contain PNC as first row', function() {
-          const row = transformedResponse.rows[0]
+        it('should contain identifiers first', function() {
+          const row1 = transformedResponse.rows[0]
+          const row2 = transformedResponse.rows[1]
+          const row3 = transformedResponse.rows[2]
 
-          expect(row).to.deep.equal({
+          expect(row1).to.deep.equal({
             key: { text: '__translated__' },
             value: { text: mockPerson.identifiers[0].value },
           })
+          expect(row2).to.deep.equal({
+            key: { text: '__translated__' },
+            value: { text: mockPerson.identifiers[1].value },
+          })
+          expect(row3).to.deep.equal({
+            key: { text: '__translated__' },
+            value: { text: mockPerson.identifiers[2].value },
+          })
         })
 
-        it('should contain date of birth as second row', function() {
-          const row = transformedResponse.rows[1]
+        it('should contain date of birth', function() {
+          const row = transformedResponse.rows[3]
 
           expect(row).to.deep.equal({
             key: { text: '__translated__' },
@@ -59,8 +77,8 @@ describe('Presenters', function() {
           })
         })
 
-        it('should contain gender as third row', function() {
-          const row = transformedResponse.rows[2]
+        it('should contain gender', function() {
+          const row = transformedResponse.rows[4]
 
           expect(row).to.deep.equal({
             key: { text: '__translated__' },
@@ -70,8 +88,8 @@ describe('Presenters', function() {
           })
         })
 
-        it('should contain ethnicity as fourth row', function() {
-          const row = transformedResponse.rows[3]
+        it('should contain ethnicity', function() {
+          const row = transformedResponse.rows[5]
 
           expect(row).to.deep.equal({
             key: { text: '__translated__' },
@@ -85,32 +103,38 @@ describe('Presenters', function() {
           expect(i18n.t.firstCall).to.be.calledWithExactly('age')
         })
 
-        it('should translate PNC number label', function() {
-          expect(i18n.t.secondCall).to.be.calledWithExactly(
+        it('should translate identifiers', function() {
+          expect(i18n.t.getCall(1)).to.be.calledWithExactly(
             'fields::police_national_computer.label'
+          )
+          expect(i18n.t.getCall(2)).to.be.calledWithExactly(
+            'fields::prison_number.label'
+          )
+          expect(i18n.t.getCall(3)).to.be.calledWithExactly(
+            'fields::criminal_records_office.label'
           )
         })
 
         it('should translate date of birth label', function() {
-          expect(i18n.t.thirdCall).to.be.calledWithExactly(
+          expect(i18n.t.getCall(4)).to.be.calledWithExactly(
             'fields::date_of_birth.label'
           )
         })
 
         it('should translate gender label', function() {
-          expect(i18n.t.getCall(3)).to.be.calledWithExactly(
+          expect(i18n.t.getCall(5)).to.be.calledWithExactly(
             'fields::gender.label'
           )
         })
 
         it('should translate ethnicity label', function() {
-          expect(i18n.t.getCall(4)).to.be.calledWithExactly(
+          expect(i18n.t.getCall(6)).to.be.calledWithExactly(
             'fields::ethnicity.label'
           )
         })
 
         it('should translate correct number of times', function() {
-          expect(i18n.t).to.be.callCount(5)
+          expect(i18n.t).to.be.callCount(7)
         })
       })
     })
@@ -123,7 +147,7 @@ describe('Presenters', function() {
       })
 
       describe('response', function() {
-        it('should return an empty string for police national computer', function() {
+        it('should return an empty string for date of birth', function() {
           const row = transformedResponse.rows[0]
 
           expect(row).to.deep.equal({
@@ -132,7 +156,7 @@ describe('Presenters', function() {
           })
         })
 
-        it('should return an empty string for date of birth', function() {
+        it('should return an empty string for gender', function() {
           const row = transformedResponse.rows[1]
 
           expect(row).to.deep.equal({
@@ -141,17 +165,8 @@ describe('Presenters', function() {
           })
         })
 
-        it('should return an empty string for gender', function() {
-          const row = transformedResponse.rows[2]
-
-          expect(row).to.deep.equal({
-            key: { text: '__translated__' },
-            value: { text: '' },
-          })
-        })
-
         it('should return an empty string for ethnicity', function() {
-          const row = transformedResponse.rows[3]
+          const row = transformedResponse.rows[2]
 
           expect(row).to.deep.equal({
             key: { text: '__translated__' },
@@ -174,7 +189,7 @@ describe('Presenters', function() {
 
       describe('response', function() {
         it('should return only gender name', function() {
-          const row = transformedResponse.rows[2]
+          const row = transformedResponse.rows[1]
 
           expect(row).to.deep.equal({
             key: { text: '__translated__' },

--- a/locales/en/fields.json
+++ b/locales/en/fields.json
@@ -2,6 +2,12 @@
   "police_national_computer": {
     "label": "PNC number"
   },
+  "prison_number": {
+    "label": "Prison number"
+  },
+  "criminal_records_office": {
+    "label": "CRO  number"
+  },
   "first_names": {
     "label": "First name(s)"
   },


### PR DESCRIPTION
This maps over the identifiers on the person model and displays them
in the personal details section of the move detail page.

## What it looks like

![localhost_3000_move_391872f3-8ec8-4499-a0a3-d8756e74485f](https://user-images.githubusercontent.com/3327997/65278074-3d485680-db23-11e9-9fba-5874f640e65a.png)
