### PR TITLE
[P4-742] Move button logic to controller

### DIFF
--- a/app/move/controllers/create/base.js
+++ b/app/move/controllers/create/base.js
@@ -10,9 +10,23 @@ class CreateBaseController extends FormWizardController {
 
   middlewareLocals() {
     super.middlewareLocals()
+    this.use(this.setButtonText)
     this.use(this.setCancelUrl)
     this.use(this.setMoveSummary)
     this.use(this.setJourneyTimer)
+  }
+
+  setButtonText(req, res, next) {
+    const nextStep = this.getNextStep(req, res)
+    const steps = Object.keys(req.form.options.steps)
+    const lastStep = steps[steps.length - 1]
+    const buttonText = nextStep.includes(lastStep)
+      ? 'actions::schedule_move'
+      : 'actions::continue'
+
+    req.form.options.buttonText = req.form.options.buttonText || buttonText
+
+    next()
   }
 
   setCancelUrl(req, res, next) {

--- a/app/move/controllers/create/base.test.js
+++ b/app/move/controllers/create/base.test.js
@@ -40,8 +40,105 @@ describe('Move controllers', function() {
           .calledOnce
       })
 
+      it('should call set button text method', function() {
+        expect(controller.use.getCall(0)).to.have.been.calledWithExactly(
+          controller.setButtonText
+        )
+      })
+
       it('should call set cancel url method', function() {
-        expect(controller.use).to.have.been.calledWith(controller.setCancelUrl)
+        expect(controller.use.getCall(1)).to.have.been.calledWithExactly(
+          controller.setCancelUrl
+        )
+      })
+
+      it('should call set move summary method', function() {
+        expect(controller.use.getCall(2)).to.have.been.calledWithExactly(
+          controller.setMoveSummary
+        )
+      })
+
+      it('should call set journey timer method', function() {
+        expect(controller.use.getCall(3)).to.have.been.calledWithExactly(
+          controller.setJourneyTimer
+        )
+      })
+
+      it('should call correct number of middleware', function() {
+        expect(controller.use).to.be.callCount(4)
+      })
+    })
+
+    describe('#setButtonText()', function() {
+      let req, nextSpy
+
+      beforeEach(function() {
+        nextSpy = sinon.spy()
+        req = {
+          form: {
+            options: {
+              steps: {
+                '/': {},
+                '/step-one': {},
+                '/last-step': {},
+              },
+            },
+          },
+        }
+        sinon.stub(FormController.prototype, 'getNextStep')
+      })
+
+      context('with buttonText option', function() {
+        beforeEach(function() {
+          req.form.options.buttonText = 'Override button text'
+          FormController.prototype.getNextStep.returns('/')
+
+          controller.setButtonText(req, {}, nextSpy)
+        })
+
+        it('should set cancel url correctly', function() {
+          expect(req.form.options.buttonText).to.equal('Override button text')
+        })
+
+        it('should call next', function() {
+          expect(nextSpy).to.be.calledOnceWithExactly()
+        })
+      })
+
+      context('with no buttonText option', function() {
+        context('when step is not penultimate step', function() {
+          beforeEach(function() {
+            FormController.prototype.getNextStep.returns('/step-one')
+
+            controller.setButtonText(req, {}, nextSpy)
+          })
+
+          it('should set cancel url correctly', function() {
+            expect(req.form.options.buttonText).to.equal('actions::continue')
+          })
+
+          it('should call next', function() {
+            expect(nextSpy).to.be.calledOnceWithExactly()
+          })
+        })
+
+        context('when step is penultimate step', function() {
+          beforeEach(function() {
+            FormController.prototype.getNextStep.returns('/last-step')
+
+            controller.setButtonText(req, {}, nextSpy)
+          })
+
+          it('should set cancel url correctly', function() {
+            expect(req.form.options.buttonText).to.equal(
+              'actions::schedule_move'
+            )
+          })
+
+          it('should call next', function() {
+            expect(nextSpy).to.be.calledOnceWithExactly()
+          })
+        })
       })
     })
 

--- a/app/move/steps/create.js
+++ b/app/move/steps/create.js
@@ -1,4 +1,3 @@
-const { FEATURE_FLAGS } = require('../../../config')
 const {
   Base,
   PersonalDetails,
@@ -26,7 +25,6 @@ module.exports = {
     action: '/move/new/pnc-search-results',
     template: 'move/views/create/pnc-search',
     pageTitle: 'moves::steps.police_national_computer_search_term.heading',
-    buttonText: 'actions::continue',
     next: 'pnc-search-results',
     fields: ['police_national_computer_search_term'],
   },
@@ -108,9 +106,6 @@ module.exports = {
     controller: Assessment,
     next: 'save',
     pageTitle: 'moves::steps.health_information.heading',
-    buttonText: FEATURE_FLAGS.DOCUMENTS
-      ? 'actions::continue'
-      : 'actions::schedule_move', // TODO: move this logic to a more sensible place, like a controller
     fields: [
       'health',
       'health__special_diet_or_allergy',
@@ -126,12 +121,10 @@ module.exports = {
     controller: Document,
     next: 'save',
     pageTitle: 'moves::steps.document.heading',
-    buttonText: 'actions::schedule_move',
     fields: ['documents'],
   },
   '/save': {
     skip: true,
     controller: Save,
-    next: 'document',
   },
 }


### PR DESCRIPTION
This change moves the logic to set the correct button text for the
create journey, whether to display continue or schedule move, to
the controller so that this logic doesn't need to live in each step.

It also makes it easier when using the forking via next as the button
text will be dynamically set based on the next step of each current
step.