### PR TITLE
fix: Update prison number key

### DIFF
--- a/app/move/fields/create.js
+++ b/app/move/fields/create.js
@@ -121,12 +121,12 @@ module.exports = {
       classes: 'govuk-label--s',
     },
   },
-  'filter.nomis_offender_no': {
+  'filter.prison_number': {
     ...personSearchFilter,
-    id: 'filter.nomis_offender_no',
-    name: 'filter.nomis_offender_no',
+    id: 'filter.prison_number',
+    name: 'filter.prison_number',
     label: {
-      html: 'fields::filter.nomis_offender_no.label',
+      html: 'fields::filter.prison_number.label',
       classes: 'govuk-label--s',
     },
   },

--- a/app/move/steps/create.js
+++ b/app/move/steps/create.js
@@ -69,7 +69,7 @@ module.exports = {
   },
   '/person-lookup-prison-number': {
     ...personSearchStep,
-    fields: ['filter.nomis_offender_no'],
+    fields: ['filter.prison_number'],
   },
   '/person-lookup-pnc': {
     ...personSearchStep,

--- a/locales/en/fields.json
+++ b/locales/en/fields.json
@@ -6,7 +6,7 @@
     "police_national_computer": {
       "label": "Police National Computer (PNC) number"
     },
-    "nomis_offender_no": {
+    "prison_number": {
       "label": "Prison number"
     }
   },


### PR DESCRIPTION
Previously we were using a different filter for the prison number
identifier. Trying to alias `nomis_offender_no` to `prison_number`
on the API caused issues so we're rolling the change back to only
consistently use `prison_number` for now.

This change updates the filter on the frontend to use the new API
filter.