### PR TITLE
[P4-788] - Send create a move journey time to GA

### DIFF
--- a/app/move/controllers/confirmation.js
+++ b/app/move/controllers/confirmation.js
@@ -1,5 +1,15 @@
-function confirmation(req, res) {
+const { sendJourneyTime } = require('../../../common/lib/analytics')
+
+async function confirmation(req, res, next) {
   const { move_type: moveType, to_location: toLocation } = res.locals.move
+
+  try {
+    await sendJourneyTime(req, 'createMoveJourneyTime', {
+      utv: 'Create a move',
+    })
+  } catch (err) {
+    next(err)
+  }
 
   const locals = {
     location:

--- a/app/move/controllers/confirmation.test.js
+++ b/app/move/controllers/confirmation.test.js
@@ -1,3 +1,5 @@
+const proxyquire = require('proxyquire')
+const sendJourneyTimeStub = sinon.stub().resolves('GA hit sent')
 const controller = require('./confirmation')
 
 const mockMove = {
@@ -6,13 +8,14 @@ const mockMove = {
     title: 'Axminster Crown Court',
   },
 }
+const mockTimestampKey = 'createMoveJourneyTime'
 
 describe('Move controllers', function() {
   describe('#confirmation()', function() {
     describe('with move_type "court_appearance"', function() {
-      let req, res
+      let req, res, nextSpy
 
-      beforeEach(function() {
+      beforeEach(async function() {
         req = {}
         res = {
           render: sinon.spy(),
@@ -20,8 +23,9 @@ describe('Move controllers', function() {
             move: mockMove,
           },
         }
+        nextSpy = sinon.spy()
 
-        controller(req, res)
+        await controller(req, res, nextSpy)
       })
 
       it('should render confirmation template', function() {
@@ -39,9 +43,9 @@ describe('Move controllers', function() {
     })
 
     describe('with move_type "prison_recall"', function() {
-      let req, res
+      let req, res, nextSpy
 
-      beforeEach(function() {
+      beforeEach(async function() {
         req = {
           t: sinon.stub().returnsArg(0),
         }
@@ -54,8 +58,9 @@ describe('Move controllers', function() {
             },
           },
         }
+        nextSpy = sinon.spy()
 
-        controller(req, res)
+        await controller(req, res, nextSpy)
       })
 
       it('should render confirmation template', function() {
@@ -71,6 +76,89 @@ describe('Move controllers', function() {
         expect(req.t.firstCall).to.have.been.calledWithExactly(
           'fields::move_type.items.prison_recall.label'
         )
+      })
+    })
+
+    describe('with Create Move Journey Timestamp', function() {
+      const controller = proxyquire('./confirmation', {
+        '../../../common/lib/analytics': {
+          sendJourneyTime: sendJourneyTimeStub,
+        },
+      })
+      let req, res, nextSpy
+
+      beforeEach(async function() {
+        req = {}
+        res = {
+          render: sinon.spy(),
+          locals: {
+            move: mockMove,
+          },
+        }
+        nextSpy = sinon.spy()
+
+        await controller(req, res, nextSpy)
+      })
+
+      it('should call GA sendJourneyTime method', function() {
+        expect(sendJourneyTimeStub).to.be.calledOnce
+        expect(sendJourneyTimeStub).to.be.calledWithExactly(
+          req,
+          mockTimestampKey,
+          {
+            utv: 'Create a move',
+          }
+        )
+      })
+
+      it('should render confirmation template', function() {
+        const template = res.render.args[0][0]
+
+        expect(res.render.calledOnce).to.be.true
+        expect(template).to.equal('move/views/confirmation')
+      })
+
+      it('should contain a location param', function() {
+        const params = res.render.args[0][1]
+        expect(params).to.have.property('location')
+        expect(params.location).to.equal(mockMove.to_location.title)
+      })
+    })
+
+    describe('when sendJourneyTime fails', function() {
+      const errorMock = new Error('Problem')
+      const controller = proxyquire('./confirmation', {
+        '../../../common/lib/analytics': {
+          sendJourneyTime: sinon.stub().throws(errorMock),
+          '../../config': {
+            ANALYTICS: {
+              GA_ID: '11111',
+            },
+          },
+        },
+      })
+
+      let req, res, nextSpy
+
+      beforeEach(async function() {
+        req = {}
+        res = {
+          render: sinon.spy(),
+          locals: {
+            move: mockMove,
+          },
+        }
+        nextSpy = sinon.spy()
+
+        await controller(req, res, nextSpy)
+      })
+
+      it('should call next with the error', function() {
+        expect(nextSpy).to.be.calledWith(errorMock)
+      })
+
+      it('should call next once', function() {
+        expect(nextSpy).to.be.calledOnce
       })
     })
   })

--- a/app/move/controllers/create/base.js
+++ b/app/move/controllers/create/base.js
@@ -1,3 +1,4 @@
+const { get, set } = require('lodash')
 const FormWizardController = require('../../../../common/controllers/form-wizard')
 const presenters = require('../../../../common/presenters')
 
@@ -11,10 +12,19 @@ class CreateBaseController extends FormWizardController {
     super.middlewareLocals()
     this.use(this.setCancelUrl)
     this.use(this.setMoveSummary)
+    this.use(this.setJourneyTimer)
   }
 
   setCancelUrl(req, res, next) {
     res.locals.cancelUrl = res.locals.MOVES_URL
+    next()
+  }
+
+  setJourneyTimer(req, res, next) {
+    if (!get(req, 'session.createMoveJourneyTime')) {
+      set(req, 'session.createMoveJourneyTime', process.hrtime())
+    }
+
     next()
   }
 

--- a/app/move/controllers/create/base.test.js
+++ b/app/move/controllers/create/base.test.js
@@ -4,6 +4,8 @@ const CreateBaseController = require('./base')
 
 const controller = new CreateBaseController({ route: '/' })
 
+const mockHrTime = [11111, 22222]
+
 describe('Move controllers', function() {
   describe('Create base controller', function() {
     describe('#middlewareChecks()', function() {
@@ -214,6 +216,55 @@ describe('Move controllers', function() {
         })
 
         it('should call next without error', function() {
+          expect(nextSpy).to.be.calledOnceWithExactly()
+        })
+      })
+    })
+
+    describe('#setJourneyTimer()', function() {
+      let req, nextSpy
+
+      beforeEach(function() {
+        sinon.stub(process, 'hrtime').returns(mockHrTime)
+        nextSpy = sinon.spy()
+      })
+
+      context('with no time in the session', function() {
+        beforeEach(function() {
+          req = {
+            session: {
+              createMoveJourneyTime: undefined,
+            },
+          }
+
+          controller.setJourneyTimer(req, {}, nextSpy)
+        })
+
+        it('should set time', function() {
+          expect(req.session.createMoveJourneyTime).to.equal(mockHrTime)
+        })
+
+        it('should call next', function() {
+          expect(nextSpy).to.be.calledOnceWithExactly()
+        })
+      })
+
+      context('with time in the session', function() {
+        beforeEach(function() {
+          req = {
+            session: {
+              createMoveJourneyTime: mockHrTime,
+            },
+          }
+          controller.setJourneyTimer(req, {}, nextSpy)
+        })
+
+        it('should not set time', function() {
+          expect(process.hrtime).to.not.be.called
+          expect(req.session.createMoveJourneyTime).to.equal(mockHrTime)
+        })
+
+        it('should call next', function() {
           expect(nextSpy).to.be.calledOnceWithExactly()
         })
       })

--- a/common/lib/analytics.js
+++ b/common/lib/analytics.js
@@ -1,0 +1,73 @@
+const uuidv4 = require('uuid/v4')
+const axios = require('axios')
+const { get } = require('lodash')
+const {
+  ANALYTICS: { GA_ID },
+  API: { TIMEOUT: timeout },
+} = require('../../config')
+
+/**
+ *
+ * Server side implementation of sending hit data to Google Analytics
+ * Measurement Protocol
+ * https://developers.google.com/analytics/devguides/collection/protocol/v1/devguide
+ *
+ * @param params
+ * @returns {Promise<AxiosResponse<T>>}
+ */
+function sendHit(params) {
+  return axios.post('https://www.google-analytics.com/collect', null, {
+    params: {
+      ...params,
+      cid: uuidv4(),
+      tid: GA_ID,
+    },
+    timeout,
+  })
+}
+
+/**
+ * Send a 'timing' hit to Google Analytics Measurement Protocol
+ * @param req
+ * @param timestampKey
+ * @param params
+ * @returns {Promise<unknown>|Promise<string>}
+ */
+function sendJourneyTime(req, timestampKey, params = {}) {
+  if (!GA_ID) {
+    return Promise.resolve('No GA ID!')
+  }
+
+  const user = get(req, 'session.user')
+  const [seconds, nanoseconds] = process.hrtime(
+    get(req, `session.${timestampKey}`)
+  )
+  const journeyDuration = Math.round(
+    (seconds * 1000000000 + nanoseconds) / 1000000
+  )
+
+  return sendHit({
+    v: 1,
+    t: 'timing',
+    utl: 'Journey duration',
+    utt: journeyDuration,
+    utc: user.role,
+    ...params,
+  }).then(() => {
+    delete req.session[timestampKey]
+
+    return req.session.save(
+      error =>
+        new Promise((resolve, reject) => {
+          if (error) {
+            reject(error)
+          }
+          resolve('GA hit sent')
+        })
+    )
+  })
+}
+
+module.exports = {
+  sendJourneyTime,
+}

--- a/common/lib/analytics.test.js
+++ b/common/lib/analytics.test.js
@@ -1,0 +1,79 @@
+const proxyquire = require('proxyquire')
+const mockHrTime = [44444, 55555]
+
+describe('Analytics', function() {
+  describe('#sendJourneyTime()', function() {
+    context('without GA_ID', function() {
+      let result, analytics
+
+      beforeEach(async function() {
+        analytics = proxyquire('./analytics', {
+          '../../config': {
+            ANALYTICS: {
+              GA_ID: '',
+            },
+          },
+        })
+
+        result = await analytics.sendJourneyTime('111111', {})
+      })
+
+      it('should resolve with empty promise', function() {
+        expect(result).to.equal('No GA ID!')
+      })
+    })
+
+    context('with GA_ID', function() {
+      const mockUUID = '3333'
+      const mockGaID = '11111'
+      let analytics, result, req
+
+      beforeEach(async function() {
+        req = {
+          session: {
+            user: {
+              role: 'robocop',
+            },
+            createMoveJourneyTime: mockHrTime,
+            save: sinon.stub().callsFake(() => Promise.resolve('GA hit sent')),
+          },
+        }
+
+        sinon.stub(process, 'hrtime').returns(mockHrTime)
+
+        analytics = proxyquire('./analytics', {
+          'uuid/v4': () => mockUUID,
+          '../../config': {
+            ANALYTICS: {
+              GA_ID: mockGaID,
+            },
+          },
+        })
+
+        nock('https://www.google-analytics.com')
+          .post(
+            `/collect?v=1&t=timing&utl=Journey+duration&utt=44444000&utc=robocop&cid=${mockUUID}&tid=${mockGaID}`
+          )
+          .reply(200, {})
+
+        result = await analytics.sendJourneyTime(
+          req,
+          'createMoveJourneyTime',
+          {}
+        )
+      })
+
+      it('should send data to GA', function() {
+        expect(result).to.equal('GA hit sent')
+      })
+
+      it('should post hit to GA', function() {
+        expect(nock.isDone()).to.be.true
+      })
+
+      it('should reset the journey timer', function() {
+        expect(req.session.createMoveJourneyTime).to.be.undefined
+      })
+    })
+  })
+})

--- a/common/lib/user.js
+++ b/common/lib/user.js
@@ -4,9 +4,24 @@ function User({ fullname, roles = [], locations = [] } = {}) {
   this.fullname = fullname
   this.permissions = this.getPermissions(roles)
   this.locations = locations
+  this.role = this.getRole(roles)
 }
 
 User.prototype = {
+  getRole(roles = []) {
+    let role
+
+    if (roles.includes('ROLE_PECS_PRISON')) {
+      role = 'Prison'
+    }
+
+    if (roles.includes('ROLE_PECS_POLICE')) {
+      role = 'Police'
+    }
+
+    return role
+  },
+
   getPermissions(roles = []) {
     const permissions = []
 

--- a/common/lib/user.test.js
+++ b/common/lib/user.test.js
@@ -36,6 +36,30 @@ describe('User class', function() {
       })
     })
 
+    context('with police role', function() {
+      beforeEach(function() {
+        sinon.stub(User.prototype, 'getPermissions').returnsArg(0)
+        roles = ['ROLE_PECS_POLICE']
+      })
+
+      it('should set police role', function() {
+        user = new User({ name: 'USERNAME', roles })
+        expect(user.role).to.equal('Police')
+      })
+    })
+
+    context('with prison role', function() {
+      beforeEach(function() {
+        sinon.stub(User.prototype, 'getPermissions').returnsArg(0)
+        roles = ['ROLE_PECS_PRISON']
+      })
+
+      it('should set prison role', function() {
+        user = new User({ name: 'USERNAME', roles })
+        expect(user.role).to.equal('Prison')
+      })
+    })
+
     context('without roles', function() {
       it('should set permissions to empty array', function() {
         user = new User()

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "serve-favicon": "2.5.0",
     "slashify": "1.0.0",
     "sticky-sidebar": "3.3.1",
+    "uuid": "3.3.3",
     "winston": "3.2.1"
   },
   "devDependencies": {


### PR DESCRIPTION
# Description

This work sends the Create a Move Journey duration to Google analytics.

It can be found in 
`behaviour` 
`-> site speed` 
`-> user timings`

## Screen shot
This is GA from the demo site:
![ga-timing-hit](https://user-images.githubusercontent.com/2305016/68683558-e37e6e80-055e-11ea-8140-f1d90323882d.gif)
