### PR TITLE
Prevent field helper failing with no input

### DIFF
--- a/common/helpers/field.js
+++ b/common/helpers/field.js
@@ -189,23 +189,25 @@ function insertItemConditional({ key, field }) {
   }
 }
 
-function mapPersonToOption(person) {
+function mapPersonToOption(person = {}) {
   return {
-    text: person.fullname.toUpperCase(),
+    text: person.fullname ? person.fullname.toUpperCase() : '',
     label: {
       classes: 'govuk-label--s',
     },
-    value: person.id,
+    value: person.id || '',
     hint: {
       html: componentService.getComponent('appResults', {
         items: [
           {
             label: 'Date of Birth',
-            text: format(parseISO(person.date_of_birth), 'd MMM yyyy'),
+            text: person.date_of_birth
+              ? format(parseISO(person.date_of_birth), 'd MMM yyyy')
+              : '',
           },
           {
             label: 'Gender',
-            text: person.gender.title,
+            text: get(person, 'gender.title', ''),
           },
         ],
       }),

--- a/common/helpers/field.test.js
+++ b/common/helpers/field.test.js
@@ -849,19 +849,67 @@ describe('Form helpers', function() {
 
     beforeEach(function() {
       sinon.stub(componentService, 'getComponent').returnsArg(0)
-      response = mapPersonToOption(personMock)
     })
 
-    it('should not call translation method', function() {
-      expect(response).to.deep.equal({
-        text: 'BAZ, BOO',
-        label: {
-          classes: 'govuk-label--s',
-        },
-        value: '7777',
-        hint: {
-          html: 'appResults',
-        },
+    context('with person object', function() {
+      beforeEach(function() {
+        response = mapPersonToOption(personMock)
+      })
+
+      it('should call component correctly', function() {
+        expect(componentService.getComponent).to.be.calledOnceWithExactly(
+          'appResults',
+          {
+            items: [
+              { label: 'Date of Birth', text: '24 Apr 1948' },
+              { label: 'Gender', text: personMock.gender.title },
+            ],
+          }
+        )
+      })
+
+      it('should return option', function() {
+        expect(response).to.deep.equal({
+          text: 'BAZ, BOO',
+          label: {
+            classes: 'govuk-label--s',
+          },
+          value: '7777',
+          hint: {
+            html: 'appResults',
+          },
+        })
+      })
+    })
+
+    context('with empty object', function() {
+      beforeEach(function() {
+        response = mapPersonToOption()
+      })
+
+      it('should call component correctly', function() {
+        expect(componentService.getComponent).to.be.calledOnceWithExactly(
+          'appResults',
+          {
+            items: [
+              { label: 'Date of Birth', text: '' },
+              { label: 'Gender', text: '' },
+            ],
+          }
+        )
+      })
+
+      it('should return option', function() {
+        expect(response).to.deep.equal({
+          text: '',
+          label: {
+            classes: 'govuk-label--s',
+          },
+          value: '',
+          hint: {
+            html: 'appResults',
+          },
+        })
       })
     })
   })


### PR DESCRIPTION
The field helper that builds the search results for the person search
will currently error if certain properties don't exist.

This ensures there are relevant defaults and adds test coverage for
these scenarios.