### PR TITLE
fix: Ensure the code is checked out before running the GitHub release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -180,6 +180,10 @@ jobs:
   publish_release_to_github:
     <<: *circle_container
     steps:
+      - checkout
+      - *restore_cache
+      - *install_dependencies
+      - *save_cache
       - run:
           name: Publish release to GitHub
           command: npm run release:github


### PR DESCRIPTION
The GitHub release command was being run without the code being checked
out for that job.

This should fix that the next time that workflow is released.