### PR TITLE
Mobile sticky sidebar fix

### DIFF
--- a/common/assets/scss/components/_sticky-sidebar.scss
+++ b/common/assets/scss/components/_sticky-sidebar.scss
@@ -6,4 +6,8 @@
   transform: translate(0, 0); /* For browsers don't support translate3d. */
   transform: translate3d(0, 0, 0);
   will-change: position, transform;
+
+  @include mq ($until: tablet) {
+    position: static !important;
+  }
 }


### PR DESCRIPTION
# Summary panel appears over content on mobile

## Problem
The summary panel appears over the content on mobile

![screencapture-localhost-3000-move-new-move-details-2019-09-23-13_03_56](https://user-images.githubusercontent.com/2305016/65424646-f187fc80-de03-11e9-9867-e73fa279cfef.png)

## Solution 
Add an override class to stop this happening
![screencapture-localhost-3000-move-new-health-information-2019-09-23-13_02_50](https://user-images.githubusercontent.com/2305016/65424669-006eaf00-de04-11e9-9170-50f3e4f5aa80.png)
