### PR TITLE
[P4-1106] Display NOMIS alerts on assessment pages

### DIFF
--- a/app/move/controllers/create/assessment.js
+++ b/app/move/controllers/create/assessment.js
@@ -1,4 +1,4 @@
-const { flatten, values } = require('lodash')
+const { flatten } = require('lodash')
 
 const CreateBaseController = require('./base')
 const fieldHelpers = require('../../../../common/helpers/field')
@@ -25,7 +25,6 @@ class AssessmentController extends CreateBaseController {
   }
 
   saveValues(req, res, next) {
-    const person = req.sessionModel.get('person') || {}
     const assessment = req.sessionModel.get('assessment') || {}
     const formValues = flatten(Object.values(req.form.values))
     const { assessmentCategory } = req.form.options
@@ -40,10 +39,6 @@ class AssessmentController extends CreateBaseController {
       })
 
     req.form.values.assessment = assessment
-    req.form.values.person = {
-      ...person,
-      assessment_answers: flatten(values(assessment)),
-    }
 
     super.saveValues(req, res, next)
   }

--- a/app/move/controllers/create/assessment.test.js
+++ b/app/move/controllers/create/assessment.test.js
@@ -1,5 +1,6 @@
 const referenceDataService = require('../../../../common/services/reference-data')
 const fieldHelpers = require('../../../../common/helpers/field')
+const presenters = require('../../../../common/presenters')
 
 const BaseController = require('./base')
 const Controller = require('./assessment')
@@ -145,6 +146,221 @@ describe('Move controllers', function() {
       })
     })
 
