### PR TITLE
[P4-935] Update multi field component

### DIFF
--- a/app/move/controllers/create/document.js
+++ b/app/move/controllers/create/document.js
@@ -30,10 +30,8 @@ class DocumentUploadController extends CreateBaseController {
 
   xhrErrorResponse(t, errorType) {
     return {
-      href: '#document_upload',
-      text: `${t('fields::document_upload.label')} ${t(
-        `validation::${errorType}`
-      )}`,
+      href: '#documents',
+      text: `${t('fields::documents.label')} ${t(`validation::${errorType}`)}`,
     }
   }
 
@@ -62,12 +60,7 @@ class DocumentUploadController extends CreateBaseController {
 
         if (!isXhr) {
           return next({
-            document_upload: this.serverError(
-              req,
-              res,
-              'document_upload',
-              errorType
-            ),
+            documents: this.serverError(req, res, 'documents', errorType),
           })
         }
       }
@@ -84,7 +77,7 @@ class DocumentUploadController extends CreateBaseController {
 
   async populateDocumentUpload(req, res, next) {
     const { id } = req.sessionModel.get('move') || {}
-    const { document_upload: documentUpload } = req.form.options.fields
+    const { documents: documentUpload } = req.form.options.fields
 
     try {
       if (id) {
@@ -173,7 +166,7 @@ class DocumentUploadController extends CreateBaseController {
         await this.processDocumentUpload(req, res)
       } catch (error) {
         return next({
-          document_upload: this.serverError(req, res, 'document_upload'),
+          documents: this.serverError(req, res, 'documents'),
         })
       }
     }
@@ -183,7 +176,7 @@ class DocumentUploadController extends CreateBaseController {
         await documentService.delete(moveId, documentId)
       } catch (error) {
         return next({
-          document_upload: this.serverError(req, res, 'document_upload'),
+          documents: this.serverError(req, res, 'documents'),
         })
       }
     }

--- a/app/move/controllers/create/document.test.js
+++ b/app/move/controllers/create/document.test.js
@@ -170,13 +170,13 @@ describe('Move controllers', function() {
 
         it('should call parent method', function() {
           expect(response).to.deep.equal({
-            href: '#document_upload',
+            href: '#documents',
             text: '__translated__ __translated__',
           })
         })
 
         it('should translate document upload label', function() {
-          expect(t.firstCall).to.be.calledWith('fields::document_upload.label')
+          expect(t.firstCall).to.be.calledWith('fields::documents.label')
         })
 
         it('should translate validation generic error', function() {
@@ -193,13 +193,13 @@ describe('Move controllers', function() {
 
         it('should call parent method', function() {
           expect(response).to.deep.equal({
-            href: '#document_upload',
+            href: '#documents',
             text: '__translated__ __translated__',
           })
         })
 
         it('should translate document upload label', function() {
-          expect(t.firstCall).to.be.calledWith('fields::document_upload.label')
+          expect(t.firstCall).to.be.calledWith('fields::documents.label')
         })
 
         it('should translate validation filesize error', function() {
@@ -335,7 +335,7 @@ describe('Move controllers', function() {
 
               it('should translate document upload label', function() {
                 expect(req.t.firstCall).to.be.calledWith(
-                  'fields::document_upload.label'
+                  'fields::documents.label'
                 )
               })
 
@@ -347,7 +347,7 @@ describe('Move controllers', function() {
                 expect(res.json).to.have.been.calledOnce
                 expect(res.json).to.have.been.calledWithExactly([
                   {
-                    href: '#document_upload',
+                    href: '#documents',
                     text: '__translated__ __translated__',
                   },
                 ])
@@ -388,7 +388,7 @@ describe('Move controllers', function() {
 
               it('should translate document upload label', function() {
                 expect(req.t.firstCall).to.be.calledWith(
-                  'fields::document_upload.label'
+                  'fields::documents.label'
                 )
               })
 
@@ -402,7 +402,7 @@ describe('Move controllers', function() {
                 expect(res.json).to.have.been.calledOnce
                 expect(res.json).to.have.been.calledWithExactly([
                   {
-                    href: '#document_upload',
+                    href: '#documents',
                     text: '__translated__ __translated__',
                   },
                 ])
@@ -439,18 +439,14 @@ describe('Move controllers', function() {
 
               it('should call next with error', function() {
                 expect(nextSpy).to.be.calledOnce
-                expect(nextSpy.args[0][0].document_upload).to.be.an.instanceOf(
+                expect(nextSpy.args[0][0].documents).to.be.an.instanceOf(
                   FormError
                 )
-                expect(nextSpy.args[0][0].document_upload.errorGroup).to.equal(
-                  'document_upload'
+                expect(nextSpy.args[0][0].documents.errorGroup).to.equal(
+                  'documents'
                 )
-                expect(nextSpy.args[0][0].document_upload.key).to.equal(
-                  'document_upload'
-                )
-                expect(nextSpy.args[0][0].document_upload.type).to.equal(
-                  'generic'
-                )
+                expect(nextSpy.args[0][0].documents.key).to.equal('documents')
+                expect(nextSpy.args[0][0].documents.type).to.equal('generic')
               })
             })
 
@@ -483,18 +479,14 @@ describe('Move controllers', function() {
 
               it('should call next with error', function() {
                 expect(nextSpy).to.be.calledOnce
-                expect(nextSpy.args[0][0].document_upload).to.be.an.instanceOf(
+                expect(nextSpy.args[0][0].documents).to.be.an.instanceOf(
                   FormError
                 )
-                expect(nextSpy.args[0][0].document_upload.errorGroup).to.equal(
-                  'document_upload'
+                expect(nextSpy.args[0][0].documents.errorGroup).to.equal(
+                  'documents'
                 )
-                expect(nextSpy.args[0][0].document_upload.key).to.equal(
-                  'document_upload'
-                )
-                expect(nextSpy.args[0][0].document_upload.type).to.equal(
-                  'filesize'
-                )
+                expect(nextSpy.args[0][0].documents.key).to.equal('documents')
+                expect(nextSpy.args[0][0].documents.type).to.equal('filesize')
               })
             })
           })
@@ -515,7 +507,7 @@ describe('Move controllers', function() {
           form: {
             options: {
               fields: {
-                document_upload: {},
+                documents: {},
               },
             },
           },
@@ -544,14 +536,14 @@ describe('Move controllers', function() {
             )
           })
 
-          it('should set documents on document_upload field', function() {
-            expect(
-              req.form.options.fields.document_upload.documents
-            ).to.deep.equal(mockMove.documents)
+          it('should set documents on documents field', function() {
+            expect(req.form.options.fields.documents.documents).to.deep.equal(
+              mockMove.documents
+            )
           })
 
-          it('should set xhrUrl on document_upload field', function() {
-            expect(req.form.options.fields.document_upload.xhrUrl).to.equal(
+          it('should set xhrUrl on documents field', function() {
+            expect(req.form.options.fields.documents.xhrUrl).to.equal(
               mockOriginalUrl
             )
           })
@@ -574,16 +566,12 @@ describe('Move controllers', function() {
             )
           })
 
-          it('should not set documents on document_upload field', function() {
-            expect(
-              req.form.options.fields.document_upload.documents
-            ).to.be.undefined
+          it('should not set documents on documents field', function() {
+            expect(req.form.options.fields.documents.documents).to.be.undefined
           })
 
-          it('should not set xhrUrl on document_upload field', function() {
-            expect(
-              req.form.options.fields.document_upload.xhrUrl
-            ).to.be.undefined
+          it('should not set xhrUrl on documents field', function() {
+            expect(req.form.options.fields.documents.xhrUrl).to.be.undefined
           })
 
           it('should call next with error', function() {
@@ -606,14 +594,12 @@ describe('Move controllers', function() {
           expect(moveService.getById).to.not.have.been.called
         })
 
-        it('should not set documents on document_upload field', function() {
-          expect(
-            req.form.options.fields.document_upload.documents
-          ).to.be.undefined
+        it('should not set documents on documents field', function() {
+          expect(req.form.options.fields.documents.documents).to.be.undefined
         })
 
-        it('should set xhrUrl on document_upload field', function() {
-          expect(req.form.options.fields.document_upload.xhrUrl).to.equal(
+        it('should set xhrUrl on documents field', function() {
+          expect(req.form.options.fields.documents.xhrUrl).to.equal(
             mockOriginalUrl
           )
         })
@@ -717,7 +703,7 @@ describe('Move controllers', function() {
               expect(res.json).to.have.been.calledOnce
               expect(res.json).to.have.been.calledWithExactly([
                 {
-                  href: '#document_upload',
+                  href: '#documents',
                   text: '__translated__ __translated__',
                 },
               ])
@@ -725,7 +711,7 @@ describe('Move controllers', function() {
 
             it('should translate document upload label', function() {
               expect(req.t.firstCall).to.be.calledWith(
-                'fields::document_upload.label'
+                'fields::documents.label'
               )
             })
 
@@ -761,7 +747,7 @@ describe('Move controllers', function() {
               expect(res.json).to.have.been.calledOnce
               expect(res.json).to.have.been.calledWithExactly([
                 {
-                  href: '#document_upload',
+                  href: '#documents',
                   text: '__translated__ __translated__',
                 },
               ])
@@ -769,7 +755,7 @@ describe('Move controllers', function() {
 
             it('should translate document upload label', function() {
               expect(req.t.firstCall).to.be.calledWith(
-                'fields::document_upload.label'
+                'fields::documents.label'
               )
             })
 
@@ -833,11 +819,7 @@ describe('Move controllers', function() {
 
             it('should call next with error', function() {
               expect(nextSpy).to.be.calledWithExactly({
-                document_upload: controller.serverError(
-                  req,
-                  res,
-                  'document_upload'
-                ),
+                documents: controller.serverError(req, res, 'documents'),
               })
             })
 
@@ -889,11 +871,7 @@ describe('Move controllers', function() {
 
             it('should call next with error', function() {
               expect(nextSpy).to.be.calledWithExactly({
-                document_upload: controller.serverError(
-                  req,
-                  res,
-                  'document_upload'
-                ),
+                documents: controller.serverError(req, res, 'documents'),
               })
             })
 
@@ -1056,7 +1034,7 @@ describe('Move controllers', function() {
               expect(res.json).to.have.been.calledOnce
               expect(res.json).to.have.been.calledWithExactly([
                 {
-                  href: '#document_upload',
+                  href: '#documents',
                   text: '__translated__ __translated__',
                 },
               ])
@@ -1064,7 +1042,7 @@ describe('Move controllers', function() {
 
             it('should translate document upload label', function() {
               expect(req.t.firstCall).to.be.calledWith(
-                'fields::document_upload.label'
+                'fields::documents.label'
               )
             })
 
@@ -1097,7 +1075,7 @@ describe('Move controllers', function() {
               expect(res.json).to.have.been.calledOnce
               expect(res.json).to.have.been.calledWithExactly([
                 {
-                  href: '#document_upload',
+                  href: '#documents',
                   text: '__translated__ __translated__',
                 },
               ])
@@ -1105,7 +1083,7 @@ describe('Move controllers', function() {
 
             it('should translate document upload label', function() {
               expect(req.t.firstCall).to.be.calledWith(
-                'fields::document_upload.label'
+                'fields::documents.label'
               )
             })
 
@@ -1209,7 +1187,7 @@ describe('Move controllers', function() {
       })
 
       context('default call', function() {
-        const mockFieldName = 'document_upload'
+        const mockFieldName = 'documents'
 
         beforeEach(function() {
           serverError = controller.serverError(req, res, mockFieldName)
@@ -1221,9 +1199,9 @@ describe('Move controllers', function() {
             args: {
               generic: undefined,
             },
-            errorGroup: 'document_upload',
+            errorGroup: 'documents',
             headerMessage: undefined,
-            key: 'document_upload',
+            key: 'documents',
             message: undefined,
             redirect: undefined,
             type: 'generic',

--- a/app/move/fields/create.js
+++ b/app/move/fields/create.js
@@ -294,15 +294,19 @@ module.exports = {
   court__solicitor: assessmentQuestionComments,
   court__interpreter: assessmentQuestionComments,
   court__other_court: requiredAssessmentQuestionComments,
-  document_upload: {
+  documents: {
+    id: 'documents',
+    name: 'documents',
     component: 'appMultiFileUpload',
     heading: {
-      text: 'Only include documents that will help plan the move.',
+      text: 'fields::documents.heading',
     },
     label: {
-      text: 'fields::first_names.label',
-      classes: 'govuk-label--s',
+      text: 'fields::documents.label',
+      classes: 'govuk-label--m',
     },
-    id: 'multi-file-upload',
+    hint: {
+      text: 'fields::documents.hint',
+    },
   },
 }

--- a/app/move/steps/create.js
+++ b/app/move/steps/create.js
@@ -127,7 +127,7 @@ module.exports = {
     next: 'save',
     pageTitle: 'moves::steps.document.heading',
     buttonText: 'actions::schedule_move',
-    fields: ['document_upload'],
+    fields: ['documents'],
   },
   '/save': {
     skip: true,

--- a/common/components/multi-file-upload/multi-file-upload.js
+++ b/common/components/multi-file-upload/multi-file-upload.js
@@ -293,10 +293,7 @@ MultiFileUpload.prototype = {
         )
 
         $uploadActions.appendChild(
-          this.buildDeleteButton(
-            documentDetail.id,
-            documentDetail.attributes.filename
-          )
+          this.buildDeleteButton(documentDetail.id, documentDetail.filename)
         )
       })
       .catch(errors => this.renderErrors(errors, $fileUploadRow))

--- a/common/components/multi-file-upload/multi-file-upload.js
+++ b/common/components/multi-file-upload/multi-file-upload.js
@@ -37,6 +37,9 @@ MultiFileUpload.prototype = {
       '.js-file-form-group'
     )
     this.$htmlTitle = document.querySelector('title')
+    this.$fileInput = this.params.container.querySelector(
+      '.js-upload-file-input'
+    )
 
     this.buildDropZone()
     this.setupFileInput()
@@ -204,7 +207,7 @@ MultiFileUpload.prototype = {
         <dd class="govuk-summary-list__value app-row__value js-upload-message">
           <span class="app-multi-file-upload__progress-bar js-upload-progress-bar"></span>
           <span class="app-multi-file-upload__progress-number js-upload-progress-number">0%</span>
-        </dd>      
+        </dd>
         <dd class="govuk-summary-list__actions app-row__actions js-upload-actions"></dd>
       </div>`.trim()
   },
@@ -240,7 +243,7 @@ MultiFileUpload.prototype = {
 
     this.resetErrors()
 
-    formData.append('file', file)
+    formData.append(this.$fileInput.name, file)
     formData.append('x-csrf-token', xsrfToken.value)
 
     const $tmpDiv = document.createElement('div')
@@ -315,7 +318,7 @@ MultiFileUpload.prototype = {
     if (errorData.length === 0) {
       errorData.push({
         text: 'Something went wrong',
-        href: '#document_upload',
+        href: `#${this.$fileInput.id}`,
       })
     }
 

--- a/common/components/multi-file-upload/multi-file-upload.yaml
+++ b/common/components/multi-file-upload/multi-file-upload.yaml
@@ -28,20 +28,20 @@ params:
 
 examples:
   - name: default
-    description: The multi upload component without uploaded documents
+    description: The multi upload component without uploaded files
     data:
       heading:
         text: example default heading
       hint:
         text: You can upload Word, Excel, PDF and JPEG documents up to 50MB.
       xhrUrl: '/example/text/xhr-endpoint'
-  - name: with document uploads
-    description: The multi upload component with uploaded documents
+  - name: with files
+    description: The multi upload component with uploaded files
     data:
       heading:
         text: example heading with documents
       xhrUrl: '/example/text/xhr-endpoint'
-      documents:
+      value:
       - id: 'example-id-01'
         filename: 'example-file-01-png'
       - id: 'example-id-02'

--- a/common/components/multi-file-upload/multi-file-upload.yaml
+++ b/common/components/multi-file-upload/multi-file-upload.yaml
@@ -31,13 +31,15 @@ examples:
     description: The multi upload component without uploaded documents
     data:
       heading:
-       text: example default heading
+        text: example default heading
+      hint:
+        text: You can upload Word, Excel, PDF and JPEG documents up to 50MB.
       xhrUrl: '/example/text/xhr-endpoint'
   - name: with document uploads
     description: The multi upload component with uploaded documents
     data:
       heading:
-       text: example heading with documents
+        text: example heading with documents
       xhrUrl: '/example/text/xhr-endpoint'
       documents:
       - id: 'example-id-01'

--- a/common/components/multi-file-upload/template.njk
+++ b/common/components/multi-file-upload/template.njk
@@ -4,10 +4,10 @@
 <div class="app-multi-file-upload" data-module="app-multi-file-upload" data-xhr-url="{{ params.xhrUrl }}">
   <h2 class="govuk-body-l">{{ params.heading.text }}</h2>
   <dl class="app-multi-file-upload__list govuk-summary-list js-upload-list">
-    {% for document in params.documents %}
-    <div class="govuk-summary-list__row app-row js-upload-row" data-document-id="{{ document.id }}">
+    {% for file in params.value %}
+    <div class="govuk-summary-list__row app-row js-upload-row" data-document-id="{{ file.id }}">
       <dt class="govuk-summary-list__key app-row__key">
-        {{ document.filename }}
+        {{ file.filename }}
       </dt>
       <dd class="govuk-summary-list__value app-row__value js-upload-message">
         <span class="app-multi-file-upload-message app-multi-file-upload-message__success">
@@ -15,12 +15,16 @@
         </span>
       </dd>
       <dd class="govuk-summary-list__actions app-row__actions js-upload-actions">
-        <button class="govuk-button govuk-button--secondary govuk-!-margin-bottom-0 js-upload-delete"
-                value="{{ document.id }}"
-                name="document_id">
-          Delete
-          <span class="govuk-visually-hidden">{{ document.filename }}</span>
-        </button>
+        {% set deleteLabel %}
+          Delete <span class="govuk-visually-hidden">{{ file.filename }}</span>
+        {% endset %}
+
+        {{ govukButton({
+          html: deleteLabel,
+          classes: "govuk-button--secondary govuk-!-margin-bottom-0 js-upload-delete",
+          name: "delete",
+          value: file.id
+        }) }}
       </dd>
     </div>
     {% endfor %}

--- a/common/components/multi-file-upload/template.njk
+++ b/common/components/multi-file-upload/template.njk
@@ -27,16 +27,11 @@
   </dl>
 
   {{ govukFileUpload({
-    id: "file",
-    name: "file",
+    id: params.id,
+    name: params.name,
     classes: 'js-upload-file-input',
-    label: {
-      text: "Upload documents (optional)",
-      classes: 'govuk-label--m'
-    },
-    hint: {
-      text: "You can upload Word, Excel, PDF and JPEG documents up to 50MB."
-    },
+    label: params.label,
+    hint: params.hint,
     attributes: { multiple: "" },
     value: "",
     errorMessage: params.errorMessage,
@@ -47,7 +42,7 @@
 
   {{ govukButton({
     text: "Upload",
-    classes: "govuk-button govuk-button--secondary app-js-hidden",
+    classes: "govuk-button--secondary app-js-hidden",
     name: "upload",
     value: "upload"
   }) }}

--- a/common/components/multi-file-upload/template.test.js
+++ b/common/components/multi-file-upload/template.test.js
@@ -66,7 +66,7 @@ describe('Multi file upload component', function() {
   })
 
   context('with uploaded documents', function() {
-    const mockData = examples['with document uploads']
+    const mockData = examples['with files']
     let $component
 
     beforeEach(function() {
@@ -80,12 +80,12 @@ describe('Multi file upload component', function() {
 
     it('should render documents', function() {
       expect($component.find('.js-upload-row').length).to.equal(
-        mockData.documents.length
+        mockData.value.length
       )
     })
 
     it('should render first document', function() {
-      const documentMockData = mockData.documents[0]
+      const documentMockData = mockData.value[0]
       const $document = $component.find(
         `[data-document-id="${documentMockData.id}"]`
       )
@@ -99,7 +99,7 @@ describe('Multi file upload component', function() {
     })
 
     it('should render second document', function() {
-      const documentMockData = mockData.documents[1]
+      const documentMockData = mockData.value[1]
       const $document = $component.find(
         `[data-document-id="${documentMockData.id}"]`
       )

--- a/common/components/multi-file-upload/template.test.js
+++ b/common/components/multi-file-upload/template.test.js
@@ -52,7 +52,7 @@ describe('Multi file upload component', function() {
     it('should render upload hint', function() {
       expect(
         $component
-          .find('#file-hint')
+          .find('.govuk-hint')
           .text()
           .trim()
       ).to.equal(

--- a/common/helpers/field.js
+++ b/common/helpers/field.js
@@ -140,6 +140,8 @@ function translateField(translate) {
       'hint.html',
       'fieldset.legend.text',
       'fieldset.legend.html',
+      'heading.text',
+      'heading.html',
     ]
 
     translationPaths.forEach(path => {

--- a/common/helpers/field.test.js
+++ b/common/helpers/field.test.js
@@ -654,6 +654,16 @@ describe('Form helpers', function() {
             },
           },
         },
+        'heading.text': {
+          heading: {
+            text: 'heading.text',
+          },
+        },
+        'heading.html': {
+          heading: {
+            html: 'heading.html',
+          },
+        },
       }
 
       Object.entries(scenarios).forEach(function([path, properties]) {

--- a/locales/en/fields.json
+++ b/locales/en/fields.json
@@ -125,7 +125,9 @@
   "health__other_health": {
     "label": "Any other requirements details"
   },
-  "document_upload": {
-    "label": "Document upload"
+  "documents": {
+    "heading": "Only include documents that will help plan the move.",
+    "label": "Document upload (optional)",
+    "hint": "You can upload Word, Excel, PDF and JPEG documents up to 50MB."
   }
 }


### PR DESCRIPTION
This change is linked to P4-935 which will allow documents to be uploaded without the need for a move ID.

As part of this work some updates to the multi file upload component were required so this work is being split out to make it easier to review.

See breakdown of commits for reasoning behind changes.