### PR TITLE
[P4-961] Add separate special vehicle step

### DIFF
--- a/app/move/steps/create.js
+++ b/app/move/steps/create.js
@@ -27,7 +27,28 @@ const riskStep = {
   controller: Assessment,
   pageTitle: 'moves::steps.risk_information.heading',
   assessmentCategory: 'risk',
-  next: 'health-information',
+  next: [
+    {
+      field: 'from_location_type',
+      value: 'prison',
+      next: 'special-vehicle',
+    },
+    'health-information',
+  ],
+}
+
+const healthStep = {
+  controller: Assessment,
+  assessmentCategory: 'health',
+  pageTitle: 'moves::steps.health_information.heading',
+  next: [
+    {
+      field: 'can_upload_documents',
+      value: true,
+      next: 'document',
+    },
+    'save',
+  ],
 }
 
 module.exports = {
@@ -144,17 +165,7 @@ module.exports = {
     fields: ['not_for_release'],
   },
   '/health-information': {
-    controller: Assessment,
-    assessmentCategory: 'health',
-    next: [
-      {
-        field: 'can_upload_documents',
-        value: true,
-        next: 'document',
-      },
-      'save',
-    ],
-    pageTitle: 'moves::steps.health_information.heading',
+    ...healthStep,
     fields: [
       'special_diet_or_allergy',
       'health_issue',
@@ -164,6 +175,11 @@ module.exports = {
       'other_health',
       'special_vehicle',
     ],
+  },
+  '/special-vehicle': {
+    ...healthStep,
+    pageTitle: 'moves::steps.special_vehicle.heading',
+    fields: ['special_vehicle'],
   },
   '/document': {
     enctype: 'multipart/form-data',

--- a/locales/en/fields.json
+++ b/locales/en/fields.json
@@ -135,8 +135,8 @@
     "label": "Special vehicle details"
   },
   "special_vehicle__yesno": {
-    "label": "Do they require a special vehicle?",
-    "hint": ""
+    "label": "Does this person need to travel in a special vehicle?",
+    "hint": "This could be a specially-adapted prison van (for example, to accomodate wheelchairs)"
   },
   "not_for_release": {
     "label": "Release status details"

--- a/locales/en/moves.json
+++ b/locales/en/moves.json
@@ -53,6 +53,9 @@
     "health_information": {
       "heading": "Does this person’s health affect transport?"
     },
+    "special_vehicle": {
+      "heading": "Special vehicle"
+    },
     "document": {
       "heading": "Are there any documents to upload?"
     }


### PR DESCRIPTION
This change creates a separate step just for capturing the special
vehicle assessment question for journeys where someone is being sent
from Prison.

It uses the same logic for the risk/release status steps.

## What it looks like

### Prison journey

![image](https://user-images.githubusercontent.com/3327997/75177478-25a67700-572e-11ea-8a03-5c4f2351846c.png)

### Police journey

![image](https://user-images.githubusercontent.com/3327997/75177541-48389000-572e-11ea-98d8-02b513c1a7cc.png)

@Andy-Millar I tweaked the label very slightly to match the rest of the page headings/field labels:

I swapped "they" for "this person".