### PR TITLE
[P4-1106] Update assessment question helpers

### DIFF
--- a/app/move/controllers/create/assessment.js
+++ b/app/move/controllers/create/assessment.js
@@ -2,7 +2,6 @@ const { flatten, values } = require('lodash')
 
 const CreateBaseController = require('./base')
 const fieldHelpers = require('../../../../common/helpers/field')
-const createFields = require('../../fields/create')
 const referenceDataService = require('../../../../common/services/reference-data')
 
 class AssessmentController extends CreateBaseController {
@@ -12,28 +11,10 @@ class AssessmentController extends CreateBaseController {
       const questions = await referenceDataService.getAssessmentQuestions(
         assessmentCategory
       )
-      const implicitQuestions = questions.filter(
-        fieldHelpers.extractItemsForImplicitFields.bind(null, fields)
-      )
 
-      if (implicitQuestions.length) {
-        const implicitField = createFields.assessmentCategory(
-          assessmentCategory
-        )
-
-        req.form.options.fields[assessmentCategory] = {
-          ...implicitField,
-          items: implicitQuestions
-            .map(fieldHelpers.mapAssessmentQuestionToConditionalField)
-            .map(fieldHelpers.mapAssessmentQuestionToTranslation)
-            .map(fieldHelpers.mapReferenceDataToOption),
-        }
-      }
-
-      req.form.options.fields = fieldHelpers.mapDependentFields(
+      req.form.options.fields = fieldHelpers.populateAssessmentFields(
         fields,
-        questions,
-        assessmentCategory
+        questions
       )
 
       req.questions = questions
@@ -46,20 +27,15 @@ class AssessmentController extends CreateBaseController {
   saveValues(req, res, next) {
     const person = req.sessionModel.get('person') || {}
     const assessment = req.sessionModel.get('assessment') || {}
+    const formValues = flatten(Object.values(req.form.values))
     const { assessmentCategory } = req.form.options
-    const implicitAnswers = req.form.values[assessmentCategory] || []
 
     assessment[assessmentCategory] = req.questions
-      .filter(({ id, key }) => {
-        return (
-          implicitAnswers.includes(id) ||
-          req.form.values[`${key}__yesno`] === 'yes'
-        )
-      })
-      .map(question => {
+      .filter(({ id }) => formValues.includes(id))
+      .map(({ id, key }) => {
         return {
-          assessment_question_id: question.id,
-          comments: req.form.values[`${question.key}`],
+          assessment_question_id: id,
+          comments: req.form.values[key],
         }
       })
 

--- a/app/move/controllers/create/assessment.test.js
+++ b/app/move/controllers/create/assessment.test.js
@@ -1,5 +1,4 @@
 const referenceDataService = require('../../../../common/services/reference-data')
-const createFields = require('../../../move/fields/create')
 const fieldHelpers = require('../../../../common/helpers/field')
 
 const BaseController = require('./base')
@@ -15,101 +14,11 @@ describe('Move controllers', function() {
       beforeEach(function() {
         sinon.stub(BaseController.prototype, 'configure')
         sinon.stub(referenceDataService, 'getAssessmentQuestions')
-        sinon.stub(createFields, 'assessmentCategory')
-        sinon.stub(fieldHelpers, 'mapDependentFields').returnsArg(0)
+        sinon.stub(fieldHelpers, 'populateAssessmentFields')
         nextSpy = sinon.spy()
       })
 
-      context('with explicit fields', function() {
-        const mockQuestionsResponse = [
-          {
-            id: 'e6faaf20-3072-4a65-91f7-93d52b16260f',
-            type: 'assessment_questions',
-            key: 'special_diet_or_allergy',
-            category: 'health',
-            title: 'Special diet or allergy',
-            disabled_at: null,
-          },
-          {
-            id: '1a73d31a-8dd4-47b6-90a0-15ce4e332539',
-            type: 'assessment_questions',
-            key: 'special_vehicle',
-            category: 'health',
-            title: 'Special vehicle',
-            disabled_at: null,
-          },
-        ]
-
-        beforeEach(async function() {
-          referenceDataService.getAssessmentQuestions.resolves(
-            mockQuestionsResponse
-          )
-          req = {
-            form: {
-              options: {
-                assessmentCategory: 'health',
-                fields: {
-                  special_diet_or_allergy: {
-                    skip: true,
-                    rows: 3,
-                    component: 'govukTextarea',
-                    classes: 'govuk-input--width-20',
-                    label: {
-                      text: 'fields::assessment_comment.optional',
-                      classes: 'govuk-label--s',
-                    },
-                  },
-                  special_vehicle: {
-                    skip: true,
-                    rows: 3,
-                    component: 'govukTextarea',
-                    classes: 'govuk-input--width-20',
-                    label: {
-                      text: 'fields::assessment_comment.required',
-                      classes: 'govuk-label--s',
-                    },
-                    validate: 'required',
-                    explicit: true,
-                  },
-                },
-              },
-            },
-          }
-          await controller.configure(req, {}, nextSpy)
-        })
-
-        it('produces the correct result', function() {
-          expect(req.form.options.fields).to.deep.equal(req.form.options.fields)
-        })
-
-        it('invokes getAssessmentQuestions', function() {
-          expect(
-            referenceDataService.getAssessmentQuestions
-          ).to.be.calledOnceWithExactly('health')
-        })
-
-        it('invokes assessmentCategory', function() {
-          expect(createFields.assessmentCategory).to.be.calledOnceWithExactly(
-            'health'
-          )
-        })
-
-        it('invokes mapDependentFields with correct arguments', function() {
-          expect(fieldHelpers.mapDependentFields).to.be.calledOnceWithExactly(
-            req.form.options.fields,
-            mockQuestionsResponse,
-            req.form.options.assessmentCategory
-          )
-        })
-
-        it('should call parent configure method', function() {
-          expect(
-            BaseController.prototype.configure
-          ).to.be.calledOnceWithExactly(req, {}, nextSpy)
-        })
-      })
-
-      context('without explicit fields', function() {
+      context('when getAssessmentQuestions resolves', function() {
         const mockQuestionsResponse = [
           {
             id: 'af8cfc67-757c-4019-9d5e-618017de1617',
@@ -128,8 +37,31 @@ describe('Move controllers', function() {
             disabled_at: null,
           },
         ]
+        const mockPopulateAssessmentFieldsResponse = {
+          foo: 'bar',
+        }
+        const mockFields = {
+          first_names: {
+            name: 'first_names',
+          },
+          violent: {
+            skip: true,
+            rows: 3,
+            component: 'govukTextarea',
+            classes: 'govuk-input--width-20',
+            label: {
+              text: 'fields::assessment_comment.required',
+              classes: 'govuk-label--s',
+            },
+            validate: 'required',
+            explicit: true,
+          },
+        }
 
         beforeEach(async function() {
+          fieldHelpers.populateAssessmentFields.returns(
+            mockPopulateAssessmentFieldsResponse
+          )
           referenceDataService.getAssessmentQuestions.resolves(
             mockQuestionsResponse
           )
@@ -137,37 +69,12 @@ describe('Move controllers', function() {
             form: {
               options: {
                 assessmentCategory: 'risk',
-                fields: {
-                  risk: {
-                    name: 'risk',
-                    items: [],
-                  },
-                  first_names: {
-                    name: 'first_names',
-                  },
-                  violent: {
-                    skip: true,
-                    rows: 3,
-                    component: 'govukTextarea',
-                    classes: 'govuk-input--width-20',
-                    label: {
-                      text: 'fields::assessment_comment.required',
-                      classes: 'govuk-label--s',
-                    },
-                    validate: 'required',
-                  },
-                },
+                fields: mockFields,
               },
             },
           }
 
           await controller.configure(req, {}, nextSpy)
-        })
-
-        it('should not update name field', function() {
-          expect(req.form.options.fields.first_names).to.deep.equal({
-            name: 'first_names',
-          })
         })
 
         it('invokes getAssessmentQuestions', function() {
@@ -176,101 +83,20 @@ describe('Move controllers', function() {
           ).to.be.calledOnceWithExactly('risk')
         })
 
-        it('invokes assessmentCategory', function() {
-          expect(createFields.assessmentCategory).to.be.calledOnceWithExactly(
-            'risk'
-          )
-        })
-
-        it('invokes mapDependentFields with correct arguments', function() {
-          expect(fieldHelpers.mapDependentFields).to.be.calledOnceWithExactly(
-            req.form.options.fields,
-            mockQuestionsResponse,
-            req.form.options.assessmentCategory
-          )
-        })
-
-        it('should call parent configure method', function() {
+        it('should call populateAssessmentFields', function() {
           expect(
-            BaseController.prototype.configure
-          ).to.be.calledOnceWithExactly(req, {}, nextSpy)
+            fieldHelpers.populateAssessmentFields
+          ).to.be.calledOnceWithExactly(mockFields, mockQuestionsResponse)
         })
-      })
 
-      context('without implicit fields', function() {
-        const mockQuestionsResponse = [
-          {
-            id: 'af8cfc67-757c-4019-9d5e-618017de1617',
-            type: 'assessment_questions',
-            key: 'violent',
-            category: 'risk',
-            title: 'Violent',
-            disabled_at: null,
-          },
-          {
-            id: 'f2db9a8f-a5a9-40cf-875b-d1f5f62b2497',
-            type: 'assessment_questions',
-            key: 'escape',
-            category: 'risk',
-            title: 'Escape',
-            disabled_at: null,
-          },
-        ]
-
-        beforeEach(async function() {
-          referenceDataService.getAssessmentQuestions.resolves(
-            mockQuestionsResponse
+        it('should set fields to populateAssessmentFields reponse', function() {
+          expect(req.form.options.fields).to.deep.equal(
+            mockPopulateAssessmentFieldsResponse
           )
-          req = {
-            form: {
-              options: {
-                assessmentCategory: 'risk',
-                fields: {
-                  first_names: {
-                    name: 'first_names',
-                  },
-                  violent: {
-                    skip: true,
-                    rows: 3,
-                    component: 'govukTextarea',
-                    classes: 'govuk-input--width-20',
-                    label: {
-                      text: 'fields::assessment_comment.required',
-                      classes: 'govuk-label--s',
-                    },
-                    validate: 'required',
-                    explicit: true,
-                  },
-                },
-              },
-            },
-          }
-
-          await controller.configure(req, {}, nextSpy)
         })
 
-        it('should not update name field', function() {
-          expect(req.form.options.fields.first_names).to.deep.equal({
-            name: 'first_names',
-          })
-        })
-
-        it('invokes getAssessmentQuestions', function() {
-          expect(
-            referenceDataService.getAssessmentQuestions
-          ).to.be.calledOnceWithExactly('risk')
-        })
-
-        it('not create implicit field', function() {
-          expect(createFields.assessmentCategory).not.to.be.called
-        })
-
-        it('invokes mapDependentFields with correct arguments', function() {
-          expect(fieldHelpers.mapDependentFields).to.be.calledOnceWithExactly(
-            req.form.options.fields,
-            mockQuestionsResponse,
-            req.form.options.assessmentCategory
-          )
+        it('should set questions on request', function() {
+          expect(req.questions).to.deep.equal(mockQuestionsResponse)
         })
 
         it('should call parent configure method', function() {
@@ -581,6 +407,12 @@ describe('Move controllers', function() {
                 key: 'self',
                 category: 'risk',
               },
+              {
+                id: '29f8177c-2cf8-41e8-b1ad-1f66c3a1fda0',
+                type: 'assessment_questions',
+                key: 'bully',
+                category: 'risk',
+              },
             ],
             form: {
               options: {
@@ -593,9 +425,12 @@ describe('Move controllers', function() {
                   'a1f6a3b5-a448-4a78-8cf7-6659a71661c2',
                   '534b05af-8b55-4a37-9f36-d36a60f04aa8',
                 ],
+                violent_explicit: 'Violent comments',
                 violent: 'Violent comments',
                 escape: 'Escape comments',
                 self: 'Self comments',
+                bully_explicit: '29f8177c-2cf8-41e8-b1ad-1f66c3a1fda0',
+                bully: 'Bully comments',
               },
             },
             sessionModel: {
@@ -623,12 +458,16 @@ describe('Move controllers', function() {
                 comments: 'Self comments',
                 assessment_question_id: '534b05af-8b55-4a37-9f36-d36a60f04aa8',
               },
+              {
+                comments: 'Bully comments',
+                assessment_question_id: '29f8177c-2cf8-41e8-b1ad-1f66c3a1fda0',
+              },
             ],
           })
         })
 
         it('should includes all flatten values on assessment_answers property', function() {
-          expect(req.form.values.person.assessment_answers.length).to.equal(3)
+          expect(req.form.values.person.assessment_answers.length).to.equal(4)
           expect(req.form.values.person.assessment_answers).to.deep.equal([
             {
               comments: 'Violent comments',
@@ -641,6 +480,10 @@ describe('Move controllers', function() {
             {
               comments: 'Self comments',
               assessment_question_id: '534b05af-8b55-4a37-9f36-d36a60f04aa8',
+            },
+            {
+              comments: 'Bully comments',
+              assessment_question_id: '29f8177c-2cf8-41e8-b1ad-1f66c3a1fda0',
             },
           ])
         })

--- a/app/move/fields/create.js
+++ b/app/move/fields/create.js
@@ -30,20 +30,20 @@ const requiredAssessmentQuestionComments = {
   validate: 'required',
 }
 
-function assessmentCategory(category) {
+function implicitAssessmentQuestions(name) {
   return {
+    name,
     component: 'govukCheckboxes',
     multiple: true,
     items: [],
-    name: category,
     fieldset: {
       legend: {
-        text: `fields::${category}.label`,
+        text: `fields::${name}.label`,
         classes: 'govuk-visually-hidden govuk-fieldset__legend--m',
       },
     },
     hint: {
-      text: `fields::${category}.hint`,
+      text: `fields::${name}.hint`,
     },
   }
 }
@@ -71,11 +71,11 @@ function toLocationType(type, props) {
   }
 }
 
-function explicitYesNo(name) {
+function explicitAssessmentQuestion(name, value, conditional) {
   return {
+    name,
     validate: 'required',
     component: 'govukRadios',
-    name: name,
     fieldset: {
       legend: {
         text: `fields::${name}.label`,
@@ -87,11 +87,12 @@ function explicitYesNo(name) {
     },
     items: [
       {
-        value: 'yes',
+        value,
+        conditional,
         text: 'Yes',
       },
       {
-        value: 'no',
+        value: 'false',
         text: 'No',
       },
     ],
@@ -340,7 +341,6 @@ module.exports = {
     },
   },
   // risk information
-  risk: assessmentCategory('risk'),
   violent: assessmentQuestionComments,
   escape: assessmentQuestionComments,
   hold_separately: assessmentQuestionComments,
@@ -363,7 +363,6 @@ module.exports = {
     explicit: true,
   },
   // court information
-  court: assessmentCategory('court'),
   solicitor: assessmentQuestionComments,
   interpreter: assessmentQuestionComments,
   other_court: requiredAssessmentQuestionComments,
@@ -445,6 +444,6 @@ module.exports = {
       value: true,
     },
   },
-  assessmentCategory,
-  explicitYesNo,
+  implicitAssessmentQuestions,
+  explicitAssessmentQuestion,
 }

--- a/app/move/fields/create.test.js
+++ b/app/move/fields/create.test.js
@@ -1,8 +1,8 @@
-const { explicitYesNo } = require('./create')
+const { explicitAssessmentQuestion } = require('./create')
 
-describe('explicitYesNo', function() {
+describe('explicitAssessmentQuestion', function() {
   it('returns a radio component with 2 items', function() {
-    const { items, component } = explicitYesNo('field1')
+    const { items, component } = explicitAssessmentQuestion('field1')
     expect(items.length).to.equal(2)
     expect(component).to.equal('govukRadios')
   })

--- a/common/helpers/field.test.js
+++ b/common/helpers/field.test.js
@@ -10,9 +10,7 @@ const {
   insertInitialOption,
   insertItemConditional,
   mapPersonToOption,
-  appendDependent,
-  decorateWithExplicitFields,
-  mapDependentFields,
+  populateAssessmentFields,
 } = require('./field')
 
 const personMock = {
@@ -36,6 +34,27 @@ const personMock = {
     },
   ],
 }
+
+const mockAssessmentQuestions = [
+  {
+    id: 'e6faaf20-3072-4a65-91f7-93d52b16260f',
+    key: 'special_diet_or_allergy',
+    category: 'health',
+    title: 'Special diet or allergy',
+  },
+  {
+    id: '7ac3ffc9-57ac-4d0f-aa06-ad15b55c3cee',
+    key: 'medication',
+    category: 'health',
+    title: 'Medication',
+  },
+  {
+    id: '1a73d31a-8dd4-47b6-90a0-15ce4e332539',
+    key: 'special_vehicle',
+    category: 'health',
+    title: 'Requires special vehicle',
+  },
+]
 
 describe('Form helpers', function() {
   describe('#mapReferenceDataToOption()', function() {
@@ -914,174 +933,174 @@ describe('Form helpers', function() {
     })
   })
 
-  describe('appendDependent', function() {
-    const questions = [
-      {
-        id: 'e6faaf20-3072-4a65-91f7-93d52b16260f',
-        type: 'assessment_questions',
-        key: 'special_diet_or_allergy',
-        category: 'health',
-        title: 'Special diet or allergy',
-        disabled_at: null,
-      },
-      {
-        id: '1a73d31a-8dd4-47b6-90a0-15ce4e332539',
-        type: 'assessment_questions',
-        key: 'special_vehicle',
-        category: 'health',
-        title: 'Special vehicle',
-        disabled_at: null,
-      },
-    ]
-    const assessmentCategory = 'health'
-    const field = {
-      explicit: true,
-    }
-    const key = 'special_vehicle'
-    it('for explicit fields', function() {
-      const output = appendDependent(questions, assessmentCategory, field, key)
-      expect(output).to.deep.equal({
-        explicit: true,
-        dependent: {
-          field: 'special_vehicle__yesno',
-          value: 'yes',
-        },
+  describe('#populateAssessmentFields()', function() {
+    let fields
+
+    context('with only implicit fields', function() {
+      const mockFields = {
+        special_diet_or_allergy: {},
+        medication: {},
+      }
+
+      beforeEach(function() {
+        fields = populateAssessmentFields(mockFields, mockAssessmentQuestions)
       })
-    })
-    it('for implicit (normal) fields', function() {
-      const output = appendDependent(questions, assessmentCategory, {}, key)
-      expect(output).to.deep.equal({
-        dependent: {
-          field: 'health',
-          value: '1a73d31a-8dd4-47b6-90a0-15ce4e332539',
-        },
-      })
-    })
-  })
-  describe('decorateWithExplicitFields', function() {
-    const questions = [
-      {
-        id: 'e6faaf20-3072-4a65-91f7-93d52b16260f',
-        type: 'assessment_questions',
-        key: 'special_diet_or_allergy',
-        category: 'health',
-        title: 'Special diet or allergy',
-        disabled_at: null,
-      },
-      {
-        id: '1a73d31a-8dd4-47b6-90a0-15ce4e332539',
-        type: 'assessment_questions',
-        key: 'special_vehicle',
-        category: 'health',
-        title: 'Special vehicle',
-        disabled_at: null,
-      },
-    ]
-    const field = {
-      explicit: true,
-    }
-    const key = 'special_vehicle'
-    let fieldsCollection
-    beforeEach(function() {
-      fieldsCollection = {}
-    })
-    it('fields remain untouched for implicit (normal) fields', function() {
-      decorateWithExplicitFields(questions, fieldsCollection, {}, key)
-      expect(fieldsCollection).to.deep.equal({})
-    })
-    it('creates an additional field for explicit fields', function() {
-      decorateWithExplicitFields(questions, fieldsCollection, field, key)
-      expect(fieldsCollection).to.deep.equal({
-        special_vehicle__yesno: {
-          validate: 'required',
-          component: 'govukRadios',
-          name: 'special_vehicle__yesno',
-          fieldset: {
-            legend: {
-              text: 'fields::special_vehicle__yesno.label',
-              classes: 'govuk-fieldset__legend--m',
-            },
-          },
-          hint: {
-            text: 'fields::special_vehicle__yesno.hint',
-          },
+
+      it('should create impicit field', function() {
+        expect(fields).to.contain.property('health')
+        expect(fields.health).to.deep.equal({
+          name: 'health',
+          component: 'govukCheckboxes',
+          multiple: true,
           items: [
             {
-              value: 'yes',
-              text: 'Yes',
-              conditional: 'special_vehicle',
+              value: 'e6faaf20-3072-4a65-91f7-93d52b16260f',
+              text: 'Special diet or allergy',
+              key: 'special_diet_or_allergy',
+              conditional: 'special_diet_or_allergy',
             },
             {
-              value: 'no',
-              text: 'No',
+              value: '7ac3ffc9-57ac-4d0f-aa06-ad15b55c3cee',
+              text: 'Medication',
+              key: 'medication',
+              conditional: 'medication',
             },
           ],
-        },
-      })
-    })
-  })
-
-  describe('mapDependentFields', function() {
-    const fields = {
-      special_diet_or_allergy: {
-        skip: true,
-      },
-      special_vehicle: {
-        skip: true,
-        validate: 'required',
-        explicit: true,
-      },
-      health: {
-        multiple: true,
-        items: [
-          {
-            value: 'e6faaf20-3072-4a65-91f7-93d52b16260f',
-            text: 'Special diet or allergy',
-            key: 'special_diet_or_allergy',
-            conditional: 'special_diet_or_allergy',
+          fieldset: {
+            legend: {
+              text: 'fields::health.label',
+              classes: 'govuk-visually-hidden govuk-fieldset__legend--m',
+            },
           },
-        ],
-        name: 'health',
-      },
-    }
-    const questions = [
-      {
-        id: 'e6faaf20-3072-4a65-91f7-93d52b16260f',
-        type: 'assessment_questions',
-        key: 'special_diet_or_allergy',
-        category: 'health',
-      },
-      {
-        id: '1a73d31a-8dd4-47b6-90a0-15ce4e332539',
-        type: 'assessment_questions',
-        key: 'special_vehicle',
-        category: 'health',
-      },
-    ]
+          hint: { text: 'fields::health.hint' },
+        })
+      })
 
-    it('returns an object', function() {
-      expect(mapDependentFields(fields, questions, 'health')).to.be.an('object')
-    })
-
-    it('appends the explicit fields and their dependents', async function() {
-      expect(mapDependentFields(fields, questions, 'health')).to.deep.equal({
-        special_diet_or_allergy: {
-          skip: true,
+      it('should append dependent field properties', function() {
+        expect(fields.special_diet_or_allergy).to.deep.equal({
           dependent: {
             field: 'health',
             value: 'e6faaf20-3072-4a65-91f7-93d52b16260f',
           },
-        },
-        special_vehicle: {
-          skip: true,
-          validate: 'required',
-          explicit: true,
+        })
+        expect(fields.medication).to.deep.equal({
           dependent: {
-            field: 'special_vehicle__yesno',
-            value: 'yes',
+            field: 'health',
+            value: '7ac3ffc9-57ac-4d0f-aa06-ad15b55c3cee',
           },
+        })
+      })
+
+      it('should return the correct number of fields', function() {
+        expect(Object.keys(fields).length).to.equal(3)
+      })
+    })
+
+    context('with only explicit fields', function() {
+      const mockFields = {
+        special_diet_or_allergy: {
+          explicit: true,
         },
-        health: {
+        medication: {
+          explicit: true,
+        },
+      }
+
+      beforeEach(function() {
+        fields = populateAssessmentFields(mockFields, mockAssessmentQuestions)
+      })
+
+      it('should not create impicit field', function() {
+        expect(fields).not.to.contain.property('health')
+      })
+
+      it('should create medication explicit field', function() {
+        expect(fields).to.contain.property('medication__explicit')
+        expect(fields.medication__explicit).to.deep.equal({
+          name: 'medication__explicit',
+          validate: 'required',
+          component: 'govukRadios',
+          fieldset: {
+            legend: {
+              text: 'fields::medication__explicit.label',
+              classes: 'govuk-fieldset__legend--m',
+            },
+          },
+          hint: { text: 'fields::medication__explicit.hint' },
+          items: [
+            {
+              value: '7ac3ffc9-57ac-4d0f-aa06-ad15b55c3cee',
+              conditional: 'medication',
+              text: 'Yes',
+            },
+            { value: 'false', text: 'No' },
+          ],
+        })
+      })
+
+      it('should create special diet explicit field', function() {
+        expect(fields).to.contain.property('special_diet_or_allergy__explicit')
+        expect(fields.special_diet_or_allergy__explicit).to.deep.equal({
+          name: 'special_diet_or_allergy__explicit',
+          validate: 'required',
+          component: 'govukRadios',
+          fieldset: {
+            legend: {
+              text: 'fields::special_diet_or_allergy__explicit.label',
+              classes: 'govuk-fieldset__legend--m',
+            },
+          },
+          hint: { text: 'fields::special_diet_or_allergy__explicit.hint' },
+          items: [
+            {
+              value: 'e6faaf20-3072-4a65-91f7-93d52b16260f',
+              conditional: 'special_diet_or_allergy',
+              text: 'Yes',
+            },
+            { value: 'false', text: 'No' },
+          ],
+        })
+      })
+
+      it('should append dependent field properties', function() {
+        expect(fields.special_diet_or_allergy).to.deep.equal({
+          dependent: {
+            field: 'special_diet_or_allergy__explicit',
+            value: 'e6faaf20-3072-4a65-91f7-93d52b16260f',
+          },
+          explicit: true,
+        })
+        expect(fields.medication).to.deep.equal({
+          dependent: {
+            field: 'medication__explicit',
+            value: '7ac3ffc9-57ac-4d0f-aa06-ad15b55c3cee',
+          },
+          explicit: true,
+        })
+      })
+
+      it('should return the correct number of fields', function() {
+        expect(Object.keys(fields).length).to.equal(4)
+      })
+    })
+
+    context('with both implicit and explicit fields', function() {
+      const mockFields = {
+        special_diet_or_allergy: {},
+        medication: {
+          explicit: true,
+        },
+      }
+
+      beforeEach(function() {
+        fields = populateAssessmentFields(mockFields, mockAssessmentQuestions)
+      })
+
+      it('should create impicit field', function() {
+        expect(fields).to.contain.property('health')
+        expect(fields.health).to.deep.equal({
+          name: 'health',
+          component: 'govukCheckboxes',
           multiple: true,
           items: [
             {
@@ -1091,33 +1110,62 @@ describe('Form helpers', function() {
               conditional: 'special_diet_or_allergy',
             },
           ],
-          name: 'health',
-        },
-        special_vehicle__yesno: {
+          fieldset: {
+            legend: {
+              text: 'fields::health.label',
+              classes: 'govuk-visually-hidden govuk-fieldset__legend--m',
+            },
+          },
+          hint: { text: 'fields::health.hint' },
+        })
+      })
+
+      it('should create medication explicit field', function() {
+        expect(fields).to.contain.property('medication__explicit')
+        expect(fields.medication__explicit).to.deep.equal({
+          name: 'medication__explicit',
           validate: 'required',
-          name: 'special_vehicle__yesno',
           component: 'govukRadios',
           fieldset: {
             legend: {
-              text: 'fields::special_vehicle__yesno.label',
+              text: 'fields::medication__explicit.label',
               classes: 'govuk-fieldset__legend--m',
             },
           },
-          hint: {
-            text: 'fields::special_vehicle__yesno.hint',
-          },
+          hint: { text: 'fields::medication__explicit.hint' },
           items: [
             {
-              value: 'yes',
+              value: '7ac3ffc9-57ac-4d0f-aa06-ad15b55c3cee',
+              conditional: 'medication',
               text: 'Yes',
-              conditional: 'special_vehicle',
             },
-            {
-              value: 'no',
-              text: 'No',
-            },
+            { value: 'false', text: 'No' },
           ],
-        },
+        })
+      })
+
+      it('should append dependent field properties', function() {
+        expect(fields.medication).to.deep.equal({
+          dependent: {
+            field: 'medication__explicit',
+            value: '7ac3ffc9-57ac-4d0f-aa06-ad15b55c3cee',
+          },
+          explicit: true,
+        })
+      })
+
+      it('should return the correct number of fields', function() {
+        expect(Object.keys(fields).length).to.equal(4)
+      })
+    })
+
+    context('with no implicit or explicit fields', function() {
+      beforeEach(function() {
+        fields = populateAssessmentFields({}, mockAssessmentQuestions)
+      })
+
+      it('should return original fields', function() {
+        expect(fields).to.deep.equal({})
       })
     })
   })

--- a/locales/en/fields.json
+++ b/locales/en/fields.json
@@ -135,14 +135,14 @@
   "special_vehicle": {
     "label": "Special vehicle details"
   },
-  "special_vehicle__yesno": {
+  "special_vehicle__explicit": {
     "label": "Does this person need to travel in a special vehicle?",
     "hint": "This could be a specially-adapted prison van (for example, to accomodate wheelchairs)"
   },
   "not_to_be_released": {
     "label": "Release status details"
   },
-  "not_to_be_released__yesno": {
+  "not_to_be_released__explicit": {
     "label": "Is there a reason this person should not be released?",
     "hint": "For example, they may be wanted by immigration or recalled to custody"
   },


### PR DESCRIPTION
This refactors the way the assessment questions are populated. The main thing is to move the logic out of the controller and into one central place.

It also means we don't have to know about the suffix in too many different places. Only the locales files now.