### PR TITLE
fix: Ensure date field runs formatter

### DIFF
--- a/app/move/fields/create.js
+++ b/app/move/fields/create.js
@@ -99,26 +99,14 @@ function explicitYesNo(name) {
 }
 
 const dateField = {
-  validate: ['required', 'date', 'after'],
-  formatter: ['date'],
+  validate: ['date'],
+  formatter: [date],
   component: 'govukInput',
   autocomplete: 'off',
   classes: 'govuk-input--width-10',
   hint: {
-    text: 'fields::date_custom.hint',
+    text: 'fields::date.hint',
   },
-}
-
-const dateRangeField = function(id) {
-  return {
-    ...dateField,
-    id: id,
-    name: id,
-    label: {
-      text: `fields::${id}.label`,
-      classes: 'govuk-label--s',
-    },
-  }
 }
 
 module.exports = {
@@ -196,20 +184,14 @@ module.exports = {
     autocomplete: 'off',
   },
   date_of_birth: {
-    validate: ['required', 'date', 'before'],
-    formatter: [date],
-    component: 'govukInput',
+    ...dateField,
+    validate: [...dateField.validate, 'required', 'before'],
     label: {
       text: 'fields::date_of_birth.label',
       classes: 'govuk-label--s',
     },
-    hint: {
-      text: 'fields::date_of_birth.hint',
-    },
     id: 'date_of_birth',
     name: 'date_of_birth',
-    classes: 'govuk-input--width-10',
-    autocomplete: 'off',
   },
   gender: {
     validate: 'required',
@@ -324,6 +306,7 @@ module.exports = {
   },
   date_custom: {
     ...dateField,
+    validate: [...dateField.validate, 'required', 'after'],
     skip: true,
     dependent: {
       field: 'date_type',
@@ -336,8 +319,26 @@ module.exports = {
       classes: 'govuk-label--s',
     },
   },
-  date_from: dateRangeField('date_from'),
-  date_to: dateRangeField('date_to'),
+  date_from: {
+    ...dateField,
+    validate: [...dateField.validate, 'required', 'after'],
+    id: 'date_from',
+    name: 'date_from',
+    label: {
+      text: 'fields::date_from.label',
+      classes: 'govuk-label--s',
+    },
+  },
+  date_to: {
+    ...dateField,
+    validate: [...dateField.validate, 'required', 'after'],
+    id: 'date_to',
+    name: 'date_to',
+    label: {
+      text: 'fields::date_to.label',
+      classes: 'govuk-label--s',
+    },
+  },
   // risk information
   risk: assessmentCategory('risk'),
   violent: assessmentQuestionComments,

--- a/locales/en/fields.json
+++ b/locales/en/fields.json
@@ -1,4 +1,7 @@
 {
+  "date": {
+    "hint": "For example 28/10/1990 or 28 October 1990"
+  },
   "filter": {
     "police_national_computer": {
       "label": "Police National Computer (PNC) number"
@@ -27,8 +30,7 @@
     "label": "Last name"
   },
   "date_of_birth": {
-    "label": "Date of birth",
-    "hint": "For example 28/10/1990 or 28 October 1990"
+    "label": "Date of birth"
   },
   "gender": {
     "label": "Gender"
@@ -81,8 +83,7 @@
     }
   },
   "date_custom": {
-    "label": "Date of travel",
-    "hint": "For example 28/10/2019 or 28 October 2019"
+    "label": "Date of travel"
   },
   "time_due": {
     "label": "Time due"

--- a/test/e2e/page-model.js
+++ b/test/e2e/page-model.js
@@ -89,7 +89,7 @@ export default class Page {
         first_names: faker.name.firstName(),
         date_of_birth: format(
           faker.date.between('01-01-1940', '01-01-1990'),
-          'yyyy-MM-dd'
+          'do MMMM yyyy'
         ),
       },
       options: {


### PR DESCRIPTION
The date refactor change the formatter to use a string rather than
the function that it needed to. This meant that certain date strings
that were previously supported no longer were supported.

This ensures the formatter is called correctly and uses the shared
date field object with other date fields, like date of birth.

It also includes an update to the e2e tests to catch if this changes
again in the future.