### PR TITLE
P4 558 display status

### DIFF
--- a/app/move/controllers/view.js
+++ b/app/move/controllers/view.js
@@ -4,9 +4,14 @@ module.exports = function view(req, res) {
   const { move } = res.locals
   const {
     person,
+    status,
     cancellation_reason: cancellationReason,
-    cancellation_reason_comments: cancellationComments,
+    cancellation_reason_comment: cancellationComments,
   } = move
+  const reason =
+    cancellationReason === 'other'
+      ? cancellationComments
+      : req.t(`fields::cancellation_reason.items.${cancellationReason}.label`)
   const locals = {
     moveSummary: presenters.moveToMetaListComponent(move),
     personalDetailsSummary: presenters.personToSummaryListComponent(person),
@@ -17,15 +22,11 @@ module.exports = function view(req, res) {
       'court'
     ),
     documentsList: presenters.documentsToMetaListComponent(move.documents),
-  }
-
-  if (cancellationReason) {
-    const reasonLabel = req.t(
-      `fields::cancellation_reason.items.${cancellationReason}.label`
-    )
-
-    locals.cancellationReason =
-      cancellationReason !== 'other' ? reasonLabel : cancellationComments
+    messageTitle: req.t('statuses::' + status),
+    messageContent: req.t('statuses::description', {
+      context: status,
+      reason,
+    }),
   }
 
   res.render('move/views/view', locals)

--- a/app/move/views/view.njk
+++ b/app/move/views/view.njk
@@ -25,19 +25,15 @@
     {{ t("actions::print_move_detail") }}
   </a>
 
-  {% if move.status == "cancelled" %}
+  {% if move.status %}
     {{ appMessage({
       allowDismiss: false,
-      classes: "app-message--temporary",
+      classes: "app-message--info",
       title: {
-        text: t("moves::cancel.panel.heading")
+        text: messageTitle
       },
       content: {
-        text: t("moves::cancel.panel.content", {
-          reason: cancellationReason
-        }) if cancellationReason else t("statuses::" + move.status, {
-            context: "description"
-        })
+        text: messageContent
       }
     }) }}
   {% endif %}
@@ -48,7 +44,6 @@
     <h1 class="govuk-heading-xl govuk-!-margin-bottom-1">
       {{ move.person.fullname | upper }}
     </h1>
-
     <span class="govuk-caption-xl">
       {{ t("moves::move_reference", {
         reference: move.reference

--- a/app/move/views/view.njk
+++ b/app/move/views/view.njk
@@ -35,7 +35,9 @@
       content: {
         text: t("moves::cancel.panel.content", {
           reason: cancellationReason
-        }) if cancellationReason
+        }) if cancellationReason else t("statuses::" + move.status, {
+            context: "description"
+        })
       }
     }) }}
   {% endif %}

--- a/common/assets/scss/application.scss
+++ b/common/assets/scss/application.scss
@@ -34,6 +34,7 @@ $govuk-font-family: "Inter", system-ui, sans-serif;
 
 // Import MoJ Frontend Components
 @import "@ministryofjustice/frontend/moj/components/organisation-switcher/_organisation-switcher.scss";
+@import "@ministryofjustice/frontend/moj/components/badge/_badge.scss";
 
 // Import app settings/tools/helpers
 @import "helpers/all";

--- a/common/components/card/_card.scss
+++ b/common/components/card/_card.scss
@@ -15,11 +15,19 @@
   display: block;
 }
 
-.app-card__caption {
-  @include govuk-clearfix;
+.app-card__badge {
+  display: inline-block;
+  margin-bottom: govuk-spacing(2);
+
+  @include mq ($from: desktop) {
+    float: right;
+    margin-bottom: 0;
+    margin-left: govuk-spacing(3);
+  }
 }
 
 .app-card__caption {
+  @include govuk-clearfix;
   @include govuk-font($size: 16);
   color: govuk-colour("dark-grey");
 }

--- a/common/components/card/card.yaml
+++ b/common/components/card/card.yaml
@@ -78,6 +78,13 @@ examples:
     data:
       title:
         text: Card title
+  - name: with status
+    data:
+      title:
+        text: Card with status
+      status:
+        text: Requested
+        classes: app-tag--inactive
   - name: with image
     data:
       title:

--- a/common/components/card/template.njk
+++ b/common/components/card/template.njk
@@ -1,4 +1,5 @@
 {% from "tag/macro.njk" import appTag %}
+{% from "moj/components/badge/macro.njk" import mojBadge %}
 
 {% set headingLevel = params.headingLevel if params.headingLevel else 2 %}
 
@@ -11,6 +12,12 @@
 
   <div class="app-card__content">
     <header class="app-card__header">
+      {% if params.status %}
+        <span class="app-card__badge">
+          {{ mojBadge(params.status) }}
+        </span>
+      {% endif %}
+
       <h2 class="app-card__title">
         {% if params.href %}
           <a href="{{ params.href }}"  class="app-card__link">

--- a/common/components/card/template.test.js
+++ b/common/components/card/template.test.js
@@ -132,6 +132,16 @@ describe('Card component', function() {
     })
   })
 
