### PR TITLE
Remove prison option for prison moves

### DIFF
--- a/app/move/fields/create.js
+++ b/app/move/fields/create.js
@@ -259,11 +259,12 @@ module.exports = {
         text: 'fields::move_type.items.court_appearance.label',
         conditional: 'to_location_court_appearance',
       },
-      {
-        value: 'prison',
-        text: 'fields::move_type.items.prison.label',
-        conditional: 'to_location_prison',
-      },
+      // TODO: Remove once we want to allow this journey
+      // {
+      //   value: 'prison',
+      //   text: 'fields::move_type.items.prison.label',
+      //   conditional: 'to_location_prison',
+      // },
     ],
   },
   move_type__police: {

--- a/app/move/fields/create.js
+++ b/app/move/fields/create.js
@@ -10,6 +10,18 @@ const personSearchFilter = {
   autocomplete: 'off',
 }
 
+const moveType = {
+  validate: 'required',
+  component: 'govukRadios',
+  name: 'move_type',
+  fieldset: {
+    legend: {
+      text: 'fields::move_type.label',
+      classes: 'govuk-fieldset__legend--m',
+    },
+  },
+}
+
 const assessmentQuestionComments = {
   skip: true,
   rows: 3,
@@ -237,18 +249,25 @@ module.exports = {
     items: [],
   },
   // move details
-  from_location: {},
   to_location: {},
   move_type: {
-    validate: 'required',
-    component: 'govukRadios',
-    name: 'move_type',
-    fieldset: {
-      legend: {
-        text: 'fields::move_type.label',
-        classes: 'govuk-fieldset__legend--m',
+    ...moveType,
+    items: [
+      {
+        id: 'move_type',
+        value: 'court_appearance',
+        text: 'fields::move_type.items.court_appearance.label',
+        conditional: 'to_location_court_appearance',
       },
-    },
+      {
+        value: 'prison',
+        text: 'fields::move_type.items.prison.label',
+        conditional: 'to_location_prison',
+      },
+    ],
+  },
+  move_type__police: {
+    ...moveType,
     items: [
       {
         id: 'move_type',
@@ -258,6 +277,8 @@ module.exports = {
       },
       {
         value: 'prison_recall',
+        text: 'fields::move_type.items.prison_recall.label',
+        conditional: 'additional_information',
       },
     ],
   },

--- a/app/move/steps/create.js
+++ b/app/move/steps/create.js
@@ -24,6 +24,25 @@ const personSearchStep = {
   ],
 }
 
+const moveDetailsStep = {
+  controller: MoveDetails,
+  template: 'move-details',
+  pageTitle: 'moves::steps.move_details.heading',
+  next: [
+    {
+      field: 'move_type',
+      value: 'court_appearance',
+      next: 'court-information',
+    },
+    {
+      field: 'from_location_type',
+      value: 'prison',
+      next: 'release-status',
+    },
+    'risk-information',
+  ],
+}
+
 const riskStep = {
   controller: Assessment,
   assessmentCategory: 'risk',
@@ -88,6 +107,11 @@ module.exports = {
         value: true,
         next: 'personal-details',
       },
+      {
+        field: 'from_location_type',
+        value: 'police',
+        next: 'move-details-police',
+      },
       'move-details',
     ],
     fields: ['people'],
@@ -95,7 +119,14 @@ module.exports = {
   '/personal-details': {
     controller: PersonalDetails,
     pageTitle: 'moves::steps.personal_details.heading',
-    next: 'move-details',
+    next: [
+      {
+        field: 'from_location_type',
+        value: 'police',
+        next: 'move-details-police',
+      },
+      'move-details',
+    ],
     fields: [
       'police_national_computer',
       'last_name',
@@ -116,27 +147,23 @@ module.exports = {
     fields: ['prison_transfer_reason', 'prison_transfer_reason_comments'],
   },
   '/move-details': {
-    controller: MoveDetails,
-    template: 'move-details',
-    pageTitle: 'moves::steps.move_details.heading',
-    next: [
-      {
-        field: 'move_type',
-        value: 'court_appearance',
-        next: 'court-information',
-      },
-      {
-        field: 'from_location_type',
-        value: 'prison',
-        next: 'release-status',
-      },
-      'risk-information',
-    ],
+    ...moveDetailsStep,
     fields: [
-      'from_location',
       'to_location',
       'move_type',
       'to_location_prison',
+      'to_location_court_appearance',
+      'date',
+      'date_type',
+      'date_custom',
+    ],
+  },
+  '/move-details-police': {
+    ...moveDetailsStep,
+    fields: [
+      'to_location',
+      'move_type__police',
+      'to_location_prison_recall',
       'to_location_court_appearance',
       'additional_information',
       'date',

--- a/locales/en/fields.json
+++ b/locales/en/fields.json
@@ -50,9 +50,11 @@
     "label": "Move to",
     "short_label": "To",
     "items": {
+      "prison": {
+        "label": "Prison"
+      },
       "prison_recall": {
-        "label": "Prison",
-        "labelForPrisonRecall": "Prison recall"
+        "label": "Prison recall"
       },
       "court_appearance": {
         "label": "Court"
@@ -64,6 +66,9 @@
   },
   "to_location_court_appearance": {
     "label": "Name of court"
+  },
+  "to_location_prison": {
+    "label": "Name of prison"
   },
   "additional_information": {
     "label": "Additional information (optional)"
@@ -150,10 +155,6 @@
     "heading": "Only include documents that will help plan the move.",
     "label": "Upload a file (optional)",
     "hint": "You can upload Word, Excel, PDF and JPEG documents up to 50 megabytes"
-  },
-  "to_location_prison": {
-    "label": "Move to",
-    "hint": "Name of prison"
   },
   "prison_transfer_reason": {
     "label": "Move type"


### PR DESCRIPTION
This change moves how the different fields are set within the move
details step.

We were doing a lot of logic in the initial configure method of the
controller. This adjusts some of that and makes use of the middleware
hooks within the form wizard to reduce the complexity of the methods,
also making them easier to test.