### PR TITLE
Refactor locations to cater for suppliers

### DIFF
--- a/common/lib/user.js
+++ b/common/lib/user.js
@@ -29,7 +29,12 @@ User.prototype = {
     }
 
     if (roles.includes('ROLE_PECS_SUPPLIER')) {
-      permissions.push('moves:view:all', 'moves:download:all')
+      permissions.push(
+        'moves:view:all',
+        'moves:download:all',
+        'moves:view:by_location',
+        'moves:download:by_location'
+      )
     }
 
     return uniq(permissions)

--- a/common/lib/user.test.js
+++ b/common/lib/user.test.js
@@ -120,6 +120,8 @@ describe('User class', function() {
         expect(permissions).to.deep.equal([
           'moves:view:all',
           'moves:download:all',
+          'moves:view:by_location',
+          'moves:download:by_location',
         ])
       })
     })

--- a/common/services/reference-data.js
+++ b/common/services/reference-data.js
@@ -77,6 +77,14 @@ const referenceDataService = {
     })
   },
 
+  getLocationsBySupplierId(supplierId) {
+    return referenceDataService.getLocations({
+      filter: {
+        'filter[supplier_ids]': supplierId,
+      },
+    })
+  },
+
   mapLocationIdsToLocations(ids, callback) {
     const locationPromises = ids.map(id => {
       return callback(id).catch(() => false)

--- a/common/services/reference-data.test.js
+++ b/common/services/reference-data.test.js
@@ -550,4 +550,69 @@ describe('Reference Data Service', function() {
       })
     })
   })
+
+  describe('#getLocationsBySupplierId()', function() {
+    const mockResponse = mockLocations
+    let locations
+
+    beforeEach(async function() {
+      sinon.stub(referenceDataService, 'getLocations').resolves(mockResponse)
+    })
+
+    context('without id', function() {
+      beforeEach(async function() {
+        locations = await referenceDataService.getLocationsBySupplierId()
+      })
+
+      it('should call getMoves methods', function() {
+        expect(referenceDataService.getLocations).to.be.calledOnce
+      })
+
+      it('should return first result', function() {
+        expect(locations).to.deep.equal(mockResponse)
+      })
+
+      describe('filters', function() {
+        let filters
+
+        beforeEach(function() {
+          filters = referenceDataService.getLocations.args[0][0].filter
+        })
+
+        it('should set location_type filter to undefined', function() {
+          expect(filters).to.contain.property('filter[supplier_ids]')
+          expect(filters['filter[supplier_ids]']).to.equal(undefined)
+        })
+      })
+    })
+
+    context('with id', function() {
+      const mockId = 'd335715f-c9d1-415c-a7c8-06e830158214'
+
+      beforeEach(async function() {
+        locations = await referenceDataService.getLocationsBySupplierId(mockId)
+      })
+
+      it('should call getMoves methods', function() {
+        expect(referenceDataService.getLocations).to.be.calledOnce
+      })
+
+      it('should return first result', function() {
+        expect(locations).to.deep.equal(mockResponse)
+      })
+
+      describe('filters', function() {
+        let filters
+
+        beforeEach(function() {
+          filters = referenceDataService.getLocations.args[0][0].filter
+        })
+
+        it('should set location_type filter to agency ID', function() {
+          expect(filters).to.contain.property('filter[supplier_ids]')
+          expect(filters['filter[supplier_ids]']).to.equal(mockId)
+        })
+      })
+    })
+  })
 })


### PR DESCRIPTION
This change refactors the way locations are retrieved for supplier users.

When a user has a supplier role it will lookup the list of locations using a different filter from the API.

This then allows the user to be treated the same way as other users and to see a list of locations they can access.

This is the first step in filtering moves for suppliers.