### PR TITLE
[NOJIRA] fix: Add fallback if role has no permissions

### DIFF
--- a/common/lib/user.js
+++ b/common/lib/user.js
@@ -25,7 +25,8 @@ User.prototype = {
 
   getPermissions(roles = []) {
     const permissions = roles.reduce((accumulator, role) => {
-      return [...accumulator, ...permissionsByRole[role]]
+      const additionalPermissions = permissionsByRole[role] || []
+      return [...accumulator, ...additionalPermissions]
     }, [])
     return uniq(permissions)
   },

--- a/common/lib/user.test.js
+++ b/common/lib/user.test.js
@@ -68,6 +68,16 @@ describe('User class', function() {
       })
     })
 
+    context("with a role that isn't expected", function() {
+      it('should set permissions to an empty array for unknown roles', function() {
+        user = new User({
+          roles: ['ROLE_PECS_UNKNOWN'],
+        })
+
+        expect(user.permissions).to.deep.equal([])
+      })
+    })
+
     context('with locations', function() {
       beforeEach(function() {
         locations = ['PECS_TEST']
@@ -177,6 +187,22 @@ describe('User class', function() {
           'moves:view:by_location',
           'moves:download:by_location',
           'move:view',
+        ])
+      })
+    })
+
+    context('when user has ROLE_PECS_OCA', function() {
+      beforeEach(function() {
+        permissions = user.getPermissions(['ROLE_PECS_OCA'])
+      })
+
+      it('should contain correct permission', function() {
+        expect(permissions).to.deep.equal([
+          'moves:view:by_location',
+          'moves:download:by_location',
+          'moves:view:proposed',
+          'move:view',
+          'move:create',
         ])
       })
     })


### PR DESCRIPTION
My previous PR causes login to fail if the role is not in the list of the permissions.

### Checklist

- [x] If adding new environment variables, they have been documented in the [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md)
- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
