### PR TITLE
fix(createmove): Update e2e tests for special vehicle

### DIFF
--- a/test/e2e/moves.test.js
+++ b/test/e2e/moves.test.js
@@ -64,7 +64,10 @@ test('Court move', async t => {
     .expect(page.nodes.pageHeading.innerText)
     .eql('Does this person’s health affect transport?')
 
-  await selectFieldsetOption('Do they require a special vehicle?', 'No')
+  await selectFieldsetOption(
+    'Does this person need to travel in a special vehicle?',
+    'No'
+  )
 
   await t.click(page.nodes.scheduleMoveButton)
 
@@ -149,7 +152,10 @@ test('Court move with existing PNC', async t => {
     .expect(page.nodes.pageHeading.innerText)
     .eql('Does this person’s health affect transport?')
 
-  await selectFieldsetOption('Do they require a special vehicle?', 'No')
+  await selectFieldsetOption(
+    'Does this person need to travel in a special vehicle?',
+    'No'
+  )
 
   await t.click(page.nodes.scheduleMoveButton)
 
@@ -226,7 +232,10 @@ test('Prison recall', async t => {
     .expect(page.nodes.pageHeading.innerText)
     .eql('Does this person’s health affect transport?')
 
-  await selectFieldsetOption('Do they require a special vehicle?', 'No')
+  await selectFieldsetOption(
+    'Does this person need to travel in a special vehicle?',
+    'No'
+  )
 
   await t.click(page.nodes.scheduleMoveButton)
 
@@ -302,7 +311,10 @@ test('Upload documents', async t => {
     .expect(page.nodes.pageHeading.innerText)
     .eql('Does this person’s health affect transport?')
 
-  await selectFieldsetOption('Do they require a special vehicle?', 'No')
+  await selectFieldsetOption(
+    'Does this person need to travel in a special vehicle?',
+    'No'
+  )
 
   await t.click(page.nodes.scheduleMoveButton)
 
@@ -391,7 +403,10 @@ test('Navigate tags in detailed move', async t => {
 
   // Does this person’s health affect transport?
   await selectFieldsetOption('Add health information', 'Medication')
-  await selectFieldsetOption('Do they require a special vehicle?', 'No')
+  await selectFieldsetOption(
+    'Does this person need to travel in a special vehicle?',
+    'No'
+  )
 
   await t.click(page.nodes.scheduleMoveButton)
 


### PR DESCRIPTION
A recent change to the special vehicle step broke the e2e tests as they
look for specific text.

In the future we will need to update them so they're not as dependent
on content but for now this will fix the breaking build.
