### PR TITLE
Allow users to view all locations at once

### DIFF
--- a/app/locations/controllers.js
+++ b/app/locations/controllers.js
@@ -21,7 +21,20 @@ function setLocation(req, res, next) {
   res.redirect('/')
 }
 
+function setAllLocations(req, res, next) {
+  const { permissions = [] } = req.session.user || {}
+
+  if (!permissions.includes('moves:view:all')) {
+    return next()
+  }
+
+  req.session.currentLocation = null
+
+  res.redirect('/')
+}
+
 module.exports = {
   locations,
   setLocation,
+  setAllLocations,
 }

--- a/app/locations/controllers.test.js
+++ b/app/locations/controllers.test.js
@@ -122,4 +122,59 @@ describe('Locations controllers', function() {
       })
     })
   })
+
+  describe('#setAllLocations', function() {
+    let nextSpy
+
+    beforeEach(function() {
+      req = {
+        session: {},
+      }
+      res = {
+        redirect: sinon.spy(),
+      }
+      nextSpy = sinon.spy()
+    })
+
+    context('when user does not have permission', function() {
+      beforeEach(function() {
+        controllers.setAllLocations(req, res, nextSpy)
+      })
+
+      it('should call next without args', function() {
+        expect(nextSpy).to.be.calledOnceWithExactly()
+      })
+
+      it('should not set currentLocation', function() {
+        expect(req.session).not.to.have.property('currentLocation')
+      })
+
+      it('should not redirect', function() {
+        expect(res.redirect).not.to.be.called
+      })
+    })
+
+    context('when locationId is found in user locations', function() {
+      beforeEach(function() {
+        req.session.user = {
+          permissions: ['moves:view:all'],
+        }
+
+        controllers.setAllLocations(req, res, nextSpy)
+      })
+
+      it('should set currentLocation', function() {
+        expect(req.session).to.have.property('currentLocation')
+        expect(req.session.currentLocation).to.equal(null)
+      })
+
+      it('should redirect to homepage', function() {
+        expect(res.redirect).to.be.calledOnceWithExactly('/')
+      })
+
+      it('should not call next', function() {
+        expect(nextSpy).not.to.be.called
+      })
+    })
+  })
 })

--- a/app/locations/index.js
+++ b/app/locations/index.js
@@ -2,13 +2,14 @@
 const router = require('express').Router()
 
 // Local dependencies
-const { locations, setLocation } = require('./controllers')
+const { locations, setAllLocations, setLocation } = require('./controllers')
 const { setUserLocations, checkLocationsLength } = require('./middleware')
 
 router.use(setUserLocations)
 
 // Define routes
 router.get('/', checkLocationsLength, locations)
+router.get('/all', setAllLocations)
 router.get('/:locationId', setLocation)
 
 // Export

--- a/app/locations/views/locations.njk
+++ b/app/locations/views/locations.njk
@@ -13,6 +13,14 @@
     </h1>
   </header>
 
+  {% if canAccess("moves:view:all") %}
+    <p class="govuk-list govuk-!-font-size-24 govuk-!-font-weight-bold">
+      <a href="/locations/all">{{ t("locations::view_all_locations") }}</a>
+    </p>
+
+    <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+  {% endif %}
+
   {% if locations | length %}
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">