+    describe('#middlewareLocals()', function() {
+      beforeEach(function() {
+        sinon.stub(BaseController.prototype, 'middlewareLocals')
+        sinon.stub(controller, 'use')
+
+        controller.middlewareLocals()
+      })
+
+      it('should call parent method', function() {
+        expect(BaseController.prototype.middlewareLocals).to.have.been
+          .calledOnce
+      })
+
+      it('should call set previous assessment method', function() {
+        expect(controller.use.firstCall).to.have.been.calledWithExactly(
+          controller.setPreviousAssessment
+        )
+      })
+
+      it('should call correct number of middleware', function() {
+        expect(controller.use).to.be.callCount(1)
+      })
+    })
+
+    describe('#setPreviousAssessment', function() {
+      let req, res, nextSpy
+
+      beforeEach(function() {
+        sinon.stub(presenters, 'assessmentByCategory').returns([
+          {
+            key: 'risk',
+            answers: ['stubbed'],
+          },
+        ])
+        req = {
+          form: {
+            options: {
+              assessmentCategory: 'risk',
+              fields: {
+                violent: {},
+                self_harm: {},
+                escape: {},
+              },
+            },
+          },
+          sessionModel: {
+            get: sinon.stub(),
+          },
+        }
+        res = {
+          locals: {},
+        }
+        nextSpy = sinon.spy()
+      })
+
+      context(
+        'when the step includes ability to show previous assessment',
+        function() {
+          beforeEach(function() {
+            req.form.options.showPreviousAssessment = true
+          })
+
+          context('with answers from a different category', function() {
+            beforeEach(function() {
+              req.sessionModel.get.withArgs('person').returns({
+                assessment_answers: [
+                  {
+                    category: 'risk',
+                    key: 'violent',
+                    imported_from_nomis: true,
+                  },
+                  {
+                    category: 'health',
+                    key: 'medication',
+                    imported_from_nomis: true,
+                  },
+                  {
+                    category: 'court',
+                    key: 'interpreter',
+                    imported_from_nomis: true,
+                  },
+                ],
+              })
+              controller.setPreviousAssessment(req, res, nextSpy)
+            })
+
+            it('should set previous assessment on local', function() {
+              expect(res.locals).to.contain.property('previousAssessment')
+              expect(res.locals.previousAssessment).to.deep.equal({
+                key: 'risk',
+                answers: ['stubbed'],
+              })
+            })
+
+            it('should call presenter with filtered assessment', function() {
+              expect(
+                presenters.assessmentByCategory
+              ).to.be.calledOnceWithExactly([
+                {
+                  category: 'risk',
+                  key: 'violent',
+                  imported_from_nomis: true,
+                },
+              ])
+            })
+
+            it('should call next', function() {
+              expect(nextSpy).to.be.calledOnceWithExactly()
+            })
+          })
+
+          context('with answers not in the fields list', function() {
+            beforeEach(function() {
+              req.sessionModel.get.withArgs('person').returns({
+                assessment_answers: [
+                  {
+                    category: 'risk',
+                    key: 'violent',
+                    imported_from_nomis: true,
+                  },
+                  {
+                    category: 'risk',
+                    key: 'self_harm',
+                    imported_from_nomis: true,
+                  },
+                  {
+                    category: 'risk',
+                    key: 'missing_key',
+                    imported_from_nomis: true,
+                  },
+                ],
+              })
+              controller.setPreviousAssessment(req, res, nextSpy)
+            })
+
+            it('should call presenter with filtered assessment', function() {
+              expect(
+                presenters.assessmentByCategory
+              ).to.be.calledOnceWithExactly([
+                {
+                  category: 'risk',
+                  key: 'violent',
+                  imported_from_nomis: true,
+                },
+                {
+                  category: 'risk',
+                  key: 'self_harm',
+                  imported_from_nomis: true,
+                },
+              ])
+            })
+          })
+
+          context('with non imported answers', function() {
+            beforeEach(function() {
+              req.sessionModel.get.withArgs('person').returns({
+                assessment_answers: [
+                  {
+                    category: 'risk',
+                    key: 'violent',
+                    imported_from_nomis: true,
+                  },
+                  {
+                    category: 'risk',
+                    key: 'self_harm',
+                  },
+                  {
+                    category: 'risk',
+                    key: 'escape',
+                  },
+                ],
+              })
+              controller.setPreviousAssessment(req, res, nextSpy)
+            })
+
+            it('should call presenter with filtered assessment', function() {
+              expect(
+                presenters.assessmentByCategory
+              ).to.be.calledOnceWithExactly([
+                {
+                  category: 'risk',
+                  key: 'violent',
+                  imported_from_nomis: true,
+                },
+              ])
+            })
+          })
+        }
+      )
+
+      context(
+        'when the step does not include ability to show previous assessment',
+        function() {
+          beforeEach(function() {
+            req.sessionModel.get.withArgs('person').returns({
+              assessment_answers: [],
+            })
+            controller.setPreviousAssessment(req, res, nextSpy)
+          })
+
+          it('should not set previous assessment on locals', function() {
+            expect(res.locals).not.to.contain.property('previousAssessment')
+          })
+
+          it('should not call presenter', function() {
+            expect(presenters.assessmentByCategory).not.to.be.called
+          })
+
+          it('should call next', function() {
+            expect(nextSpy).to.be.calledOnceWithExactly()
+          })
+        }
+      )
+    })
+
     describe('#saveValues()', function() {
       let nextSpy
       const mockFields = {
@@ -214,6 +430,7 @@ describe('Move controllers', function() {
             risk: [
               {
                 comments: 'Additional comments',
+                key: 'violent',
                 assessment_question_id: 'a1f6a3b5-a448-4a78-8cf7-6659a71661c2',
               },
             ],
@@ -285,6 +502,7 @@ describe('Move controllers', function() {
           expect(req.form.values.assessment.risk).to.deep.equal([
             {
               comments: 'Additional comments',
+              key: 'violent',
               assessment_question_id: 'a1f6a3b5-a448-4a78-8cf7-6659a71661c2',
             },
           ])
@@ -345,6 +563,7 @@ describe('Move controllers', function() {
             risk: [
               {
                 comments: '',
+                key: 'violent',
                 assessment_question_id: 'a1f6a3b5-a448-4a78-8cf7-6659a71661c2',
               },
             ],
@@ -417,18 +636,22 @@ describe('Move controllers', function() {
             risk: [
               {
                 comments: 'Violent comments',
+                key: 'violent',
                 assessment_question_id: 'a1f6a3b5-a448-4a78-8cf7-6659a71661c2',
               },
               {
                 comments: 'Escape comments',
+                key: 'escape',
                 assessment_question_id: '7360ea7b-f4c2-4a09-88fd-5e3b57de1a47',
               },
               {
                 comments: 'Self comments',
+                key: 'self',
                 assessment_question_id: '534b05af-8b55-4a37-9f36-d36a60f04aa8',
               },
               {
                 comments: 'Bully comments',
+                key: 'bully',
                 assessment_question_id: '29f8177c-2cf8-41e8-b1ad-1f66c3a1fda0',
               },
             ],

--- a/app/move/controllers/create/assessment.test.js
+++ b/app/move/controllers/create/assessment.test.js
@@ -220,15 +220,6 @@ describe('Move controllers', function() {
           })
         })
 
-        it('should flatten values on assessment_answers property', function() {
-          expect(req.form.values.person.assessment_answers).to.deep.equal([
-            {
-              comments: 'Additional comments',
-              assessment_question_id: 'a1f6a3b5-a448-4a78-8cf7-6659a71661c2',
-            },
-          ])
-        })
-
         it('should call parent configure method', function() {
           expect(
             BaseController.prototype.saveValues
@@ -308,19 +299,6 @@ describe('Move controllers', function() {
           ])
         })
 
-        it('should flatten values on assessment_answers property', function() {
-          expect(req.form.values.person.assessment_answers).to.deep.equal([
-            {
-              comments: 'Additional comments',
-              assessment_question_id: 'a1f6a3b5-a448-4a78-8cf7-6659a71661c2',
-            },
-            {
-              comments: '',
-              assessment_question_id: '7360ea7b-f4c2-4a09-88fd-5e3b57de1a47',
-            },
-          ])
-        })
-
         it('should call parent configure method', function() {
           expect(
             BaseController.prototype.saveValues
@@ -371,15 +349,6 @@ describe('Move controllers', function() {
               },
             ],
           })
-        })
-
-        it('should flatten values on assessment_answers property', function() {
-          expect(req.form.values.person.assessment_answers).to.deep.equal([
-            {
-              comments: '',
-              assessment_question_id: 'a1f6a3b5-a448-4a78-8cf7-6659a71661c2',
-            },
-          ])
         })
       })
 
@@ -464,28 +433,6 @@ describe('Move controllers', function() {
               },
             ],
           })
-        })
-
-        it('should includes all flatten values on assessment_answers property', function() {
-          expect(req.form.values.person.assessment_answers.length).to.equal(4)
-          expect(req.form.values.person.assessment_answers).to.deep.equal([
-            {
-              comments: 'Violent comments',
-              assessment_question_id: 'a1f6a3b5-a448-4a78-8cf7-6659a71661c2',
-            },
-            {
-              comments: 'Escape comments',
-              assessment_question_id: '7360ea7b-f4c2-4a09-88fd-5e3b57de1a47',
-            },
-            {
-              comments: 'Self comments',
-              assessment_question_id: '534b05af-8b55-4a37-9f36-d36a60f04aa8',
-            },
-            {
-              comments: 'Bully comments',
-              assessment_question_id: '29f8177c-2cf8-41e8-b1ad-1f66c3a1fda0',
-            },
-          ])
         })
       })
     })

