### PR TITLE
[P4-487] Extend session expiry on page loads

### DIFF
--- a/server.js
+++ b/server.js
@@ -99,6 +99,7 @@ app.use(
     name: config.SESSION.NAME,
     saveUninitialized: false,
     resave: false,
+    rolling: true,
     cookie: {
       secure: config.IS_PRODUCTION,
       maxAge: config.SESSION.TTL,


### PR DESCRIPTION
## Requirement 
We need to reset the expiry time in the client side cookie each time the user visits a new page so that they aren't logged out after doing 30 minutes of activity.

## Feature
Force a session identifier cookie to be set on every response by adding the `rolling: true` property to the `express-session` config. 
Information can be found https://github.com/expressjs/session#rolling