### PR TITLE
Ensure download users correct middleware

### DIFF
--- a/app/moves/index.js
+++ b/app/moves/index.js
@@ -43,7 +43,7 @@ router.get(
 router.get(
   '/:date/download.:extension(csv|json)',
   protectRoute('moves:download:all'),
-  setMovesByDateAndLocation,
+  setMovesByDateAllLocations,
   download
 )
 router.get(


### PR DESCRIPTION
The download all moves route was using the middleware for
a single location rather than all locations and was there not
filtering the moves.

This fix ensures the routes use the correct controller.