### PR TITLE
fix: Set correct journey for prison to prison moves

### DIFF
--- a/app/move/steps/create.js
+++ b/app/move/steps/create.js
@@ -117,6 +117,11 @@ module.exports = {
         value: 'court_appearance',
         next: 'court-information',
       },
+      {
+        field: 'from_location_type',
+        value: 'prison',
+        next: 'release-status',
+      },
       'risk-information',
     ],
     fields: [


### PR DESCRIPTION
This adds the logic needed to direct a user to the correct risk
page based on the from location. Previously it would use the
prison variation if a user selected "Prison" from the move type.