### PR TITLE
Only run production build/deploy jobs on Git tags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -192,10 +192,13 @@ workflows:
   pecs-frontend:
     jobs:
       - build_and_test
-      - e2e_test:
-          requires:
-            - deploy_staging
       - build_staging:
+          requires:
+            - build_and_test
+          filters:
+            branches:
+              only: master
+      - build_preprod:
           requires:
             - build_and_test
           filters:
@@ -204,25 +207,31 @@ workflows:
       - deploy_staging:
           requires:
             - build_staging
-      - build_preprod:
-          requires:
-            - build_and_test
-          filters:
-            branches:
-              only: master
       - deploy_preprod:
           requires:
             - build_preprod
-      - hold_production:
-          type: approval
+            - e2e_test
+      - e2e_test:
+          requires:
+            - deploy_staging
+      - build_production:
           requires:
             - build_and_test
           filters:
             branches:
-              only: master
-      - build_production:
-          requires:
-            - hold_production
-      - deploy_production:
+              ignore: /.*/
+            tags:
+              only: /^v.*/
+      - hold_production:
+          type: approval
           requires:
             - build_production
+            - e2e_test
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v.*/
+      - deploy_production:
+          requires:
+            - hold_production


### PR DESCRIPTION
This change updates the CircleCI workflow to be more specific based on branch and Git tag.

We use git tags when creating a new release to deploy to production so the workflow will now only run production jobs for git tags, including the manual approval. This means that all workflows on master will not remain "On hold" and therefore return a `pending` state.

It will allow us to see builds as success or failure on master rather than always in a pending state.

## New workflows

### On all branches and PRs

- build and tests (linting and unit testing)

![image](https://user-images.githubusercontent.com/3327997/74531866-b8bd0100-4f25-11ea-8b31-8864cffbf8e4.png)

### On master branch

- build and tests (linting and unit testing)
  - build staging
  - build preproduction
  - deploy staging
    - end to end tests
      - deploy preproduction

![image](https://user-images.githubusercontent.com/3327997/74532361-f1a9a580-4f26-11ea-97d0-5cfb3ace30ce.png)

### On Git tags

This is for deployment to production only.

- build and tests (linting and unit testing)
  - build staging
  - build preproduction
  - build production
  - deploy staging
    - end to end tests
      - deploy preproduction
      - production hold (**manual approval required**)
        - deploy production

![image](https://user-images.githubusercontent.com/3327997/74532542-5ebd3b00-4f27-11ea-9a3b-80f63291b518.png)

## Old workflows

### On all branches and PRs

![image](https://user-images.githubusercontent.com/3327997/74532498-3f261280-4f27-11ea-9f42-5b6ff5912943.png)

### On master branch

![image](https://user-images.githubusercontent.com/3327997/74532478-30d7f680-4f27-11ea-868f-831b35030970.png)
