### PR TITLE
[P4-530] Remove PII information from Sentry data

### DIFF
--- a/server.js
+++ b/server.js
@@ -35,8 +35,13 @@ const router = require('./app/router')
 const healthcheckApp = require('./app/healthcheck')
 const locationsApp = require('./app/locations')
 
+const { omit } = require('lodash')
+
 if (config.SENTRY.DSN) {
   Sentry.init({
+    beforeSend(event) {
+      return omit(event, 'request.data')
+    },
     dsn: config.SENTRY.DSN,
     environment: config.SENTRY.ENVIRONMENT,
     release: config.GIT_SHA,


### PR DESCRIPTION
## Feature/fix

This work omits any request data that is being sent to Sentry. This data could potentially hold form information such as `first` and `last` name.
This change means that if `request.data` exists in the Sentry `event` it is removed.

Information around sensitive data can be seen https://docs.sentry.io/data-management/sensitive-data/