+  context('with status', function() {
+    it('should render status', function() {
+      const $ = renderComponentHtmlToCheerio('card', examples['with status'])
+      const $status = $('.app-card__badge')
+
+      expect($status.length).to.equal(1)
+      expect($status.text()).to.contain('Requested')
+    })
+  })
+
   context('with meta data', function() {
     context('with empty items array', function() {
       it('should not render meta', function() {

--- a/common/presenters/move-to-card-component.js
+++ b/common/presenters/move-to-card-component.js
@@ -5,7 +5,7 @@ const i18n = require('../../config/i18n')
 const filters = require('../../config/nunjucks/filters')
 
 function moveToCardComponent({ showMeta = true, showTags = true } = {}) {
-  return function item({ id, reference, person = {} }) {
+  return function item({ id, reference, person = {}, status }) {
     const meta = {}
     const tags = {}
     const href = `/move/${id}`
@@ -44,6 +44,9 @@ function moveToCardComponent({ showMeta = true, showTags = true } = {}) {
       href,
       meta,
       tags,
+      status: {
+        text: i18n.t(`statuses::${status}`),
+      },
       title: {
         text: fullname.toUpperCase(),
       },

--- a/common/presenters/move-to-card-component.test.js
+++ b/common/presenters/move-to-card-component.test.js
@@ -6,6 +6,7 @@ const filters = require('../../config/nunjucks/filters')
 const mockMove = {
   id: '12345',
   reference: 'AB12FS45',
+  status: 'requested',
   person: {
     fullname: 'Name, Full',
     date_of_birth: '2000-10-10',
@@ -63,6 +64,13 @@ describe('Presenters', function() {
             expect(transformedResponse).to.have.property('title')
             expect(transformedResponse.title).to.deep.equal({
               text: mockMove.person.fullname.toUpperCase(),
+            })
+          })
+
+          it('should contain a status', function() {
+            expect(transformedResponse).to.have.property('status')
+            expect(transformedResponse.status).to.deep.equal({
+              text: '__translated__',
             })
           })
 
@@ -137,15 +145,21 @@ describe('Presenters', function() {
             )
           })
 
-          it('should translate move reference', function() {
+          it('should translate status', function() {
             expect(i18n.t.getCall(3)).to.be.calledWithExactly(
+              `statuses::${mockMove.status}`
+            )
+          })
+
+          it('should translate move reference', function() {
+            expect(i18n.t.getCall(4)).to.be.calledWithExactly(
               'moves::move_reference',
               { reference: 'AB12FS45' }
             )
           })
 
           it('should translate correct number of times', function() {
-            expect(i18n.t).to.be.callCount(4)
+            expect(i18n.t).to.be.callCount(5)
           })
         })
       })

--- a/config/i18n.js
+++ b/config/i18n.js
@@ -15,6 +15,7 @@ i18next.use(Backend).init({
     'locations',
     'messages',
     'moves',
+    'statuses',
     'validation',
   ],
   defaultNS: 'default',

--- a/locales/en/moves.json
+++ b/locales/en/moves.json
@@ -101,7 +101,6 @@
     "page_title": "Cancel move for ‘{{name}}’",
     "warning": "You must also contact the supplier to cancel the move request for {{name}}",
     "panel": {
-      "heading": "Move cancelled",
       "content": "Reason — {{reason}}"
     }
   },

--- a/locales/en/statuses.json
+++ b/locales/en/statuses.json
@@ -1,0 +1,5 @@
+{
+  "requested": "Move requested",
+  "requested_description": "Move requested with supplier",
+  "cancelled": "Move cancelled"
+}

--- a/locales/en/statuses.json
+++ b/locales/en/statuses.json
@@ -1,5 +1,7 @@
 {
   "requested": "Move requested",
-  "requested_description": "Move requested with supplier",
-  "cancelled": "Move cancelled"
+  "cancelled": "Move cancelled",
+  "description": "",
+  "description_requested": "Move requested with supplier",
+  "description_cancelled": "Reason — {{reason}}"
 }

--- a/test/unit/component-helpers.js
+++ b/test/unit/component-helpers.js
@@ -6,7 +6,11 @@ const nunjucks = require('nunjucks')
 const yaml = require('js-yaml')
 
 const configPaths = require('../../config/paths')
-const views = [configPaths.components, configPaths.govukFrontend]
+const views = [
+  configPaths.components,
+  configPaths.govukFrontend,
+  configPaths.mojFrontend,
+]
 const {
   componentNameToMacroName,
 } = require('../../common/lib/component/helpers')


### PR DESCRIPTION
The layout in app-card might be seen as a bit cheeky -- happy to look into alternatives.

## What it looks like

### Dashboard card
![image](https://user-images.githubusercontent.com/3327997/72800145-9bc44380-3c81-11ea-975e-e10763e53ddb.png)
![image](https://user-images.githubusercontent.com/3327997/72800199-be565c80-3c81-11ea-9725-a2e9921df197.png)

### Move detail
![image](https://user-images.githubusercontent.com/3327997/72800236-d4641d00-3c81-11ea-932e-a32d36761f46.png)

**Questions:**

- are the banners displayed for every possible status?
- will the statuses be translated?
- the explanation at the bottom of the big banner: which property of the move does it correspond to? (for example, is it additional_information?


### Checklist

- [ ] If adding new environment variables, they have been documented in the [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md)
- [ ] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
