### PR TITLE
[P4-690] Update a person if they already exist

### DIFF
--- a/app/move/controllers/create/personal-details.js
+++ b/app/move/controllers/create/personal-details.js
@@ -1,3 +1,5 @@
+const { get } = require('lodash')
+
 const CreateBaseController = require('./base')
 const fieldHelpers = require('../../../../common/helpers/field')
 const personService = require('../../../../common/services/person')
@@ -34,9 +36,22 @@ class PersonalDetailsController extends CreateBaseController {
     }
   }
 
+  savePerson(id, data) {
+    if (id) {
+      return personService.update({
+        id,
+        ...data,
+      })
+    }
+
+    return personService.create(data)
+  }
+
   async saveValues(req, res, next) {
     try {
-      req.form.values.person = await personService.create(req.form.values)
+      const id = get(req.sessionModel.get('person'), 'id')
+
+      req.form.values.person = await this.savePerson(id, req.form.values)
       super.saveValues(req, res, next)
     } catch (error) {
       next(error)


### PR DESCRIPTION
The current create journey creates a new person in the API each time the personal details step is saved. 
So if a user does:
- User completes personal details step
- Hits continue
- Hits "Back" on move details steps
- Hits continue

Then duplicate people will be created in the API

### Solution
If a person already exists in the session then update their details via the personService rather than creating a duplicate. This avoids duplicate people being saved to the API and stops duplicates being created when a user goes back in the browser to update a person details.

