### PR TITLE
Tidy up some sentry errors

### DIFF
--- a/common/lib/access-token.js
+++ b/common/lib/access-token.js
@@ -1,5 +1,9 @@
 module.exports = {
   decodeAccessToken(token) {
+    if (!token) {
+      return {}
+    }
+
     const payload = token.split('.')[1]
     return JSON.parse(Buffer.from(payload, 'base64').toString('utf8'))
   },

--- a/common/lib/access-token.test.js
+++ b/common/lib/access-token.test.js
@@ -13,5 +13,11 @@ describe('Access token library', function() {
         expect(decodeAccessToken(token)).to.deep.equal(payload)
       })
     })
+
+    context('with undefined token', function() {
+      it('should return an empty object', function() {
+        expect(decodeAccessToken()).to.deep.equal({})
+      })
+    })
   })
 })


### PR DESCRIPTION
This fixes a few errors we've been seeing in Sentry.

It also handles the case of a failed token better by returning a `403` to the user.