### PR TITLE
[P4-1149] feat: Primary navigation with link to the dashboard

### DIFF
--- a/app/moves/middleware.js
+++ b/app/moves/middleware.js
@@ -1,6 +1,8 @@
 const { format } = require('date-fns')
 const { find, get, chunk, cloneDeep } = require('lodash')
 
+const permissions = require('../../common/middleware/permissions')
+
 const {
   getDateRange,
   getDateFromParams,
@@ -40,7 +42,16 @@ const movesMiddleware = {
     const currentLocation = get(req.session, 'currentLocation.id')
 
     if (currentLocation) {
-      return res.redirect(`${req.baseUrl}/day/${today}/${currentLocation}`)
+      const userPermissions = get(req.session, 'user.permissions')
+      const canViewProposedMoves = permissions.check(
+        'moves:view:proposed',
+        userPermissions
+      )
+      return res.redirect(
+        `${req.baseUrl}/day/${today}/${currentLocation}/${
+          canViewProposedMoves ? 'proposed' : ''
+        }`
+      )
     }
 
     return res.redirect(`${req.baseUrl}/day/${today}`)

--- a/app/moves/middleware.test.js
+++ b/app/moves/middleware.test.js
@@ -35,37 +35,49 @@ describe('Moves middleware', function() {
     })
 
     context('with current location', function() {
-      context('when location type is police', function() {
+      context(
+        "when user hasn't got permission to see the proposed moves",
+        function() {
+          context('when there is a location', function() {
+            const mockLocation = {
+              id: 'c249ed09-0cd5-4f52-8aee-0506e2dc7579',
+            }
+
+            beforeEach(function() {
+              req.session = {
+                currentLocation: mockLocation,
+                user: {
+                  permissions: [],
+                },
+              }
+
+              middleware.redirectBaseUrl(req, res)
+            })
+
+            it('should redirect to moves by location', function() {
+              expect(res.redirect).to.have.been.calledOnceWithExactly(
+                `/moves/day/${mockMoveDate}/${mockLocation.id}/`
+              )
+            })
+          })
+        }
+      )
+      context('when user has permission to see the proposed moves', function() {
         const mockLocation = {
           id: 'c249ed09-0cd5-4f52-8aee-0506e2dc7579',
-          location_type: 'police',
         }
 
         beforeEach(function() {
-          req.session.currentLocation = mockLocation
+          req.session = {
+            currentLocation: mockLocation,
+            user: {
+              permissions: ['moves:view:proposed'],
+            },
+          }
 
           middleware.redirectBaseUrl(req, res)
         })
-
-        it('should redirect to moves by location', function() {
-          expect(res.redirect).to.have.been.calledOnceWithExactly(
-            `/moves/day/${mockMoveDate}/${mockLocation.id}`
-          )
-        })
-      })
-      context('when location type is prison', function() {
-        const mockLocation = {
-          id: 'c249ed09-0cd5-4f52-8aee-0506e2dc7579',
-          location_type: 'prison',
-        }
-
-        beforeEach(function() {
-          req.session.currentLocation = mockLocation
-
-          middleware.redirectBaseUrl(req, res)
-        })
-
-        it('should redirect to moves by location', function() {
+        it('should redirect to proposed moves by location if the user can see them', function() {
           expect(res.redirect).to.have.been.calledOnceWithExactly(
             `/moves/day/${mockMoveDate}/${mockLocation.id}/proposed`
           )
@@ -76,11 +88,31 @@ describe('Moves middleware', function() {
       beforeEach(function() {
         middleware.redirectBaseUrl(req, res)
       })
-
-      it('should redirect to moves without location', function() {
-        expect(res.redirect).to.have.been.calledOnceWithExactly(
-          `/moves/day/${mockMoveDate}`
-        )
+      context(
+        "when user hasn't got permission to see the proposed moves",
+        function() {
+          it('should redirect to moves without location', function() {
+            expect(res.redirect).to.have.been.calledOnceWithExactly(
+              `/moves/day/${mockMoveDate}`
+            )
+          })
+        }
+      )
+      context('when user has permission to see the proposed moves', function() {
+        beforeEach(function() {
+          req.session = {
+            user: {
+              permissions: ['move:proposed:view'],
+            },
+          }
+          res.redirect.resetHistory()
+          middleware.redirectBaseUrl(req, res)
+        })
+        it('should redirect to moves without location', function() {
+          expect(res.redirect).to.have.been.calledOnceWithExactly(
+            `/moves/day/${mockMoveDate}`
+          )
+        })
       })
     })
   })

--- a/app/moves/middleware.test.js
+++ b/app/moves/middleware.test.js
@@ -35,23 +35,43 @@ describe('Moves middleware', function() {
     })
 
     context('with current location', function() {
-      const mockLocationId = 'c249ed09-0cd5-4f52-8aee-0506e2dc7579'
-
-      beforeEach(function() {
-        req.session.currentLocation = {
-          id: mockLocationId,
+      context('when location type is police', function() {
+        const mockLocation = {
+          id: 'c249ed09-0cd5-4f52-8aee-0506e2dc7579',
+          location_type: 'police',
         }
 
-        middleware.redirectBaseUrl(req, res)
-      })
+        beforeEach(function() {
+          req.session.currentLocation = mockLocation
 
-      it('should redirect to moves by location', function() {
-        expect(res.redirect).to.have.been.calledOnceWithExactly(
-          `/moves/day/${mockMoveDate}/${mockLocationId}`
-        )
+          middleware.redirectBaseUrl(req, res)
+        })
+
+        it('should redirect to moves by location', function() {
+          expect(res.redirect).to.have.been.calledOnceWithExactly(
+            `/moves/day/${mockMoveDate}/${mockLocation.id}`
+          )
+        })
+      })
+      context('when location type is prison', function() {
+        const mockLocation = {
+          id: 'c249ed09-0cd5-4f52-8aee-0506e2dc7579',
+          location_type: 'prison',
+        }
+
+        beforeEach(function() {
+          req.session.currentLocation = mockLocation
+
+          middleware.redirectBaseUrl(req, res)
+        })
+
+        it('should redirect to moves by location', function() {
+          expect(res.redirect).to.have.been.calledOnceWithExactly(
+            `/moves/day/${mockMoveDate}/${mockLocation.id}/proposed`
+          )
+        })
       })
     })
-
     context('without current location', function() {
       beforeEach(function() {
         middleware.redirectBaseUrl(req, res)

--- a/common/assets/scss/application.scss
+++ b/common/assets/scss/application.scss
@@ -22,7 +22,6 @@ $govuk-font-family: "Inter", system-ui, sans-serif;
 @import "govuk-frontend/govuk/components/input/input.scss";
 @import "govuk-frontend/govuk/components/inset-text/inset-text.scss";
 @import "govuk-frontend/govuk/components/panel/panel.scss";
-@import "govuk-frontend/govuk/components/phase-banner/phase-banner.scss";
 @import "govuk-frontend/govuk/components/radios/radios.scss";
 @import "govuk-frontend/govuk/components/select/select.scss";
 @import "govuk-frontend/govuk/components/skip-link/skip-link.scss";
@@ -30,12 +29,16 @@ $govuk-font-family: "Inter", system-ui, sans-serif;
 @import "govuk-frontend/govuk/components/textarea/textarea.scss";
 @import "govuk-frontend/govuk/components/warning-text/warning-text.scss";
 
+
 @import "govuk-frontend/govuk/utilities/all";
 @import "govuk-frontend/govuk/overrides/all";
 
 // Import MoJ Frontend Components
-@import "@ministryofjustice/frontend/moj/components/organisation-switcher/_organisation-switcher.scss";
-@import "@ministryofjustice/frontend/moj/components/badge/_badge.scss";
+@import "@ministryofjustice/frontend/moj/settings/all";
+@import "@ministryofjustice/frontend/moj/objects/all";
+@import "@ministryofjustice/frontend/moj/components/organisation-switcher/organisation-switcher";
+@import "@ministryofjustice/frontend/moj/components/primary-navigation/primary-navigation";
+@import "@ministryofjustice/frontend/moj/components/badge/badge";
 
 // Import app settings/tools/helpers
 @import "helpers/all";

--- a/common/assets/scss/application.scss
+++ b/common/assets/scss/application.scss
@@ -29,7 +29,6 @@ $govuk-font-family: "Inter", system-ui, sans-serif;
 @import "govuk-frontend/govuk/components/textarea/textarea.scss";
 @import "govuk-frontend/govuk/components/warning-text/warning-text.scss";
 
-
 @import "govuk-frontend/govuk/utilities/all";
 @import "govuk-frontend/govuk/overrides/all";
 

--- a/common/templates/layouts/base.njk
+++ b/common/templates/layouts/base.njk
@@ -6,6 +6,7 @@
 {% from "govuk/components/checkboxes/macro.njk"        import govukCheckboxes %}
 {% from "govuk/components/details/macro.njk"           import govukDetails %}
 {% from "govuk/components/error-summary/macro.njk"     import govukErrorSummary %}
+{% from "govuk/components/footer/macro.njk"            import govukFooter %}
 {% from "govuk/components/input/macro.njk"             import govukInput %}
 {% from "govuk/components/inset-text/macro.njk"        import govukInsetText %}
 {% from "govuk/components/panel/macro.njk"             import govukPanel %}
@@ -116,6 +117,19 @@
   {% endblock %}
 
   {% include "includes/messages.njk" %}
+{% endblock %}
+
+{% block footer %}
+    {{ govukFooter({
+      meta: {
+        items: [
+          {
+            href: FEEDBACK_URL,
+            text: t("feedback_link")
+          }
+        ] if FEEDBACK_URL
+      }
+    }) }}
 {% endblock %}
 
 {% block bodyEnd %}

--- a/common/templates/layouts/base.njk
+++ b/common/templates/layouts/base.njk
@@ -9,7 +9,6 @@
 {% from "govuk/components/input/macro.njk"             import govukInput %}
 {% from "govuk/components/inset-text/macro.njk"        import govukInsetText %}
 {% from "govuk/components/panel/macro.njk"             import govukPanel %}
-{% from "govuk/components/phase-banner/macro.njk"      import govukPhaseBanner %}
 {% from "govuk/components/radios/macro.njk"            import govukRadios %}
 {% from "govuk/components/select/macro.njk"            import govukSelect %}
 {% from "govuk/components/summary-list/macro.njk"      import govukSummaryList %}
@@ -17,6 +16,7 @@
 {% from "govuk/components/warning-text/macro.njk"      import govukWarningText %}
 
 {% from "moj/components/organisation-switcher/macro.njk" import mojOrganisationSwitcher %}
+{% from "moj/components/primary-navigation/macro.njk" import mojPrimaryNavigation %}
 
 {# App level components #}
 {% from "card/macro.njk"              import appCard %}
@@ -91,18 +91,17 @@
       }
     ]
   }) }}
+  {{ mojPrimaryNavigation({
+    label: 'Primary navigation',
+    items: [{
+      text: t("default::primary_navigation.single_moves") if CURRENT_LOCATION and CURRENT_LOCATION.location_type === 'prison' else t("default::primary_navigation.upcoming_moves"),
+      href: '/moves'
+    }]
+  }) }}
 {% endblock %}
 
 {% block beforeContent %}
-  {{ govukPhaseBanner({
-    tag: {
-      text: "Beta"
-    },
-    html: t("phase_banner", {
-      context: "with_feedback" if FEEDBACK_URL,
-      url: FEEDBACK_URL
-    })
-  }) }}
+
 
   {% block organisationSwitcher %}
     {% if CURRENT_LOCATION or canAccess("moves:view:all") %}

--- a/locales/en/default.json
+++ b/locales/en/default.json
@@ -1,4 +1,5 @@
 {
+  "feedback_link": "Give us feedback",
   "age": "Age",
   "age_with_date_of_birth": "{{date_of_birth}} (Age {{age}})",
   "primary_navigation": {

--- a/locales/en/default.json
+++ b/locales/en/default.json
@@ -1,6 +1,8 @@
 {
-  "phase_banner": "This is a new service",
-  "phase_banner_with_feedback": "This is a new service – your <a class=\"govuk-link\" href=\"{{url}}\">feedback</a> will help us to improve it.",
   "age": "Age",
-  "age_with_date_of_birth": "{{date_of_birth}} (Age {{age}})"
+  "age_with_date_of_birth": "{{date_of_birth}} (Age {{age}})",
+  "primary_navigation": {
+    "upcoming_moves": "Upcoming moves",
+    "single_moves": "Single moves"
+  }
 }


### PR DESCRIPTION
This pr removes the beta banner and adds a primary navigation in every page.

N.B. This change affects the whole site! Do not merge unless approved on every level :-)

<img width="1078" alt="Screenshot 2020-03-25 at 12 07 15" src="https://user-images.githubusercontent.com/853989/77537515-2437ae00-6e96-11ea-82de-bfa38f1ba092.png">



### Checklist

- [x] If adding new environment variables, they have been documented in the [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md)
- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
