### PR TITLE
Update tests to have expected timezone

### DIFF
--- a/app/move/controllers/create/base.test.js
+++ b/app/move/controllers/create/base.test.js
@@ -1,4 +1,5 @@
 const FormController = require('hmpo-form-wizard').Controller
+const timezoneMock = require('timezone-mock')
 
 const moveService = require('../../../../common/services/move')
 const CreateBaseController = require('./base')
@@ -303,6 +304,7 @@ describe('Move controllers', function() {
       }
 
       beforeEach(function() {
+        timezoneMock.register('UTC')
         nextSpy = sinon.spy()
         req = {
           session: {
@@ -314,6 +316,10 @@ describe('Move controllers', function() {
         res = {
           locals: {},
         }
+      })
+
+      afterEach(function() {
+        timezoneMock.unregister()
       })
 
       context('when current location exists', function() {

--- a/app/moves/controllers/download.test.js
+++ b/app/moves/controllers/download.test.js
@@ -1,9 +1,12 @@
+const { format } = require('date-fns')
+
 const presenters = require('../../../common/presenters')
 
 const controller = require('./download')
 
 const mockMoveDate = '2018-10-10'
-const mockDownloadDate = new Date(Date.UTC(2019, 10, 10, 15, 30, 15))
+const mockUTCDate = Date.UTC(2019, 10, 10, 15, 30, 15)
+const mockDownloadDate = new Date(mockUTCDate)
 const requestedMovesStub = [
   { foo: 'bar', status: 'requested' },
   { fizz: 'buzz', status: 'requested' },
@@ -87,7 +90,7 @@ describe('Moves controllers', function() {
       it('should translate filename', function() {
         expect(req.t).to.be.calledOnceWithExactly('moves::download_filename', {
           date: mockMoveDate,
-          timestamp: '2019-11-10 15:30:15',
+          timestamp: format(new Date(mockUTCDate), 'yyyy-MM-dd HH:mm:ss'),
         })
       })
 
@@ -124,7 +127,7 @@ describe('Moves controllers', function() {
             'moves::download_filename',
             {
               date: mockMoveDate,
-              timestamp: '2019-11-10 15:30:15',
+              timestamp: format(new Date(mockUTCDate), 'yyyy-MM-dd HH:mm:ss'),
             }
           )
         })

--- a/common/presenters/move-to-meta-list-component.test.js
+++ b/common/presenters/move-to-meta-list-component.test.js
@@ -1,4 +1,5 @@
 const { subDays, addDays } = require('date-fns')
+const timezoneMock = require('timezone-mock')
 
 const moveToMetaListComponent = require('./move-to-meta-list-component')
 const i18n = require('../../config/i18n')
@@ -26,15 +27,12 @@ describe('Presenters', function() {
       let transformedResponse
 
       beforeEach(function() {
-        this.clock = sinon.useFakeTimers(
-          subDays(new Date(mockMove.date), 3).getTime()
-        )
-
+        timezoneMock.register('UTC')
         transformedResponse = moveToMetaListComponent(mockMove)
       })
 
       afterEach(function() {
-        this.clock.restore()
+        timezoneMock.unregister()
       })
 
       describe('response', function() {

--- a/config/nunjucks/filters.test.js
+++ b/config/nunjucks/filters.test.js
@@ -230,61 +230,6 @@ describe('Nunjucks filters', function() {
     })
 
     context('when given a valid datetime', function() {
-      context('when the time is 12am', function() {
-        it('should midnight as a string', function() {
-          const time = filters.formatTime('2000-01-01T00:00:00Z')
-          expect(time).to.equal('Midnight')
-        })
-      })
-
-      context('when the time is 12pm', function() {
-        it('should midday as a string', function() {
-          const time = filters.formatTime('2000-01-01T12:00:00Z')
-          expect(time).to.equal('Midday')
-        })
-      })
-
-      context('when time is in the morning', function() {
-        it('should return correct format', function() {
-          const time = filters.formatTime('2000-01-01T08:00:00Z')
-          expect(time).to.equal('8am')
-        })
-
-        it('should return correct format', function() {
-          const time = filters.formatTime('2000-01-01T10:00:00Z')
-          expect(time).to.equal('10am')
-        })
-      })
-
-      context('when time is in the afternoon', function() {
-        it('should return correct format', function() {
-          const time = filters.formatTime('2000-01-01T14:00:00Z')
-          expect(time).to.equal('2pm')
-        })
-
-        it('should return correct format', function() {
-          const time = filters.formatTime('2000-01-01T17:00:00Z')
-          expect(time).to.equal('5pm')
-        })
-      })
-
-      context('when time is not on the hour', function() {
-        it('should return correct format', function() {
-          const time = filters.formatTime('2000-01-01T23:59:59Z')
-          expect(time).to.equal('11:59pm')
-        })
-
-        it('should return correct format', function() {
-          const time = filters.formatTime('2000-01-01T11:59:59Z')
-          expect(time).to.equal('11:59am')
-        })
-
-        it('should return correct format', function() {
-          const time = filters.formatTime('2000-01-01T09:30:00Z')
-          expect(time).to.equal('9:30am')
-        })
-      })
-
       context('when timezone is UTC', function() {
         beforeEach(function() {
           timezoneMock.register('UTC')
@@ -292,6 +237,61 @@ describe('Nunjucks filters', function() {
 
         afterEach(function() {
           timezoneMock.unregister()
+        })
+
+        context('when the time is 12am', function() {
+          it('should midnight as a string', function() {
+            const time = filters.formatTime('2000-01-01T00:00:00Z')
+            expect(time).to.equal('Midnight')
+          })
+        })
+
+        context('when the time is 12pm', function() {
+          it('should midday as a string', function() {
+            const time = filters.formatTime('2000-01-01T12:00:00Z')
+            expect(time).to.equal('Midday')
+          })
+        })
+
+        context('when time is in the morning', function() {
+          it('should return correct format', function() {
+            const time = filters.formatTime('2000-01-01T08:00:00Z')
+            expect(time).to.equal('8am')
+          })
+
+          it('should return correct format', function() {
+            const time = filters.formatTime('2000-01-01T10:00:00Z')
+            expect(time).to.equal('10am')
+          })
+        })
+
+        context('when time is in the afternoon', function() {
+          it('should return correct format', function() {
+            const time = filters.formatTime('2000-01-01T14:00:00Z')
+            expect(time).to.equal('2pm')
+          })
+
+          it('should return correct format', function() {
+            const time = filters.formatTime('2000-01-01T17:00:00Z')
+            expect(time).to.equal('5pm')
+          })
+        })
+
+        context('when time is not on the hour', function() {
+          it('should return correct format', function() {
+            const time = filters.formatTime('2000-01-01T23:59:59Z')
+            expect(time).to.equal('11:59pm')
+          })
+
+          it('should return correct format', function() {
+            const time = filters.formatTime('2000-01-01T11:59:59Z')
+            expect(time).to.equal('11:59am')
+          })
+
+          it('should return correct format', function() {
+            const time = filters.formatTime('2000-01-01T09:30:00Z')
+            expect(time).to.equal('9:30am')
+          })
         })
 
         it('should return correct format', function() {


### PR DESCRIPTION
Currently when the tests are run from a different timezone they fail
as they are expecting text based on a UTC timezone.

This updates the tests to mock run tests in UTC where possible so that
time related tests will always pass as expected no matter the timezone.