### PR TITLE
[P4-709] Add the 'Error:' prefix to cancel error page title

### DIFF
--- a/app/move/views/cancel.njk
+++ b/app/move/views/cancel.njk
@@ -4,7 +4,7 @@
   gtag('set', {'page_title': 'Cancel move'});
 {% endblock %}
 
-{% block pageTitle %}
+{% block innerPageTitle %}
   {{ t("moves::cancel.page_title", { name: move.person.fullname | upper }) }}
 {% endblock %}
 

--- a/common/templates/form-wizard.njk
+++ b/common/templates/form-wizard.njk
@@ -6,7 +6,9 @@
   {%- if errors.errorList.length -%}
   {{ t("validation::page_title_prefix") }}:
   {%- endif %}
-  {{ t(options.pageTitle) }} - {{ t(options.journeyPageTitle) }}
+  {% block innerPageTitle %}
+    {{ t(options.pageTitle) }} - {{ t(options.journeyPageTitle) }}
+  {% endblock %}
 {% endblock %}
 
 {% block beforeContent %}


### PR DESCRIPTION
## Problem
The Error page when you try and cancel a move and it the form validation errors does not have the `'Error:'` prefix in the page title element.

## Solution
This work adds the `'Error:'` prefix in to the page title element.

### Without form validation error
![Screenshot 2019-09-30 at 14 08 34](https://user-images.githubusercontent.com/2305016/65882112-602d0300-e38c-11e9-9ee4-c4b5fe5b43d7.png)


### With form validation error
![Screenshot 2019-09-30 at 14 08 22](https://user-images.githubusercontent.com/2305016/65882094-5a372200-e38c-11e9-8d5b-f15e3d12007f.png)
