### PR TITLE
[P4-788] - Switch to use Date for timing Create a move Journey - Analytics

### DIFF
--- a/app/move/controllers/confirmation.js
+++ b/app/move/controllers/confirmation.js
@@ -4,7 +4,7 @@ async function confirmation(req, res, next) {
   const { move_type: moveType, to_location: toLocation } = res.locals.move
 
   try {
-    await sendJourneyTime(req, 'createMoveJourneyTime', {
+    await sendJourneyTime(req, 'createMoveJourneyTimestamp', {
       utv: 'Create a move',
     })
   } catch (err) {

--- a/app/move/controllers/confirmation.test.js
+++ b/app/move/controllers/confirmation.test.js
@@ -8,7 +8,7 @@ const mockMove = {
     title: 'Axminster Crown Court',
   },
 }
-const mockTimestampKey = 'createMoveJourneyTime'
+const mockTimestampKey = 'createMoveJourneyTimestamp'
 
 describe('Move controllers', function() {
   describe('#confirmation()', function() {

--- a/app/move/controllers/create/base.js
+++ b/app/move/controllers/create/base.js
@@ -21,8 +21,8 @@ class CreateBaseController extends FormWizardController {
   }
 
   setJourneyTimer(req, res, next) {
-    if (!get(req, 'session.createMoveJourneyTime')) {
-      set(req, 'session.createMoveJourneyTime', process.hrtime())
+    if (!get(req, 'session.createMoveJourneyTimestamp')) {
+      set(req, 'session.createMoveJourneyTimestamp', new Date().getTime())
     }
 
     next()

--- a/app/move/controllers/create/base.test.js
+++ b/app/move/controllers/create/base.test.js
@@ -4,8 +4,6 @@ const CreateBaseController = require('./base')
 
 const controller = new CreateBaseController({ route: '/' })
 
-const mockHrTime = [11111, 22222]
-
 describe('Move controllers', function() {
   describe('Create base controller', function() {
     describe('#middlewareChecks()', function() {
@@ -225,23 +223,22 @@ describe('Move controllers', function() {
       let req, nextSpy
 
       beforeEach(function() {
-        sinon.stub(process, 'hrtime').returns(mockHrTime)
+        this.clock = sinon.useFakeTimers(new Date('2017-08-10').getTime())
         nextSpy = sinon.spy()
       })
 
-      context('with no time in the session', function() {
+      context('with no timestamp in the session', function() {
         beforeEach(function() {
           req = {
             session: {
-              createMoveJourneyTime: undefined,
+              createMoveJourneyTimestamp: undefined,
             },
           }
-
           controller.setJourneyTimer(req, {}, nextSpy)
         })
 
-        it('should set time', function() {
-          expect(req.session.createMoveJourneyTime).to.equal(mockHrTime)
+        it('should set timestamp', function() {
+          expect(req.session.createMoveJourneyTimestamp).to.equal(1502323200000)
         })
 
         it('should call next', function() {
@@ -249,19 +246,20 @@ describe('Move controllers', function() {
         })
       })
 
-      context('with time in the session', function() {
+      context('with timestamp in the session', function() {
+        const mockTimestamp = 11212121212
+
         beforeEach(function() {
           req = {
             session: {
-              createMoveJourneyTime: mockHrTime,
+              createMoveJourneyTimestamp: mockTimestamp,
             },
           }
           controller.setJourneyTimer(req, {}, nextSpy)
         })
 
-        it('should not set time', function() {
-          expect(process.hrtime).to.not.be.called
-          expect(req.session.createMoveJourneyTime).to.equal(mockHrTime)
+        it('should not set timestamp', function() {
+          expect(req.session.createMoveJourneyTimestamp).to.equal(mockTimestamp)
         })
 
         it('should call next', function() {

--- a/common/lib/analytics.js
+++ b/common/lib/analytics.js
@@ -38,13 +38,9 @@ function sendJourneyTime(req, timestampKey, params = {}) {
     return Promise.resolve('No GA ID!')
   }
 
+  const timestamp = get(req, `session.${timestampKey}`)
   const user = get(req, 'session.user')
-  const [seconds, nanoseconds] = process.hrtime(
-    get(req, `session.${timestampKey}`)
-  )
-  const journeyDuration = Math.round(
-    (seconds * 1000000000 + nanoseconds) / 1000000
-  )
+  const journeyDuration = Math.round(new Date().getTime() - timestamp)
 
   return sendHit({
     v: 1,

--- a/common/lib/analytics.test.js
+++ b/common/lib/analytics.test.js
@@ -1,5 +1,4 @@
 const proxyquire = require('proxyquire')
-const mockHrTime = [44444, 55555]
 
 describe('Analytics', function() {
   describe('#sendJourneyTime()', function() {
@@ -34,12 +33,12 @@ describe('Analytics', function() {
             user: {
               role: 'robocop',
             },
-            createMoveJourneyTime: mockHrTime,
+            createMoveJourneyTimestamp: 12233535,
             save: sinon.stub().callsFake(() => Promise.resolve('GA hit sent')),
           },
         }
 
-        sinon.stub(process, 'hrtime').returns(mockHrTime)
+        this.clock = sinon.useFakeTimers(new Date('2017-08-10').getTime())
 
         analytics = proxyquire('./analytics', {
           'uuid/v4': () => mockUUID,
@@ -52,13 +51,13 @@ describe('Analytics', function() {
 
         nock('https://www.google-analytics.com')
           .post(
-            `/collect?v=1&t=timing&utl=Journey+duration&utt=44444000&utc=robocop&cid=${mockUUID}&tid=${mockGaID}`
+            `/collect?v=1&t=timing&utl=Journey+duration&utt=1502310966465&utc=robocop&cid=${mockUUID}&tid=${mockGaID}`
           )
           .reply(200, {})
 
         result = await analytics.sendJourneyTime(
           req,
-          'createMoveJourneyTime',
+          'createMoveJourneyTimestamp',
           {}
         )
       })
@@ -72,7 +71,7 @@ describe('Analytics', function() {
       })
 
       it('should reset the journey timer', function() {
-        expect(req.session.createMoveJourneyTime).to.be.undefined
+        expect(req.session.createMoveJourneyTimestamp).to.be.undefined
       })
     })
   })


### PR DESCRIPTION
## Switch to use Date for timing Create a move Journey - Analytics

It was discovered by @spikeheap that `process.hrtime()` doesn't work across PODS on K8's. This work reverts the code to use the original implementation of `Date` rather than `process.hrtime()`

## Screenshot
Of note - this has been tested on `heroku` and appears to be working correctly.

![Screenshot 2019-11-19 at 08 39 05](https://user-images.githubusercontent.com/2305016/69130288-26cd6580-0aa8-11ea-8379-44107c70a219.png)
![Screenshot 2019-11-19 at 08 39 15](https://user-images.githubusercontent.com/2305016/69130289-2765fc00-0aa8-11ea-8a74-9b989b7cd71c.png)
![Screenshot 2019-11-19 at 08 39 24](https://user-images.githubusercontent.com/2305016/69130290-2765fc00-0aa8-11ea-9780-a4418ce7ddd7.png)