--- a/common/middleware/ensure-current-location.js
+++ b/common/middleware/ensure-current-location.js
@@ -1,14 +1,11 @@
+const { isUndefined } = require('lodash')
+
 function ensureCurrentLocation({ locationsMountpath, whitelist = [] } = {}) {
   return (req, res, next) => {
-    const { permissions = [], locations = [] } = req.session.user || {}
-    const canViewAllMovesWithoutLocations =
-      permissions.includes('moves:view:all') && !locations.length
-
     if (
-      req.session.currentLocation ||
+      !isUndefined(req.session.currentLocation) ||
       whitelist.includes(req.url) ||
-      req.url.includes(locationsMountpath) ||
-      canViewAllMovesWithoutLocations
+      req.url.includes(locationsMountpath)
     ) {
       return next()
     }

--- a/common/middleware/ensure-current-location.test.js
+++ b/common/middleware/ensure-current-location.test.js
@@ -16,9 +16,27 @@ describe('Ensure current location middleware', function() {
     }
   })
 
-  context('when current location exists on session', function() {
+  context('when current is a string', function() {
     beforeEach(function() {
       req.session.currentLocation = 'current-location'
+
+      ensureCurrentLocation({
+        locationsMountpath,
+      })(req, res, nextSpy)
+    })
+
+    it('should call next', function() {
+      expect(nextSpy).to.be.calledOnceWithExactly()
+    })
+
+    it('should not redirect', function() {
+      expect(res.redirect).not.to.be.called
+    })
+  })
+
+  context('when current location is null', function() {
+    beforeEach(function() {
+      req.session.currentLocation = null
 
       ensureCurrentLocation({
         locationsMountpath,
@@ -84,71 +102,6 @@ describe('Ensure current location middleware', function() {
 
     it('should redirect to locations mountpath', function() {
       expect(res.redirect).to.be.calledOnceWithExactly(locationsMountpath)
-    })
-  })
-
-  context('when user has view all moves permission', function() {
-    beforeEach(function() {
-      req.session.user = {
-        permissions: ['moves:view:all'],
-      }
-    })
-
-    context('when user locations contains items', function() {
-      beforeEach(function() {
-        req.session.user.locations = [
-          {
-            id: '1',
-            name: 'Location one',
-          },
-        ]
-
-        ensureCurrentLocation({
-          locationsMountpath,
-        })(req, res, nextSpy)
-      })
-
-      it('should not call next', function() {
-        expect(nextSpy).not.to.be.called
-      })
-
-      it('should redirect to locations mountpath', function() {
-        expect(res.redirect).to.be.calledOnceWithExactly(locationsMountpath)
-      })
-    })
-
-    context('when user locations is empty list', function() {
-      beforeEach(function() {
-        req.session.user.locations = []
-
-        ensureCurrentLocation({
-          locationsMountpath,
-        })(req, res, nextSpy)
-      })
-
-      it('should call next', function() {
-        expect(nextSpy).to.be.calledOnceWithExactly()
-      })
-
-      it('should not redirect', function() {
-        expect(res.redirect).not.to.be.called
-      })
-    })
-
-    context('when user locations does not exist', function() {
-      beforeEach(function() {
-        ensureCurrentLocation({
-          locationsMountpath,
-        })(req, res, nextSpy)
-      })
-
-      it('should call next', function() {
-        expect(nextSpy).to.be.calledOnceWithExactly()
-      })
-
-      it('should not redirect', function() {
-        expect(res.redirect).not.to.be.called
-      })
     })
   })
 })

--- a/common/templates/layouts/base.njk
+++ b/common/templates/layouts/base.njk
@@ -100,9 +100,9 @@
   }) }}
 
   {% block organisationSwitcher %}
-    {% if CURRENT_LOCATION %}
+    {% if CURRENT_LOCATION or canAccess("moves:view:all") %}
       {{ mojOrganisationSwitcher({
-        text: CURRENT_LOCATION.title,
+        text: CURRENT_LOCATION.title or t("locations::all_locations"),
         link: {
           text: t("actions::switch_location"),
           href: '/locations'

--- a/locales/en/locations.json
+++ b/locales/en/locations.json
@@ -1,5 +1,6 @@
 {
   "heading": "Choose location",
+  "all_locations": "All locations",
   "view_all_locations": "View all locations",
   "no_locations": {
     "heading": "You do not have locations set up",

--- a/locales/en/locations.json
+++ b/locales/en/locations.json
@@ -1,5 +1,6 @@
 {
   "heading": "Choose location",
+  "view_all_locations": "View all locations",
   "no_locations": {
     "heading": "You do not have locations set up",
     "content": "Contact support to add your location. This is usually where you work.",


### PR DESCRIPTION
This change updates how a location is checked and set.

This allows users with a role of `moves:view:all` to be able to select all moves available to them.