### PR TITLE
[NOJIRA] fix: Today date in pagination is to be current date, not the base date

### DIFF
--- a/app/moves/middleware.js
+++ b/app/moves/middleware.js
@@ -63,6 +63,7 @@ module.exports = {
   },
   setPagination: (req, res, next) => {
     const { locationId = '', period, status } = req.params
+    const today = format(new Date(), dateFormat)
     const baseDate = getDateFromParams(req)
     const interval = period === 'week' ? 7 : 1
 
@@ -73,7 +74,7 @@ module.exports = {
     const statusInUrl = status ? `/${status}` : ''
 
     res.locals.pagination = {
-      todayUrl: `${req.baseUrl}/${period}/${baseDate}${locationInUrl}${statusInUrl}`,
+      todayUrl: `${req.baseUrl}/${period}/${today}${locationInUrl}${statusInUrl}`,
       nextUrl: `${req.baseUrl}/${period}/${nextPeriod}${locationInUrl}${statusInUrl}`,
       prevUrl: `${req.baseUrl}/${period}/${previousPeriod}${locationInUrl}${statusInUrl}`,
     }

--- a/app/moves/middleware.test.js
+++ b/app/moves/middleware.test.js
@@ -482,7 +482,7 @@ describe('Moves middleware', function() {
     const mockDateRange = ['2019-10-10', '2019-10-10']
     let req, res, nextSpy
     beforeEach(function() {
-      this.clock = sinon.useFakeTimers(new Date(mockDateRange).getTime())
+      this.clock = sinon.useFakeTimers(new Date(mockDateRange[0]).getTime())
       nextSpy = sinon.spy()
     })
 


### PR DESCRIPTION
Fixed a logical error in pagination, related to today's date.

### Checklist

- [x] If adding new environment variables, they have been documented in the [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md)
- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
