### PR TITLE
Fix for date being passed into formatDate

### DIFF
--- a/config/nunjucks/filters.js
+++ b/config/nunjucks/filters.js
@@ -6,6 +6,7 @@ const {
   differenceInYears,
   parseISO,
   isValid: isValidDate,
+  isDate,
 } = require('date-fns')
 const { kebabCase } = require('lodash')
 
@@ -25,12 +26,12 @@ function formatDate(value, formattedDateStr = DATE_FORMATS.LONG) {
   if (!value) {
     return value
   }
-  const parsedDate = parseISO(value)
+  const date = isDate(value) ? value : parseISO(value)
 
-  if (!isValidDate(parsedDate)) {
+  if (!isValidDate(date)) {
     return value
   }
-  return format(parsedDate, formattedDateStr)
+  return format(date, formattedDateStr)
 }
 
 /**

--- a/config/nunjucks/filters.test.js
+++ b/config/nunjucks/filters.test.js
@@ -45,6 +45,26 @@ describe('Nunjucks filters', function() {
         })
       })
     })
+
+    context('when given a valid date object', function() {
+      const mockDate = new Date('2010-05-15')
+
+      context('when no format is specified', function() {
+        it('should return date in default format', function() {
+          const formattedDate = filters.formatDate(mockDate)
+
+          expect(formattedDate).to.equal('15 May 2010')
+        })
+      })
+
+      context('when a format is specified', function() {
+        it('should return date in that format', function() {
+          const formattedDate = filters.formatDate(mockDate, 'dd/MM/yy')
+
+          expect(formattedDate).to.equal('15/05/10')
+        })
+      })
+    })
   })
 
   describe('#formatDateWithDay()', function() {


### PR DESCRIPTION
# formateDate Fix
FormateDate also excepts a date object. This work ensures that a date
and a string are formatted to the correct date

## Before fix
![Screenshot 2019-09-23 at 18 05 09](https://user-images.githubusercontent.com/2305016/65446650-b4843000-de2c-11e9-8b5d-8ae6c99319ba.png)

## After fix
![Screenshot 2019-09-23 at 17 52 48](https://user-images.githubusercontent.com/2305016/65446604-9cacac00-de2c-11e9-854f-16bd5f424816.png)

