### PR TITLE
[P4-545] Mandatory other free text

### DIFF
--- a/app/move/controllers/create/assessment.js
+++ b/app/move/controllers/create/assessment.js
@@ -7,9 +7,9 @@ class AssessmentController extends CreateBaseController {
   async configure(req, res, next) {
     try {
       const { fields } = req.form.options
-
-      await fieldHelpers.setupAssessmentQuestions(fields)
-
+      req.form.options.fields = await fieldHelpers.populateAssessmentQuestions(
+        fields
+      )
       super.configure(req, res, next)
     } catch (error) {
       next(error)

--- a/app/move/controllers/create/assessment.js
+++ b/app/move/controllers/create/assessment.js
@@ -2,33 +2,13 @@ const { flatten, values } = require('lodash')
 
 const CreateBaseController = require('./base')
 const fieldHelpers = require('../../../../common/helpers/field')
-const referenceDataService = require('../../../../common/services/reference-data')
-const referenceDataHelpers = require('../../../../common/helpers/reference-data')
 
 class AssessmentController extends CreateBaseController {
   async configure(req, res, next) {
     try {
       const { fields } = req.form.options
 
-      await Promise.all(
-        Object.keys(fields).map(key => {
-          const field = fields[key]
-
-          if (!Object.prototype.hasOwnProperty.call(field, 'items')) {
-            return
-          }
-
-          return referenceDataService
-            .getAssessmentQuestions(key)
-            .then(response => {
-              field.items = response
-                .filter(referenceDataHelpers.filterDisabled())
-                .map(fieldHelpers.mapAssessmentQuestionToConditionalField)
-                .map(fieldHelpers.mapAssessmentQuestionToTranslation)
-                .map(fieldHelpers.mapReferenceDataToOption)
-            })
-        })
-      )
+      await fieldHelpers.setupAssessmentQuestions(fields)
 
       super.configure(req, res, next)
     } catch (error) {

--- a/app/move/fields/create.js
+++ b/app/move/fields/create.js
@@ -11,6 +11,15 @@ const assessmentQuestionComments = {
   },
 }
 
+const requiredAssessmentQuestionComments = {
+  ...assessmentQuestionComments,
+  label: {
+    text: 'fields::assessment_comment.required',
+    classes: 'govuk-label--s',
+  },
+  validate: 'required',
+}
+
 function assessmentCategory(category) {
   return {
     component: 'govukCheckboxes',
@@ -244,7 +253,7 @@ module.exports = {
   risk__hold_separately: assessmentQuestionComments,
   risk__self_harm: assessmentQuestionComments,
   risk__concealed_items: assessmentQuestionComments,
-  risk__other_risks: assessmentQuestionComments,
+  risk__other_risks: requiredAssessmentQuestionComments,
   // health information
   health: assessmentCategory('health'),
   health__special_diet_or_allergy: assessmentQuestionComments,
@@ -252,10 +261,10 @@ module.exports = {
   health__medication: assessmentQuestionComments,
   health__wheelchair: assessmentQuestionComments,
   health__pregnant: assessmentQuestionComments,
-  health__other_health: assessmentQuestionComments,
+  health__other_health: requiredAssessmentQuestionComments,
   // court information
   court: assessmentCategory('court'),
   court__solicitor: assessmentQuestionComments,
   court__interpreter: assessmentQuestionComments,
-  court__other_court: assessmentQuestionComments,
+  court__other_court: requiredAssessmentQuestionComments,
 }

--- a/common/helpers/field.js
+++ b/common/helpers/field.js
@@ -192,8 +192,9 @@ function setDependentValidation(key, field, fieldWithItems) {
   }
 }
 
-async function setupAssessmentQuestions(fields) {
-  const fieldWithItems = Object.values(fields).find(field => {
+async function populateAssessmentQuestions(fields) {
+  const fieldsClone = { ...fields }
+  const fieldWithItems = Object.values(fieldsClone).find(field => {
     if (Object.prototype.hasOwnProperty.call(field, 'items')) {
       return true
     }
@@ -210,10 +211,12 @@ async function setupAssessmentQuestions(fields) {
       .map(mapAssessmentQuestionToTranslation)
       .map(mapReferenceDataToOption)
 
-    Object.entries(fields).forEach(([key, field]) =>
+    Object.entries(fieldsClone).forEach(([key, field]) =>
       setDependentValidation(key, field, fieldWithItems)
     )
   }
+
+  return fieldsClone
 }
 
 module.exports = {
@@ -224,5 +227,5 @@ module.exports = {
   translateField,
   insertInitialOption,
   insertItemConditional,
-  setupAssessmentQuestions,
+  populateAssessmentQuestions,
 }

--- a/common/helpers/field.test.js
+++ b/common/helpers/field.test.js
@@ -12,7 +12,7 @@ const {
   translateField,
   insertInitialOption,
   insertItemConditional,
-  setupAssessmentQuestions,
+  populateAssessmentQuestions,
 } = require('./field')
 
 const questionsMock = [
@@ -75,8 +75,9 @@ describe('Form helpers', function() {
     })
   })
 
-  describe('#setupAssessmentQuestions()', function() {
+  describe('#populateAssessmentQuestions()', function() {
     let fields
+    let response
 
     beforeEach(function() {
       sinon
@@ -107,38 +108,38 @@ describe('Form helpers', function() {
 
     context('by default', function() {
       beforeEach(async function() {
-        await setupAssessmentQuestions(fields)
+        response = await populateAssessmentQuestions(fields)
       })
 
       it('should add conditional property', function() {
-        expect(fields.risk.items[0]).to.have.property('conditional')
-        expect(fields.risk.items[0].conditional).to.equal('risk__violent')
+        expect(response.risk.items[0]).to.have.property('conditional')
+        expect(response.risk.items[0].conditional).to.equal('risk__violent')
       })
     })
 
     context('without available translations', function() {
       beforeEach(async function() {
         sinon.stub(i18n, 'exists').returns(false)
-        await setupAssessmentQuestions(fields)
+        response = await populateAssessmentQuestions(fields)
       })
 
       it('should return correctly formatted option', function() {
-        expect(fields.risk.items[0].text).to.equal('Violent')
-        expect(fields.risk.items[0].hint).to.be.undefined
+        expect(response.risk.items[0].text).to.equal('Violent')
+        expect(response.risk.items[0].hint).to.be.undefined
       })
     })
 
     context('with available translations', function() {
       beforeEach(async function() {
         sinon.stub(i18n, 'exists').returns(true)
-        await setupAssessmentQuestions(fields)
+        response = await populateAssessmentQuestions(fields)
       })
 
       it('should return with translation strings', function() {
-        expect(fields.risk.items[0].text).to.equal(
+        expect(response.risk.items[0].text).to.equal(
           'fields::risk.items.violent.label'
         )
-        expect(fields.risk.items[0].hint).to.deep.equal({
+        expect(response.risk.items[0].hint).to.deep.equal({
           text: 'fields::risk.items.violent.hint',
         })
       })
@@ -146,11 +147,11 @@ describe('Form helpers', function() {
 
     context('with validation', function() {
       beforeEach(async function() {
-        await setupAssessmentQuestions(fields)
+        response = await populateAssessmentQuestions(fields)
       })
 
       it('should return with dependent details', function() {
-        expect(fields.risk__violent.dependent).to.deep.equal({
+        expect(response.risk__violent.dependent).to.deep.equal({
           field: 'risk',
           value: 'd3a50d7a-6cf4-4eeb-a013-1ff8c5c47cc1',
         })
@@ -165,11 +166,11 @@ describe('Form helpers', function() {
           risk__violent: {},
         }
         expectedFields = { ...fields }
-        await setupAssessmentQuestions(fields)
+        response = await populateAssessmentQuestions(fields)
       })
 
       it('should not mutate original item', function() {
-        expect(fields).to.deep.equal(expectedFields)
+        expect(response).to.deep.equal(expectedFields)
       })
     })
   })

--- a/common/helpers/field.test.js
+++ b/common/helpers/field.test.js
@@ -1,19 +1,30 @@
 const { cloneDeep, set } = require('lodash')
+const referenceDataService = require('../../common/services/reference-data')
+const referenceDataHelpers = require('../../common/helpers/reference-data')
+const componentService = require('../services/component')
+const i18n = require('../../config/i18n')
 
 const {
-  mapAssessmentQuestionToTranslation,
   mapReferenceDataToOption,
-  mapAssessmentQuestionToConditionalField,
   renderConditionalFields,
   setFieldValue,
   setFieldError,
   translateField,
   insertInitialOption,
   insertItemConditional,
+  setupAssessmentQuestions,
 } = require('./field')
 
-const componentService = require('../services/component')
-const i18n = require('../../config/i18n')
+const questionsMock = [
+  {
+    id: 'd3a50d7a-6cf4-4eeb-a013-1ff8c5c47cc1',
+    type: 'profile_attribute_types',
+    category: 'risk',
+    key: 'violent',
+    title: 'Violent',
+    hint: 'mock hint',
+  },
+]
 
 describe('Form helpers', function() {
   describe('#mapReferenceDataToOption()', function() {
@@ -62,105 +73,103 @@ describe('Form helpers', function() {
         })
       })
     })
-
-    context('with hint property', function() {
-      it('should return correctly formatted option', function() {
-        const option = mapReferenceDataToOption({
-          key: 'unique_key',
-          id: '416badc8-e3ac-47d7-b116-ae3f5b2e4697',
-          title: 'Foo',
-          hint: 'eat more vegetables',
-        })
-
-        expect(option).to.deep.equal({
-          key: 'unique_key',
-          value: '416badc8-e3ac-47d7-b116-ae3f5b2e4697',
-          text: 'Foo',
-          hint: {
-            text: 'eat more vegetables',
-          },
-        })
-      })
-    })
   })
 
-  describe('#mapAssessmentQuestionToTranslation()', function() {
-    const mockItem = {
-      title: 'example title',
-      category: 'mock-category',
-      key: 'mock-key',
-      hint: 'mock hint',
-    }
+  describe('#setupAssessmentQuestions()', function() {
+    let fields
 
-    context('without available translations', function() {
-      beforeEach(function() {
-        sinon.stub(i18n, 'exists').returns(false)
+    beforeEach(function() {
+      sinon
+        .stub(referenceDataHelpers, 'filterDisabled')
+        .callsFake(() => () => true)
+      sinon
+        .stub(referenceDataService, 'getAssessmentQuestions')
+        .resolves(questionsMock)
+
+      fields = {
+        risk: {
+          name: 'risk',
+          items: [],
+        },
+        risk__violent: {
+          skip: true,
+          rows: 3,
+          component: 'govukTextarea',
+          classes: 'govuk-input--width-20',
+          label: {
+            text: 'fields::assessment_comment.required',
+            classes: 'govuk-label--s',
+          },
+          validate: 'required',
+        },
+      }
+    })
+
+    context('by default', function() {
+      beforeEach(async function() {
+        await setupAssessmentQuestions(fields)
       })
 
-      it('should return unchanged item', function() {
-        const option = mapAssessmentQuestionToTranslation(mockItem)
+      it('should add conditional property', function() {
+        expect(fields.risk.items[0]).to.have.property('conditional')
+        expect(fields.risk.items[0].conditional).to.equal('risk__violent')
+      })
+    })
 
-        expect(option).to.deep.equal({
-          title: 'example title',
-          category: 'mock-category',
-          hint: undefined,
-          key: 'mock-key',
-        })
+    context('without available translations', function() {
+      beforeEach(async function() {
+        sinon.stub(i18n, 'exists').returns(false)
+        await setupAssessmentQuestions(fields)
+      })
+
+      it('should return correctly formatted option', function() {
+        expect(fields.risk.items[0].text).to.equal('Violent')
+        expect(fields.risk.items[0].hint).to.be.undefined
       })
     })
 
     context('with available translations', function() {
-      beforeEach(function() {
+      beforeEach(async function() {
         sinon.stub(i18n, 'exists').returns(true)
+        await setupAssessmentQuestions(fields)
       })
 
-      it('should return item with translation strings', function() {
-        const option = mapAssessmentQuestionToTranslation(mockItem)
-
-        expect(option).to.deep.equal({
-          title: 'fields::mock-category.items.mock-key.label',
-          category: 'mock-category',
-          hint: 'fields::mock-category.items.mock-key.hint',
-          key: 'mock-key',
+      it('should return with translation strings', function() {
+        expect(fields.risk.items[0].text).to.equal(
+          'fields::risk.items.violent.label'
+        )
+        expect(fields.risk.items[0].hint).to.deep.equal({
+          text: 'fields::risk.items.violent.hint',
         })
       })
     })
-  })
 
-  describe('#mapAssessmentQuestionToConditionalField()', function() {
-    context('by default', function() {
-      let item, response
-
-      beforeEach(function() {
-        item = {
-          id: '416badc8-e3ac-47d7-b116-ae3f5b2e4697',
-          category: 'risk',
-          key: 'violent',
-        }
-
-        response = mapAssessmentQuestionToConditionalField(item)
+    context('with validation', function() {
+      beforeEach(async function() {
+        await setupAssessmentQuestions(fields)
       })
 
-      it('should add conditional property', function() {
-        expect(response).to.have.property('conditional')
-        expect(response.conditional).to.equal('risk__violent')
-      })
-
-      it('should keep original properties', function() {
-        expect(response).to.deep.equal({
-          id: '416badc8-e3ac-47d7-b116-ae3f5b2e4697',
-          category: 'risk',
-          key: 'violent',
-          conditional: 'risk__violent',
+      it('should return with dependent details', function() {
+        expect(fields.risk__violent.dependent).to.deep.equal({
+          field: 'risk',
+          value: 'd3a50d7a-6cf4-4eeb-a013-1ff8c5c47cc1',
         })
+      })
+    })
+
+    context('without parent field', function() {
+      let expectedFields
+      beforeEach(async function() {
+        fields = {
+          risk: {},
+          risk__violent: {},
+        }
+        expectedFields = { ...fields }
+        await setupAssessmentQuestions(fields)
       })
 
       it('should not mutate original item', function() {
-        expect(item).to.deep.equal({
-          id: '416badc8-e3ac-47d7-b116-ae3f5b2e4697',
-          category: 'risk',
-          key: 'violent',
-        })
+        expect(fields).to.deep.equal(expectedFields)
       })
     })
   })

--- a/locales/en/fields.json
+++ b/locales/en/fields.json
@@ -108,5 +108,14 @@
   },
   "cancellation_reason_comment": {
     "label": "Give details"
+  },
+  "court__other_court": {
+    "label": "Any other information details"
+  },
+  "risk__other_risks": {
+    "label": "Any other risks details"
+  },
+  "health__other_health": {
+    "label": "Any other requirements details"
   }
 }


### PR DESCRIPTION
## Make other comments boxes mandatory

This work makes the "other" comment boxes in the assessment section of the move journey mandatory.

### Screenshots
![give-details-other-errors](https://user-images.githubusercontent.com/2305016/65981084-47961900-e470-11e9-8db1-b979709556a2.gif)
