### PR TITLE
[P4-900] Add completed moves to move requests

### DIFF
--- a/app/moves/controllers/download.js
+++ b/app/moves/controllers/download.js
@@ -4,8 +4,8 @@ const presenters = require('../../../common/presenters')
 
 module.exports = function download(req, res, next) {
   const { extension } = req.params
-  const { moveDate, requestedMovesByDate, cancelledMovesByDate } = res.locals
-  const moves = [...requestedMovesByDate, ...cancelledMovesByDate]
+  const { moveDate, activeMovesByDate, cancelledMovesByDate } = res.locals
+  const moves = [...activeMovesByDate, ...cancelledMovesByDate]
   const currentTimestamp = format(new Date(), 'yyyy-MM-dd HH:mm:ss')
   const filename = req.t('moves::download_filename', {
     date: moveDate,

--- a/app/moves/controllers/download.test.js
+++ b/app/moves/controllers/download.test.js
@@ -7,7 +7,7 @@ const controller = require('./download')
 const mockMoveDate = '2018-10-10'
 const mockUTCDate = Date.UTC(2019, 10, 10, 15, 30, 15)
 const mockDownloadDate = new Date(mockUTCDate)
-const requestedMovesStub = [
+const activeMovesStub = [
   { foo: 'bar', status: 'requested' },
   { fizz: 'buzz', status: 'requested' },
 ]
@@ -35,7 +35,7 @@ describe('Moves controllers', function() {
         setHeader: sinon.stub(),
         locals: {
           moveDate: mockMoveDate,
-          requestedMovesByDate: requestedMovesStub,
+          activeMovesByDate: activeMovesStub,
           cancelledMovesByDate: cancelledMovesStub,
         },
       }
@@ -103,7 +103,7 @@ describe('Moves controllers', function() {
 
       it('should render moves as JSON', function() {
         expect(res.json).to.be.calledOnceWithExactly([
-          ...requestedMovesStub,
+          ...activeMovesStub,
           ...cancelledMovesStub,
         ])
       })
@@ -148,7 +148,7 @@ describe('Moves controllers', function() {
 
         it('should call CSV presenter with combined moves', function() {
           expect(presenters.movesToCSV).to.be.calledOnceWithExactly([
-            ...requestedMovesStub,
+            ...activeMovesStub,
             ...cancelledMovesStub,
           ])
         })

--- a/app/moves/controllers/list.js
+++ b/app/moves/controllers/list.js
@@ -6,7 +6,7 @@ const presenters = require('../../../common/presenters')
 module.exports = function list(req, res) {
   const {
     cancelledMovesByDate = [],
-    requestedMovesByDate = [],
+    activeMovesByDate = [],
     fromLocationId,
   } = res.locals
   const userPermissions = get(req.session, 'user.permissions')
@@ -15,7 +15,7 @@ module.exports = function list(req, res) {
     canViewMove && fromLocationId ? 'moves/views/list' : 'moves/views/download'
   const locals = {
     pageTitle: 'moves::dashboard.upcoming_moves',
-    destinations: presenters.movesByToLocation(requestedMovesByDate),
+    destinations: presenters.movesByToLocation(activeMovesByDate),
     cancelledMoves: cancelledMovesByDate.map(
       presenters.moveToCardComponent({
         showMeta: false,

--- a/app/moves/controllers/list.test.js
+++ b/app/moves/controllers/list.test.js
@@ -3,7 +3,7 @@ const permissions = require('../../../common/middleware/permissions')
 
 const controller = require('./list')
 
-const mockRequestedMovesByDate = [
+const mockActiveMovesByDate = [
   { foo: 'bar', status: 'requested' },
   { fizz: 'buzz', status: 'requested' },
 ]
@@ -32,7 +32,7 @@ describe('Moves controllers', function() {
     describe('template params', function() {
       context('with moves', function() {
         beforeEach(function() {
-          res.locals.requestedMovesByDate = mockRequestedMovesByDate
+          res.locals.activeMovesByDate = mockActiveMovesByDate
           res.locals.cancelledMovesByDate = mockCancelledMovesByDate
 
           controller(req, res)
@@ -44,7 +44,7 @@ describe('Moves controllers', function() {
 
         it('should call movesByToLocation presenter', function() {
           expect(presenters.movesByToLocation).to.be.calledOnceWithExactly(
-            mockRequestedMovesByDate
+            mockActiveMovesByDate
           )
         })
 
@@ -59,7 +59,7 @@ describe('Moves controllers', function() {
         it('should contain destinations property', function() {
           const params = res.render.args[0][1]
           expect(params).to.have.property('destinations')
-          expect(params.destinations).to.deep.equal(mockRequestedMovesByDate)
+          expect(params.destinations).to.deep.equal(mockActiveMovesByDate)
         })
       })
 

--- a/app/moves/middleware.js
+++ b/app/moves/middleware.js
@@ -81,12 +81,12 @@ module.exports = {
     }
 
     try {
-      const [requestedMoves, cancelledMoves] = await Promise.all([
-        moveService.getRequested({ moveDate, fromLocationId }),
+      const [activeMoves, cancelledMoves] = await Promise.all([
+        moveService.getActive({ moveDate, fromLocationId }),
         moveService.getCancelled({ moveDate, fromLocationId }),
       ])
 
-      res.locals.requestedMovesByDate = requestedMoves
+      res.locals.activeMovesByDate = activeMoves
       res.locals.cancelledMovesByDate = cancelledMoves
 
       next()
@@ -114,12 +114,12 @@ module.exports = {
         id.join(',')
       )
 
-      const [requestedMoves, cancelledMoves] = (await Promise.all([
-        makeMultipleRequests(moveService.getRequested, moveDate, idChunks),
+      const [activeMoves, cancelledMoves] = (await Promise.all([
+        makeMultipleRequests(moveService.getActive, moveDate, idChunks),
         makeMultipleRequests(moveService.getCancelled, moveDate, idChunks),
       ])).map(response => response.flat())
 
-      res.locals.requestedMovesByDate = requestedMoves
+      res.locals.activeMovesByDate = activeMoves
       res.locals.cancelledMovesByDate = cancelledMoves
       next()
     } catch (error) {

--- a/common/services/move.js
+++ b/common/services/move.js
@@ -54,6 +54,18 @@ const moveService = {
     })
   },
 
+  getActive({ moveDate, fromLocationId, toLocationId } = {}) {
+    return moveService.getAll({
+      filter: {
+        'filter[status]': 'requested,accepted,completed',
+        'filter[date_from]': moveDate,
+        'filter[date_to]': moveDate,
+        'filter[from_location_id]': fromLocationId,
+        'filter[to_location_id]': toLocationId,
+      },
+    })
+  },
+
   getCancelled({ moveDate, fromLocationId, toLocationId } = {}) {
     return moveService.getAll({
       filter: {

--- a/common/services/move.test.js
+++ b/common/services/move.test.js
@@ -324,6 +324,66 @@ describe('Move Service', function() {
     })
   })
 
+  describe('#getActive()', function() {
+    let moves
+
+    beforeEach(async function() {
+      sinon.stub(moveService, 'getAll').resolves(mockMoves)
+    })
+
+    context('without arguments', function() {
+      beforeEach(async function() {
+        moves = await moveService.getActive()
+      })
+
+      it('should call getAll with active statuses', function() {
+        expect(moveService.getAll).to.be.calledOnceWithExactly({
+          filter: {
+            'filter[status]': 'requested,accepted,completed',
+            'filter[date_from]': undefined,
+            'filter[date_to]': undefined,
+            'filter[from_location_id]': undefined,
+            'filter[to_location_id]': undefined,
+          },
+        })
+      })
+
+      it('should return moves', function() {
+        expect(moves).to.deep.equal(mockMoves)
+      })
+    })
+
+    context('with arguments', function() {
+      const mockMoveDate = '2019-10-10'
+      const mockFromLocationId = 'b695d0f0-af8e-4b97-891e-92020d6820b9'
+      const mockToLocationId = 'b195d0f0-df8e-4b97-891e-92020d6820b9'
+
+      beforeEach(async function() {
+        moves = await moveService.getActive({
+          moveDate: mockMoveDate,
+          fromLocationId: mockFromLocationId,
+          toLocationId: mockToLocationId,
+        })
+      })
+
+      it('should call getAll with active statuses', function() {
+        expect(moveService.getAll).to.be.calledOnceWithExactly({
+          filter: {
+            'filter[status]': 'requested,accepted,completed',
+            'filter[date_from]': mockMoveDate,
+            'filter[date_to]': mockMoveDate,
+            'filter[from_location_id]': mockFromLocationId,
+            'filter[to_location_id]': mockToLocationId,
+          },
+        })
+      })
+
+      it('should return moves', function() {
+        expect(moves).to.deep.equal(mockMoves)
+      })
+    })
+  })
+
   describe('#getCancelled()', function() {
     const mockResponse = []
     let moves


### PR DESCRIPTION
This change extends the move service to include a method to get all
active move statuses. Currently that includes `requested`, `accepted` and `completed`
that we know of.

This will extend as more statuses are known.