### PR TITLE
[P4-776] - Bug fixes PNC search

### DIFF
--- a/app/move/controllers/create/pnc-search-results.test.js
+++ b/app/move/controllers/create/pnc-search-results.test.js
@@ -107,7 +107,7 @@ describe('Move controllers', function() {
                 label: {
                   classes: 'govuk-label--s',
                 },
-                text: 'Foo, Bar',
+                text: 'FOO, BAR',
                 value: '3333',
               },
               {
@@ -117,7 +117,7 @@ describe('Move controllers', function() {
                 label: {
                   classes: 'govuk-label--s',
                 },
-                text: 'Baz, Boo',
+                text: 'BAZ, BOO',
                 value: '4444',
               },
             ])

--- a/app/move/steps/create.js
+++ b/app/move/steps/create.js
@@ -22,7 +22,6 @@ module.exports = {
     method: 'get',
     action: '/move/new/pnc-search-results',
     template: 'move/views/create/pnc-search',
-    backLink: null,
     pageTitle: 'moves::steps.police_national_computer_search_term.heading',
     buttonText: 'actions::continue',
     next: 'pnc-search-results',
@@ -30,6 +29,7 @@ module.exports = {
   },
   '/pnc-search-results': {
     checkJourney: false,
+    backLink: 'pnc-search',
     controller: PncSearchResults,
     template: 'move/views/create/pnc-search-results',
     pageTitle:

--- a/app/move/views/create/pnc-search-results.njk
+++ b/app/move/views/create/pnc-search-results.njk
@@ -38,7 +38,7 @@
 
 {% block formActions %}
   <p class="govuk-body">
-    <a href="/move/new/personal-details">{{ t("actions::create_move_different_person") }}</a>
+    <a href="/move/new/personal-details{{ "?police_national_computer_search_term=" + pncSearchTerm }}">{{ t("actions::create_move_different_person") }}</a>
   </p>
   {{ super() }}
 {% endblock %}

--- a/common/helpers/field.js
+++ b/common/helpers/field.js
@@ -222,7 +222,7 @@ async function populateAssessmentQuestions(fields) {
 
 function mapPersonToOption(person) {
   return {
-    text: person.fullname,
+    text: person.fullname.toUpperCase(),
     label: {
       classes: 'govuk-label--s',
     },

--- a/common/helpers/field.test.js
+++ b/common/helpers/field.test.js
@@ -955,7 +955,7 @@ describe('Form helpers', function() {
 
     it('should not call translation method', function() {
       expect(response).to.deep.equal({
-        text: 'Baz, Boo',
+        text: 'BAZ, BOO',
         label: {
           classes: 'govuk-label--s',
         },

--- a/test/e2e/moves.test.js
+++ b/test/e2e/moves.test.js
@@ -123,7 +123,7 @@ test('Court move with existing PNC', async t => {
     .eql(`Matches for ${courtMovePncNumber}`)
 
   await page.fillInPncSearchResults(
-    `${courtMovePersonalDetails.text.last_name}, ${courtMovePersonalDetails.text.first_names}`
+    `${courtMovePersonalDetails.text.last_name}, ${courtMovePersonalDetails.text.first_names}`.toUpperCase()
   )
   await t.click(page.nodes.continueButton)
 


### PR DESCRIPTION
## Description
Bug fixes for the PNC search journey
- Upper case the detainees name
- Provide a `back` link on the PNC search results page
- Pre-populate the  PNC number when a user clicks the `Create a move for a different person` link

## Screen shot
![pnc-search-bug-fixes](https://user-images.githubusercontent.com/2305016/68017948-da082300-fc8f-11e9-99d9-1ab2d2f26cd5.gif)

