### PR TITLE
[P4-1086] Prevent prison person creation

### DIFF
--- a/app/move/steps/create.js
+++ b/app/move/steps/create.js
@@ -75,6 +75,7 @@ module.exports = {
     fields: ['filter.police_national_computer'],
   },
   '/person-lookup-results': {
+    hideBackLink: true,
     controller: PersonSearchResults,
     template: 'move/views/create/person-search-results',
     pageTitle: 'moves::steps.person_search_results.heading',

--- a/app/move/views/create/person-search-results.njk
+++ b/app/move/views/create/person-search-results.njk
@@ -1,9 +1,23 @@
 {% extends "form-wizard.njk" %}
 
+{% set defaultActions %}
+  <a href="{{ backLink }}">{{ t("actions::search_again") }}</a>
+  {{ t("moves::steps.person_search_results.or") }}
+  <a href="?skip">
+    {{ t("moves::steps.person_search_results.move_someone_else") }}
+  </a>
+{% endset %}
+
+{% set prisonActions %}
+  <a href="{{ backLink }}">{{ t("actions::search_again") }}</a>
+{% endset %}
+
 {% block beforeFields %}
-  <h2 class="govuk-heading-l">
+  <h2 class="govuk-heading-m govuk-!-margin-bottom-2">
     {{ t("moves::steps::person_search_results::secondary_heading", {
-      count: resultCount
+      type: "person" | pluralize(resultCount),
+      count: resultCount,
+      searchTerm: "123"
     }) }}
   </h2>
 {% endblock %}
@@ -11,15 +25,48 @@
 {% block fields %}
   {% if resultCount %}
     {{ super() }}
-  {% endif %}
 
-  <p class="govuk-body govuk-!-margin-bottom-6">
-    <a href="{{ backLink }}">{{ t("actions::search_again") }}</a>
-    {{ t("moves::steps.person_search_results.or") }}
-    <a href="?skip">
-      {{ t("moves::steps.person_search_results.move_someone_else") }}
-    </a>
-  </p>
+    {% set html %}
+      {% if values.from_location_type == "prison" %}
+        <p class="govuk-body">
+          {{ t("moves::steps.person_search_results.search_source") }}
+        </p>
+
+        <p class="govuk-body">
+          {{ prisonActions | safe }}
+        </p>
+      {% else %}
+        {{ defaultActions | safe }}
+      {% endif %}
+    {% endset %}
+
+    {{ govukDetails({
+      summaryText: t("moves::steps.person_search_results.cant_find_person"),
+      html: html
+    }) }}
+  {% else %}
+    {% if values.from_location_type == "prison" %}
+      {{ govukInsetText({
+        text: t("moves::steps.person_search_results.ensure_person_exists")
+      }) }}
+    {% endif %}
+
+    <p class="govuk-body govuk-!-margin-top-4  govuk-!-margin-bottom-6">
+      {{ (prisonActions if values.from_location_type == "prison" else defaultActions) | safe }}
+    </p>
+  {% endif %}
+{% endblock %}
+
+{% block submitAction %}
+  {% if resultCount %}
+    {{ super() }}
+  {% endif %}
+{% endblock %}
+
+{% block cancelAction %}
+  {% if (not resultCount and values.from_location_type != "prison") or resultCount %}
+    {{ super() }}
+  {% endif %}
 {% endblock %}
 
 {% block contentSidebar %}{% endblock %}

--- a/app/move/views/create/person-search.njk
+++ b/app/move/views/create/person-search.njk
@@ -3,9 +3,17 @@
 {% block fields %}
   {{ super() }}
 
-  <p class="govuk-body govuk-!-margin-bottom-6">
-    <a href="?skip">{{ t("moves::steps.person_search.no_number") }}</a>
-  </p>
+  {% set detailsHTML %}
+    {{ t("moves::steps.person_search.unknown_number", {
+      context: values.from_location_type,
+      href: "?skip"
+    }) | safe }}
+  {% endset %}
+
+  {{ govukDetails({
+    summaryText: t("moves::steps.person_search.no_number"),
+    html: detailsHTML
+  }) }}
 {% endblock %}
 
 {% block contentSidebar %}{% endblock %}

--- a/common/assets/scss/application.scss
+++ b/common/assets/scss/application.scss
@@ -20,6 +20,7 @@ $govuk-font-family: "Inter", system-ui, sans-serif;
 @import "govuk-frontend/govuk/components/footer/footer.scss";
 @import "govuk-frontend/govuk/components/header/header.scss";
 @import "govuk-frontend/govuk/components/input/input.scss";
+@import "govuk-frontend/govuk/components/inset-text/inset-text.scss";
 @import "govuk-frontend/govuk/components/panel/panel.scss";
 @import "govuk-frontend/govuk/components/phase-banner/phase-banner.scss";
 @import "govuk-frontend/govuk/components/radios/radios.scss";

--- a/common/assets/scss/overrides/_buttons.scss
+++ b/common/assets/scss/overrides/_buttons.scss
@@ -4,6 +4,8 @@
   color: $govuk-link-colour;
   text-align: left;
   text-decoration: underline;
+  padding-left: 0;
+  padding-right: 0;
 
   &:link,
   &:visited {
@@ -24,5 +26,11 @@
   &:hover,
   &:focus {
     background: none;
+  }
+}
+
+.govuk-button + .govuk-button {
+  @include mq ($from: tablet) {
+    margin-left: govuk-spacing(3);
   }
 }

--- a/common/templates/form-wizard.njk
+++ b/common/templates/form-wizard.njk
@@ -14,7 +14,7 @@
 {% block beforeContent %}
   {{ super() }}
 
-  {% if backLink %}
+  {% if backLink and not options.hideBackLink %}
     {{ govukBackLink({
       text: t("actions::back"),
       href: backLink

--- a/common/templates/form-wizard.njk
+++ b/common/templates/form-wizard.njk
@@ -65,16 +65,20 @@
     {% endblock %}
 
     {% block formActions %}
-      {{ govukButton({
-        text: t(options.buttonText or "actions::continue"),
-        classes: options.buttonClasses
-      }) }}
+      {% block submitAction %}
+        {{ govukButton({
+          text: t(options.buttonText or "actions::continue"),
+          classes: options.buttonClasses
+        }) }}
+      {% endblock %}
 
-      {% if cancelUrl %}
-        <a href="{{ cancelUrl }}" class="govuk-button govuk-button--text">
-          {{ t("actions::cancel") }}
-        </a>
-      {% endif %}
+      {% block cancelAction %}
+        {% if cancelUrl %}
+          <a href="{{ cancelUrl }}" class="govuk-button govuk-button--text">
+            {{ t("actions::cancel") }}
+          </a>
+        {% endif %}
+      {% endblock %}
     {% endblock %}
   </form>
 {% endblock %}

--- a/common/templates/layouts/base.njk
+++ b/common/templates/layouts/base.njk
@@ -7,6 +7,7 @@
 {% from "govuk/components/details/macro.njk"           import govukDetails %}
 {% from "govuk/components/error-summary/macro.njk"     import govukErrorSummary %}
 {% from "govuk/components/input/macro.njk"             import govukInput %}
+{% from "govuk/components/inset-text/macro.njk"        import govukInsetText %}
 {% from "govuk/components/panel/macro.njk"             import govukPanel %}
 {% from "govuk/components/phase-banner/macro.njk"      import govukPhaseBanner %}
 {% from "govuk/components/radios/macro.njk"            import govukRadios %}

--- a/config/nunjucks/filters.js
+++ b/config/nunjucks/filters.js
@@ -9,6 +9,7 @@ const {
   isDate,
 } = require('date-fns')
 const { kebabCase, startCase } = require('lodash')
+const pluralize = require('pluralize')
 
 const { DATE_FORMATS } = require('../index')
 
@@ -130,4 +131,5 @@ module.exports = {
   formatTime,
   kebabcase: kebabCase,
   startCase,
+  pluralize,
 }

--- a/locales/en/moves.json
+++ b/locales/en/moves.json
@@ -24,13 +24,17 @@
   "steps": {
     "person_search": {
       "heading": "Who is being moved?",
-      "no_number": "I don’t know this number"
+      "no_number": "I don’t have this number",
+      "unknown_number": "<p>Book a secure move uses the PNC number to ensure moves are linked to the correct person.</p><p>If you don’t have this number you can <a href=\"{{href}}\">move a person without a PNC number</a>.</p>",
+      "unknown_number_prison": "<p>Book a secure move uses the prison number to ensures moves are linked to the correct person.</p><p>Ensure the person you are looking for is in NOMIS.</p>"
     },
     "person_search_results": {
       "heading": "Who is being moved?",
-      "secondary_heading": "{{- count}} people found",
+      "secondary_heading": "{{- count}} {{type}} found for “{{searchTerm}}”",
+      "cant_find_person": "I can’t find the person I’m looking for",
       "or": "or",
-      "move_someone_else": "move someone else"
+      "move_someone_else": "move someone else",
+      "ensure_person_exists": "Ensure the person you are looking for is in NOMIS."
     },
     "personal_details": {
       "heading": "Personal details"


### PR DESCRIPTION
When a user searches for someone with a prison number and there are no
results we need to ensure that they can't create a new person in our
system.

This adds logic to not allow a user to progress to the personal
details step.

It also includes some changes to the display logic of the messages
depending on if there are results or not.

## What it looks like

### From a Police site

#### Person search

![localhost_3000_move_new_person-lookup-pnc (1)](https://user-images.githubusercontent.com/3327997/75338298-61eceb00-5886-11ea-806b-6f6142561707.png)

#### Search results

![localhost_3000_move_new_person-lookup-results_filter police_national_computer =123 (2)](https://user-images.githubusercontent.com/3327997/75338266-5699bf80-5886-11ea-91af-add002be8b1a.png)

#### Search no results

![localhost_3000_move_new_person-lookup-results_filter police_national_computer =123123123](https://user-images.githubusercontent.com/3327997/75341248-f4dc5400-588b-11ea-870a-921833538204.png)

### From a Prison site

#### Person search

![localhost_3000_move_new_person-lookup-prison-number (2)](https://user-images.githubusercontent.com/3327997/75340456-6e734280-588a-11ea-9a13-9cc81636b1ab.png)

#### Search results

![localhost_3000_move_new_person-lookup-results_filter police_national_computer =123 (3)](https://user-images.githubusercontent.com/3327997/75340498-7fbc4f00-588a-11ea-932b-4411b6531ecf.png)

#### Search no results

![localhost_3000_move_new_person-lookup-results_filter nomis_offender_no =123 (1)](https://user-images.githubusercontent.com/3327997/75340529-8ba81100-588a-11ea-8191-8be0714954f4.png)
