### PR TITLE
fix: Add back missing translation

### DIFF
--- a/locales/en/moves.json
+++ b/locales/en/moves.json
@@ -24,7 +24,8 @@
       "heading": "This information is currently in NOMIS",
       "details": {
         "summary": "This information is not correct"
-      }
+      },
+      "empty": "There are currently no active alerts. If you don’t think this is correct, update NOMIS."
     },
     "incorrect_nomis_information": {
       "lede": "You will need to",


### PR DESCRIPTION
As part of a previous update a translation key was removed.

This meant the content wasn't being displayed in the view anymore. This
change adds it back in.