### PR TITLE
Remove headers argument

### DIFF
--- a/common/lib/api-client/auth-request.js
+++ b/common/lib/api-client/auth-request.js
@@ -3,7 +3,7 @@ const axios = require('axios')
 const auth = require('./auth')()
 const { API } = require('../../../config')
 
-async function authRequest(headers) {
+async function authRequest() {
   const token = await auth.getAccessToken()
 
   return axios.create({
@@ -11,7 +11,6 @@ async function authRequest(headers) {
     timeout: API.TIMEOUT,
     headers: {
       Authorization: `Bearer ${token}`,
-      ...headers,
     },
   })
 }

--- a/common/lib/api-client/auth-request.test.js
+++ b/common/lib/api-client/auth-request.test.js
@@ -12,9 +12,6 @@ const authRequest = proxyquire('./auth-request', {
     API: mockAPI,
   },
 })
-const mockHeaders = {
-  'Content-type': 'application/json',
-}
 
 function MockAuth() {}
 MockAuth.prototype.getAccessToken = sinon.stub()
@@ -25,7 +22,7 @@ describe('Auth Request', function() {
       sinon.spy(axios, 'create')
       MockAuth.prototype.getAccessToken.resolves(mockToken)
 
-      await authRequest(mockHeaders)
+      await authRequest()
     })
 
     it('should call auth library', function() {
@@ -38,7 +35,6 @@ describe('Auth Request', function() {
         baseURL: mockAPI.BASE_URL,
         headers: {
           Authorization: `Bearer ${mockToken}`,
-          'Content-type': 'application/json',
         },
         timeout: mockAPI.TIMEOUT,
       })
@@ -59,7 +55,7 @@ describe('Auth Request', function() {
         .reply(200, JSON.stringify(mockResponseMessage))
 
       MockAuth.prototype.getAccessToken.resolves(mockToken)
-      authorisedRequest = await authRequest(mockHeaders)
+      authorisedRequest = await authRequest()
     })
 
     it('should call get as expected', async function() {


### PR DESCRIPTION
This argument is no longer needed as you can send the headers via config
in the `.post` method


