### PR TITLE
Only notify slack on CircleCI failures

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,8 @@
 version: 2.1
 
+orbs:
+  slack: circleci/slack@3.4.2
+
 aliases:
   - &node_version circleci/node:12
 
@@ -18,6 +21,9 @@ aliases:
       key: dependency-cache-{{ checksum "package.json" }}
       paths:
         - ./node_modules
+  - &notify_slack
+    slack/notify-on-failure:
+      only_for_branches: master
 
 references:
   cloud_container: &cloud_container
@@ -134,6 +140,7 @@ jobs:
           path: reports
       - store_artifacts:
           path: coverage
+      - *notify_slack
 
   e2e_test:
     docker:
@@ -150,6 +157,7 @@ jobs:
           path: reports/testcafe
       - store_artifacts:
           path: artifacts
+      - *notify_slack
 
 
   build_staging:


### PR DESCRIPTION
This uses the slack Orb in CircleCI config to only alert the channel
on master failures, not branches.