### PR TITLE
Remove the need for user roles

### DIFF
--- a/app/move/controllers/confirmation.js
+++ b/app/move/controllers/confirmation.js
@@ -1,15 +1,5 @@
-const { sendJourneyTime } = require('../../../common/lib/analytics')
-
-async function confirmation(req, res, next) {
+function confirmation(req, res) {
   const { move_type: moveType, to_location: toLocation } = res.locals.move
-
-  try {
-    await sendJourneyTime(req, 'createMoveJourneyTimestamp', {
-      utv: 'Create a move',
-    })
-  } catch (err) {
-    next(err)
-  }
 
   const locals = {
     location:

--- a/app/move/controllers/create/base.js
+++ b/app/move/controllers/create/base.js
@@ -1,4 +1,3 @@
-const { get, set } = require('lodash')
 const FormWizardController = require('../../../../common/controllers/form-wizard')
 const presenters = require('../../../../common/presenters')
 
@@ -35,8 +34,8 @@ class CreateBaseController extends FormWizardController {
   }
 
   setJourneyTimer(req, res, next) {
-    if (!get(req, 'session.createMoveJourneyTimestamp')) {
-      set(req, 'session.createMoveJourneyTimestamp', new Date().getTime())
+    if (!req.sessionModel.get('journeyTimestamp')) {
+      req.sessionModel.set('journeyTimestamp', new Date().getTime())
     }
 
     next()

--- a/app/move/controllers/create/base.test.js
+++ b/app/move/controllers/create/base.test.js
@@ -327,21 +327,26 @@ describe('Move controllers', function() {
 
       beforeEach(function() {
         this.clock = sinon.useFakeTimers(new Date('2017-08-10').getTime())
+        req = {
+          sessionModel: {
+            get: sinon.stub(),
+            set: sinon.stub(),
+          },
+        }
         nextSpy = sinon.spy()
       })
 
       context('with no timestamp in the session', function() {
         beforeEach(function() {
-          req = {
-            session: {
-              createMoveJourneyTimestamp: undefined,
-            },
-          }
+          req.sessionModel.get.withArgs('journeyTimestamp').returns(undefined)
           controller.setJourneyTimer(req, {}, nextSpy)
         })
 
         it('should set timestamp', function() {
-          expect(req.session.createMoveJourneyTimestamp).to.equal(1502323200000)
+          expect(req.sessionModel.set).to.be.calledOnceWithExactly(
+            'journeyTimestamp',
+            1502323200000
+          )
         })
 
         it('should call next', function() {
@@ -353,16 +358,14 @@ describe('Move controllers', function() {
         const mockTimestamp = 11212121212
 
         beforeEach(function() {
-          req = {
-            session: {
-              createMoveJourneyTimestamp: mockTimestamp,
-            },
-          }
+          req.sessionModel.get
+            .withArgs('journeyTimestamp')
+            .returns(mockTimestamp)
           controller.setJourneyTimer(req, {}, nextSpy)
         })
 
         it('should not set timestamp', function() {
-          expect(req.session.createMoveJourneyTimestamp).to.equal(mockTimestamp)
+          expect(req.sessionModel.set).not.to.be.called
         })
 
         it('should call next', function() {

--- a/app/move/index.js
+++ b/app/move/index.js
@@ -17,8 +17,8 @@ const wizardConfig = {
 const createConfig = {
   ...wizardConfig,
   controller: create.Base,
-  name: 'create-move',
-  journeyName: 'create-move',
+  name: 'create-a-move',
+  journeyName: 'create-a-move',
   journeyPageTitle: 'actions::create_move',
 }
 const cancelConfig = {

--- a/common/lib/analytics.test.js
+++ b/common/lib/analytics.test.js
@@ -1,45 +1,31 @@
-const proxyquire = require('proxyquire')
+const proxyquire = require('proxyquire').noCallThru()
 
 describe('Analytics', function() {
   describe('#sendJourneyTime()', function() {
-    context('without GA_ID', function() {
-      let result, analytics
+    let response, analytics
 
+    context('without GA_ID', function() {
       beforeEach(async function() {
         analytics = proxyquire('./analytics', {
-          '../../config': {
-            ANALYTICS: {
-              GA_ID: '',
-            },
-          },
+          '../../config': {},
         })
 
-        result = await analytics.sendJourneyTime('111111', {})
+        response = await analytics.sendJourneyTime()
       })
 
       it('should resolve with empty promise', function() {
-        expect(result).to.equal('No GA ID!')
+        expect(response).to.equal()
       })
     })
 
     context('with GA_ID', function() {
       const mockUUID = '3333'
       const mockGaID = '11111'
-      let analytics, result, req
+      const mockResponse = {
+        success: true,
+      }
 
-      beforeEach(async function() {
-        req = {
-          session: {
-            user: {
-              role: 'robocop',
-            },
-            createMoveJourneyTimestamp: 12233535,
-            save: sinon.stub().callsFake(() => Promise.resolve('GA hit sent')),
-          },
-        }
-
-        this.clock = sinon.useFakeTimers(new Date('2017-08-10').getTime())
-
+      beforeEach(function() {
         analytics = proxyquire('./analytics', {
           'uuid/v4': () => mockUUID,
           '../../config': {
@@ -48,30 +34,50 @@ describe('Analytics', function() {
             },
           },
         })
-
-        nock('https://www.google-analytics.com')
-          .post(
-            `/collect?v=1&t=timing&utl=Journey+duration&utt=1502310966465&utc=robocop&cid=${mockUUID}&tid=${mockGaID}`
-          )
-          .reply(200, {})
-
-        result = await analytics.sendJourneyTime(
-          req,
-          'createMoveJourneyTimestamp',
-          {}
-        )
       })
 
-      it('should send data to GA', function() {
-        expect(result).to.equal('GA hit sent')
+      context('without params', function() {
+        beforeEach(async function() {
+          nock('https://www.google-analytics.com')
+            .post(
+              `/collect?v=1&t=timing&utl=Journey+duration&cid=${mockUUID}&tid=${mockGaID}`
+            )
+            .reply(200, mockResponse)
+
+          response = await analytics.sendJourneyTime()
+        })
+
+        it('should send data to GA', function() {
+          expect(response).to.deep.equal(mockResponse)
+        })
+
+        it('should post hit to GA', function() {
+          expect(nock.isDone()).to.be.true
+        })
       })
 
-      it('should post hit to GA', function() {
-        expect(nock.isDone()).to.be.true
-      })
+      context('with params', function() {
+        beforeEach(async function() {
+          nock('https://www.google-analytics.com')
+            .post(
+              `/collect?v=1&t=timing&utl=Journey+duration&utv=Journey+name&utt=10000&utc=Type&cid=${mockUUID}&tid=${mockGaID}`
+            )
+            .reply(200, mockResponse)
 
-      it('should reset the journey timer', function() {
-        expect(req.session.createMoveJourneyTimestamp).to.be.undefined
+          response = await analytics.sendJourneyTime({
+            utv: 'Journey name',
+            utt: 10000,
+            utc: 'Type',
+          })
+        })
+
+        it('should send data to GA', function() {
+          expect(response).to.deep.equal(mockResponse)
+        })
+
+        it('should post hit to GA', function() {
+          expect(nock.isDone()).to.be.true
+        })
       })
     })
   })

--- a/common/lib/user.js
+++ b/common/lib/user.js
@@ -5,24 +5,9 @@ function User({ fullname, roles = [], locations = [] } = {}) {
   this.fullname = fullname
   this.permissions = this.getPermissions(roles)
   this.locations = locations
-  this.role = this.getRole(roles)
 }
 
 User.prototype = {
-  getRole(roles = []) {
-    let role
-
-    if (roles.includes('ROLE_PECS_PRISON')) {
-      role = 'Prison'
-    }
-
-    if (roles.includes('ROLE_PECS_POLICE')) {
-      role = 'Police'
-    }
-
-    return role
-  },
-
   getPermissions(roles = []) {
     const permissions = roles.reduce((accumulator, role) => {
       const additionalPermissions = permissionsByRole[role] || []

--- a/common/lib/user.test.js
+++ b/common/lib/user.test.js
@@ -36,30 +36,6 @@ describe('User class', function() {
       })
     })
 
-    context('with police role', function() {
-      beforeEach(function() {
-        sinon.stub(User.prototype, 'getPermissions').returnsArg(0)
-        roles = ['ROLE_PECS_POLICE']
-      })
-
-      it('should set police role', function() {
-        user = new User({ name: 'USERNAME', roles })
-        expect(user.role).to.equal('Police')
-      })
-    })
-
-    context('with prison role', function() {
-      beforeEach(function() {
-        sinon.stub(User.prototype, 'getPermissions').returnsArg(0)
-        roles = ['ROLE_PECS_PRISON']
-      })
-
-      it('should set prison role', function() {
-        user = new User({ name: 'USERNAME', roles })
-        expect(user.role).to.equal('Prison')
-      })
-    })
-
     context('without roles', function() {
       it('should set permissions to empty array', function() {
         user = new User()


### PR DESCRIPTION
This refactor removes the only current use of a user's role within
the codebase - sending journey times to analytics.

This logic is also no longer what we use to determine different journeys.

It also includes reworking the location of it to be confined to the
actual create journey and its session so we don't need to manipulate
the session within an analytics library and avoids us neeeding to pass
in the request object.