### PR TITLE
[P4-968] Prison risk logic

### DIFF
--- a/app/move/controllers/create/assessment.js
+++ b/app/move/controllers/create/assessment.js
@@ -39,7 +39,7 @@ class AssessmentController extends CreateBaseController {
     const person = req.sessionModel.get('person') || {}
     const assessment = req.sessionModel.get('assessment') || {}
     const { assessmentCategory } = req.form.options
-    const implicitAnswers = req.form.values[assessmentCategory]
+    const implicitAnswers = req.form.values[assessmentCategory] || []
 
     assessment[assessmentCategory] = req.questions
       .filter(({ id, key }) => {

--- a/app/move/fields/create.js
+++ b/app/move/fields/create.js
@@ -343,6 +343,10 @@ module.exports = {
   self_harm: assessmentQuestionComments,
   concealed_items: assessmentQuestionComments,
   other_risks: requiredAssessmentQuestionComments,
+  not_for_release: {
+    ...requiredAssessmentQuestionComments,
+    explicit: true,
+  },
   // health information
   special_diet_or_allergy: assessmentQuestionComments,
   health_issue: assessmentQuestionComments,

--- a/app/move/fields/create.js
+++ b/app/move/fields/create.js
@@ -82,6 +82,9 @@ function explicitYesNo(name) {
         classes: 'govuk-fieldset__legend--m',
       },
     },
+    hint: {
+      text: `fields::${name}.hint`,
+    },
     items: [
       {
         value: 'yes',

--- a/app/move/steps/create.js
+++ b/app/move/steps/create.js
@@ -23,6 +23,13 @@ const personSearchStep = {
   ],
 }
 
+const riskStep = {
+  controller: Assessment,
+  pageTitle: 'moves::steps.risk_information.heading',
+  assessmentCategory: 'risk',
+  next: 'health-information',
+}
+
 module.exports = {
   '/': {
     entryPoint: true,
@@ -110,14 +117,18 @@ module.exports = {
     controller: Assessment,
     pageTitle: 'moves::steps.court_information.heading',
     assessmentCategory: 'court',
-    next: 'risk-information',
+    next: [
+      {
+        field: 'from_location_type',
+        value: 'prison',
+        next: 'release-status',
+      },
+      'risk-information',
+    ],
     fields: ['solicitor', 'interpreter', 'other_court'],
   },
   '/risk-information': {
-    controller: Assessment,
-    assessmentCategory: 'risk',
-    pageTitle: 'moves::steps.risk_information.heading',
-    next: 'health-information',
+    ...riskStep,
     fields: [
       'violent',
       'escape',
@@ -126,6 +137,11 @@ module.exports = {
       'concealed_items',
       'other_risks',
     ],
+  },
+  '/release-status': {
+    ...riskStep,
+    pageTitle: 'moves::steps.release_status.heading',
+    fields: ['not_for_release'],
   },
   '/health-information': {
     controller: Assessment,

--- a/common/helpers/field.test.js
+++ b/common/helpers/field.test.js
@@ -1002,6 +1002,9 @@ describe('Form helpers', function() {
               classes: 'govuk-fieldset__legend--m',
             },
           },
+          hint: {
+            text: 'fields::special_vehicle__yesno.hint',
+          },
           items: [
             {
               value: 'yes',
@@ -1099,6 +1102,9 @@ describe('Form helpers', function() {
               text: 'fields::special_vehicle__yesno.label',
               classes: 'govuk-fieldset__legend--m',
             },
+          },
+          hint: {
+            text: 'fields::special_vehicle__yesno.hint',
           },
           items: [
             {

--- a/locales/en/fields.json
+++ b/locales/en/fields.json
@@ -135,13 +135,15 @@
     "label": "Special vehicle details"
   },
   "special_vehicle__yesno": {
-    "label": "Do they require a special vehicle?"
+    "label": "Do they require a special vehicle?",
+    "hint": ""
   },
   "not_for_release": {
     "label": "Release status details"
   },
   "not_for_release__yesno": {
-    "label": "Is there a reason this person should not be released?"
+    "label": "Is there a reason this person should not be released?",
+    "hint": "For example, they may be wanted by immigration or recalled to custody"
   },
   "documents": {
     "heading": "Only include documents that will help plan the move.",

--- a/locales/en/fields.json
+++ b/locales/en/fields.json
@@ -137,6 +137,12 @@
   "special_vehicle__yesno": {
     "label": "Do they require a special vehicle?"
   },
+  "not_for_release": {
+    "label": "Release status details"
+  },
+  "not_for_release__yesno": {
+    "label": "Is there a reason this person should not be released?"
+  },
   "documents": {
     "heading": "Only include documents that will help plan the move.",
     "label": "Upload a file (optional)",

--- a/locales/en/moves.json
+++ b/locales/en/moves.json
@@ -47,6 +47,9 @@
     "risk_information": {
       "heading": "Are there risks with moving this person?"
     },
+    "release_status": {
+      "heading": "Release status"
+    },
     "health_information": {
       "heading": "Does this person’s health affect transport?"
     },


### PR DESCRIPTION
This creates logic to split how different journeys will see the release status question.

Users sending some from Police/STC/SCH will see it asked as part of the risk step.

Prison users will see it asked as a separate step.

## What it looks like

### From Police

![image](https://user-images.githubusercontent.com/3327997/75245003-c778a300-57c4-11ea-8b75-78f8bb1bcd8d.png)

### From Prison

![image](https://user-images.githubusercontent.com/3327997/75166898-80cf6e00-571c-11ea-8965-aaabb33c1b99.png)
