### PR TITLE
fix: Update default template for create wizard

### DIFF
--- a/app/move/index.js
+++ b/app/move/index.js
@@ -19,6 +19,7 @@ const createConfig = {
   controller: create.Base,
   name: 'create-a-move',
   templatePath: 'move/views/create/',
+  template: '../../../form-wizard',
   journeyName: 'create-a-move',
   journeyPageTitle: 'actions::create_move',
 }


### PR DESCRIPTION
A change made in `a556d2b` updated the create form wizard config to use
a shared template path. However, this meant that the default
`form-wizard` template was no longer found in that folder.

This change updates the path to the default template for the create
wizard.