### PR TITLE
Add completed status to locales

### DIFF
--- a/locales/en/statuses.json
+++ b/locales/en/statuses.json
@@ -1,9 +1,11 @@
 {
   "requested": "Move requested",
   "accepted": "Move accepted",
+  "completed": "Move completed",
   "cancelled": "Move cancelled",
   "description": "",
   "description_requested": "This move has been requested with the supplier",
   "description_accepted": "This move has been accepted by the supplier",
+  "description_completed": "This move has been completed",
   "description_cancelled": "Reason — {{reason}}"
 }


### PR DESCRIPTION
This adds content for the completed status to the locales file so that
if moves with a completed status come through they are displayed
correctly.
