### PR TITLE
[P4 1064] Skeleton of the dashboard that will be displaying proposed moves

### DIFF
--- a/app/moves/controllers/index.js
+++ b/app/moves/controllers/index.js
@@ -1,7 +1,9 @@
 const download = require('./download')
 const list = require('./list')
+const listProposed = require('./list-proposed')
 
 module.exports = {
   download,
   list,
+  listProposed,
 }

--- a/app/moves/controllers/list-proposed.js
+++ b/app/moves/controllers/list-proposed.js
@@ -1,0 +1,18 @@
+const presenters = require('../../../common/presenters')
+
+module.exports = function list(req, res) {
+  // todo: this will become proposed moves instead of active
+  const { activeMovesByDate = [] } = res.locals
+  const template = 'moves/views/list-proposed'
+  const locals = {
+    pageTitle: 'moves::dashboard.single_moves',
+    moves: activeMovesByDate.map(
+      presenters.moveToCardComponent({
+        showMeta: false,
+        showTags: false,
+      })
+    ),
+  }
+
+  res.render(template, locals)
+}

--- a/app/moves/index.js
+++ b/app/moves/index.js
@@ -3,7 +3,7 @@ const router = require('express').Router()
 
 // Local dependencies
 const { protectRoute } = require('../../common/middleware/permissions')
-const { download, list } = require('./controllers')
+const { download, list, listProposed } = require('./controllers')
 const {
   redirectBaseUrl,
   saveUrl,
@@ -39,6 +39,14 @@ router.get(
   setMovesByDateAndLocation,
   setPagination,
   list
+)
+router.get(
+  `/:date/:locationId(${uuidRegex})/proposed`,
+  protectRoute('moves:view:by_location'),
+  protectRoute('moves:view:proposed'),
+  setMovesByDateAndLocation,
+  setPagination,
+  listProposed
 )
 router.get(
   '/:date/download.:extension(csv|json)',

--- a/app/moves/views/_layout.njk
+++ b/app/moves/views/_layout.njk
@@ -23,21 +23,23 @@
           }) }}
         </h1>
 
-        {{ appPagination({
-          classes: "app-pagination--inline app-print--hide",
-          previous: {
-            href: pagination.prevUrl,
-            text: t("actions::previous_day")
-          },
-          next: {
-            href: pagination.nextUrl,
-            text: t("actions::next_day")
-          },
-          items: [{
-            href: pagination.todayUrl,
-            text: t("actions::current_day")
-          }]
-        }) }}
+        {% block dateNavigation %}
+          {{ appPagination({
+            classes: "app-pagination--inline app-print--hide",
+            previous: {
+              href: pagination.prevUrl,
+              text: t("actions::previous_day")
+            },
+            next: {
+              href: pagination.nextUrl,
+              text: t("actions::next_day")
+            },
+            items: [{
+              href: pagination.todayUrl,
+              text: t("actions::current_day")
+            }]
+          }) }}
+        {% endblock %}
 
         {% block headerActions %}{% endblock %}
       </div>

--- a/app/moves/views/list-proposed.njk
+++ b/app/moves/views/list-proposed.njk
@@ -1,0 +1,31 @@
+{% extends "./_layout.njk" %}
+
+{% block dateNavigation %}{% endblock %}
+
+{% block headerActions %}
+  {% if canAccess('move:create') %}
+    {{ govukButton({
+      isStartButton: true,
+      text: t("actions::create_move"),
+      href: "/move/new",
+      classes: "govuk-!-margin-top-2 app-print--hide"
+    }) }}
+  {% endif %}
+{% endblock %}
+
+{% block pageContent %}
+{% if moves.length %}
+  {% for move in moves %}
+    {{ appCard(move) }}
+  {% endfor %}
+{% else %}
+    {{ appMessage({
+      classes: "app-message--muted govuk-!-margin-top-7",
+      allowDismiss: false,
+      content: {
+        html: t("moves::dashboard.single_moves_no_results")
+      }
+    }) }}
+{% endif %}
+{% endblock %}
+

--- a/common/lib/permissions.js
+++ b/common/lib/permissions.js
@@ -1,0 +1,40 @@
+const policePermissions = [
+  'moves:view:by_location',
+  'moves:download:by_location',
+  'move:view',
+  'move:create',
+  'move:cancel',
+]
+const supplierPermissions = [
+  'moves:view:all',
+  'moves:download:all',
+  'moves:view:by_location',
+  'moves:download:by_location',
+  'move:view',
+]
+const prisonPermissions = [
+  'moves:view:by_location',
+  'moves:download:by_location',
+  'move:view',
+]
+const ocaPermissions = [
+  'moves:view:by_location',
+  'moves:download:by_location',
+  'moves:view:proposed',
+  'move:view',
+  'move:create',
+]
+
+const permissionsByRole = {
+  ROLE_PECS_POLICE: policePermissions,
+  ROLE_PECS_SCH: policePermissions,
+  ROLE_PECS_STC: policePermissions,
+  ROLE_PECS_PRISON: prisonPermissions,
+  ROLE_PECS_HMYOI: prisonPermissions,
+  ROLE_PECS_OCA: ocaPermissions,
+  ROLE_PECS_SUPPLIER: supplierPermissions,
+}
+
+module.exports = {
+  permissionsByRole,
+}

