### PR TITLE
Add support to define keys to show for previous assessment

### DIFF
--- a/app/move/controllers/create/assessment.js
+++ b/app/move/controllers/create/assessment.js
@@ -31,18 +31,14 @@ class AssessmentController extends CreateBaseController {
   }
 
   setPreviousAssessment(req, res, next) {
-    const {
-      assessmentCategory,
-      showPreviousAssessment,
-      fields,
-    } = req.form.options
+    const { assessmentCategory, previousAssessmentKeys = [] } = req.form.options
     const person = req.sessionModel.get('person') || {}
     const filteredAssessment = person.assessment_answers
       .filter(answer => answer.category === assessmentCategory)
-      .filter(answer => Object.keys(fields).includes(answer.key))
+      .filter(answer => previousAssessmentKeys.includes(answer.key))
       .filter(answer => answer.imported_from_nomis)
 
-    if (showPreviousAssessment) {
+    if (previousAssessmentKeys.length) {
       const previousAssessmentByCategory = presenters.assessmentByCategory(
         filteredAssessment
       )

--- a/app/move/controllers/create/assessment.test.js
+++ b/app/move/controllers/create/assessment.test.js
@@ -201,90 +201,64 @@ describe('Move controllers', function() {
         nextSpy = sinon.spy()
       })
 
-      context(
-        'when the step includes ability to show previous assessment',
-        function() {
+      context('when the step includes previous assessment keys', function() {
+        beforeEach(function() {
+          req.form.options.previousAssessmentKeys = ['violent', 'self_harm']
+        })
+
+        context('with answers in the list of keys', function() {
           beforeEach(function() {
-            req.form.options.showPreviousAssessment = true
-          })
-
-          context('with answers from a different category', function() {
-            beforeEach(function() {
-              req.sessionModel.get.withArgs('person').returns({
-                assessment_answers: [
-                  {
-                    category: 'risk',
-                    key: 'violent',
-                    imported_from_nomis: true,
-                  },
-                  {
-                    category: 'health',
-                    key: 'medication',
-                    imported_from_nomis: true,
-                  },
-                  {
-                    category: 'court',
-                    key: 'interpreter',
-                    imported_from_nomis: true,
-                  },
-                ],
-              })
-              controller.setPreviousAssessment(req, res, nextSpy)
-            })
-
-            it('should set previous assessment on local', function() {
-              expect(res.locals).to.contain.property('previousAssessment')
-              expect(res.locals.previousAssessment).to.deep.equal({
-                key: 'risk',
-                answers: ['stubbed'],
-              })
-            })
-
-            it('should call presenter with filtered assessment', function() {
-              expect(
-                presenters.assessmentByCategory
-              ).to.be.calledOnceWithExactly([
+            req.sessionModel.get.withArgs('person').returns({
+              assessment_answers: [
                 {
                   category: 'risk',
                   key: 'violent',
                   imported_from_nomis: true,
                 },
-              ])
+                {
+                  category: 'health',
+                  key: 'medication',
+                  imported_from_nomis: true,
+                },
+                {
+                  category: 'court',
+                  key: 'interpreter',
+                  imported_from_nomis: true,
+                },
+              ],
             })
+            controller.setPreviousAssessment(req, res, nextSpy)
+          })
 
-            it('should call next', function() {
-              expect(nextSpy).to.be.calledOnceWithExactly()
+          it('should set previous assessment on local', function() {
+            expect(res.locals).to.contain.property('previousAssessment')
+            expect(res.locals.previousAssessment).to.deep.equal({
+              key: 'risk',
+              answers: ['stubbed'],
             })
           })
 
-          context('with answers not in the fields list', function() {
-            beforeEach(function() {
-              req.sessionModel.get.withArgs('person').returns({
-                assessment_answers: [
-                  {
-                    category: 'risk',
-                    key: 'violent',
-                    imported_from_nomis: true,
-                  },
-                  {
-                    category: 'risk',
-                    key: 'self_harm',
-                    imported_from_nomis: true,
-                  },
-                  {
-                    category: 'risk',
-                    key: 'missing_key',
-                    imported_from_nomis: true,
-                  },
-                ],
-              })
-              controller.setPreviousAssessment(req, res, nextSpy)
-            })
+          it('should call presenter with filtered assessment', function() {
+            expect(presenters.assessmentByCategory).to.be.calledOnceWithExactly(
+              [
+                {
+                  category: 'risk',
+                  key: 'violent',
+                  imported_from_nomis: true,
+                },
+              ]
+            )
+          })
 
-            it('should call presenter with filtered assessment', function() {
-              expect(
-                presenters.assessmentByCategory
-              ).to.be.calledOnceWithExactly([
+          it('should call next', function() {
+            expect(nextSpy).to.be.calledOnceWithExactly()
+          })
+        })
+
+        context('with answers not in the list of keys', function() {
+          beforeEach(function() {
+            req.sessionModel.get.withArgs('person').returns({
+              assessment_answers: [
                 {
                   category: 'risk',
                   key: 'violent',
@@ -295,49 +269,72 @@ describe('Move controllers', function() {
                   key: 'self_harm',
                   imported_from_nomis: true,
                 },
-              ])
+                {
+                  category: 'risk',
+                  key: 'missing_key',
+                  imported_from_nomis: true,
+                },
+              ],
             })
+            controller.setPreviousAssessment(req, res, nextSpy)
           })
 
-          context('with non imported answers', function() {
-            beforeEach(function() {
-              req.sessionModel.get.withArgs('person').returns({
-                assessment_answers: [
-                  {
-                    category: 'risk',
-                    key: 'violent',
-                    imported_from_nomis: true,
-                  },
-                  {
-                    category: 'risk',
-                    key: 'self_harm',
-                  },
-                  {
-                    category: 'risk',
-                    key: 'escape',
-                  },
-                ],
-              })
-              controller.setPreviousAssessment(req, res, nextSpy)
-            })
-
-            it('should call presenter with filtered assessment', function() {
-              expect(
-                presenters.assessmentByCategory
-              ).to.be.calledOnceWithExactly([
+          it('should call presenter with filtered assessment', function() {
+            expect(presenters.assessmentByCategory).to.be.calledOnceWithExactly(
+              [
                 {
                   category: 'risk',
                   key: 'violent',
                   imported_from_nomis: true,
                 },
-              ])
-            })
+                {
+                  category: 'risk',
+                  key: 'self_harm',
+                  imported_from_nomis: true,
+                },
+              ]
+            )
           })
-        }
-      )
+        })
+
+        context('with non imported answers', function() {
+          beforeEach(function() {
+            req.sessionModel.get.withArgs('person').returns({
+              assessment_answers: [
+                {
+                  category: 'risk',
+                  key: 'violent',
+                  imported_from_nomis: true,
+                },
+                {
+                  category: 'risk',
+                  key: 'self_harm',
+                },
+                {
+                  category: 'risk',
+                  key: 'escape',
+                },
+              ],
+            })
+            controller.setPreviousAssessment(req, res, nextSpy)
+          })
+
+          it('should call presenter with filtered assessment', function() {
+            expect(presenters.assessmentByCategory).to.be.calledOnceWithExactly(
+              [
+                {
+                  category: 'risk',
+                  key: 'violent',
+                  imported_from_nomis: true,
+                },
+              ]
+            )
+          })
+        })
+      })
 
       context(
-        'when the step does not include ability to show previous assessment',
+        'when the step does not include previous assessment keys',
         function() {
           beforeEach(function() {
             req.sessionModel.get.withArgs('person').returns({

--- a/app/move/steps/create.js
+++ b/app/move/steps/create.js
@@ -203,7 +203,7 @@ module.exports = {
   },
   '/release-status': {
     ...riskStep,
-    showPreviousAssessment: true,
+    previousAssessmentKeys: ['not_to_be_released'],
     pageTitle: 'moves::steps.release_status.heading',
     fields: ['not_to_be_released'],
   },
@@ -221,7 +221,7 @@ module.exports = {
   },
   '/special-vehicle': {
     ...healthStep,
-    showPreviousAssessment: true,
+    previousAssessmentKeys: ['special_vehicle', 'pregnant'],
     pageTitle: 'moves::steps.special_vehicle.heading',
     fields: ['special_vehicle'],
   },


### PR DESCRIPTION
This change allows a step to define what assessment answer keys should
be played back to the user for that step.

Before it relied on showing only fields that were in the step, but in
one case we also wanted to include pregnancy in the list of answers
we show.

## Before

![image](https://user-images.githubusercontent.com/3327997/76975615-b423a800-692a-11ea-8415-270ed45bad9d.png)

## After

![image](https://user-images.githubusercontent.com/3327997/76975559-9fdfab00-692a-11ea-985b-a2b017220d1a.png)
