### PR TITLE
Wrap download file name in quotes

### DIFF
--- a/app/moves/controllers/download.js
+++ b/app/moves/controllers/download.js
@@ -18,7 +18,7 @@ module.exports = function download(req, res, next) {
 
   res.setHeader(
     'Content-disposition',
-    `attachment; filename=${filename}.${extension}`
+    `attachment; filename="${filename}.${extension}"`
   )
 
   if (extension === 'json') {

--- a/app/moves/controllers/download.test.js
+++ b/app/moves/controllers/download.test.js
@@ -94,7 +94,7 @@ describe('Moves controllers', function() {
       it('should set content disposition header', function() {
         expect(res.setHeader).to.be.calledOnceWithExactly(
           'Content-disposition',
-          'attachment; filename=moves::download_filename.json'
+          'attachment; filename="moves::download_filename.json"'
         )
       })
 
@@ -132,7 +132,7 @@ describe('Moves controllers', function() {
         it('should set content disposition header', function() {
           expect(res.setHeader.firstCall).to.be.calledWithExactly(
             'Content-disposition',
-            'attachment; filename=moves::download_filename.csv'
+            'attachment; filename="moves::download_filename.csv"'
           )
         })
 


### PR DESCRIPTION
This fixes the download file name issue in Firefox.