--- a/app/move/controllers/create/save.js
+++ b/app/move/controllers/create/save.js
@@ -1,9 +1,21 @@
-const { omit, capitalize, flatten, values } = require('lodash')
+const { omit, capitalize, flatten, values, some } = require('lodash')
 
 const CreateBaseController = require('./base')
 const moveService = require('../../../../common/services/move')
 const personService = require('../../../../common/services/person')
 const analytics = require('../../../../common/lib/analytics')
+
+function filterAnswer(currentAssessment, searchKey) {
+  return item => {
+    if (
+      !some(currentAssessment, { key: searchKey }) &&
+      item.key === searchKey
+    ) {
+      return false
+    }
+    return true
+  }
+}
 
 class SaveController extends CreateBaseController {
   async saveValues(req, res, next) {
@@ -16,7 +28,7 @@ class SaveController extends CreateBaseController {
       const move = await moveService.create(data)
       await personService.update({
         ...data.person,
-        assessment_answers: flatten(values(data.assessment)),
+        assessment_answers: data.assessment,
       })
 
       req.sessionModel.set('move', move)
@@ -25,6 +37,34 @@ class SaveController extends CreateBaseController {
     } catch (error) {
       next(error)
     }
+  }
+
+  process(req, res, next) {
+    const {
+      person,
+      assessment,
+      from_location_type: fromLocationType,
+    } = req.form.values
+    const currentAssessment = flatten(values(assessment))
+
+    if (fromLocationType !== 'prison') {
+      req.sessionModel.set('assessment', currentAssessment)
+      return super.process(req, res, next)
+    }
+
+    const existingAssessment = person.assessment_answers
+      // keep all existing NOMIS alerts
+      .filter(answer => answer.nomis_alert_code)
+      // filter out requested answers
+      .filter(filterAnswer(currentAssessment, 'not_to_be_released'))
+      .filter(filterAnswer(currentAssessment, 'special_vehicle'))
+
+    req.sessionModel.set('assessment', [
+      ...existingAssessment,
+      ...currentAssessment,
+    ])
+
+    super.process(req, res, next)
   }
 
   async successHandler(req, res, next) {

--- a/app/move/controllers/create/save.js
+++ b/app/move/controllers/create/save.js
@@ -1,4 +1,4 @@
-const { omit, capitalize } = require('lodash')
+const { omit, capitalize, flatten, values } = require('lodash')
 
 const CreateBaseController = require('./base')
 const moveService = require('../../../../common/services/move')
@@ -14,7 +14,10 @@ class SaveController extends CreateBaseController {
         'errorValues',
       ])
       const move = await moveService.create(data)
-      await personService.update(data.person)
+      await personService.update({
+        ...data.person,
+        assessment_answers: flatten(values(data.assessment)),
+      })
 
       req.sessionModel.set('move', move)
 

--- a/app/move/controllers/create/save.test.js
+++ b/app/move/controllers/create/save.test.js
@@ -1,7 +1,7 @@
-const { capitalize, flatten, values } = require('lodash')
+const { capitalize } = require('lodash')
 const proxyquire = require('proxyquire')
-const FormController = require('hmpo-form-wizard').Controller
 
+const BaseController = require('./base')
 const Controller = proxyquire('./save', {
   '../../../moves': {
     mountpath: '/moves',
@@ -95,7 +95,6 @@ describe('Move controllers', function() {
 
       context('when move save is successful', function() {
         beforeEach(async function() {
-          sinon.spy(FormController.prototype, 'configure')
           sinon.stub(moveService, 'create').resolves(mockMove)
           sinon.stub(personService, 'update').resolves(mockPerson)
           await controller.saveValues(req, {}, nextSpy)
@@ -117,11 +116,8 @@ describe('Move controllers', function() {
         it('should call person update', function() {
           expect(personService.update).to.be.calledOnceWithExactly({
             ...valuesMock.person,
-            assessment_answers: flatten(values(valuesMock.assessment)),
+            assessment_answers: valuesMock.assessment,
           })
-          expect(
-            personService.update.args[0][0].assessment_answers.length
-          ).to.equal(5)
         })
 
         it('should set response to session model', function() {
@@ -152,6 +148,411 @@ describe('Move controllers', function() {
 
         it('should not set person response on form values', function() {
           expect(req.form.values).not.to.have.property('person')
+        })
+      })
+    })
+
+    describe('#process()', function() {
+      let req
+      const mockCurrentAssessmentWithoutExplicit = {
+        court: [
+          {
+            key: 'other_court',
+            assessment_question_id: '80ca9b7f-a260-4406-a3af-17e190bdc714',
+            comments: 'Other court details',
+          },
+        ],
+        risk: [
+          {
+            key: 'escape',
+            assessment_question_id: '3174ebe6-0ab3-4f08-afa6-ff7b04cc215b',
+            comments: 'Likely to escape',
+          },
+        ],
+        health: [
+          {
+            key: 'health_issue',
+            assessment_question_id: 'cbb6d55e-bbde-4928-baa0-a9156b45bcef',
+            comments: 'Recurring health issue',
+          },
+        ],
+      }
+      const mockCurrentAssessmentWithExplicit = {
+        court: [
+          {
+            key: 'other_court',
+            assessment_question_id: '80ca9b7f-a260-4406-a3af-17e190bdc714',
+            comments: 'Other court details',
+          },
+        ],
+        risk: [
+          {
+            key: 'escape',
+            assessment_question_id: '3174ebe6-0ab3-4f08-afa6-ff7b04cc215b',
+            comments: 'Likely to escape',
+          },
+          {
+            key: 'not_to_be_released',
+            assessment_question_id: 'a3534a54-d3a9-46c7-a1f0-de7e762ca95a',
+            comments: '',
+          },
+        ],
+        health: [
+          {
+            key: 'health_issue',
+            assessment_question_id: 'cbb6d55e-bbde-4928-baa0-a9156b45bcef',
+            comments: 'Recurring health issue',
+          },
+          {
+            key: 'special_vehicle',
+            assessment_question_id: '16566785-a75f-4b8a-8da8-180ec4c615df',
+            comments: '',
+          },
+        ],
+      }
+      const mockExistingAssessment = [
+        {
+          key: 'self_harm',
+          comments: 'History of self harm',
+          assessment_question_id: '4e7e54b4-a40c-488f-bdff-c6b2268ca4eb',
+          category: 'risk',
+          nomis_alert_type: 'H',
+          nomis_alert_code: 'HA',
+          nomis_alert_type_description: 'Self Harm',
+          nomis_alert_description: 'ACCT Open (HMPS)',
+          imported_from_nomis: true,
+        },
+        {
+          key: 'violent',
+          assessment_question_id: 'af8cfc67-757c-4019-9d5e-618017de1617',
+          category: 'risk',
+          nomis_alert_type: 'X',
+          nomis_alert_code: 'XB',
+          nomis_alert_type_description: 'Security',
+          nomis_alert_description: 'Bully',
+          imported_from_nomis: true,
+        },
+        {
+          key: 'not_to_be_released',
+          assessment_question_id: 'a3534a54-d3a9-46c7-a1f0-de7e762ca95a',
+          category: 'risk',
+          nomis_alert_type: 'X',
+          nomis_alert_code: 'XNR',
+          nomis_alert_type_description: 'Security',
+          nomis_alert_description: 'Not For Release (NFR)',
+          imported_from_nomis: true,
+        },
+        {
+          key: 'health_issue',
+          assessment_question_id: 'cbb6d55e-bbde-4928-baa0-a9156b45bcef',
+          comments: 'Recurring health issue',
+          nomis_alert_type: 'M',
+          nomis_alert_code: 'MAS',
+          nomis_alert_type_description: 'Medical',
+          nomis_alert_description: 'Asthmatic',
+          imported_from_nomis: true,
+        },
+        {
+          key: 'special_vehicle',
+          assessment_question_id: '16566785-a75f-4b8a-8da8-180ec4c615df',
+          nomis_alert_type: 'M',
+          nomis_alert_code: 'MFL',
+          nomis_alert_type_description: 'Medical',
+          nomis_alert_description: 'False limbs',
+          imported_from_nomis: true,
+        },
+      ]
+
+      beforeEach(function() {
+        sinon.stub(BaseController.prototype, 'process')
+        req = {
+          form: {
+            values: {
+              assessment: mockCurrentAssessmentWithoutExplicit,
+              person: {
+                assessment_answers: [],
+              },
+            },
+          },
+          sessionModel: {
+            get: sinon.stub(),
+            set: sinon.stub(),
+          },
+        }
+      })
+
+      context('when from location is not Prison', function() {
+        beforeEach(function() {
+          controller.process(req, {}, {})
+        })
+
+        it('should save flattened assessment from form values', function() {
+          expect(req.sessionModel.set).to.be.calledOnceWithExactly(
+            'assessment',
+            [
+              {
+                key: 'other_court',
+                assessment_question_id: '80ca9b7f-a260-4406-a3af-17e190bdc714',
+                comments: 'Other court details',
+              },
+              {
+                key: 'escape',
+                assessment_question_id: '3174ebe6-0ab3-4f08-afa6-ff7b04cc215b',
+                comments: 'Likely to escape',
+              },
+              {
+                key: 'health_issue',
+                assessment_question_id: 'cbb6d55e-bbde-4928-baa0-a9156b45bcef',
+                comments: 'Recurring health issue',
+              },
+            ]
+          )
+        })
+
+        it('should call parent process method', function() {
+          expect(
+            BaseController.prototype.process
+          ).to.have.been.calledOnceWithExactly(req, {}, {})
+        })
+      })
+
+      context('when from location is Prison', function() {
+        beforeEach(function() {
+          req.form.values.from_location_type = 'prison'
+        })
+
+        context('without NOMIS imported assessment answers', function() {
+          context(
+            'with `not_to_be_released` and `special_vehicle`',
+            function() {
+              beforeEach(function() {
+                req.form.values.assessment = mockCurrentAssessmentWithExplicit
+                controller.process(req, {}, {})
+              })
+
+              it('should save assessment', function() {
+                expect(req.sessionModel.set).to.be.calledOnceWithExactly(
+                  'assessment',
+                  [
+                    {
+                      key: 'other_court',
+                      assessment_question_id:
+                        '80ca9b7f-a260-4406-a3af-17e190bdc714',
+                      comments: 'Other court details',
+                    },
+                    {
+                      key: 'escape',
+                      assessment_question_id:
+                        '3174ebe6-0ab3-4f08-afa6-ff7b04cc215b',
+                      comments: 'Likely to escape',
+                    },
+                    {
+                      key: 'not_to_be_released',
+                      assessment_question_id:
+                        'a3534a54-d3a9-46c7-a1f0-de7e762ca95a',
+                      comments: '',
+                    },
+                    {
+                      key: 'health_issue',
+                      assessment_question_id:
+                        'cbb6d55e-bbde-4928-baa0-a9156b45bcef',
+                      comments: 'Recurring health issue',
+                    },
+                    {
+                      key: 'special_vehicle',
+                      assessment_question_id:
+                        '16566785-a75f-4b8a-8da8-180ec4c615df',
+                      comments: '',
+                    },
+                  ]
+                )
+              })
+
+              it('should call parent process method', function() {
+                expect(
+                  BaseController.prototype.process
+                ).to.have.been.calledOnceWithExactly(req, {}, {})
+              })
+            }
+          )
+
+          context(
+            'without `not_to_be_released` and `special_vehicle`',
+            function() {
+              beforeEach(function() {
+                controller.process(req, {}, {})
+              })
+
+              it('should save assessment from form values', function() {
+                expect(req.sessionModel.set).to.be.calledOnceWithExactly(
+                  'assessment',
+                  [
+                    {
+                      key: 'other_court',
+                      assessment_question_id:
+                        '80ca9b7f-a260-4406-a3af-17e190bdc714',
+                      comments: 'Other court details',
+                    },
+                    {
+                      key: 'escape',
+                      assessment_question_id:
+                        '3174ebe6-0ab3-4f08-afa6-ff7b04cc215b',
+                      comments: 'Likely to escape',
+                    },
+                    {
+                      key: 'health_issue',
+                      assessment_question_id:
+                        'cbb6d55e-bbde-4928-baa0-a9156b45bcef',
+                      comments: 'Recurring health issue',
+                    },
+                  ]
+                )
+              })
+
+              it('should call parent process method', function() {
+                expect(
+                  BaseController.prototype.process
+                ).to.have.been.calledOnceWithExactly(req, {}, {})
+              })
+            }
+          )
+        })
+
+        context('with NOMIS imported assessment answers', function() {
+          beforeEach(function() {
+            req.form.values.person.assessment_answers = mockExistingAssessment
+          })
+
+          context(
+            'with `not_to_be_released` and `special_vehicle`',
+            function() {
+              beforeEach(function() {
+                req.form.values.assessment = mockCurrentAssessmentWithExplicit
+                controller.process(req, {}, {})
+              })
+
+              it('should save assessment and retain NOMIS answers', function() {
+                expect(req.sessionModel.set).to.be.calledOnceWithExactly(
+                  'assessment',
+                  [
+                    ...mockExistingAssessment,
+                    {
+                      key: 'other_court',
+                      assessment_question_id:
+                        '80ca9b7f-a260-4406-a3af-17e190bdc714',
+                      comments: 'Other court details',
+                    },
+                    {
+                      key: 'escape',
+                      assessment_question_id:
+                        '3174ebe6-0ab3-4f08-afa6-ff7b04cc215b',
+                      comments: 'Likely to escape',
+                    },
+                    {
+                      key: 'not_to_be_released',
+                      assessment_question_id:
+                        'a3534a54-d3a9-46c7-a1f0-de7e762ca95a',
+                      comments: '',
+                    },
+                    {
+                      key: 'health_issue',
+                      assessment_question_id:
+                        'cbb6d55e-bbde-4928-baa0-a9156b45bcef',
+                      comments: 'Recurring health issue',
+                    },
+                    {
+                      key: 'special_vehicle',
+                      assessment_question_id:
+                        '16566785-a75f-4b8a-8da8-180ec4c615df',
+                      comments: '',
+                    },
+                  ]
+                )
+              })
+
+              it('should call parent process method', function() {
+                expect(
+                  BaseController.prototype.process
+                ).to.have.been.calledOnceWithExactly(req, {}, {})
+              })
+            }
+          )
+
+          context(
+            'without `not_to_be_released` and `special_vehicle`',
+            function() {
+              beforeEach(function() {
+                req.form.values.assessment = mockCurrentAssessmentWithoutExplicit
+                controller.process(req, {}, {})
+              })
+
+              it('should save assessment but exclude `not_to_be_released` and `special_vehicle` NOMIS answers', function() {
+                expect(req.sessionModel.set).to.be.calledOnceWithExactly(
+                  'assessment',
+                  [
+                    {
+                      key: 'self_harm',
+                      comments: 'History of self harm',
+                      assessment_question_id:
+                        '4e7e54b4-a40c-488f-bdff-c6b2268ca4eb',
+                      category: 'risk',
+                      nomis_alert_type: 'H',
+                      nomis_alert_code: 'HA',
+                      nomis_alert_type_description: 'Self Harm',
+                      nomis_alert_description: 'ACCT Open (HMPS)',
+                      imported_from_nomis: true,
+                    },
+                    {
+                      key: 'violent',
+                      assessment_question_id:
+                        'af8cfc67-757c-4019-9d5e-618017de1617',
+                      category: 'risk',
+                      nomis_alert_type: 'X',
+                      nomis_alert_code: 'XB',
+                      nomis_alert_type_description: 'Security',
+                      nomis_alert_description: 'Bully',
+                      imported_from_nomis: true,
+                    },
+                    {
+                      key: 'health_issue',
+                      assessment_question_id:
+                        'cbb6d55e-bbde-4928-baa0-a9156b45bcef',
+                      comments: 'Recurring health issue',
+                      nomis_alert_type: 'M',
+                      nomis_alert_code: 'MAS',
+                      nomis_alert_type_description: 'Medical',
+                      nomis_alert_description: 'Asthmatic',
+                      imported_from_nomis: true,
+                    },
+                    {
+                      key: 'other_court',
+                      assessment_question_id:
+                        '80ca9b7f-a260-4406-a3af-17e190bdc714',
+                      comments: 'Other court details',
+                    },
+                    {
+                      key: 'escape',
+                      assessment_question_id:
+                        '3174ebe6-0ab3-4f08-afa6-ff7b04cc215b',
+                      comments: 'Likely to escape',
+                    },
+                    {
+                      key: 'health_issue',
+                      assessment_question_id:
+                        'cbb6d55e-bbde-4928-baa0-a9156b45bcef',
+                      comments: 'Recurring health issue',
+                    },
+                  ]
+                )
+              })
+
+              it('should call parent process method', function() {
+                expect(
+                  BaseController.prototype.process
+                ).to.have.been.calledOnceWithExactly(req, {}, {})
+              })
+            }
+          )
         })
       })
     })

--- a/app/move/controllers/create/save.test.js
+++ b/app/move/controllers/create/save.test.js
@@ -1,4 +1,4 @@
-const { capitalize } = require('lodash')
+const { capitalize, flatten, values } = require('lodash')
 const proxyquire = require('proxyquire')
 const FormController = require('hmpo-form-wizard').Controller
 
@@ -45,6 +45,34 @@ const valuesMock = {
     first_names: 'Steve',
     last_name: 'Smith',
   },
+  assessment: {
+    court: [
+      {
+        assessment_question_id: '2222',
+        comments: '',
+      },
+    ],
+    risk: [
+      {
+        assessment_question_id: '1111',
+        comments: 'Good climber',
+      },
+    ],
+    health: [
+      {
+        assessment_question_id: '4444',
+        comments: 'Health issue',
+      },
+      {
+        assessment_question_id: '3333',
+        comments: '',
+      },
+      {
+        assessment_question_id: '5555',
+        comments: 'Needs bigger car',
+      },
+    ],
+  },
 }
 
 describe('Move controllers', function() {
@@ -82,11 +110,18 @@ describe('Move controllers', function() {
               first_names: 'Steve',
               last_name: 'Smith',
             },
+            assessment: valuesMock.assessment,
           })
         })
 
         it('should call person update', function() {
-          expect(personService.update).to.be.calledWith(valuesMock.person)
+          expect(personService.update).to.be.calledOnceWithExactly({
+            ...valuesMock.person,
+            assessment_answers: flatten(values(valuesMock.assessment)),
+          })
+          expect(
+            personService.update.args[0][0].assessment_answers.length
+          ).to.equal(5)
         })
 
         it('should set response to session model', function() {

--- a/app/move/index.js
+++ b/app/move/index.js
@@ -18,6 +18,7 @@ const createConfig = {
   ...wizardConfig,
   controller: create.Base,
   name: 'create-a-move',
+  templatePath: 'move/views/create/',
   journeyName: 'create-a-move',
   journeyPageTitle: 'actions::create_move',
 }

--- a/app/move/steps/create.js
+++ b/app/move/steps/create.js
@@ -12,7 +12,7 @@ const {
 const personSearchStep = {
   controller: PersonSearch,
   buttonText: 'actions::search',
-  template: 'move/views/create/person-search',
+  template: 'person-search',
   pageTitle: 'moves::steps.person_search.heading',
   next: [
     {
@@ -78,7 +78,7 @@ module.exports = {
   '/person-lookup-results': {
     hideBackLink: true,
     controller: PersonSearchResults,
-    template: 'move/views/create/person-search-results',
+    template: 'person-search-results',
     pageTitle: 'moves::steps.person_search_results.heading',
     next: [
       {
@@ -115,7 +115,7 @@ module.exports = {
   },
   '/move-details': {
     controller: MoveDetails,
-    template: 'move/views/create/move-details',
+    template: 'move-details',
     pageTitle: 'moves::steps.move_details.heading',
     next: [
       {

--- a/app/move/steps/create.js
+++ b/app/move/steps/create.js
@@ -26,8 +26,9 @@ const personSearchStep = {
 
 const riskStep = {
   controller: Assessment,
-  pageTitle: 'moves::steps.risk_information.heading',
   assessmentCategory: 'risk',
+  template: 'assessment',
+  pageTitle: 'moves::steps.risk_information.heading',
   next: [
     {
       field: 'from_location_type',
@@ -41,6 +42,7 @@ const riskStep = {
 const healthStep = {
   controller: Assessment,
   assessmentCategory: 'health',
+  template: 'assessment',
   pageTitle: 'moves::steps.health_information.heading',
   next: [
     {
@@ -148,8 +150,9 @@ module.exports = {
   },
   '/court-information': {
     controller: Assessment,
-    pageTitle: 'moves::steps.court_information.heading',
     assessmentCategory: 'court',
+    template: 'assessment',
+    pageTitle: 'moves::steps.court_information.heading',
     next: [
       {
         field: 'from_location_type',
@@ -173,6 +176,7 @@ module.exports = {
   },
   '/release-status': {
     ...riskStep,
+    showPreviousAssessment: true,
     pageTitle: 'moves::steps.release_status.heading',
     fields: ['not_to_be_released'],
   },
@@ -190,6 +194,7 @@ module.exports = {
   },
   '/special-vehicle': {
     ...healthStep,
+    showPreviousAssessment: true,
     pageTitle: 'moves::steps.special_vehicle.heading',
     fields: ['special_vehicle'],
   },

--- a/app/move/views/create/assessment.njk
+++ b/app/move/views/create/assessment.njk
@@ -1,0 +1,63 @@
+{% extends "form-wizard.njk" %}
+
+{% block fields %}
+  {% if previousAssessment %}
+    <h2 class="govuk-heading-m govuk-!-margin-bottom-2">
+      {{ t("moves::assessment.retrieved_from_nomis.heading") }}
+    </h2>
+
+    <p>
+      {{ t("moves::assessment.retrieved_from_nomis.description") }}
+    </p>
+
+    {% for title, answers in previousAssessment.answersByTitle %}
+      {% call appPanel({
+        classes: "govuk-!-margin-bottom-6",
+        attributes: {
+          id: title | kebabcase
+        },
+        tag: {
+          text: title,
+          classes: previousAssessment.tagClass
+        }
+      }) %}
+
+        {% set items = [] %}
+        {% for answer in answers %}
+          {% set answerHtml %}
+            {% if answer.nomis_alert_description %}
+              <h4 class="govuk-!-margin-top-0 govuk-!-margin-bottom-2">
+                {{ answer.nomis_alert_description }}
+              </h4>
+            {% endif %}
+
+            {{ answer.comments if answer.comments }}
+
+            {% if answer.created_at %}
+              <div class="govuk-!-margin-top-2 govuk-!-font-size-16">
+                Created on {{ answer.created_at | formatDateWithDay }}
+              </div>
+            {% endif %}
+          {% endset %}
+
+          {% set items = (items.push({ value: { html: answerHtml } }), items) %}
+        {% endfor %}
+
+        {{ appMetaList({
+          classes: "app-meta-list--divider",
+          items: items
+        }) }}
+      {% endcall %}
+    {% else %}
+      {{ appMessage({
+        classes: "app-message--muted govuk-!-margin-bottom-6",
+        allowDismiss: false,
+        content: {
+          html: t("moves::assessment.retrieved_from_nomis.empty")
+        }
+      }) }}
+    {% endfor %}
+  {% endif %}
+
+  {{ super() }}
+{% endblock %}

--- a/locales/en/moves.json
+++ b/locales/en/moves.json
@@ -19,6 +19,11 @@
         "heading": "Uploaded documents",
         "empty": "No uploaded documents"
       }
+    },
+    "retrieved_from_nomis": {
+      "heading": "This information is currently in NOMIS",
+      "description": "If you notice something missing, update NOMIS and it will also update here.",
+      "empty": "There are currently no active alerts. If you don’t think this is correct, update NOMIS."
     }
   },
   "steps": {


### PR DESCRIPTION
This change includes a way to replay answers that we have for a user in NOMIS around their release status and their need for a special vehicle.

It uses the same pattern for displaying the flags as on the profile page.

## What it looks like

![image](https://user-images.githubusercontent.com/3327997/76210898-f6e3d280-61fc-11ea-8ac5-5942a693a81e.png)

![image](https://user-images.githubusercontent.com/3327997/76210715-92287800-61fc-11ea-86a4-f9a5fad501b1.png)
