### PR TITLE
[P4 1063] - Step for the move range input. Will appear only on journeys whose origin is a prison.

### DIFF
--- a/app/move/fields/create.js
+++ b/app/move/fields/create.js
@@ -95,6 +95,29 @@ function explicitYesNo(name) {
   }
 }
 
+const dateField = {
+  validate: ['required', 'date', 'after'],
+  formatter: ['date'],
+  component: 'govukInput',
+  autocomplete: 'off',
+  classes: 'govuk-input--width-10',
+  hint: {
+    text: 'fields::date_custom.hint',
+  },
+}
+
+const dateRangeField = function(id) {
+  return {
+    ...dateField,
+    id: id,
+    name: id,
+    label: {
+      text: `fields::${id}.label`,
+      classes: 'govuk-label--s',
+    },
+  }
+}
+
 module.exports = {
   // Person search
   'filter.police_national_computer': {
@@ -297,26 +320,21 @@ module.exports = {
     ],
   },
   date_custom: {
+    ...dateField,
     skip: true,
-    validate: ['required', 'date', 'after'],
     dependent: {
       field: 'date_type',
       value: 'custom',
     },
-    formatter: [date],
-    component: 'govukInput',
     id: 'date_custom',
     name: 'date_custom',
     label: {
       text: 'fields::date_custom.label',
       classes: 'govuk-label--s',
     },
-    hint: {
-      text: 'fields::date_custom.hint',
-    },
-    classes: 'govuk-input--width-10',
-    autocomplete: 'off',
   },
+  date_from: dateRangeField('date_from'),
+  date_to: dateRangeField('date_to'),
   // risk information
   risk: assessmentCategory('risk'),
   violent: assessmentQuestionComments,

--- a/app/move/steps/create.js
+++ b/app/move/steps/create.js
@@ -74,6 +74,10 @@ module.exports = {
       'gender_additional_information',
     ],
   },
+  '/move-date': {
+    pageTitle: 'moves::steps.move_date.heading',
+    fields: ['date_from', 'date_to'],
+  },
   '/move-details': {
     controller: MoveDetails,
     template: 'move/views/create/move-details',

--- a/locales/en/fields.json
+++ b/locales/en/fields.json
@@ -151,5 +151,11 @@
   },
   "move_agreed_by": {
     "label": "Name of person who agreed the move"
+  },
+  "date_from": {
+    "label": "Earliest date of travel"
+  },
+  "date_to": {
+    "label": "Latest date of travel"
   }
 }

--- a/locales/en/moves.json
+++ b/locales/en/moves.json
@@ -35,6 +35,9 @@
     "personal_details": {
       "heading": "Personal details"
     },
+    "move_date": {
+      "heading": "When is this person moving?"
+    },
     "move_details": {
       "heading": "Where is this person moving?"
     },


### PR DESCRIPTION
Step for the move range input. Will appear only on journeys whose origin is a prison.

<img width="822" alt="Screenshot 2020-02-24 at 13 19 39" src="https://user-images.githubusercontent.com/853989/75155688-77d4a180-5708-11ea-8242-1f7a7a22fa69.png">

<img width="806" alt="Screenshot 2020-02-24 at 13 19 08" src="https://user-images.githubusercontent.com/853989/75155703-7efbaf80-5708-11ea-86e0-37e0a409cb7c.png">


### Checklist

- [x] If adding new environment variables, they have been documented in the [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md)
- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
