### PR TITLE
[P4 1082] fix: Prevent garbled message on failed attempt to upload file on STC/SCH move

### DIFF
--- a/common/lib/api-client/index.js
+++ b/common/lib/api-client/index.js
@@ -1,6 +1,6 @@
 const JsonApi = require('devour-client')
 
-const { API, IS_DEV } = require('../../../config')
+const { API, IS_DEV, FILE_UPLOADS } = require('../../../config')
 const { auth, errors, request, requestTimeout, post } = require('./middleware')
 const models = require('./models')
 
@@ -17,7 +17,7 @@ module.exports = function() {
   })
 
   instance.replaceMiddleware('errors', errors)
-  instance.replaceMiddleware('POST', post)
+  instance.replaceMiddleware('POST', post(FILE_UPLOADS.MAX_FILE_SIZE))
   instance.replaceMiddleware('axios-request', request(API.CACHE_EXPIRY))
   instance.insertMiddlewareBefore('axios-request', requestTimeout(API.TIMEOUT))
   instance.insertMiddlewareBefore('axios-request', auth)

--- a/common/lib/api-client/index.test.js
+++ b/common/lib/api-client/index.test.js
@@ -9,6 +9,9 @@ const mockConfig = {
     TIMEOUT: 1000,
     CACHE_EXPIRY: 5000,
   },