--- a/common/lib/user.js
+++ b/common/lib/user.js
@@ -1,4 +1,5 @@
 const { uniq } = require('lodash')
+const { permissionsByRole } = require('./permissions')
 
 function User({ fullname, roles = [], locations = [] } = {}) {
   this.fullname = fullname
@@ -23,43 +24,9 @@ User.prototype = {
   },
 
   getPermissions(roles = []) {
-    const permissions = []
-
-    if (
-      roles.includes('ROLE_PECS_POLICE') ||
-      roles.includes('ROLE_PECS_SCH') ||
-      roles.includes('ROLE_PECS_STC')
-    ) {
-      permissions.push(
-        'moves:view:by_location',
-        'moves:download:by_location',
-        'move:view',
-        'move:create',
-        'move:cancel'
-      )
-    }
-
-    if (
-      roles.includes('ROLE_PECS_PRISON') ||
-      roles.includes('ROLE_PECS_HMYOI')
-    ) {
-      permissions.push(
-        'moves:view:by_location',
-        'moves:download:by_location',
-        'move:view'
-      )
-    }
-
-    if (roles.includes('ROLE_PECS_SUPPLIER')) {
-      permissions.push(
-        'moves:view:all',
-        'moves:download:all',
-        'moves:view:by_location',
-        'moves:download:by_location',
-        'move:view'
-      )
-    }
-
+    const permissions = roles.reduce((accumulator, role) => {
+      return [...accumulator, ...permissionsByRole[role]]
+    }, [])
     return uniq(permissions)
   },
 }

--- a/common/services/move.js
+++ b/common/services/move.js
@@ -42,6 +42,18 @@ const moveService = {
       })
   },
 
+  getProposed({ createdAtRange = [], fromLocationId } = {}) {
+    const [createdAtFrom, createdAtTo] = createdAtRange
+    return moveService.getAll({
+      filter: {
+        'filter[status]': 'proposed',
+        'filter[created_at_from]': createdAtFrom,
+        'filter[created_at_to]': createdAtTo,
+        'filter[from_location_id]': fromLocationId,
+      },
+    })
+  },
+
   getRequested({ moveDate, fromLocationId, toLocationId } = {}) {
     return moveService.getAll({
       filter: {

--- a/common/services/move.test.js
+++ b/common/services/move.test.js
@@ -445,6 +445,54 @@ describe('Move Service', function() {
     })
   })
 
+  describe('#getProposed', function() {
+    let moves
+    const mockCreatedAtRange = ['2019-10-10', '2019-10-17']
+    const mockFromLocationId = 'b695d0f0-af8e-4b97-891e-92020d6820b9'
+    beforeEach(async function() {
+      sinon.stub(moveService, 'getAll').resolves(['moves'])
+    })
+    context('with arguments', async function() {
+      beforeEach(async function() {
+        moves = await moveService.getProposed({
+          createdAtRange: mockCreatedAtRange,
+          fromLocationId: mockFromLocationId,
+        })
+      })
+      it('calls getAll', function() {
+        expect(moveService.getAll).to.be.calledOnceWithExactly({
+          filter: {
+            'filter[status]': 'proposed',
+            'filter[created_at_from]': mockCreatedAtRange[0],
+            'filter[created_at_to]': mockCreatedAtRange[1],
+            'filter[from_location_id]': mockFromLocationId,
+          },
+        })
+      })
+      it('returns moves', function() {
+        expect(moves).to.deep.equal(['moves'])
+      })
+    })
+    context('without arguments', function() {
+      beforeEach(async function() {
+        moves = await moveService.getProposed()
+      })
+      it('calls getAll', function() {
+        expect(moveService.getAll).to.be.calledOnceWithExactly({
+          filter: {
+            'filter[status]': 'proposed',
+            'filter[created_at_from]': undefined,
+            'filter[created_at_to]': undefined,
+            'filter[from_location_id]': undefined,
+          },
+        })
+      })
+      it('returns moves', function() {
+        expect(moves).to.deep.equal(['moves'])
+      })
+    })
+  })
+
   describe('#getById()', function() {
     context('without move ID', function() {
       it('should reject with error', function() {

--- a/locales/en/moves.json
+++ b/locales/en/moves.json
@@ -106,7 +106,9 @@
     "upcoming_moves": "Upcoming moves for {{date}}",
     "cancelled_moves": "{{count}} cancelled moves",
     "move_to": "Move to",
-    "no_results": "No moves scheduled"
+    "no_results": "No moves scheduled",
+    "single_moves": "Single moves",
+    "single_moves_no_results": "No moves proposed"
   },
   "detail": {
     "page_title": "Move details for {{name}}"


### PR DESCRIPTION
To note:
- this covers the story for the dashboard route only
- displays active moves instead of proposed moves
- displays moves by day instead of by week (will be tackled in P4-1065)
- has no download button

<img width="986" alt="Screenshot 2020-02-26 at 16 40 38" src="https://user-images.githubusercontent.com/853989/75366817-3df5cd80-58b7-11ea-96b6-6d1062c66b24.png">
### Checklist

- [x] If adding new environment variables, they have been documented in the [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md)
- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
