### PR TITLE
Remove cookie parser middleware

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3527,15 +3527,6 @@
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
       "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
     },
-    "cookie-parser": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.4.tgz",
-      "integrity": "sha512-lo13tqF3JEtFO7FyA49CqbhaFkskRJ0u/UAiINgrIXeRCY41c88/zxtrECl8AKH3B0hj9q10+h3Kt8I7KlW4tw==",
-      "requires": {
-        "cookie": "0.3.1",
-        "cookie-signature": "1.0.6"
-      }
-    },
     "cookie-signature": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
     "compression": "1.7.4",
     "connect-flash": "0.1.1",
     "connect-redis": "4.0.2",
-    "cookie-parser": "1.4.4",
     "date-fns": "2.3.0",
     "debug": "4.1.1",
     "devour-client": "2.1.0",

--- a/server.js
+++ b/server.js
@@ -3,7 +3,6 @@ const path = require('path')
 
 // NPM dependencies
 const compression = require('compression')
-const cookieParser = require('cookie-parser')
 const express = require('express')
 const helmet = require('helmet')
 const morgan = require('morgan')
@@ -90,7 +89,6 @@ app.use(morgan('dev'))
 app.use(compression())
 app.use(express.json())
 app.use(express.urlencoded({ extended: true, limit: '1mb' }))
-app.use(cookieParser())
 app.use(responseTime())
 app.use(
   session({


### PR DESCRIPTION
The cookie parser middleware is no longer needed for express session as
per the note found https://github.com/expressjs/session#sessionoptions

This work removes the cookie parser middleware.

Note: we are not using `req.cookies` anywhere in the app so this middleware has been added because it used to be required for `express-session` to work.
