### PR TITLE
Fix for the matches header containing html

### DIFF
--- a/locales/en/moves.json
+++ b/locales/en/moves.json
@@ -23,7 +23,7 @@
     },
     "police_national_computer_search_term_result": {
       "heading": "Create a move",
-      "secondary_heading": "Matches for {{searchTerm}}"
+      "secondary_heading": "Matches for {{- searchTerm}}"
     },
     "personal_details": {
       "heading": "Personal details"


### PR DESCRIPTION
This fix means the search query is not escaped when it is passed to be displayed in the matches header. This is because PNC numbers generally contain a forward slash.

## Before
![Screenshot 2019-11-05 at 11 12 22](https://user-images.githubusercontent.com/2305016/68203191-2bc8ea00-ffbd-11e9-94ee-ea420a8df32b.png)

## After
![Screenshot 2019-11-05 at 11 07 38](https://user-images.githubusercontent.com/2305016/68203203-31263480-ffbd-11e9-9eef-30db340e9750.png)
