### PR TITLE
Update missing location error handling

### DIFF
--- a/app/move/controllers/create/base.js
+++ b/app/move/controllers/create/base.js
@@ -20,7 +20,8 @@ class CreateBaseController extends FormWizardController {
 
   checkCurrentLocation(req, res, next) {
     if (!req.session.currentLocation) {
-      const error = new Error('Current location is not set in session.')
+      const error = new Error('Current location is not set in session')
+      error.code = 'MISSING_LOCATION'
       return next(error)
     }
 

--- a/app/move/controllers/create/base.test.js
+++ b/app/move/controllers/create/base.test.js
@@ -118,8 +118,9 @@ describe('Move controllers', function() {
           expect(nextSpy).to.be.calledOnce
           expect(nextSpy.args[0][0]).to.be.an('error')
           expect(nextSpy.args[0][0].message).to.equal(
-            'Current location is not set in session.'
+            'Current location is not set in session'
           )
+          expect(nextSpy.args[0][0].code).to.equal('MISSING_LOCATION')
         })
       })
     })

--- a/common/controllers/form-wizard.js
+++ b/common/controllers/form-wizard.js
@@ -26,7 +26,11 @@ class FormController extends Controller {
       return res.redirect(err.redirect)
     }
 
-    if (err.code === 'SESSION_TIMEOUT' || err.code === 'MISSING_PREREQ') {
+    if (
+      ['SESSION_TIMEOUT', 'MISSING_PREREQ', 'MISSING_LOCATION'].includes(
+        err.code
+      )
+    ) {
       return res.render('form-wizard-error', {
         journeyName: req.form.options.journeyName.replace('-', '_'),
         journeyBaseUrl: req.baseUrl,

--- a/common/controllers/form-wizard.test.js
+++ b/common/controllers/form-wizard.test.js
@@ -6,323 +6,355 @@ const fieldHelpers = require('../helpers/field')
 
 const controller = new Controller({ route: '/' })
 
-describe('Move controllers', function() {
-  describe('Form wizard', function() {
-    describe('#getErrors()', function() {
-      let errors
+describe('Form wizard', function() {
+  describe('#getErrors()', function() {
+    let errors
 
+    beforeEach(function() {
+      sinon.stub(FormController.prototype, 'getErrors')
+    })
+
+    context('when parent returns empty errors object', function() {
       beforeEach(function() {
-        sinon.stub(FormController.prototype, 'getErrors')
+        FormController.prototype.getErrors.returns({})
+        errors = controller.getErrors({}, {})
       })
 
-      context('when parent returns empty errors object', function() {
-        beforeEach(function() {
-          FormController.prototype.getErrors.returns({})
-          errors = controller.getErrors({}, {})
-        })
-
-        it('should set an empty error list property', function() {
-          expect(errors.errorList.length).to.equal(0)
-        })
-      })
-
-      context('when parent returns an errors object', function() {
-        beforeEach(function() {
-          FormController.prototype.getErrors.returns({
-            fieldOne: {
-              key: 'fieldOne',
-              type: 'required',
-              url: '/step-url',
-            },
-            fieldTwo: {
-              key: 'fieldTwo',
-              type: 'required',
-              url: '/step-url',
-            },
-          })
-          const reqMock = {
-            t: sinon.stub().returnsArg(0),
-          }
-          errors = controller.getErrors(reqMock, {})
-        })
-
-        it('should contain correct number of errors', function() {
-          expect(errors.errorList.length).to.equal(2)
-        })
-
-        it('should transform and append messages property', function() {
-          expect(errors).to.deep.equal({
-            fieldOne: {
-              key: 'fieldOne',
-              type: 'required',
-              url: '/step-url',
-            },
-            fieldTwo: {
-              key: 'fieldTwo',
-              type: 'required',
-              url: '/step-url',
-            },
-            errorList: [
-              {
-                href: '#fieldOne',
-                text: 'fields::fieldOne.label validation::required',
-              },
-              {
-                href: '#fieldTwo',
-                text: 'fields::fieldTwo.label validation::required',
-              },
-            ],
-          })
-        })
+      it('should set an empty error list property', function() {
+        expect(errors.errorList.length).to.equal(0)
       })
     })
 
-    describe('#errorHandler()', function() {
-      let errorMock, resMock
-
+    context('when parent returns an errors object', function() {
       beforeEach(function() {
-        errorMock = new Error()
-        resMock = {
-          redirect: sinon.spy(),
-          render: sinon.spy(),
+        FormController.prototype.getErrors.returns({
+          fieldOne: {
+            key: 'fieldOne',
+            type: 'required',
+            url: '/step-url',
+          },
+          fieldTwo: {
+            key: 'fieldTwo',
+            type: 'required',
+            url: '/step-url',
+          },
+        })
+        const reqMock = {
+          t: sinon.stub().returnsArg(0),
         }
-        sinon.spy(FormController.prototype, 'errorHandler')
+        errors = controller.getErrors(reqMock, {})
       })
 
-      context('when a redirect property is set', function() {
-        beforeEach(function() {
-          errorMock.code = 'MISSING_PREREQ'
-          errorMock.redirect = '/error-redirect-path/'
-
-          controller.errorHandler(errorMock, {}, resMock)
-        })
-
-        it('redirect to specified value', function() {
-          expect(resMock.redirect).to.be.calledWith(errorMock.redirect)
-        })
-
-        it('should not call parent error handler', function() {
-          expect(FormController.prototype.errorHandler).not.to.be.called
-        })
+      it('should contain correct number of errors', function() {
+        expect(errors.errorList.length).to.equal(2)
       })
 
-      context('when it returns session timeout error', function() {
-        let reqMock
-
-        beforeEach(function() {
-          errorMock.code = 'SESSION_TIMEOUT'
-          reqMock = {
-            baseUrl: '/journey-base-url',
-            form: {
-              options: {
-                journeyName: 'mock-journey',
-              },
+      it('should transform and append messages property', function() {
+        expect(errors).to.deep.equal({
+          fieldOne: {
+            key: 'fieldOne',
+            type: 'required',
+            url: '/step-url',
+          },
+          fieldTwo: {
+            key: 'fieldTwo',
+            type: 'required',
+            url: '/step-url',
+          },
+          errorList: [
+            {
+              href: '#fieldOne',
+              text: 'fields::fieldOne.label validation::required',
             },
-          }
-
-          controller.errorHandler(errorMock, reqMock, resMock)
-        })
-
-        it('should render the timeout template', function() {
-          expect(resMock.render.args[0][0]).to.equal('form-wizard-error')
-        })
-
-        it('should pass the correct data to the view', function() {
-          expect(resMock.render.args[0][1]).to.deep.equal({
-            journeyBaseUrl: reqMock.baseUrl,
-            errorKey: errorMock.code.toLowerCase(),
-            journeyName: 'mock_journey',
-          })
-        })
-
-        it('should not call parent error handler', function() {
-          expect(FormController.prototype.errorHandler).not.to.be.called
-        })
-      })
-
-      context('when it returns missing prereq error', function() {
-        let reqMock
-
-        beforeEach(function() {
-          errorMock.code = 'MISSING_PREREQ'
-          reqMock = {
-            baseUrl: '/journey-base-url-other',
-            form: {
-              options: {
-                journeyName: 'mock-journey',
-              },
+            {
+              href: '#fieldTwo',
+              text: 'fields::fieldTwo.label validation::required',
             },
-          }
-
-          controller.errorHandler(errorMock, reqMock, resMock)
-        })
-
-        it('should render the timeout template', function() {
-          expect(resMock.render.args[0][0]).to.equal('form-wizard-error')
-        })
-
-        it('should pass the correct data to the view', function() {
-          expect(resMock.render.args[0][1]).to.deep.equal({
-            journeyBaseUrl: reqMock.baseUrl,
-            errorKey: errorMock.code.toLowerCase(),
-            journeyName: 'mock_journey',
-          })
-        })
-
-        it('should not call parent error handler', function() {
-          expect(FormController.prototype.errorHandler).not.to.be.called
-        })
-      })
-
-      context('when it returns validation error', function() {
-        let nextSpy
-
-        beforeEach(function() {
-          errorMock.statusCode = 422
-
-          nextSpy = sinon.spy()
-          sinon.spy(Sentry, 'withScope')
-          sinon.stub(Sentry, 'captureException')
-
-          controller.errorHandler(errorMock, {}, {}, nextSpy)
-        })
-
-        it('should call sentry with scope', function() {
-          expect(Sentry.withScope).to.be.calledOnce
-        })
-
-        it('should send error to sentry', function() {
-          expect(Sentry.captureException).to.be.calledOnceWithExactly(errorMock)
-        })
-
-        it('should call parent error handler', function() {
-          expect(FormController.prototype.errorHandler).to.be.calledWith(
-            errorMock,
-            {},
-            {},
-            nextSpy
-          )
-        })
-      })
-
-      context('when any other errors are triggered', function() {
-        let nextSpy
-
-        beforeEach(function() {
-          errorMock.code = 'OTHER_ERROR'
-          nextSpy = sinon.spy()
-        })
-
-        it('should call parent error handler', function() {
-          controller.errorHandler(errorMock, {}, {}, nextSpy)
-
-          expect(FormController.prototype.errorHandler).to.be.calledWith(
-            errorMock,
-            {},
-            {},
-            nextSpy
-          )
+          ],
         })
       })
     })
+  })
 
-    describe('#render()', function() {
-      let reqMock, nextSpy
+  describe('#errorHandler()', function() {
+    let errorMock, resMock
+
+    beforeEach(function() {
+      errorMock = new Error()
+      resMock = {
+        redirect: sinon.spy(),
+        render: sinon.spy(),
+      }
+      sinon.spy(FormController.prototype, 'errorHandler')
+    })
+
+    context('when a redirect property is set', function() {
+      beforeEach(function() {
+        errorMock.code = 'MISSING_PREREQ'
+        errorMock.redirect = '/error-redirect-path/'
+
+        controller.errorHandler(errorMock, {}, resMock)
+      })
+
+      it('redirect to specified value', function() {
+        expect(resMock.redirect).to.be.calledWith(errorMock.redirect)
+      })
+
+      it('should not call parent error handler', function() {
+        expect(FormController.prototype.errorHandler).not.to.be.called
+      })
+    })
+
+    context('when it returns session timeout error', function() {
+      let reqMock
 
       beforeEach(function() {
-        nextSpy = sinon.spy()
-        sinon.spy(FormController.prototype, 'render')
-        sinon
-          .stub(fieldHelpers, 'setFieldValue')
-          .callsFake(() => ([key, field]) => {
-            return [key, { ...field, setFieldValue: true }]
-          })
-        sinon
-          .stub(fieldHelpers, 'setFieldError')
-          .callsFake(() => ([key, field]) => {
-            return [key, { ...field, setFieldError: true }]
-          })
-        sinon
-          .stub(fieldHelpers, 'translateField')
-          .callsFake(() => ([key, field]) => {
-            return [key, { ...field, translateField: true }]
-          })
-        sinon
-          .stub(fieldHelpers, 'renderConditionalFields')
-          .callsFake(([key, field]) => {
-            return [key, { ...field, renderConditionalFields: true }]
-          })
-
+        errorMock.code = 'SESSION_TIMEOUT'
         reqMock = {
+          baseUrl: '/journey-base-url',
           form: {
             options: {
-              fields: {
-                field_1: {
-                  name: 'Field 1',
-                },
-                field_2: {
-                  name: 'Field 2',
-                },
-                field_3: {
-                  name: 'Field 3',
-                },
-              },
+              journeyName: 'mock-journey',
             },
           },
         }
 
-        controller.render(reqMock, {}, nextSpy)
+        controller.errorHandler(errorMock, reqMock, resMock)
       })
 
-      it('should call renderConditionalFields on each field', function() {
-        expect(fieldHelpers.renderConditionalFields).to.be.calledThrice
+      it('should render the timeout template', function() {
+        expect(resMock.render.args[0][0]).to.equal('form-wizard-error')
       })
 
-      it('should call setFieldValue', function() {
-        expect(fieldHelpers.setFieldValue).to.be.calledOnce
-      })
-
-      it('should call setFieldError', function() {
-        expect(fieldHelpers.setFieldError).to.be.calledOnce
-      })
-
-      it('should call translateField', function() {
-        expect(fieldHelpers.setFieldValue).to.be.calledOnce
-      })
-
-      it('should mutate fields object', function() {
-        expect(reqMock.form.options.fields).to.deep.equal({
-          field_1: {
-            renderConditionalFields: true,
-            setFieldValue: true,
-            setFieldError: true,
-            translateField: true,
-            name: 'Field 1',
-          },
-          field_2: {
-            renderConditionalFields: true,
-            setFieldValue: true,
-            setFieldError: true,
-            translateField: true,
-            name: 'Field 2',
-          },
-          field_3: {
-            renderConditionalFields: true,
-            setFieldValue: true,
-            setFieldError: true,
-            translateField: true,
-            name: 'Field 3',
-          },
+      it('should pass the correct data to the view', function() {
+        expect(resMock.render.args[0][1]).to.deep.equal({
+          journeyBaseUrl: reqMock.baseUrl,
+          errorKey: errorMock.code.toLowerCase(),
+          journeyName: 'mock_journey',
         })
       })
 
-      it('should call parent render method', function() {
-        expect(FormController.prototype.render).to.be.calledOnceWithExactly(
-          reqMock,
+      it('should not call parent error handler', function() {
+        expect(FormController.prototype.errorHandler).not.to.be.called
+      })
+    })
+
+    context('when it returns missing prereq error', function() {
+      let reqMock
+
+      beforeEach(function() {
+        errorMock.code = 'MISSING_PREREQ'
+        reqMock = {
+          baseUrl: '/journey-base-url-other',
+          form: {
+            options: {
+              journeyName: 'mock-journey',
+            },
+          },
+        }
+
+        controller.errorHandler(errorMock, reqMock, resMock)
+      })
+
+      it('should render the timeout template', function() {
+        expect(resMock.render.args[0][0]).to.equal('form-wizard-error')
+      })
+
+      it('should pass the correct data to the view', function() {
+        expect(resMock.render.args[0][1]).to.deep.equal({
+          journeyBaseUrl: reqMock.baseUrl,
+          errorKey: errorMock.code.toLowerCase(),
+          journeyName: 'mock_journey',
+        })
+      })
+
+      it('should not call parent error handler', function() {
+        expect(FormController.prototype.errorHandler).not.to.be.called
+      })
+    })
+
+    context('when it returns missing prereq error', function() {
+      let reqMock
+
+      beforeEach(function() {
+        errorMock.code = 'MISSING_LOCATION'
+        reqMock = {
+          baseUrl: '/journey-base-url-other',
+          form: {
+            options: {
+              journeyName: 'mock-journey',
+            },
+          },
+        }
+
+        controller.errorHandler(errorMock, reqMock, resMock)
+      })
+
+      it('should render the timeout template', function() {
+        expect(resMock.render.args[0][0]).to.equal('form-wizard-error')
+      })
+
+      it('should pass the correct data to the view', function() {
+        expect(resMock.render.args[0][1]).to.deep.equal({
+          journeyBaseUrl: reqMock.baseUrl,
+          errorKey: errorMock.code.toLowerCase(),
+          journeyName: 'mock_journey',
+        })
+      })
+
+      it('should not call parent error handler', function() {
+        expect(FormController.prototype.errorHandler).not.to.be.called
+      })
+    })
+
+    context('when it returns validation error', function() {
+      let nextSpy
+
+      beforeEach(function() {
+        errorMock.statusCode = 422
+
+        nextSpy = sinon.spy()
+        sinon.spy(Sentry, 'withScope')
+        sinon.stub(Sentry, 'captureException')
+
+        controller.errorHandler(errorMock, {}, {}, nextSpy)
+      })
+
+      it('should call sentry with scope', function() {
+        expect(Sentry.withScope).to.be.calledOnce
+      })
+
+      it('should send error to sentry', function() {
+        expect(Sentry.captureException).to.be.calledOnceWithExactly(errorMock)
+      })
+
+      it('should call parent error handler', function() {
+        expect(FormController.prototype.errorHandler).to.be.calledWith(
+          errorMock,
+          {},
           {},
           nextSpy
         )
       })
+    })
+
+    context('when any other errors are triggered', function() {
+      let nextSpy
+
+      beforeEach(function() {
+        errorMock.code = 'OTHER_ERROR'
+        nextSpy = sinon.spy()
+      })
+
+      it('should call parent error handler', function() {
+        controller.errorHandler(errorMock, {}, {}, nextSpy)
+
+        expect(FormController.prototype.errorHandler).to.be.calledWith(
+          errorMock,
+          {},
+          {},
+          nextSpy
+        )
+      })
+    })
+  })
+
+  describe('#render()', function() {
+    let reqMock, nextSpy
+
+    beforeEach(function() {
+      nextSpy = sinon.spy()
+      sinon.spy(FormController.prototype, 'render')
+      sinon
+        .stub(fieldHelpers, 'setFieldValue')
+        .callsFake(() => ([key, field]) => {
+          return [key, { ...field, setFieldValue: true }]
+        })
+      sinon
+        .stub(fieldHelpers, 'setFieldError')
+        .callsFake(() => ([key, field]) => {
+          return [key, { ...field, setFieldError: true }]
+        })
+      sinon
+        .stub(fieldHelpers, 'translateField')
+        .callsFake(() => ([key, field]) => {
+          return [key, { ...field, translateField: true }]
+        })
+      sinon
+        .stub(fieldHelpers, 'renderConditionalFields')
+        .callsFake(([key, field]) => {
+          return [key, { ...field, renderConditionalFields: true }]
+        })
+
+      reqMock = {
+        form: {
+          options: {
+            fields: {
+              field_1: {
+                name: 'Field 1',
+              },
+              field_2: {
+                name: 'Field 2',
+              },
+              field_3: {
+                name: 'Field 3',
+              },
+            },
+          },
+        },
+      }
+
+      controller.render(reqMock, {}, nextSpy)
+    })
+
+    it('should call renderConditionalFields on each field', function() {
+      expect(fieldHelpers.renderConditionalFields).to.be.calledThrice
+    })
+
+    it('should call setFieldValue', function() {
+      expect(fieldHelpers.setFieldValue).to.be.calledOnce
+    })
+
+    it('should call setFieldError', function() {
+      expect(fieldHelpers.setFieldError).to.be.calledOnce
+    })
+
+    it('should call translateField', function() {
+      expect(fieldHelpers.setFieldValue).to.be.calledOnce
+    })
+
+    it('should mutate fields object', function() {
+      expect(reqMock.form.options.fields).to.deep.equal({
+        field_1: {
+          renderConditionalFields: true,
+          setFieldValue: true,
+          setFieldError: true,
+          translateField: true,
+          name: 'Field 1',
+        },
+        field_2: {
+          renderConditionalFields: true,
+          setFieldValue: true,
+          setFieldError: true,
+          translateField: true,
+          name: 'Field 2',
+        },
+        field_3: {
+          renderConditionalFields: true,
+          setFieldValue: true,
+          setFieldError: true,
+          translateField: true,
+          name: 'Field 3',
+        },
+      })
+    })
+
+    it('should call parent render method', function() {
+      expect(FormController.prototype.render).to.be.calledOnceWithExactly(
+        reqMock,
+        {},
+        nextSpy
+      )
     })
   })
 })

--- a/common/templates/form-wizard-error.njk
+++ b/common/templates/form-wizard-error.njk
@@ -9,7 +9,7 @@
     </div>
   </header>
   <p>
-    {{ t("errors::" + errorKey + ".content", { context: journeyName }) }}
+    {{ t("errors::" + errorKey + ".content", { context: journeyName }) | safe }}
   </p>
 
   <p>
@@ -17,7 +17,7 @@
     <a href="/moves">
       {{ t("actions::back_to_dashboard") }}
     </a>
-  {% else %}
+  {% elif errorKey == "session_timeout" %}
     <a href="{{ journeyBaseUrl }}" class="govuk-button">
       {{ t("actions::restart") }}
     </a>

--- a/locales/en/errors.json
+++ b/locales/en/errors.json
@@ -7,6 +7,10 @@
     "heading": "Session timeout",
     "content": "Your session has timed out due to a long period of inactivity."
   },
+  "missing_location": {
+    "heading": "Location not chosen",
+    "content": "You must <a href=\"/locations\">choose a location</a> to create a new move."
+  },
   "not_found": {
     "heading": "Page not found",
     "content": "If you entered a web address check it was correct."


### PR DESCRIPTION
This change updates how the app handles a missing location.

If a location is missing it will be treated as an expected error
page.

It will display a message to go to the locations page to set one
before creating a move.

## Before
![localhost_3000_move_new_personal-details (1)](https://user-images.githubusercontent.com/3327997/66353793-d0262500-e95a-11e9-9f06-9e9c014c5721.png)

## After
![localhost_3000_move_new_personal-details](https://user-images.githubusercontent.com/3327997/66353749-b7b60a80-e95a-11e9-9bb6-e0be428d0556.png)
