### PR TITLE
Extend session expiry on page loads

### DIFF
--- a/server.js
+++ b/server.js
@@ -97,6 +97,7 @@ app.use(
     name: config.SESSION.NAME,
     saveUninitialized: false,
     resave: false,
+    rolling: true,
     cookie: {
       secure: config.IS_PRODUCTION,
       maxAge: config.SESSION.TTL,


### PR DESCRIPTION
## Feature

Force a session identifier cookie to be set on every response by adding
the 'rolling: true' property to express-session. Information can be
found https://github.com/expressjs/session#rolling

## Of Note
I suspect this will stop the timeout we see when a move is left for an amount of time even through the user is refreshing the page


