### PR TITLE
Improve waiting for CSV downloads helpers

### DIFF
--- a/test/e2e/helpers.js
+++ b/test/e2e/helpers.js
@@ -1,4 +1,3 @@
-import fs from 'fs'
 import { format } from 'date-fns'
 import { join } from 'path'
 import { homedir } from 'os'
@@ -139,7 +138,7 @@ export async function fillInForm(details = {}) {
  *
  * @returns {string[]}
  */
-export function getCsvDownloadsFilePaths() {
+export function getCsvDownloadFilePaths() {
   const dateStamp = format(new Date(), 'yyyy-MM-dd')
   const globPattern = `${join(
     homedir(),
@@ -161,19 +160,19 @@ export async function clickSelectorIfExists(selector) {
 }
 
 /**
- * Wait for file to exist
- *
+ * Wait for the csvDownload path to exist. Handy when the files are downloading
  * @param t
  * @param delay
- * @param fileNameAndPath
- * @returns {Promise<void>}
+ * @returns {string[]}
  */
-export async function checkFileExists(t, delay, filepath) {
+export async function waitForCsvDownloadFilePaths(t, delay) {
   for (let i = 0; i < delay; i++) {
-    await t.wait(1)
+    await t.wait(200)
 
-    if (fs.existsSync(filepath)) {
-      return
+    const csvDownloadFilePaths = getCsvDownloadFilePaths()
+
+    if (csvDownloadFilePaths.length) {
+      return csvDownloadFilePaths
     }
   }
 }

--- a/test/e2e/moves.test.js
+++ b/test/e2e/moves.test.js
@@ -5,9 +5,9 @@ import Page from './page-model'
 import {
   selectFieldsetOption,
   scrollToTop,
-  getCsvDownloadsFilePaths,
+  getCsvDownloadFilePaths,
+  waitForCsvDownloadFilePaths,
   clickSelectorIfExists,
-  checkFileExists,
   getSelectedFieldsetOption,
 } from './helpers'
 
@@ -373,7 +373,7 @@ test('Prison recall', async t => {
 
 fixture`Document uploads`
 
-test('Documents upload and view', async t => {
+test('Upload documents', async t => {
   await t.useRole(policeUser).navigateTo(page.locations.home)
 
   await clickSelectorIfExists(page.nodes.custodySuitLocationLink)
@@ -547,7 +547,7 @@ test('Navigate tags in detailed move', async t => {
 })
 
 function deleteDownloads() {
-  const csvDownloads = getCsvDownloadsFilePaths()
+  const csvDownloads = getCsvDownloadFilePaths()
   for (const file of csvDownloads) {
     try {
       unlinkSync(file)
@@ -564,11 +564,9 @@ test('Download moves as police user', async t => {
 
   await clickSelectorIfExists(page.nodes.custodySuitLocationLink)
 
-  await t.click(page.nodes.downloadMovesLink).wait(5000)
+  await t.click(page.nodes.downloadMovesLink)
 
-  const csvDownloads = getCsvDownloadsFilePaths()
-
-  await checkFileExists(t, 10, csvDownloads[0])
+  const csvDownloads = await waitForCsvDownloadFilePaths(t, 100)
 
   try {
     const csvContents = readFileSync(csvDownloads[0], 'utf8')
@@ -589,9 +587,7 @@ test('Download moves as supplier user', async t => {
 
   await t.click(page.nodes.downloadMovesLink)
 
-  const csvDownloads = getCsvDownloadsFilePaths()
-
-  await checkFileExists(t, 10, csvDownloads[0])
+  const csvDownloads = await waitForCsvDownloadFilePaths(t, 100)
 
   try {
     const csvContents = readFileSync(csvDownloads[0], 'utf8')


### PR DESCRIPTION
This work improves the CSV waiting for downloads methods. 

Basically it now waits until the `glob.sync` looking for CSV downloads returns a result. When the glob returns a result it means the files have downloaded and exist. 

This also simplifies the work that was there previously and removes the hard wait of 5 seconds
which at some point would more than likely fail.
