### PR TITLE
Update API environment variable configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,9 @@
 SESSION_SECRET=example-secret
 REDIS_URL=//localhost:6379
-API_BASE_URL=http://localhost:4000/api/v1
-API_AUTH_URL=http://localhost:4000/oauth/token
+API_BASE_URL=http://localhost:3000
+API_PATH=/api/v1
+API_HEALTHCHECK_PATH=/ping.xml
+API_AUTH_PATH=/oauth/token
 API_CLIENT_ID=
 API_SECRET=
 AUTH_PROVIDER_KEY=

--- a/README.md
+++ b/README.md
@@ -120,9 +120,10 @@ npm run lint
 | REDIS_URL **(required)** | Redis server URL, including port and protocol | |
 | REDIS_HOST **(required)** | Redis hostname. Can be used instead of `REDIS_URL`. Will override `REDIS_URL` if set | |
 | REDIS_AUTH_TOKEN | Optional auth token for the Redis instance | |
-| API_BASE_URL **(required)** | Base URL for the backend API server for this service without any path | `http://localhost:3000/api/v1` |
-| API_HEALTHCHECK_URL **(required)** | URL to which healthcheck pings are sent | |
-| API_AUTH_URL **(required)** | URL to which OAuth2 access token requests should be sent | |
+| API_BASE_URL **(required)** | Base URL for the backend API server for this service without any path | `http://localhost:3000` |
+| API_PATH **(required)** | Base base for the API | `/api/v1` |
+| API_HEALTHCHECK_PATH **(required)** | Path to which healthcheck pings are sent | |
+| API_AUTH_PATH **(required)** | Path to which OAuth2 access token requests should be sent | |
 | API_CLIENT_ID **(required)** | Client ID used to authenticate with the backend API | |
 | API_SECRET **(required)** | Client secret used to authenticate with the backend API | |
 | AUTH_PROVIDER_KEY **(required)** | Client key provided by the OAuth2 provider for user authentication | |

--- a/config/index.js
+++ b/config/index.js
@@ -5,6 +5,7 @@ const IS_DEV = process.env.NODE_ENV !== 'production'
 const IS_PRODUCTION = process.env.NODE_ENV === 'production'
 const SERVER_HOST = process.env.SERVER_HOST
 const BASE_URL = `${IS_PRODUCTION ? 'https' : 'http'}://${SERVER_HOST}`
+const API_BASE_URL = process.env.API_BASE_URL
 const AUTH_BASE_URL = process.env.AUTH_PROVIDER_URL
 const AUTH_KEY = process.env.AUTH_PROVIDER_KEY
 const NOMIS_ELITE2_API_BASE_URL = process.env.NOMIS_ELITE2_API_URL
@@ -18,6 +19,18 @@ const SESSION = {
 function _authUrl(path) {
   return AUTH_BASE_URL ? new URL(path, AUTH_BASE_URL).href : ''
 }
+
+// TODO: Remove once environments have been updated to support new format
+const useLegacyApiConfig = process.env.API_USE_LEGACY !== 'false'
+const apiBaseUrl = useLegacyApiConfig
+  ? API_BASE_URL
+  : API_BASE_URL + process.env.API_PATH
+const apiHealthcheckUrl = useLegacyApiConfig
+  ? process.env.API_HEALTHCHECK_URL
+  : API_BASE_URL + process.env.API_HEALTHCHECK_PATH
+const apiAuthUrl = useLegacyApiConfig
+  ? process.env.API_AUTH_URL
+  : API_BASE_URL + process.env.API_AUTH_PATH
 
 module.exports = {
   IS_DEV,
@@ -33,9 +46,9 @@ module.exports = {
   BUILD_BRANCH: process.env.APP_BUILD_TAG,
   GIT_SHA: process.env.APP_GIT_COMMIT,
   API: {
-    BASE_URL: process.env.API_BASE_URL,
-    HEALTHCHECK_URL: process.env.API_HEALTHCHECK_URL,
-    AUTH_URL: process.env.API_AUTH_URL,
+    BASE_URL: apiBaseUrl,
+    AUTH_URL: apiAuthUrl,
+    HEALTHCHECK_URL: apiHealthcheckUrl,
     CLIENT_ID: process.env.API_CLIENT_ID,
     SECRET: process.env.API_SECRET,
     TIMEOUT: 30000, // in milliseconds


### PR DESCRIPTION
This change amends the way the API is set in the environment variables.

Currently it requires the host to be defined 3 times for `API_BASE_URL`,
`API_HEALTHCHECK_URL` and `API_AUTH_URL`. If the host needs to be
changed, for example switching between environments when testing this
requires changing 3 variables.

This change just neatens that up so that it only needs to be defined once.

It introduces some temporary logic to make sure the change is backwards
compatible with current releases. Once all envionrments have been
updated this logic can be removed.

### Checklist

- [x] If adding new environment variables, they have been documented in the [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md)
