### PR TITLE
Use supplier auth group to retrieve locations

### DIFF
--- a/app/locations/views/locations.njk
+++ b/app/locations/views/locations.njk
@@ -13,15 +13,15 @@
     </h1>
   </header>
 
-  {% if canAccess("moves:view:all") %}
-    <p class="govuk-list govuk-!-font-size-24 govuk-!-font-weight-bold">
-      <a href="/locations/all">{{ t("locations::view_all_locations") }}</a>
-    </p>
-
-    <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
-  {% endif %}
-
   {% if locations | length %}
+    {% if canAccess("moves:view:all") %}
+      <p class="govuk-list govuk-!-font-size-24 govuk-!-font-weight-bold">
+        <a href="/locations/all">{{ t("locations::view_all_locations") }}</a>
+      </p>
+
+      <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+    {% endif %}
+
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         <ul class="govuk-list govuk-!-font-size-24 govuk-!-font-weight-bold">

--- a/common/lib/api-client/models.js
+++ b/common/lib/api-client/models.js
@@ -95,4 +95,14 @@ module.exports = {
       collectionPath: 'reference/locations',
     },
   },
+  supplier: {
+    attributes: {
+      key: '',
+      name: '',
+    },
+    options: {
+      cache: true,
+      collectionPath: 'reference/suppliers',
+    },
+  },
 }

--- a/common/lib/api-client/models.test.js
+++ b/common/lib/api-client/models.test.js
@@ -68,6 +68,18 @@ const testCases = {
       args: '1',
     },
   ],
+  supplier: [
+    {
+      method: 'findAll',
+      httpMock: 'get',
+    },
+    {
+      method: 'find',
+      httpMock: 'get',
+      mockPath: '/1',
+      args: '1',
+    },
+  ],
 }
 
 const client = proxyquire('./', {

--- a/common/services/reference-data.js
+++ b/common/services/reference-data.js
@@ -93,6 +93,18 @@ const referenceDataService = {
       locations.filter(Boolean)
     )
   },
+
+  getSuppliers() {
+    return apiClient.findAll('supplier').then(response => response.data)
+  },
+
+  getSupplierByKey(key) {
+    if (!key) {
+      return Promise.reject(new Error('No supplier key provided'))
+    }
+
+    return apiClient.find('supplier', key).then(response => response.data)
+  },
 }
 
 module.exports = referenceDataService

--- a/common/services/reference-data.test.js
+++ b/common/services/reference-data.test.js
@@ -23,6 +23,16 @@ const mockEthnicities = [
     title: 'Black (Caribbean)',
   },
 ]
+const mockSuppliers = [
+  {
+    id: 'b95bfb7c-18cd-419d-8119-2dee1506726f',
+    name: 'GEOAmey',
+  },
+  {
+    id: '35660b02-243f-4df2-9337-e3ec49b6d70d',
+    name: 'Serco',
+  },
+]
 const mockAssessmentQuestions = [
   {
     id: '76bb7065-3c69-4b7c-a17b-ac5881d7837e',
@@ -612,6 +622,64 @@ describe('Reference Data Service', function() {
           expect(filters).to.contain.property('filter[supplier_ids]')
           expect(filters['filter[supplier_ids]']).to.equal(mockId)
         })
+      })
+    })
+  })
+
+  describe('#getSuppliers()', function() {
+    const mockResponse = {
+      data: mockSuppliers,
+    }
+    let response
+
+    beforeEach(async function() {
+      sinon.stub(apiClient, 'findAll')
+      apiClient.findAll.withArgs('supplier').resolves(mockResponse)
+
+      response = await referenceDataService.getSuppliers()
+    })
+
+    it('should call API client', function() {
+      expect(apiClient.findAll).to.be.calledOnceWithExactly('supplier')
+    })
+
+    it('should correct number of results', function() {
+      expect(response.length).to.deep.equal(mockSuppliers.length)
+    })
+
+    it('should return response data', function() {
+      expect(response).to.equal(mockSuppliers)
+    })
+  })
+
+  describe('#getSupplierByKey()', function() {
+    context('without supplier key', function() {
+      it('should reject with error', function() {
+        return expect(
+          referenceDataService.getSupplierByKey()
+        ).to.be.rejectedWith('No supplier key provided')
+      })
+    })
+
+    context('with location key', function() {
+      const mockKey = 'serco'
+      const mockResponse = {
+        data: mockSuppliers[0],
+      }
+      let response
+
+      beforeEach(async function() {
+        sinon.stub(apiClient, 'find').resolves(mockResponse)
+
+        response = await referenceDataService.getSupplierByKey(mockKey)
+      })
+
+      it('should call update method with data', function() {
+        expect(apiClient.find).to.be.calledOnceWithExactly('supplier', mockKey)
+      })
+
+      it('should return supplier', function() {
+        expect(response).to.deep.equal(mockResponse.data)
       })
     })
   })

--- a/test/fixtures/api-client/supplier.find.json
+++ b/test/fixtures/api-client/supplier.find.json
@@ -1,0 +1,10 @@
+{
+  "data": {
+    "id": "3ef88a47-6f1f-5b9b-b2fc-c0fe42cb0c92",
+    "type": "suppliers",
+    "attributes": {
+      "name": "Serco",
+      "key": "serco"
+    }
+  }
+}

--- a/test/fixtures/api-client/supplier.findAll.json
+++ b/test/fixtures/api-client/supplier.findAll.json
@@ -1,0 +1,20 @@
+{
+  "data": [
+    {
+      "id": "bccf4d77-984d-560c-9ffd-9badbb9157ca",
+      "type": "suppliers",
+      "attributes": {
+        "name": "GEOAmey",
+        "key": "geoamey"
+      }
+    },
+    {
+      "id": "3ef88a47-6f1f-5b9b-b2fc-c0fe42cb0c92",
+      "type": "suppliers",
+      "attributes": {
+        "name": "Serco",
+        "key": "serco"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
This change uses the key retrieved from a supplier's auth group to get the list of available locations for that supplier.