### PR TITLE
Fix for html in error messages

### DIFF
--- a/common/controllers/form-wizard.js
+++ b/common/controllers/form-wizard.js
@@ -13,7 +13,7 @@ class FormController extends Controller {
       const message = req.t(`validation::${error.type}`)
 
       return {
-        text: `${label} ${message}`,
+        html: `${label} ${message}`,
         href: `#${error.key}`,
       }
     })

--- a/common/controllers/form-wizard.test.js
+++ b/common/controllers/form-wizard.test.js
@@ -64,11 +64,11 @@ describe('Form wizard', function() {
           errorList: [
             {
               href: '#fieldOne',
-              text: 'fields::fieldOne.label validation::required',
+              html: 'fields::fieldOne.label validation::required',
             },
             {
               href: '#fieldTwo',
-              text: 'fields::fieldTwo.label validation::required',
+              html: 'fields::fieldTwo.label validation::required',
             },
           ],
         })

--- a/common/helpers/field.js
+++ b/common/helpers/field.js
@@ -120,7 +120,7 @@ function setFieldError(errors, translate) {
       {
         ...field,
         errorMessage: {
-          text: `${label} ${message}`,
+          html: `${label} ${message}`,
         },
       },
     ]

--- a/common/helpers/field.test.js
+++ b/common/helpers/field.test.js
@@ -559,7 +559,7 @@ describe('Form helpers', function() {
           {
             name: 'error_field',
             errorMessage: {
-              text: 'fields::error_field.label validation::required',
+              html: 'fields::error_field.label validation::required',
             },
           },
         ])


### PR DESCRIPTION
The `abbr` html tag has been brought in previously for labels. This fix
changes the error messages to be html rather than text so that html can
be rendered in an error message.

### Before fix
![Screenshot 2019-10-14 at 16 39 21](https://user-images.githubusercontent.com/2305016/66764513-d4de6200-eea1-11e9-80ee-a2b9a3b2bfe7.png)


### After fix
![Screenshot 2019-10-14 at 16 37 24](https://user-images.githubusercontent.com/2305016/66764524-dd369d00-eea1-11e9-9bf7-44625a3e7d3b.png)


