### PR TITLE
Refactor component helpers

### DIFF
--- a/common/components/card/template.test.js
+++ b/common/components/card/template.test.js
@@ -1,4 +1,7 @@
-const { render, getExamples } = require('../../../test/unit/component-helpers')
+const {
+  renderComponentHtmlToCheerio,
+  getExamples,
+} = require('../../../test/unit/component-helpers')
 
 const examples = getExamples('card')
 
@@ -7,7 +10,7 @@ describe('Card component', function() {
     let $component
 
     beforeEach(function() {
-      const $ = render('card', examples.default)
+      const $ = renderComponentHtmlToCheerio('card', examples.default)
       $component = $('.app-card')
     })
 
@@ -48,7 +51,7 @@ describe('Card component', function() {
 
   context('with image', function() {
     it('should render image', function() {
-      const $ = render('card', examples['with image'])
+      const $ = renderComponentHtmlToCheerio('card', examples['with image'])
       const $image = $('.app-card__image')
 
       expect($image.length).to.equal(1)
@@ -60,7 +63,7 @@ describe('Card component', function() {
 
   context('with classes param', function() {
     it('should render classes', function() {
-      const $ = render('card', {
+      const $ = renderComponentHtmlToCheerio('card', {
         title: { text: 'Title' },
         classes: 'app-card--compact',
       })
@@ -73,7 +76,7 @@ describe('Card component', function() {
   context('with caption', function() {
     context('when html is passed to text', function() {
       it('should render escaped html', function() {
-        const $ = render('card', {
+        const $ = renderComponentHtmlToCheerio('card', {
           title: { text: 'Title' },
           caption: {
             text: '<span>Reference</span>',
@@ -90,7 +93,7 @@ describe('Card component', function() {
     context('when html is passed to html', function() {
       it('should render unescaped html', function() {
         it('should render escaped html', function() {
-          const $ = render('card', {
+          const $ = renderComponentHtmlToCheerio('card', {
             title: { text: 'Title' },
             caption: {
               html: '<span>Reference</span>',
@@ -105,7 +108,7 @@ describe('Card component', function() {
 
     context('when both html and text params are used', function() {
       it('should render unescaped html', function() {
-        const $ = render('card', {
+        const $ = renderComponentHtmlToCheerio('card', {
           title: { text: 'Title' },
           caption: {
             text: '<span>Reference</span>',
@@ -121,7 +124,7 @@ describe('Card component', function() {
 
   context('with link', function() {
     it('should render link', function() {
-      const $ = render('card', examples['with link'])
+      const $ = renderComponentHtmlToCheerio('card', examples['with link'])
       const $link = $('.app-card__link')
 
       expect($link.length).to.equal(1)
@@ -132,7 +135,7 @@ describe('Card component', function() {
   context('with meta data', function() {
     context('with empty items array', function() {
       it('should not render meta', function() {
-        const $ = render('card', {
+        const $ = renderComponentHtmlToCheerio('card', {
           title: { text: 'Title' },
           meta: { items: [] },
         })
@@ -146,7 +149,7 @@ describe('Card component', function() {
       let $, $items
 
       beforeEach(function() {
-        $ = render('card', examples['with meta items'])
+        $ = renderComponentHtmlToCheerio('card', examples['with meta items'])
         const $meta = $('.app-card__meta-list')
         $items = $meta.find('.app-card__meta-list-item')
       })
@@ -175,7 +178,7 @@ describe('Card component', function() {
   context('with tags', function() {
     context('with empty items array', function() {
       it('should not render tags', function() {
-        const $ = render('card', {
+        const $ = renderComponentHtmlToCheerio('card', {
           title: { text: 'Title' },
           tags: { items: [] },
         })
@@ -187,7 +190,7 @@ describe('Card component', function() {
 
     context('with items', function() {
       it('should render correct number of items', function() {
-        const $ = render('card', examples['with tags'])
+        const $ = renderComponentHtmlToCheerio('card', examples['with tags'])
         const $meta = $('.app-card__tag-list')
         const $items = $meta.find('.app-card__tag-list-item')
 

--- a/common/components/data/template.test.js
+++ b/common/components/data/template.test.js
@@ -1,4 +1,7 @@
-const { render, getExamples } = require('../../../test/unit/component-helpers')
+const {
+  renderComponentHtmlToCheerio,
+  getExamples,
+} = require('../../../test/unit/component-helpers')
 
 const examples = getExamples('data')
 
@@ -7,7 +10,7 @@ describe('Data component', function() {
     let $component
 
     beforeEach(function() {
-      const $ = render('data', examples.default)
+      const $ = renderComponentHtmlToCheerio('data', examples.default)
       $component = $('.app-data')
     })
 
@@ -56,7 +59,7 @@ describe('Data component', function() {
     let $component
 
     beforeEach(function() {
-      const $ = render('data', examples.inverted)
+      const $ = renderComponentHtmlToCheerio('data', examples.inverted)
       $component = $('.app-data')
     })
 
@@ -81,7 +84,10 @@ describe('Data component', function() {
 
   context('with classes', function() {
     it('should render classes', function() {
-      const $ = render('data', examples['extra large variation'])
+      const $ = renderComponentHtmlToCheerio(
+        'data',
+        examples['extra large variation']
+      )
       const $component = $('.app-data')
 
       expect($component.hasClass('app-data--xl')).to.be.true
@@ -90,7 +96,10 @@ describe('Data component', function() {
 
   context('with custom element', function() {
     it('should render custom element', function() {
-      const $ = render('data', examples['with heading as element'])
+      const $ = renderComponentHtmlToCheerio(
+        'data',
+        examples['with heading as element']
+      )
       const $component = $('.app-data')
 
       expect($component.get(0).tagName).to.equal('h2')

--- a/common/components/internal-header/template.test.js
+++ b/common/components/internal-header/template.test.js
@@ -1,17 +1,20 @@
-const { render, getExamples } = require('../../../test/unit/component-helpers')
+const {
+  renderComponentHtmlToCheerio,
+  getExamples,
+} = require('../../../test/unit/component-helpers')
 
 const examples = getExamples('internal-header')
 
 describe('Internal header component', function() {
   it('has a role of `banner`', function() {
-    const $ = render('internal-header', {})
+    const $ = renderComponentHtmlToCheerio('internal-header', {})
 
     const $component = $('.app-header')
     expect($component.attr('role')).to.equal('banner')
   })
 
   it('renders attributes correctly', function() {
-    const $ = render('internal-header', {
+    const $ = renderComponentHtmlToCheerio('internal-header', {
       attributes: {
         'data-test-attribute': 'value',
         'data-test-attribute-2': 'value-2',
@@ -24,7 +27,7 @@ describe('Internal header component', function() {
   })
 
   it('renders classes', function() {
-    const $ = render('internal-header', {
+    const $ = renderComponentHtmlToCheerio('internal-header', {
       classes: 'app-header--custom-modifier',
     })
 
@@ -33,7 +36,7 @@ describe('Internal header component', function() {
   })
 
   it('renders custom container classes', function() {
-    const $ = render('internal-header', {
+    const $ = renderComponentHtmlToCheerio('internal-header', {
       containerClasses: 'app-width-container',
     })
 
@@ -44,7 +47,7 @@ describe('Internal header component', function() {
   })
 
   it('renders home page URL', function() {
-    const $ = render('internal-header', {
+    const $ = renderComponentHtmlToCheerio('internal-header', {
       homepageUrl: '/',
     })
 
@@ -55,7 +58,10 @@ describe('Internal header component', function() {
 
   describe('with product name', function() {
     it('renders product name', function() {
-      const $ = render('internal-header', examples['full width'])
+      const $ = renderComponentHtmlToCheerio(
+        'internal-header',
+        examples['full width']
+      )
 
       const $component = $('.app-header')
       const $productName = $component.find('.app-header__product-name')
@@ -65,7 +71,10 @@ describe('Internal header component', function() {
 
   describe('with service name', function() {
     it('renders service name', function() {
-      const $ = render('internal-header', examples['with service name'])
+      const $ = renderComponentHtmlToCheerio(
+        'internal-header',
+        examples['with service name']
+      )
 
       const $component = $('.app-header')
       const $serviceName = $component.find('.app-header__link--service-name')
@@ -75,7 +84,10 @@ describe('Internal header component', function() {
 
   describe('with navigation', function() {
     it('renders navigation', function() {
-      const $ = render('internal-header', examples['with navigation'])
+      const $ = renderComponentHtmlToCheerio(
+        'internal-header',
+        examples['with navigation']
+      )
 
       const $component = $('.app-header')
       const $list = $component.find('ul.app-header__navigation')
@@ -87,7 +99,7 @@ describe('Internal header component', function() {
     })
 
     it('renders navigation item anchor with attributes', function() {
-      const $ = render('internal-header', {
+      const $ = renderComponentHtmlToCheerio('internal-header', {
         navigation: [
           {
             text: 'Item',
@@ -108,7 +120,7 @@ describe('Internal header component', function() {
     })
 
     it('renders navigation items with text only', function() {
-      const $ = render('internal-header', {
+      const $ = renderComponentHtmlToCheerio('internal-header', {
         navigation: [
           {
             text: 'Item 1',
@@ -133,7 +145,10 @@ describe('Internal header component', function() {
 
     describe('menu button', function() {
       it('has an explicit type="button" so it does not act as a submit button', function() {
-        const $ = render('internal-header', examples['with navigation'])
+        const $ = renderComponentHtmlToCheerio(
+          'internal-header',
+          examples['with navigation']
+        )
 
         const $button = $('.app-header__menu-button')
 
@@ -143,7 +158,7 @@ describe('Internal header component', function() {
   })
 
   describe('SVG logo', function() {
-    const $ = render('internal-header', {})
+    const $ = renderComponentHtmlToCheerio('internal-header', {})
     const $svg = $('.app-header__logotype-crest')
 
     it('sets focusable="false" so that IE does not treat it as an interactive element', function() {

--- a/common/components/link/template.test.js
+++ b/common/components/link/template.test.js
@@ -1,4 +1,7 @@
-const { render, getExamples } = require('../../../test/unit/component-helpers')
+const {
+  renderComponentHtmlToCheerio,
+  getExamples,
+} = require('../../../test/unit/component-helpers')
 
 const examples = getExamples('link')
 
@@ -7,7 +10,7 @@ describe('Link component', function() {
     let $component
 
     beforeEach(function() {
-      const $ = render('link', examples.default)
+      const $ = renderComponentHtmlToCheerio('link', examples.default)
       $component = $('.app-link')
     })
 
@@ -37,7 +40,7 @@ describe('Link component', function() {
     let $component
 
     beforeEach(function() {
-      const $ = render('link', examples['with hint'])
+      const $ = renderComponentHtmlToCheerio('link', examples['with hint'])
       $component = $('.app-link')
     })
 
@@ -73,7 +76,10 @@ describe('Link component', function() {
     let $component
 
     beforeEach(function() {
-      const $ = render('link', examples['with hint and meta data'])
+      const $ = renderComponentHtmlToCheerio(
+        'link',
+        examples['with hint and meta data']
+      )
       $component = $('.app-link')
     })
 
@@ -109,7 +115,7 @@ describe('Link component', function() {
     let $component
 
     beforeEach(function() {
-      const $ = render(
+      const $ = renderComponentHtmlToCheerio(
         'link',
         examples['with hint and meta data and hint text']
       )

--- a/common/components/message/template.test.js
+++ b/common/components/message/template.test.js
@@ -1,4 +1,7 @@
-const { render, getExamples } = require('../../../test/unit/component-helpers')
+const {
+  renderComponentHtmlToCheerio,
+  getExamples,
+} = require('../../../test/unit/component-helpers')
 
 const examples = getExamples('message')
 
@@ -7,7 +10,7 @@ describe('Message component', function() {
     let $component
 
     beforeEach(function() {
-      const $ = render('message', examples.default)
+      const $ = renderComponentHtmlToCheerio('message', examples.default)
       $component = $('.app-message')
     })
 
@@ -31,7 +34,7 @@ describe('Message component', function() {
 
   context('with classes', function() {
     it('should render classes', function() {
-      const $ = render('message', examples.success)
+      const $ = renderComponentHtmlToCheerio('message', examples.success)
       const $component = $('.app-message')
 
       expect($component.hasClass('app-message--success')).to.be.true
@@ -41,7 +44,7 @@ describe('Message component', function() {
   context('with a title', function() {
     context('when no content is passed', function() {
       it('should not render element', function() {
-        const $ = render('message', {})
+        const $ = renderComponentHtmlToCheerio('message', {})
 
         const $component = $('.app-message')
         expect($component.find('.app-message__heading').length).to.equal(0)
@@ -50,7 +53,7 @@ describe('Message component', function() {
 
     context('when html is passed to text', function() {
       it('should render escaped html', function() {
-        const $ = render('message', {
+        const $ = renderComponentHtmlToCheerio('message', {
           title: {
             text: 'A title with <strong>bold text</strong>',
           },
@@ -65,7 +68,7 @@ describe('Message component', function() {
 
     context('when html is passed to html', function() {
       it('should render unescaped html', function() {
-        const $ = render('message', {
+        const $ = renderComponentHtmlToCheerio('message', {
           title: {
             html: 'A title with <strong>bold text</strong>',
           },
@@ -80,7 +83,7 @@ describe('Message component', function() {
 
     context('when both html and text params are used', function() {
       it('should render unescaped html', function() {
-        const $ = render('message', {
+        const $ = renderComponentHtmlToCheerio('message', {
           title: {
             html: 'A title with <strong>bold text</strong>',
             text: 'A title with <strong>bold text</strong>',
@@ -98,7 +101,7 @@ describe('Message component', function() {
   context('with content', function() {
     context('when no content is passed', function() {
       it('should not render element', function() {
-        const $ = render('message', {})
+        const $ = renderComponentHtmlToCheerio('message', {})
 
         const $component = $('.app-message')
         expect($component.find('.app-message__content').length).to.equal(0)
@@ -107,7 +110,7 @@ describe('Message component', function() {
 
     context('when html is passed to text', function() {
       it('should render escaped html', function() {
-        const $ = render('message', {
+        const $ = renderComponentHtmlToCheerio('message', {
           content: {
             text: 'A message with <strong>bold text</strong>',
           },
@@ -122,7 +125,7 @@ describe('Message component', function() {
 
     context('when html is passed to html', function() {
       it('should render unescaped html', function() {
-        const $ = render('message', {
+        const $ = renderComponentHtmlToCheerio('message', {
           content: {
             html: 'A message with <strong>bold text</strong>',
           },
@@ -137,7 +140,7 @@ describe('Message component', function() {
 
     context('when both html and text params are used', function() {
       it('should render unescaped html', function() {
-        const $ = render('message', {
+        const $ = renderComponentHtmlToCheerio('message', {
           content: {
             html: 'A message with <strong>bold text</strong>',
             text: 'A message with <strong>bold text</strong>',
@@ -153,7 +156,10 @@ describe('Message component', function() {
 
     context('when dismiss is prevented', function() {
       it('should render unescaped html', function() {
-        const $ = render('message', examples['without dismiss'])
+        const $ = renderComponentHtmlToCheerio(
+          'message',
+          examples['without dismiss']
+        )
         expect($('.app-message').attr('data-module')).to.be.undefined
       })
     })

--- a/common/components/meta-list/template.test.js
+++ b/common/components/meta-list/template.test.js
@@ -1,4 +1,7 @@
-const { render, getExamples } = require('../../../test/unit/component-helpers')
+const {
+  renderComponentHtmlToCheerio,
+  getExamples,
+} = require('../../../test/unit/component-helpers')
 
 const examples = getExamples('meta-list')
 
@@ -7,7 +10,7 @@ describe('Meta list component', function() {
     let $, $component, $items
 
     beforeEach(function() {
-      $ = render('meta-list', examples.default)
+      $ = renderComponentHtmlToCheerio('meta-list', examples.default)
       $component = $('.app-meta-list')
       $items = $component.find('.app-meta-list__item')
     })
@@ -23,7 +26,7 @@ describe('Meta list component', function() {
 
   context('with classes', function() {
     it('should render classes', function() {
-      const $ = render('meta-list', {
+      const $ = renderComponentHtmlToCheerio('meta-list', {
         classes: 'app-meta-list--custom-class',
       })
 
@@ -36,7 +39,7 @@ describe('Meta list component', function() {
     let $, $items
 
     beforeEach(function() {
-      $ = render('meta-list', {
+      $ = renderComponentHtmlToCheerio('meta-list', {
         items: [
           {
             key: {
@@ -82,7 +85,7 @@ describe('Meta list component', function() {
     let $, $items
 
     beforeEach(function() {
-      $ = render('meta-list', {
+      $ = renderComponentHtmlToCheerio('meta-list', {
         items: [
           {
             key: {
@@ -111,7 +114,7 @@ describe('Meta list component', function() {
     let $, $items
 
     beforeEach(function() {
-      $ = render('meta-list', {
+      $ = renderComponentHtmlToCheerio('meta-list', {
         items: [
           {
             value: {
@@ -142,7 +145,7 @@ describe('Meta list component', function() {
     let $, $items
 
     beforeEach(function() {
-      $ = render('meta-list', {
+      $ = renderComponentHtmlToCheerio('meta-list', {
         items: [
           {
             key: {

--- a/common/components/multi-file-upload/template.test.js
+++ b/common/components/multi-file-upload/template.test.js
@@ -1,4 +1,7 @@
-const { render, getExamples } = require('../../../test/unit/component-helpers')
+const {
+  renderComponentHtmlToCheerio,
+  getExamples,
+} = require('../../../test/unit/component-helpers')
 
 const examples = getExamples('multi-file-upload')
 
@@ -7,7 +10,10 @@ describe('Multi file upload component', function() {
     let $component
 
     beforeEach(function() {
-      const $ = render('multi-file-upload', examples.default)
+      const $ = renderComponentHtmlToCheerio(
+        'multi-file-upload',
+        examples.default
+      )
       $component = $('[data-module="app-multi-file-upload"]')
     })
 
@@ -64,7 +70,7 @@ describe('Multi file upload component', function() {
     let $component
 
     beforeEach(function() {
-      const $ = render('multi-file-upload', mockData)
+      const $ = renderComponentHtmlToCheerio('multi-file-upload', mockData)
       $component = $('[data-module="app-multi-file-upload"]')
     })
 

--- a/common/components/pagination/template.test.js
+++ b/common/components/pagination/template.test.js
@@ -1,11 +1,14 @@
-const { render, getExamples } = require('../../../test/unit/component-helpers')
+const {
+  renderComponentHtmlToCheerio,
+  getExamples,
+} = require('../../../test/unit/component-helpers')
 
 const examples = getExamples('pagination')
 
 describe('Pagination component', function() {
   context('default', function() {
     it('should render previous link', function() {
-      const $ = render('pagination', examples.default)
+      const $ = renderComponentHtmlToCheerio('pagination', examples.default)
 
       const $component = $('.app-pagination')
       const $item = $component.find('.app-pagination__list-item--prev')
@@ -17,7 +20,7 @@ describe('Pagination component', function() {
     })
 
     it('should render next link', function() {
-      const $ = render('pagination', examples.default)
+      const $ = renderComponentHtmlToCheerio('pagination', examples.default)
 
       const $component = $('.app-pagination')
       const $item = $component.find('.app-pagination__list-item--next')
@@ -31,7 +34,7 @@ describe('Pagination component', function() {
 
   context('without next or previous', function() {
     it('should not render previous link', function() {
-      const $ = render('pagination', {})
+      const $ = renderComponentHtmlToCheerio('pagination', {})
 
       const $component = $('.app-pagination')
       const $item = $component.find('.app-pagination__list-item--prev')
@@ -39,7 +42,7 @@ describe('Pagination component', function() {
     })
 
     it('should not render next link', function() {
-      const $ = render('pagination', {})
+      const $ = renderComponentHtmlToCheerio('pagination', {})
 
       const $component = $('.app-pagination')
       const $item = $component.find('.app-pagination__list-item--next')
@@ -49,7 +52,7 @@ describe('Pagination component', function() {
 
   context('with classes', function() {
     it('should render classes', function() {
-      const $ = render('pagination', {
+      const $ = renderComponentHtmlToCheerio('pagination', {
         classes: 'app-pagination--custom-class',
       })
 
@@ -60,7 +63,7 @@ describe('Pagination component', function() {
 
   context('with labels', function() {
     it('should render previous label', function() {
-      const $ = render('pagination', {
+      const $ = renderComponentHtmlToCheerio('pagination', {
         previous: {
           href: '/page-1',
           label: '1 of 300',
@@ -77,7 +80,7 @@ describe('Pagination component', function() {
     })
 
     it('should render next label', function() {
-      const $ = render('pagination', {
+      const $ = renderComponentHtmlToCheerio('pagination', {
         next: {
           href: '/page-3',
           label: '3 of 300',
@@ -96,7 +99,7 @@ describe('Pagination component', function() {
 
   context('with custom text', function() {
     it('should render previous text', function() {
-      const $ = render('pagination', {
+      const $ = renderComponentHtmlToCheerio('pagination', {
         previous: {
           href: '/previous-day',
           text: 'Previous day',
@@ -113,7 +116,7 @@ describe('Pagination component', function() {
     })
 
     it('should render next label', function() {
-      const $ = render('pagination', {
+      const $ = renderComponentHtmlToCheerio('pagination', {
         next: {
           href: '/next-day',
           text: 'Next day',
@@ -134,7 +137,7 @@ describe('Pagination component', function() {
     let $, $component, items
 
     beforeEach(function() {
-      $ = render('pagination', examples['with items'])
+      $ = renderComponentHtmlToCheerio('pagination', examples['with items'])
       $component = $('.app-pagination')
       items = $component.find('.app-pagination__list-item')
     })

--- a/common/components/panel/template.test.js
+++ b/common/components/panel/template.test.js
@@ -1,4 +1,7 @@
-const { render, getExamples } = require('../../../test/unit/component-helpers')
+const {
+  renderComponentHtmlToCheerio,
+  getExamples,
+} = require('../../../test/unit/component-helpers')
 
 const examples = getExamples('panel')
 
@@ -7,7 +10,7 @@ describe('Panel component', function() {
     let $component
 
     beforeEach(function() {
-      const $ = render('panel', examples.default)
+      const $ = renderComponentHtmlToCheerio('panel', examples.default)
       $component = $('.app-panel')
     })
 
@@ -26,7 +29,7 @@ describe('Panel component', function() {
 
   context('with classes param', function() {
     it('should render classes', function() {
-      const $ = render('panel', {
+      const $ = renderComponentHtmlToCheerio('panel', {
         classes: 'app-panel--inactive',
       })
 
@@ -37,7 +40,7 @@ describe('Panel component', function() {
 
   context('with attributes param', function() {
     it('should render attributes', function() {
-      const $ = render('panel', {
+      const $ = renderComponentHtmlToCheerio('panel', {
         attributes: {
           'data-attribute': 'my data value',
         },
@@ -50,7 +53,7 @@ describe('Panel component', function() {
 
   context('when html is passed to text', function() {
     it('should render escaped html', function() {
-      const $ = render('panel', {
+      const $ = renderComponentHtmlToCheerio('panel', {
         text: 'Content with <strong>bold text</strong>',
       })
 
@@ -63,7 +66,7 @@ describe('Panel component', function() {
 
   context('when html is passed to html', function() {
     it('should render unescaped html', function() {
-      const $ = render('panel', {
+      const $ = renderComponentHtmlToCheerio('panel', {
         html: 'Content with <strong>bold text</strong>',
       })
 
@@ -76,7 +79,7 @@ describe('Panel component', function() {
 
   context('when both html and text params are used', function() {
     it('should render unescaped html', function() {
-      const $ = render('panel', {
+      const $ = renderComponentHtmlToCheerio('panel', {
         html: 'Content with <strong>bold text</strong>',
         text: 'Content with <strong>bold text</strong>',
       })
@@ -91,7 +94,7 @@ describe('Panel component', function() {
   context('when tag component is added', function() {
     let $, $component
     beforeEach(function() {
-      $ = render('panel', examples['with tag'])
+      $ = renderComponentHtmlToCheerio('panel', examples['with tag'])
       $component = $('.app-panel')
     })
 

--- a/common/components/results/template.test.js
+++ b/common/components/results/template.test.js
@@ -1,4 +1,7 @@
-const { render, getExamples } = require('../../../test/unit/component-helpers')
+const {
+  renderComponentHtmlToCheerio,
+  getExamples,
+} = require('../../../test/unit/component-helpers')
 
 const examples = getExamples('results')
 
@@ -7,7 +10,7 @@ describe('Results component', function() {
     let $component, $items, $
 
     beforeEach(function() {
-      $ = render('results', examples.default)
+      $ = renderComponentHtmlToCheerio('results', examples.default)
       $component = $('.app-results')
 
       const $itemsList = $('.app-results__list')
@@ -40,7 +43,7 @@ describe('Results component', function() {
 
   context('with empty items array', function() {
     it('should not render items', function() {
-      const $ = render('results', {
+      const $ = renderComponentHtmlToCheerio('results', {
         items: [],
       })
       const $itemsList = $('.app-results__list')

--- a/common/components/tag/template.test.js
+++ b/common/components/tag/template.test.js
@@ -1,4 +1,7 @@
-const { render, getExamples } = require('../../../test/unit/component-helpers')
+const {
+  renderComponentHtmlToCheerio,
+  getExamples,
+} = require('../../../test/unit/component-helpers')
 
 const examples = getExamples('tag')
 
@@ -7,7 +10,7 @@ describe('Tag component', function() {
     let $component
 
     beforeEach(function() {
-      const $ = render('tag', examples.default)
+      const $ = renderComponentHtmlToCheerio('tag', examples.default)
       $component = $('.app-tag')
     })
 
@@ -22,7 +25,7 @@ describe('Tag component', function() {
 
   context('with classes param', function() {
     it('should render classes', function() {
-      const $ = render('tag', {
+      const $ = renderComponentHtmlToCheerio('tag', {
         classes: 'app-tag--inactive',
         text: 'alpha',
       })
@@ -36,7 +39,7 @@ describe('Tag component', function() {
     let $component
 
     beforeEach(function() {
-      const $ = render('tag', {
+      const $ = renderComponentHtmlToCheerio('tag', {
         text: 'alpha',
         href: '/a-link',
       })
@@ -54,7 +57,7 @@ describe('Tag component', function() {
 
   context('when html is passed to text', function() {
     it('should render escaped html', function() {
-      const $ = render('tag', {
+      const $ = renderComponentHtmlToCheerio('tag', {
         text: '<span>alpha</span>',
       })
 
@@ -65,7 +68,7 @@ describe('Tag component', function() {
 
   context('when html is passed to html', function() {
     it('should render unescaped html', function() {
-      const $ = render('tag', {
+      const $ = renderComponentHtmlToCheerio('tag', {
         html: '<span>alpha</span>',
       })
 
@@ -76,7 +79,7 @@ describe('Tag component', function() {
 
   context('when both html and text params are used', function() {
     it('should render unescaped html', function() {
-      const $ = render('tag', {
+      const $ = renderComponentHtmlToCheerio('tag', {
         html: '<span>alpha</span>',
         text: '<span>alpha</span>',
       })

--- a/common/components/time/template.test.js
+++ b/common/components/time/template.test.js
@@ -1,4 +1,7 @@
-const { render, getExamples } = require('../../../test/unit/component-helpers')
+const {
+  renderComponentHtmlToCheerio,
+  getExamples,
+} = require('../../../test/unit/component-helpers')
 
 const examples = getExamples('time')
 
@@ -7,7 +10,7 @@ describe('Time component', function() {
     let $component
 
     beforeEach(function() {
-      const $ = render('time', examples.default)
+      const $ = renderComponentHtmlToCheerio('time', examples.default)
       $component = $('time')
     })
 
@@ -27,7 +30,7 @@ describe('Time component', function() {
 
   context('with classes', function() {
     it('should render classes', function() {
-      const $ = render('time', {
+      const $ = renderComponentHtmlToCheerio('time', {
         classes: 'custom-class',
       })
 
@@ -40,7 +43,7 @@ describe('Time component', function() {
     let $component
 
     beforeEach(function() {
-      const $ = render('time', {
+      const $ = renderComponentHtmlToCheerio('time', {
         datetime: '2019-01-10',
         text: 'Today',
       })

--- a/common/controllers/form-wizard.test.js
+++ b/common/controllers/form-wizard.test.js
@@ -259,7 +259,7 @@ describe('Form wizard', function() {
     })
   })
 
-  describe('#render()', function() {
+  describe('#renderComponentHtmlToCheerio()', function() {
     let reqMock, nextSpy
 
     beforeEach(function() {

--- a/common/lib/component/helpers.js
+++ b/common/lib/component/helpers.js
@@ -22,4 +22,5 @@ function renderComponentToHtml(componentName, params) {
 
 module.exports = {
   renderComponentToHtml,
+  componentNameToMacroName,
 }

--- a/test/unit/component-helpers.js
+++ b/test/unit/component-helpers.js
@@ -23,7 +23,7 @@ nunjucks.configure(views, {
  * @param {any} children any child components or text, pass the children to the macro
  * @returns {function} returns cheerio (jQuery) instance of the macro for easy DOM querying
  */
-function render(componentName, params, children = false) {
+function renderComponentHtmlToCheerio(componentName, params, children = false) {
   if (typeof params === 'undefined') {
     throw new Error(
       'Parameters passed to `render` should be an object but are undefined'
@@ -70,6 +70,6 @@ function getExamples(componentPath) {
 }
 
 module.exports = {
-  render,
+  renderComponentHtmlToCheerio,
   getExamples,
 }

--- a/test/unit/component-helpers.js
+++ b/test/unit/component-helpers.js
@@ -1,13 +1,9 @@
 const fs = require('fs')
 const path = require('path')
-const util = require('util')
 
 const cheerio = require('cheerio')
 const nunjucks = require('nunjucks')
 const yaml = require('js-yaml')
-
-const sass = require('node-sass')
-const sassRender = util.promisify(sass.render)
 
 const configPaths = require('../../config/paths')
 const views = [configPaths.components, configPaths.govukFrontend]
@@ -73,40 +69,7 @@ function getExamples(componentPath) {
   return examples
 }
 
-/**
- * Render Sass
- *
- * @param {object} options Options to pass to sass.render
- * @return {promise} Result of calling sass.render
- */
-function renderSass(options) {
-  return sassRender({
-    includePaths: [configPaths.src],
-    ...options,
-  })
-}
-
-/**
- * Get the raw HTML representation of a component, and remove any other
- * child elements that do not match the component.
- * Relies on B.E.M naming ensuring that child components relating to a component
- * are namespaced.
- * @param {function} $ requires an instance of cheerio (jQuery) that includes the
- * rendered component.
- * @param {string} className the top level class 'Block' in B.E.M terminology
- * @returns {string} returns HTML
- */
-function htmlWithClassName($, className) {
-  const $component = $(className)
-  const classSelector = className.replace('.', '')
-  // Remove all other elements that do not match this component
-  $component.find(`[class]:not([class^=${classSelector}])`).remove()
-  return $.html($component)
-}
-
 module.exports = {
   render,
   getExamples,
-  htmlWithClassName,
-  renderSass,
 }

--- a/test/unit/component-helpers.js
+++ b/test/unit/component-helpers.js
@@ -11,27 +11,14 @@ const sassRender = util.promisify(sass.render)
 
 const configPaths = require('../../config/paths')
 const views = [configPaths.components, configPaths.govukFrontend]
+const {
+  componentNameToMacroName,
+} = require('../../common/lib/component/helpers')
 
 nunjucks.configure(views, {
   trimBlocks: true,
   lstripBlocks: true,
 })
-
-/**
- * Return a macro name for a component
- * @param {string} componentName
- * @returns {string} returns naming convention based macro name
- */
-function _componentNameToMacroName(componentName) {
-  const macroName = componentName
-    .toLowerCase()
-    .split('-')
-    // capitalize each 'word'
-    .map(word => word.charAt(0).toUpperCase() + word.slice(1))
-    .join('')
-
-  return `app${macroName}`
-}
 
 /**
  * Render a component's macro for testing
@@ -47,7 +34,7 @@ function render(componentName, params, children = false) {
     )
   }
 
-  const macroName = _componentNameToMacroName(componentName)
+  const macroName = componentNameToMacroName(componentName)
   const macroParams = JSON.stringify(params, null, 2)
 
   let macroString = `{%- from "${componentName}/macro.njk" import ${macroName} -%}`


### PR DESCRIPTION
### Refactor component helpers

- With the rendering of components via JavaScript now available in the app I wanted to dry up the use of the methods being shared between the app and tests.

- I also wanted to be more explicit with the naming of the render method used within tests so that it isn't used in the app

- Also a little bit of tidy up and removing of work that isnt being used
