### PR TITLE
Add preprod to circleci pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -204,16 +204,12 @@ workflows:
       - deploy_staging:
           requires:
             - build_staging
-      - hold_preprod:
-          type: approval
+      - build_preprod:
           requires:
             - build_and_test
           filters:
             branches:
               only: master
-      - build_preprod:
-          requires:
-            - hold_preprod
       - deploy_preprod:
           requires:
             - build_preprod

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -164,6 +164,18 @@ jobs:
       - deploy_to_k8s:
           env: 'staging'
 
+  build_preprod:
+    <<: *cloud_container
+    steps:
+      - build_for_k8s:
+          env: 'preprod'
+
+  deploy_preprod:
+    <<: *cloud_container
+    steps:
+      - deploy_to_k8s:
+          env: 'preprod'
+
   build_production:
     <<: *cloud_container
     steps:
@@ -192,6 +204,19 @@ workflows:
       - deploy_staging:
           requires:
             - build_staging
+      - hold_preprod:
+          type: approval
+          requires:
+            - build_and_test
+          filters:
+            branches:
+              only: master
+      - build_preprod:
+          requires:
+            - hold_preprod
+      - deploy_preprod:
+          requires:
+            - build_preprod
       - hold_production:
           type: approval
           requires:


### PR DESCRIPTION
This PR adds preprod to the CircleCI pipeline. It doesn't depend on staging, and doesn't become a dependency on production.

We may want to revisit the workflow later on (e.g. to promote builds), this PR just adds the environment following the current approach.