### PR TITLE
refactor: Allow images to be controlled by env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,7 @@ It will also start a new deployment specific [job on CircleCI](https://app.circl
 | E2E_SUPPLIER_USERNAME | Supplier user username used for acceptance testing | |
 | E2E_SUPPLIER_PASSWORD | Supplier user password used for acceptance testing | |
 | LOCATIONS_BATCH_SIZE | Maximum number of location IDs to send in one request when requesting moves for all locations | 40 |
+| FEATURE_FLAG_IMAGES | Whether to display images from the API. If set to false, it will always show the fallback image | false |
 
 ### Development specific
 

--- a/app/person/controllers.js
+++ b/app/person/controllers.js
@@ -4,8 +4,14 @@ const personService = require('../../common/services/person')
 const nunjucksGlobals = require('../../config/nunjucks/globals')
 
 module.exports = {
-  image: fallbackImage => {
+  image: (fallbackImage, showImages = false) => {
     return async (req, res) => {
+      const imagePath = nunjucksGlobals.getAssetPath(fallbackImage)
+
+      if (!showImages) {
+        return res.redirect(imagePath)
+      }
+
       try {
         const imageUrl = await personService.getImageUrl(req.params.personId)
         const response = await axios.get(imageUrl, {
@@ -17,7 +23,6 @@ module.exports = {
         })
         res.end(response.data, 'binary')
       } catch (error) {
-        const imagePath = nunjucksGlobals.getAssetPath(fallbackImage)
         res.redirect(imagePath)
       }
     }

--- a/app/person/controllers.test.js
+++ b/app/person/controllers.test.js
@@ -29,10 +29,31 @@ describe('Person app', function() {
       }
     })
 
-    context('when person service errors', function() {
+    context('when set to not show images', function() {
       beforeEach(async function() {
         personService.getImageUrl.rejects(new Error())
         await controllers.image(placeholderImage)(req, res)
+      })
+
+      it('should not call res.end', function() {
+        expect(res.end).not.to.be.called
+      })
+
+      it('should get placeholder image from manifest', function() {
+        expect(nunjucksGlobals.getAssetPath).to.be.calledOnceWithExactly(
+          placeholderImage
+        )
+      })
+
+      it('should redirect to placeholder images', function() {
+        expect(res.redirect).to.be.calledOnceWithExactly(manifestImagePath)
+      })
+    })
+
+    context('when person service errors', function() {
+      beforeEach(async function() {
+        personService.getImageUrl.rejects(new Error())
+        await controllers.image(placeholderImage, true)(req, res)
       })
 
       it('should not call res.end', function() {
@@ -60,7 +81,7 @@ describe('Person app', function() {
       context('when axios errors', function() {
         beforeEach(async function() {
           axios.get.rejects(new Error())
-          await controllers.image(placeholderImage)(req, res)
+          await controllers.image(placeholderImage, true)(req, res)
         })
 
         it('should not call res.end', function() {
@@ -90,7 +111,7 @@ describe('Person app', function() {
 
         beforeEach(async function() {
           axios.get.resolves(mockResponse)
-          await controllers.image(placeholderImage)(req, res)
+          await controllers.image(placeholderImage, true)(req, res)
         })
 
         it('should set headers', function() {

--- a/app/person/index.js
+++ b/app/person/index.js
@@ -2,11 +2,14 @@
 const router = require('express').Router()
 
 // Local dependencies
-const { PLACEHOLDER_IMAGES } = require('../../config')
+const { PLACEHOLDER_IMAGES, FEATURE_FLAGS } = require('../../config')
 const { image } = require('./controllers')
 
 // Define routes
-router.get('/:personId/image', image(PLACEHOLDER_IMAGES.PERSON))
+router.get(
+  '/:personId/image',
+  image(PLACEHOLDER_IMAGES.PERSON, FEATURE_FLAGS.IMAGES)
+)
 
 // Export
 module.exports = {

--- a/config/index.js
+++ b/config/index.js
@@ -121,4 +121,7 @@ module.exports = {
     },
   },
   LOCATIONS_BATCH_SIZE: process.env.LOCATIONS_BATCH_SIZE || 40,
+  FEATURE_FLAGS: {
+    IMAGES: process.env.FEATURE_FLAG_IMAGES,
+  },
 }


### PR DESCRIPTION
This change reworks how images are retrieved from NOMIS. It introduces
a new environment variable that will allow us to turn the image sync
to NOMIS on or off by an environment variable (`FEATURE_FLAG_IMAGES`).

Once we decide we always want these on again we can revert this commit.

### Checklist

- [x] If adding new environment variables, they have been documented in the [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md)
- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
