### PR TITLE
Use book-a-secure-move GitHub group for Cloud Platform deployment through Circle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ references:
     docker:
       - image: ${ECR_ENDPOINT}/cloud-platform/tools:circleci
         environment:
-          GITHUB_TEAM_NAME_SLUG: pecs
+          GITHUB_TEAM_NAME_SLUG: book-a-secure-move
 
 commands:
   build_for_k8s:


### PR DESCRIPTION
Should fix the failing CP deployments