### PR TITLE
[P4-978] Ensure current location is persisted on session regeneration

### DIFF
--- a/app/auth/middleware.js
+++ b/app/auth/middleware.js
@@ -4,7 +4,7 @@ const { decodeAccessToken } = require('../../common/lib/access-token')
 
 function processAuthResponse() {
   return async function middleware(req, res, next) {
-    const { grant, postAuthRedirect } = req.session
+    const { grant, postAuthRedirect, currentLocation } = req.session
 
     if (!grant) {
       return next()
@@ -24,6 +24,7 @@ function processAuthResponse() {
         }
 
         req.session.authExpiry = decodedAccessToken.exp
+        req.session.currentLocation = currentLocation
         req.session.postAuthRedirect = postAuthRedirect
         req.session.user = new User({
           fullname,

--- a/app/auth/middleware.test.js
+++ b/app/auth/middleware.test.js
@@ -39,6 +39,7 @@ describe('Authentication middleware', function() {
         session: {
           id: '123',
           postAuthRedirect: '/test',
+          currentLocation: '1234567890',
           regenerate: sinon.stub(),
         },
       }
@@ -157,6 +158,10 @@ describe('Authentication middleware', function() {
 
           it('sets the redirect URL in the session', function() {
             expect(req.session.postAuthRedirect).to.equal('/test')
+          })
+
+          it('sets the location in the session', function() {
+            expect(req.session.currentLocation).to.equal('1234567890')
           })
 
           it('calls the next action', function() {


### PR DESCRIPTION
Currently there is a bug where if the session expires on the frontend,
it will attempted to redirect to the auth service which will make a
call to see if the user is still authenticated.

If they are, it will regenerate the session, persisting some values.

However, the `currentLocation` value is not persisted across this
regeneration which means that the check locations middleware then
redirects the user back to the locations mountpath to choose their
location again even though, in their eyes, they were never logged
out.

To fix this, `req.session.currentLocation` is now persisted across
this session regeneration so that the user remains on the page they
were before the re-authentication.