### PR TITLE
[P4-1139] feat: Navigation for multiple types of moves

### DIFF
--- a/app/moves/controllers/index.js
+++ b/app/moves/controllers/index.js
@@ -1,9 +1,9 @@
 const download = require('./download')
 const list = require('./list')
-const listProposed = require('./list-proposed')
+const listByStatus = require('./list-by-status')
 
 module.exports = {
   download,
   list,
-  listProposed,
+  listByStatus,
 }

--- a/app/moves/controllers/list-by-status.js
+++ b/app/moves/controllers/list-by-status.js
@@ -2,7 +2,7 @@ const presenters = require('../../../common/presenters')
 
 module.exports = function list(req, res) {
   const { movesByRangeAndStatus = [] } = res.locals
-  const template = 'moves/views/list-proposed'
+  const template = 'moves/views/list-by-status'
   const locals = {
     pageTitle: 'moves::dashboard.single_moves',
     moves: movesByRangeAndStatus.map(

--- a/app/moves/index.js
+++ b/app/moves/index.js
@@ -3,13 +3,14 @@ const router = require('express').Router()
 
 // Local dependencies
 const { protectRoute } = require('../../common/middleware/permissions')
-const { download, list, listProposed } = require('./controllers')
+const { download, list, listByStatus } = require('./controllers')
 const {
   redirectBaseUrl,
   saveUrl,
   setDateRange,
   setPeriod,
   setFromLocation,
+  setMoveTypeNavigation,
   setPagination,
   setMovesByDateAndLocation,
   setMovesByDateRangeAndStatus,
@@ -44,12 +45,13 @@ router.get(
   list
 )
 router.get(
-  `/:period(week|day)/:date/:locationId(${uuidRegex})/:status(proposed)`,
+  `/:period(week|day)/:date/:locationId(${uuidRegex})/:status(proposed|requested,accepted,completed|rejected)`,
   protectRoute('moves:view:by_location'),
   protectRoute('moves:view:proposed'),
+  setMoveTypeNavigation,
   setMovesByDateRangeAndStatus,
   setPagination,
-  listProposed
+  listByStatus
 )
 router.get(
   '/:period(week|day)/:date/download.:extension(csv|json)',
@@ -63,7 +65,6 @@ router.get(
   setMovesByDateAndLocation,
   download
 )
-
 // Export
 module.exports = {
   router,

--- a/app/moves/middleware.js
+++ b/app/moves/middleware.js
@@ -157,7 +157,7 @@ const movesMiddleware = {
         {
           dateRange,
           status,
-          locationId,
+          fromLocationId: locationId,
         }
       )
 

--- a/app/moves/middleware.js
+++ b/app/moves/middleware.js
@@ -1,5 +1,5 @@
 const { format } = require('date-fns')
-const { find, get, chunk } = require('lodash')
+const { find, get, chunk, cloneDeep } = require('lodash')
 
 const {
   getDateRange,
@@ -7,6 +7,8 @@ const {
   getPeriod,
   dateFormat,
 } = require('../../common/helpers/date-utils')
+
+const presenters = require('../../common/presenters')
 
 const moveService = require('../../common/services/move')
 const { LOCATIONS_BATCH_SIZE } = require('../../config')
@@ -18,8 +20,21 @@ function makeMultipleRequests(service, dateRange, locationIdBatches) {
     )
   )
 }
-
-module.exports = {
+const moveTypeNavigationConfig = [
+  {
+    label: 'moves::dashboard.filter.proposed',
+    filter: 'proposed',
+  },
+  {
+    label: 'moves::dashboard.filter.approved',
+    filter: 'requested,accepted,completed',
+  },
+  {
+    label: 'moves::dashboard.filter.rejected',
+    filter: 'rejected',
+  },
+]
+const movesMiddleware = {
   redirectBaseUrl: (req, res) => {
     const today = format(new Date(), dateFormat)
     const currentLocation = get(req.session, 'currentLocation.id')
@@ -80,6 +95,33 @@ module.exports = {
     }
 
     next()
+  },
+  setMoveTypeNavigation: async (req, res, next) => {
+    const { dateRange } = res.locals
+    const { locationId, period, date } = req.params
+    try {
+      res.locals.moveTypeNavigation = await Promise.all(
+        cloneDeep(moveTypeNavigationConfig).map(moveType => {
+          return moveService
+            .getMovesCount({ dateRange, status: moveType.filter, locationId })
+            .then(count => {
+              const { label } = moveType
+              return {
+                label,
+                value: count,
+                active: moveType.filter === req.params.status,
+                href: `${req.baseUrl}/${period}/${date}${
+                  locationId ? '/' + locationId : ''
+                }/${moveType.filter}`,
+              }
+            })
+            .then(presenters.moveTypesToFilterComponent)
+        })
+      )
+      next()
+    } catch (error) {
+      next(error)
+    }
   },
   setMovesByDateAndLocation: async (req, res, next) => {
     const { dateRange, fromLocationId } = res.locals
@@ -159,3 +201,5 @@ module.exports = {
     }
   },
 }
+
+module.exports = movesMiddleware

--- a/app/moves/middleware.test.js
+++ b/app/moves/middleware.test.js
@@ -255,7 +255,7 @@ describe('Moves middleware', function() {
       await middleware.setMovesByDateRangeAndStatus(req, { locals }, () => {})
       expect(moveService.getMovesByDateRangeAndStatus).to.have.been.calledWith({
         dateRange: ['2019-01-01', '2019-01-07'],
-        locationId: '123',
+        fromLocationId: '123',
         status: 'proposed',
       })
       moveService.getMovesByDateRangeAndStatus.restore()

--- a/app/moves/middleware.test.js
+++ b/app/moves/middleware.test.js
@@ -571,6 +571,97 @@ describe('Moves middleware', function() {
     })
   })
 
+  describe('#setMoveTypeNavigation', function() {
+    let next
+    let req
+    let res
+    context('happy path', function() {
+      beforeEach(async function() {
+        sinon.stub(moveService, 'getMovesCount').resolves(4)
+        next = sinon.spy()
+        req = {
+          baseUrl: '/moves',
+          url: '/moves/week/2010-09-07/123/proposed',
+          params: {
+            locationId: '123',
+            date: '2010-09-07',
+            period: 'week',
+          },
+        }
+        res = {
+          locals: {
+            dateRange: ['2010-09-03', '2010-09-10'],
+          },
+        }
+        await middleware.setMoveTypeNavigation(req, res, next)
+      })
+      afterEach(function() {
+        moveService.getMovesCount.restore()
+      })
+      it('sets res.locals.moveTypeNavigation', function() {
+        expect(res.locals).to.deep.equal({
+          dateRange: ['2010-09-03', '2010-09-10'],
+          moveTypeNavigation: [
+            {
+              active: false,
+              href: '/moves/week/2010-09-07/123/proposed',
+              label: 'proposed',
+              value: 4,
+            },
+            {
+              active: false,
+              href: '/moves/week/2010-09-07/123/requested,accepted,completed',
+              label: 'approved',
+              value: 4,
+            },
+            {
+              active: false,
+              href: '/moves/week/2010-09-07/123/rejected',
+              label: 'rejected',
+              value: 4,
+            },
+          ],
+        })
+      })
+      it('calls next', function() {
+        expect(next).to.have.been.calledWithExactly()
+      })
+      it('returns predictable results', function() {
+        const locals1 = { ...res.locals }
+        middleware.setMoveTypeNavigation({}, res, next)
+        expect(res.locals).to.deep.equal(locals1)
+      })
+    })
+    context('unhappy path', function() {
+      it('calls next with error if needed', async function() {
+        sinon.stub(moveService, 'getMovesCount').rejects(new Error('Error!'))
+        next = sinon.spy()
+        await middleware.setMoveTypeNavigation(
+          {
+            baseUrl: '/moves',
+            url: '/moves/week/2010-09-07/123/proposed',
+            params: {
+              locationId: '123',
+              date: '2010-09-07',
+            },
+          },
+          {
+            locals: {
+              period: 'week',
+              dateRange: ['2010-09-03', '2010-09-10'],
+            },
+          },
+          next
+        )
+        expect(next).to.have.been.calledWith(
+          sinon.match({
+            message: 'Error!',
+          })
+        )
+        moveService.getMovesCount.restore()
+      })
+    })
+  })
   describe('#setMovesByDateAndLocation()', function() {
     let res, nextSpy
     const mockCurrentLocation = '5555'

--- a/app/moves/views/_layout.njk
+++ b/app/moves/views/_layout.njk
@@ -22,7 +22,7 @@
 
   {% block pageHeader %}
     <header class="govuk-grid-row">
-      <div class="govuk-grid-column-two-thirds">
+      <div class="{% block headerGridColumnClass %}govuk-grid-column-two-thirds{% endblock %}">
         <span class="govuk-caption-xl">{{ t(pageTitle) }}</span>
 
         {% block dateTitle %}

--- a/app/moves/views/list-by-status.njk
+++ b/app/moves/views/list-by-status.njk
@@ -1,5 +1,7 @@
 {% extends "./_layout.njk" %}
 
+{% block headerGridColumnClass %}govuk-grid-column-full{% endblock %}
+
 {% block headerActions %}
   {% if canAccess('move:create') %}
     {{ govukButton({
@@ -9,6 +11,9 @@
       classes: "govuk-!-margin-top-2 app-print--hide"
     }) }}
   {% endif %}
+  {{ appFilter({
+    items: moveTypeNavigation
+  }) }}
 {% endblock %}
 
 {% block pageContent %}
@@ -26,4 +31,3 @@
     }) }}
 {% endif %}
 {% endblock %}
-

--- a/common/assets/scss/components/_all.scss
+++ b/common/assets/scss/components/_all.scss
@@ -15,3 +15,4 @@
 @import "results/results";
 @import "multi-file-upload/multi-file-upload";
 @import "link/link";
+@import "filter/filter";

--- a/common/components/filter/_filter.scss
+++ b/common/components/filter/_filter.scss
@@ -1,0 +1,77 @@
+.app-filter {
+  margin: 0 0 govuk-spacing(3);
+}
+
+.app-filter__list {
+  list-style: none;
+  margin: 0;
+  padding-left: 0;
+  display: flex;
+  justify-content: space-between;
+  align-items: stretch;
+
+  flex-wrap:wrap;
+  flex-direction:row;
+
+  @include govuk-font($size: 19);
+  @include govuk-media-query($until: 370px) {
+    flex-direction:column;
+  }
+  @include govuk-media-query($media-type: print) {
+    display: none;
+  }
+}
+
+.app-filter__list-item {
+  border: 2px solid govuk-colour('blue');
+  flex: 1 1 0;
+  min-height: 70px;
+  display: flex;
+  @include govuk-media-query($until: 370px) {
+    min-height: 90px;
+  }
+}
+
+.app-filter__list-item--active {
+  background: govuk-colour('white');
+  border: 2px solid govuk-colour('black');
+}
+
+.app-filter__link {
+  width: 100%;
+  height: 100%;
+  // cannot remove text-decoration from parts of the link, so we remove it everywhere and re-add it when necessary
+  text-decoration: none;
+  background: govuk-colour('blue');
+  color: govuk-colour('white');
+  display: block;
+  flex-grow: 1;
+
+  &:link,
+  &:active,
+  &:visited {
+    color: govuk-colour('white');
+  }
+
+  &:hover {
+    color: govuk-colour('light-grey');
+  }
+
+  &:focus {
+    background-color: govuk-colour('yellow');
+    color: govuk-colour('black');
+    box-shadow: none;
+    outline: none;
+  }
+}
+.app-filter__content {
+  padding: govuk-spacing(4);
+  display: inline-block;
+}
+.app-filter__value {
+  display: block;
+  @include govuk-font($size: 36, $weight: bold, $line-height: 1.25);
+}
+.app-filter__label {
+  text-decoration: underline;
+}

--- a/common/components/filter/filter.yaml
+++ b/common/components/filter/filter.yaml
@@ -1,0 +1,62 @@
+params:
+  - name: items
+    type: object
+    required: true
+    description: Options for items.
+    params:
+      - name: items
+        type: array
+        required: true
+        description: Array of item objects.
+        params:
+          - name: active
+            type: boolean
+            required: true
+            description: true if the link matches the current url.
+          - name: href
+            type: string
+            required: true
+            description: the url the link points to.
+          - name: value
+            type: string
+            required: false
+            description: the content of the big text inside the link
+          - name: label
+            type: string
+            required: false
+            description: the content of the small text inside the link
+
+examples:
+  - name: default
+    data:
+      items:
+        - active: false
+          href: /moves/proposed
+          label: Moves proposed
+          value: 4
+        - active: true
+          href: /moves/requested
+          label: Moves requested
+          value: 4
+        - active: false
+          href: /moves/rejected
+          label: Moves rejected
+          value: 4
+  - name: withoutValue
+    data:
+      items:
+        - active: false
+          href: /moves/proposed
+          label: Moves proposed
+        - active: true
+          href: /moves/requested
+          label: Moves requested
+  - name: withoutLabel
+    data:
+      items:
+        - active: false
+          href: /moves/proposed
+          value: 1
+        - active: true
+          href: /moves/requested
+          value: 2

--- a/common/components/filter/macro.njk
+++ b/common/components/filter/macro.njk
@@ -1,0 +1,3 @@
+{% macro appFilter(params) %}
+  {%- include "./template.njk" -%}
+{% endmacro %}

--- a/common/components/filter/template.njk
+++ b/common/components/filter/template.njk
@@ -1,0 +1,23 @@
+<nav class="app-filter">
+  <ul class="app-filter__list">
+    {% for item in params.items %}
+      <li class="app-filter__list-item {{ 'app-filter__list-item--active' if item.active }}">
+        {% if not item.active %}
+        <a href="{{ item.href }}" class="app-filter__link">
+        {% endif %}
+          <span class="app-filter__content">
+          {% if item.value !== undefined %}
+            <span class="app-filter__value">{{ item.value }}</span>
+          {% endif %}
+          {% if item.label !== undefined %}
+            <span class="app-filter__label">{{ item.label }}</span>
+          {% endif %}
+          </span>
+        {% if not active %}
+        </a>
+        {% endif %}
+      </li>
+    {% endfor %}
+  </ul>
+</nav>
+

--- a/common/components/filter/template.test.js
+++ b/common/components/filter/template.test.js
@@ -1,0 +1,99 @@
+const {
+  renderComponentHtmlToCheerio,
+  getExamples,
+} = require('../../../test/unit/component-helpers')
+
+const examples = getExamples('filter')
+
+describe('Results component', function() {
+  context('by default', function() {
+    let component, items, $
+
+    beforeEach(function() {
+      $ = renderComponentHtmlToCheerio('filter', examples.default)
+
+      component = $('.app-filter')
+      items = component.find('.app-filter__list-item')
+    })
+
+    it('should render component', function() {
+      expect(component.get(0).name).to.equal('nav')
+    })
+
+    it('should render a list', function() {
+      expect(component.find('ul').length).to.equal(1)
+    })
+
+    it('should render correct number of items', function() {
+      expect(items.length).to.equal(3)
+    })
+
+    it('should render correct items', function() {
+      const item1 = $(items[0])
+      const item2 = $(items[1])
+      const item3 = $(items[2])
+
+      expect(item1.html()).to.contain('Moves proposed')
+      expect(item2.html()).to.contain('Moves requested')
+      expect(item3.html()).to.contain('Moves rejected')
+    })
+    it('has link on the non active items', function() {
+      const item1 = $(items[0]).find('a')
+      const item3 = $(items[2]).find('a')
+      expect(item1.length).to.equal(1)
+      expect(item3.length).to.equal(1)
+    })
+    it('has no link on the active item', function() {
+      const item2 = $(items[1]).find('a')
+      expect(item2.length).to.equal(0)
+    })
+    it('renders the value span', function() {
+      const valueSpan = $(items[0]).find('.app-filter__value')
+      expect(valueSpan.length).to.equal(1)
+      expect(valueSpan.html()).to.equal('4')
+    })
+    it('renders the label span', function() {
+      const valueSpan = $(items[0]).find('.app-filter__label')
+      expect(valueSpan.length).to.equal(1)
+      expect(valueSpan.html()).to.equal('Moves proposed')
+    })
+  })
+  context('without value', function() {
+    let component, items, $
+
+    beforeEach(function() {
+      $ = renderComponentHtmlToCheerio('filter', examples.withoutValue)
+
+      component = $('.app-filter')
+      items = component.find('.app-filter__list-item')
+    })
+    it('does not render the value span', function() {
+      const valueSpan = $(items[0]).find('.app-filter__value')
+      expect(valueSpan.length).to.equal(0)
+    })
+    it('renders the label span', function() {
+      const valueSpan = $(items[0]).find('.app-filter__label')
+      expect(valueSpan.length).to.equal(1)
+      expect(valueSpan.html()).to.equal('Moves proposed')
+    })
+  })
+  context('without label', function() {
+    let component, items, $
+
+    beforeEach(function() {
+      $ = renderComponentHtmlToCheerio('filter', examples.withoutLabel)
+
+      component = $('.app-filter')
+      items = component.find('.app-filter__list-item')
+    })
+    it('renders the value span', function() {
+      const valueSpan = $(items[0]).find('.app-filter__value')
+      expect(valueSpan.length).to.equal(1)
+      expect(valueSpan.html()).to.equal('1')
+    })
+    it('does not render the label span', function() {
+      const valueSpan = $(items[0]).find('.app-filter__label')
+      expect(valueSpan.length).to.equal(0)
+    })
+  })
+})

--- a/common/presenters/index.js
+++ b/common/presenters/index.js
@@ -9,6 +9,7 @@ const personToSummaryListComponent = require('./person-to-summary-list-component
 const documentsToMetaListComponent = require('./documents-to-meta-list-component')
 const movesByToLocation = require('./moves-by-to-location')
 const movesToCSV = require('./moves-to-csv')
+const moveTypesToFilterComponent = require('./move-type-for-filter')
 
 module.exports = {
   assessmentAnswerToTag,
@@ -22,4 +23,5 @@ module.exports = {
   documentsToMetaListComponent,
   movesByToLocation,
   movesToCSV,
+  moveTypesToFilterComponent,
 }

--- a/common/presenters/move-type-for-filter.js
+++ b/common/presenters/move-type-for-filter.js
@@ -1,0 +1,9 @@
+const i18n = require('../../config/i18n')
+const { cloneDeep } = require('lodash')
+
+function moveTypesToFilterComponent(item) {
+  const moveType = cloneDeep(item)
+  moveType.label = i18n.t(item.label)
+  return moveType
+}
+module.exports = moveTypesToFilterComponent

--- a/common/services/move.js
+++ b/common/services/move.js
@@ -42,14 +42,18 @@ const moveService = {
       })
   },
 
-  getMovesByDateRangeAndStatus({ dateRange = [], status, locationId } = {}) {
+  getMovesByDateRangeAndStatus({
+    dateRange = [],
+    status,
+    fromLocationId,
+  } = {}) {
     const [createdAtFrom, createdAtTo] = dateRange
     return moveService.getAll({
       filter: {
         'filter[status]': status,
         'filter[created_at_from]': createdAtFrom,
         'filter[created_at_to]': createdAtTo,
-        'filter[from_location_id]': locationId,
+        'filter[from_location_id]': fromLocationId,
       },
     })
   },

--- a/common/services/move.js
+++ b/common/services/move.js
@@ -42,20 +42,33 @@ const moveService = {
       })
   },
 
-  getMovesByDateRangeAndStatus({
-    dateRange = [],
-    status,
-    fromLocationId,
-  } = {}) {
+  getMovesByDateRangeAndStatus({ dateRange = [], status, locationId } = {}) {
     const [createdAtFrom, createdAtTo] = dateRange
     return moveService.getAll({
       filter: {
         'filter[status]': status,
         'filter[created_at_from]': createdAtFrom,
         'filter[created_at_to]': createdAtTo,
-        'filter[from_location_id]': fromLocationId,
+        'filter[from_location_id]': locationId,
       },
     })
+  },
+
+  getMovesCount({ dateRange = [], status, locationId } = {}) {
+    const [createdAtFrom, createdAtTo] = dateRange
+    const filter = {
+      'filter[status]': status,
+      'filter[created_at_from]': createdAtFrom,
+      'filter[created_at_to]': createdAtTo,
+      'filter[from_location_id]': locationId,
+    }
+    return apiClient
+      .findAll('move', {
+        ...filter,
+        page: 1,
+        per_page: 1,
+      })
+      .then(response => response.meta.pagination.total_objects)
   },
 
   getRequested({ dateRange = [], fromLocationId, toLocationId } = {}) {

--- a/common/services/move.test.js
+++ b/common/services/move.test.js
@@ -458,7 +458,7 @@ describe('Move Service', function() {
         moves = await moveService.getMovesByDateRangeAndStatus({
           dateRange: mockDateRange,
           status: mockStatus,
-          locationId: mockFromLocationId,
+          fromLocationId: mockFromLocationId,
         })
       })
       it('calls getAll', function() {

--- a/common/services/move.test.js
+++ b/common/services/move.test.js
@@ -458,7 +458,7 @@ describe('Move Service', function() {
         moves = await moveService.getMovesByDateRangeAndStatus({
           dateRange: mockDateRange,
           status: mockStatus,
-          fromLocationId: mockFromLocationId,
+          locationId: mockFromLocationId,
         })
       })
       it('calls getAll', function() {
@@ -491,6 +491,63 @@ describe('Move Service', function() {
       })
       it('returns moves', function() {
         expect(moves).to.deep.equal(['moves'])
+      })
+    })
+  })
+
+  describe('#getMovesCount', function() {
+    let count
+    const mockDateRange = ['2019-10-10', '2019-10-17']
+    const mockFromLocationId = 'b695d0f0-af8e-4b97-891e-92020d6820b9'
+    const mockStatus = 'proposed'
+
+    beforeEach(async function() {
+      sinon.stub(apiClient, 'findAll').resolves({
+        meta: {
+          pagination: {
+            total_objects: 10,
+          },
+        },
+      })
+    })
+    context('with arguments', async function() {
+      beforeEach(async function() {
+        count = await moveService.getMovesCount({
+          dateRange: mockDateRange,
+          status: mockStatus,
+          locationId: mockFromLocationId,
+        })
+      })
+      it('calls the api service', function() {
+        expect(apiClient.findAll).to.be.calledOnceWithExactly('move', {
+          page: 1,
+          per_page: 1,
+          'filter[status]': mockStatus,
+          'filter[created_at_from]': mockDateRange[0],
+          'filter[created_at_to]': mockDateRange[1],
+          'filter[from_location_id]': mockFromLocationId,
+        })
+      })
+      it('returns the count', function() {
+        expect(count).to.equal(10)
+      })
+    })
+    context('without arguments', function() {
+      beforeEach(async function() {
+        count = await moveService.getMovesCount()
+      })
+      it('calls getAll', function() {
+        expect(apiClient.findAll).to.be.calledOnceWithExactly('move', {
+          page: 1,
+          per_page: 1,
+          'filter[status]': undefined,
+          'filter[created_at_from]': undefined,
+          'filter[created_at_to]': undefined,
+          'filter[from_location_id]': undefined,
+        })
+      })
+      it('returns moves', function() {
+        expect(count).to.deep.equal(10)
       })
     })
   })

--- a/common/templates/layouts/base.njk
+++ b/common/templates/layouts/base.njk
@@ -31,6 +31,7 @@
 {% from "results/macro.njk"           import appResults %}
 {% from "multi-file-upload/macro.njk" import appMultiFileUpload %}
 {% from "link/macro.njk"              import appLink %}
+{% from "filter/macro.njk"            import appFilter %}
 
 {% block head %}
   <link rel="canonical" href="{{ CANONICAL_URL }}">

--- a/locales/en/moves.json
+++ b/locales/en/moves.json
@@ -127,7 +127,12 @@
     "move_to": "Move to",
     "no_results": "No moves scheduled",
     "single_moves": "Single moves",
-    "single_moves_no_results": "No moves proposed"
+    "single_moves_no_results": "No moves proposed",
+    "filter": {
+      "proposed": "proposed",
+      "approved": "approved",
+      "rejected": "rejected"
+    }
   },
   "detail": {
     "page_title": "Move details for {{name}}"


### PR DESCRIPTION
This pr contains the routes and the links for the various types of moves displayed in the dashboard in the OCA workflow. 


![image](https://user-images.githubusercontent.com/853989/76330983-67b2e980-62e6-11ea-9b21-ca686ac134b7.png)

Small viewport:
![image](https://user-images.githubusercontent.com/853989/76639771-a8a93900-6546-11ea-909f-747954c658c3.png)

Very small viewport:
![image](https://user-images.githubusercontent.com/853989/76639792-b363ce00-6546-11ea-9b4e-586601973357.png)



### Checklist

- [x] If adding new environment variables, they have been documented in the [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md)
- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
