### PR TITLE
Reverting the removal of cookie-parser dep

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3527,6 +3527,15 @@
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
       "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
     },
+    "cookie-parser": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.4.tgz",
+      "integrity": "sha512-lo13tqF3JEtFO7FyA49CqbhaFkskRJ0u/UAiINgrIXeRCY41c88/zxtrECl8AKH3B0hj9q10+h3Kt8I7KlW4tw==",
+      "requires": {
+        "cookie": "0.3.1",
+        "cookie-signature": "1.0.6"
+      }
+    },
     "cookie-signature": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "compression": "1.7.4",
     "connect-flash": "0.1.1",
     "connect-redis": "4.0.2",
+    "cookie-parser": "1.4.4",
     "date-fns": "2.3.0",
     "debug": "4.1.1",
     "devour-client": "2.1.0",

--- a/server.js
+++ b/server.js
@@ -3,6 +3,7 @@ const path = require('path')
 
 // NPM dependencies
 const compression = require('compression')
+const cookieParser = require('cookie-parser')
 const express = require('express')
 const helmet = require('helmet')
 const morgan = require('morgan')
@@ -89,6 +90,7 @@ app.use(morgan('dev'))
 app.use(compression())
 app.use(express.json())
 app.use(express.urlencoded({ extended: true, limit: '1mb' }))
+app.use(cookieParser())
 app.use(responseTime())
 app.use(
   session({


### PR DESCRIPTION
It turns out that hmpo-form-wizard requires the use of cookie-parser.
This work reverts the previous removal of cookie-parser in #267

