### PR TITLE
fix: Unescape search term in person search results

### DIFF
--- a/locales/en/moves.json
+++ b/locales/en/moves.json
@@ -35,7 +35,7 @@
     },
     "person_search_results": {
       "heading": "Who is being moved?",
-      "secondary_heading": "{{- count}} {{type}} found for “{{searchTerm}}”",
+      "secondary_heading": "{{count}} {{type}} found for “{{-searchTerm}}”",
       "cant_find_person": "I can’t find the person I’m looking for",
       "or": "or",
       "move_someone_else": "move someone else",


### PR DESCRIPTION
The search term was being passed to the i18n library which would escape
the value. Some PNC reference numbers contains characters like `/` so
we need to make sure they're not escaped.