+  FILE_UPLOADS: {
+    MAX_FILE_SIZE: 2000,
+  },
 }
 const mockModels = {
   withoutOptions: {
@@ -89,7 +92,10 @@ describe('Back-end API client', function() {
         it('should replace post middleware', function() {
           expect(
             JsonApiStub.prototype.replaceMiddleware.secondCall
-          ).to.be.calledWithExactly('POST', postStub)
+          ).to.be.calledWithExactly(
+            'POST',
+            postStub(mockConfig.FILE_UPLOADS.MAX_FILE_SIZE)
+          )
         })
 
         it('should insert request cache', function() {

--- a/common/lib/api-client/middleware/post.js
+++ b/common/lib/api-client/middleware/post.js
@@ -1,26 +1,27 @@
 const FormData = require('form-data')
 const { find } = require('lodash')
-const { FILE_UPLOADS } = require('../../../../config')
 
-module.exports = {
-  name: 'POST',
-  req: payload => {
-    const { req, jsonApi } = payload
-    const originalMiddleware = find(jsonApi._originalMiddleware, {
-      name: 'POST',
-    })
+module.exports = function post(maxFileSize) {
+  return {
+    name: 'POST',
+    req: payload => {
+      const { req, jsonApi } = payload
+      const originalMiddleware = find(jsonApi._originalMiddleware, {
+        name: 'POST',
+      })
 
-    if (req.method === 'POST' && req.data instanceof FormData) {
-      payload.req.maxContentLength = FILE_UPLOADS.MAX_FILE_SIZE
-      payload.req.maxBodyLength = FILE_UPLOADS.MAX_FILE_SIZE
-      payload.req.headers = {
-        ...req.headers,
-        ...req.data.getHeaders(),
+      if (req.method === 'POST' && req.data instanceof FormData) {
+        payload.req.maxContentLength = maxFileSize
+        payload.req.maxBodyLength = maxFileSize
+        payload.req.headers = {
+          ...req.headers,
+          ...req.data.getHeaders(),
+        }
+
+        return payload
       }
 
-      return payload
-    }
-
-    return originalMiddleware.req(payload)
-  },
+      return originalMiddleware.req(payload)
+    },
+  }
 }

--- a/common/lib/api-client/middleware/post.js
+++ b/common/lib/api-client/middleware/post.js
@@ -1,5 +1,6 @@
 const FormData = require('form-data')
 const { find } = require('lodash')
+const { FILE_UPLOADS } = require('../../../../config')
 
 module.exports = {
   name: 'POST',
@@ -10,6 +11,8 @@ module.exports = {
     })
 
     if (req.method === 'POST' && req.data instanceof FormData) {
+      payload.req.maxContentLength = FILE_UPLOADS.MAX_FILE_SIZE
+      payload.req.maxBodyLength = FILE_UPLOADS.MAX_FILE_SIZE
       payload.req.headers = {
         ...req.headers,
         ...req.data.getHeaders(),

--- a/common/lib/api-client/middleware/post.test.js
+++ b/common/lib/api-client/middleware/post.test.js
@@ -1,7 +1,8 @@
 const FormData = require('form-data')
 
 const postMiddleware = require('./post')
-const { FILE_UPLOADS } = require('../../../../config')
+
+const MAX_FILE_SIZE = 2000
 
 const originalHeaders = {
   original: 'header',
@@ -40,7 +41,7 @@ describe('API Client', function() {
         context('when data is instance of FormData', function() {
           beforeEach(function() {
             payload.req.data = new FormData()
-            response = postMiddleware.req(payload)
+            response = postMiddleware(MAX_FILE_SIZE).req(payload)
           })
 
           it('should update headers', function() {
@@ -51,12 +52,8 @@ describe('API Client', function() {
           })
 
           it('should set correct max lengths for content and body', function() {
-            expect(response.req.maxContentLength).to.equal(
-              FILE_UPLOADS.MAX_FILE_SIZE
-            )
-            expect(response.req.maxBodyLength).to.equal(
-              FILE_UPLOADS.MAX_FILE_SIZE
-            )
+            expect(response.req.maxContentLength).to.equal(MAX_FILE_SIZE)
+            expect(response.req.maxBodyLength).to.equal(MAX_FILE_SIZE)
           })
 
           it('should return payload', function() {
@@ -70,7 +67,7 @@ describe('API Client', function() {
 
         context('when data is not instance of FormData', function() {
           beforeEach(function() {
-            response = postMiddleware.req(payload)
+            response = postMiddleware().req(payload)
           })
 
           it('should not update headers', function() {
@@ -89,7 +86,7 @@ describe('API Client', function() {
 
       context('when request is not POST', function() {
         beforeEach(function() {
-          response = postMiddleware.req(payload)
+          response = postMiddleware().req(payload)
         })
 
         it('should not update headers', function() {

--- a/common/lib/api-client/middleware/post.test.js
+++ b/common/lib/api-client/middleware/post.test.js
@@ -1,6 +1,7 @@
 const FormData = require('form-data')
 
 const postMiddleware = require('./post')
+const { FILE_UPLOADS } = require('../../../../config')
 
 const originalHeaders = {
   original: 'header',
@@ -47,6 +48,15 @@ describe('API Client', function() {
               ...payload.req.headers,
               ...payload.req.data.getHeaders(),
             })
+          })
+
+          it('should set correct max lengths for content and body', function() {
+            expect(response.req.maxContentLength).to.equal(
+              FILE_UPLOADS.MAX_FILE_SIZE
+            )
+            expect(response.req.maxBodyLength).to.equal(
+              FILE_UPLOADS.MAX_FILE_SIZE
+            )
           })
 
           it('should return payload', function() {

--- a/common/lib/multer.api-document.storage.js
+++ b/common/lib/multer.api-document.storage.js
@@ -1,4 +1,5 @@
 const concat = require('concat-stream')
+const MulterError = require('multer/lib/multer-error')
 
 const documentService = require('../services/document')
 
@@ -11,7 +12,12 @@ APIDocumentStorage.prototype = {
         documentService
           .create(file, data)
           .then(document => cb(null, document))
-          .catch(cb)
+          .catch(error => {
+            const code = 'API_DOCUMENT_STORAGE_FAILED'
+            const multerError = new MulterError(code)
+            multerError.message = multerError.message || error.message
+            cb(multerError)
+          })
       })
     )
   },

--- a/common/lib/multer.api-document.storage.test.js
+++ b/common/lib/multer.api-document.storage.test.js
@@ -45,6 +45,9 @@ describe('Multer Document Storage Engine', function() {
       it('should call callback with error', function(done) {
         function callback(error) {
           expect(error).to.equal(error)
+          expect(error.name).to.equal('MulterError')
+          expect(error.message).to.equal('Document error')
+          expect(error.code).to.equal('API_DOCUMENT_STORAGE_FAILED')
           done()
         }
 

--- a/locales/en/validation.json
+++ b/locales/en/validation.json
@@ -10,11 +10,12 @@
   "before": "must be in the past",
   "default": "is required",
   "generic": "something went wrong",
-  "LIMIT_FILE_SIZE": "must be smaller than 50 MB",
+  "LIMIT_FILE_SIZE": "must be smaller than 50MB",
   "LIMIT_PART_COUNT": "has too many parts",
   "LIMIT_FILE_COUNT": "has too mamy files",
   "LIMIT_FIELD_KEY": "must include a shorter field name",
   "LIMIT_FIELD_VALUE": "must include a shorter field value",
   "LIMIT_FIELD_COUNT": "includes too many fields",
-  "LIMIT_UNEXPECTED_FILE": "must include expected file types"
+  "LIMIT_UNEXPECTED_FILE": "must include expected file types",
+  "API_DOCUMENT_STORAGE_FAILED": "could not be uploaded – try again"
 }


### PR DESCRIPTION
Files that passed Multer's vaildation but failed to be successfully uploaded to the document store resulted in an error message like this:

![Screen Shot 2020-02-24 at 09 20 32](https://user-images.githubusercontent.com/4856/77186265-85443800-6aca-11ea-9c99-7d2d730a1d5a.png)

Post fix:

![Are_there_any_documents_to_upload__-_Create_a_move](https://user-images.githubusercontent.com/4856/77186748-4662b200-6acb-11ea-9e9b-1b41b75e4742.png)

### Checklist

- [x] If adding new environment variables, they have been documented in the [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md)
- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
