### PR TITLE
[P4-1112] Prison to Court end-to-end tests

### DIFF
--- a/common/presenters/person-to-card-component.js
+++ b/common/presenters/person-to-card-component.js
@@ -7,7 +7,7 @@ const assessmentToTagList = require('./assessment-to-tag-list')
 function personToCardComponent({ showMeta = true, showTags = true } = {}) {
   return function item({
     href,
-    gender = {},
+    gender,
     fullname = '',
     image_url: imageUrl,
     date_of_birth: dateOfBirth,
@@ -25,11 +25,11 @@ function personToCardComponent({ showMeta = true, showTags = true } = {}) {
       const metaItems = [
         {
           label: i18n.t('fields::date_of_birth.label'),
-          text: dateOfBirth ? dateOfBirthLabel : '',
+          text: dateOfBirth ? dateOfBirthLabel : undefined,
         },
         {
           label: i18n.t('fields::gender.label'),
-          text: gender.title,
+          text: gender ? gender.title : undefined,
         },
       ]
 

--- a/common/presenters/person-to-card-component.test.js
+++ b/common/presenters/person-to-card-component.test.js
@@ -148,21 +148,36 @@ describe('Presenters', function() {
         })
       })
 
-      context('when meta contains all falsey values', function() {
-        let transformedResponse
-
-        beforeEach(function() {
-          transformedResponse = personToCardComponent()({
-            last_name: 'Jones',
-            first_names: 'Steve',
+      context('when meta contains falsey values', function() {
+        it('should correctly remove false items', function() {
+          const transformedResponse = personToCardComponent()({
             date_of_birth: '',
-            gender: false,
-            ethnicity: undefined,
-            assessment_answers: [],
+            gender: '',
+            ethnicity: '',
           })
+
+          expect(transformedResponse).to.have.property('meta')
+          expect(transformedResponse.meta.items.length).to.equal(0)
         })
 
         it('should correctly remove false items', function() {
+          const transformedResponse = personToCardComponent()({
+            date_of_birth: null,
+            gender: null,
+            ethnicity: null,
+          })
+
+          expect(transformedResponse).to.have.property('meta')
+          expect(transformedResponse.meta.items.length).to.equal(0)
+        })
+
+        it('should correctly remove false items', function() {
+          const transformedResponse = personToCardComponent()({
+            date_of_birth: undefined,
+            gender: undefined,
+            ethnicity: undefined,
+          })
+
           expect(transformedResponse).to.have.property('meta')
           expect(transformedResponse.meta.items.length).to.equal(0)
         })

--- a/common/services/person.js
+++ b/common/services/person.js
@@ -1,4 +1,4 @@
-const { mapKeys, mapValues, uniqBy } = require('lodash')
+const { mapKeys, mapValues, uniqBy, omitBy, isNil } = require('lodash')
 
 const apiClient = require('../lib/api-client')()
 
@@ -46,10 +46,13 @@ const personService = {
       'identifier_type'
     )
 
-    return {
-      ...formatted,
-      identifiers,
-    }
+    return omitBy(
+      {
+        ...formatted,
+        identifiers,
+      },
+      isNil
+    )
   },
 
   create(data) {

--- a/common/services/person.test.js
+++ b/common/services/person.test.js
@@ -107,7 +107,7 @@ describe('Person Service', function() {
       })
     })
 
-    context('when relationship field is not a string', function() {
+    context('when relationship field is an object', function() {
       let formatted
 
       beforeEach(async function() {
@@ -345,6 +345,29 @@ describe('Person Service', function() {
 
         it('should not affect non relationship fields', function() {
           expect(formatted.first_names).to.equal('Foo')
+        })
+      })
+    })
+
+    context('with falsy values', function() {
+      let formatted
+
+      beforeEach(async function() {
+        formatted = await personService.format({
+          first_names: 'Foo',
+          last_name: '',
+          date_of_birth: undefined,
+          gender: null,
+          ethnicity: false,
+        })
+      })
+
+      it('should remove null and undefined', function() {
+        expect(formatted).to.deep.equal({
+          first_names: 'Foo',
+          last_name: '',
+          ethnicity: false,
+          identifiers: [],
         })
       })
     })

--- a/config/index.js
+++ b/config/index.js
@@ -135,6 +135,10 @@ module.exports = {
         username: process.env.E2E_STC_USERNAME,
         password: process.env.E2E_STC_PASSWORD,
       },
+      PRISON: {
+        username: process.env.E2E_PRISON_USERNAME,
+        password: process.env.E2E_PRISON_PASSWORD,
+      },
       SUPPLIER: {
         username: process.env.E2E_SUPPLIER_USERNAME,
         password: process.env.E2E_SUPPLIER_PASSWORD,

--- a/test/e2e/helpers.js
+++ b/test/e2e/helpers.js
@@ -91,25 +91,21 @@ export async function createPersonFixture() {
 /**
  * Select random option from autocomplete menu
  *
- * @param {string} labelText - label text for the option
+ * @param {Selector} selector - An autocomplete field
  * @param {string|number} [optionTextOrIndex] - option text or 0-based index or 'random'.
- * @returns {Selector}
+ * @returns {string} - selected value
  */
-export async function selectAutocompleteOption(labelText, optionTextOrIndex) {
-  const fieldSelector = Selector('.govuk-label').withText(labelText)
+export async function selectAutocompleteOption(selector, optionTextOrIndex) {
+  await t.click(selector)
 
-  await t.click(fieldSelector)
-
-  const optionCssSelector = '.autocomplete__menu .autocomplete__option'
-  const autocompleteMenuOptions = await fieldSelector
-    .sibling('div')
-    .find(optionCssSelector)
+  const optionsSelector = '.autocomplete__menu .autocomplete__option'
+  const autocompleteMenuOptions = await selector.parent().find(optionsSelector)
 
   return selectOption(
     autocompleteMenuOptions,
     optionTextOrIndex,
-    optionCssSelector
-  )
+    optionsSelector
+  ).then(getInnerText)
 }
 
 /**

--- a/test/e2e/helpers.js
+++ b/test/e2e/helpers.js
@@ -155,20 +155,26 @@ export async function selectFieldsetOption(
  * Fill in form details on page
  *
  * @param {FormDetails} details - text fields and select options objects with field IDs as properties
- * @returns {Promise<FormDetails>} - details used to fill the form
+ * @returns {Promise<textFields>} - details used to fill the form
  */
-export async function fillInForm(details = {}) {
-  const textFields = details.text || {}
+export async function fillInForm(fields = {}) {
+  const filledInFields = {}
 
-  for (const [id, value] of Object.entries(textFields)) {
+  for (const [id, value] of Object.entries(fields)) {
     const textInputSelector = `#${id}`
-    await t
-      .selectText(textInputSelector)
-      .pressKey('delete')
-      .typeText(textInputSelector, value)
+    const exists = await Selector(textInputSelector).exists
+
+    if (exists) {
+      await t
+        .selectText(textInputSelector)
+        .pressKey('delete')
+        .typeText(textInputSelector, value)
+
+      filledInFields[id] = value
+    }
   }
 
-  return details
+  return filledInFields
 }
 
 /**

--- a/test/e2e/move.new.police.test.js
+++ b/test/e2e/move.new.police.test.js
@@ -2,7 +2,7 @@ import { Selector } from 'testcafe'
 import faker from 'faker'
 
 import { newMove, movesByDay } from './_routes'
-import { policeUser, stcUser } from './roles'
+import { policeUser } from './roles'
 import {
   page,
   moveDetailPage,
@@ -193,62 +193,4 @@ test('Cancel move `Another reason`', async t => {
     heading: 'Move cancelled',
     content: 'Reason — Flat tyre on the van',
   })
-})
-
-fixture('New move from Secure Training Centre (STC)').beforeEach(async t => {
-  await t.useRole(stcUser).navigateTo(newMove)
-})
-
-test('Secure Training Centre to Court with new person', async t => {
-  // PNC lookup
-  await t
-    .expect(page.getCurrentUrl())
-    .contains('/move/new/person-lookup-pnc')
-    .click(createMovePage.steps.personLookup.nodes.noIdentifierLink)
-    .click(createMovePage.steps.personLookup.nodes.moveSomeoneNew)
-
-  // Personal details
-  const personalDetails = await createMovePage.fillInPersonalDetails({
-    pncNumber,
-  })
-  await page.submitForm()
-
-  // Move details
-  const moveDetails = await createMovePage.fillInMoveDetails('Court')
-  await page.submitForm()
-
-  // Court information
-  await createMovePage.fillInCourtInformation()
-  await page.submitForm()
-
-  // Risk information
-  await createMovePage.fillInRiskInformation()
-  await page.submitForm()
-
-  // Health information
-  await createMovePage.fillInHealthInformation()
-  await page.submitForm()
-
-  // Documents upload
-  const files = ['a-random-text-file.txt', 'boy-the-cat.jpg', 'leo-the-cat.png']
-  await createMovePage.fillInDocumentUploads(files)
-  await createMovePage.checkDocumentUploads(files)
-  await page.submitForm()
-
-  // Confirmation page
-  const fullname = `${personalDetails.text.last_name}, ${personalDetails.text.first_names}`.toUpperCase()
-
-  await createMovePage.checkConfirmationStep({
-    fullname,
-    location: moveDetails.to_location_court_appearance,
-  })
-  await t.click(Selector('a').withExactText(fullname))
-
-  // Move detail assertions
-  await moveDetailPage.checkHeader({ fullname })
-
-  // Personal details assertions
-  await moveDetailPage.checkPersonalDetails(personalDetails)
-
-  // TODO: Check files are present
 })

--- a/test/e2e/move.new.police.test.js
+++ b/test/e2e/move.new.police.test.js
@@ -1,5 +1,4 @@
 import { Selector } from 'testcafe'
-import faker from 'faker'
 
 import { newMove, movesByDay } from './_routes'
 import { policeUser } from './roles'
@@ -10,28 +9,30 @@ import {
   cancelMovePage,
   createMovePage,
 } from './pages'
-
-const pncNumber = faker.random.number().toString()
-let personalDetails
-let fullname
+import { generatePerson, createPersonFixture } from './helpers'
 
 fixture('New move from Police Custody').beforeEach(async t => {
   await t.useRole(policeUser).navigateTo(newMove)
 })
 
 test('Police to Court with unfound person', async t => {
+  const person = generatePerson()
+
   // PNC lookup
-  await createMovePage.fillInPncSearch(pncNumber)
+  await createMovePage.fillInPncSearch(person.police_national_computer)
   await page.submitForm()
 
   // PNC lookup results
-  await createMovePage.checkPersonLookupResults(0, pncNumber)
+  await createMovePage.checkPersonLookupResults(
+    0,
+    person.police_national_computer
+  )
   await t.click(createMovePage.steps.personLookupResults.nodes.moveSomeoneNew)
 
   // Personal details
   // TODO: Check pnc number is pre-filled
-  personalDetails = await createMovePage.fillInPersonalDetails({
-    pncNumber,
+  const personalDetails = await createMovePage.fillInPersonalDetails({
+    pncNumber: person.police_national_computer,
   })
   await page.submitForm()
 
@@ -52,29 +53,32 @@ test('Police to Court with unfound person', async t => {
   await page.submitForm()
 
   // Confirmation page
-  fullname = `${personalDetails.text.last_name}, ${personalDetails.text.first_names}`.toUpperCase()
-
   await createMovePage.checkConfirmationStep({
-    fullname,
+    fullname: personalDetails.fullname,
     location: moveDetails.to_location_court_appearance,
   })
-  await t.click(Selector('a').withExactText(fullname))
+  await t.click(Selector('a').withExactText(personalDetails.fullname))
 
   // Move detail assertions
-  await moveDetailPage.checkHeader({ fullname })
+  await moveDetailPage.checkHeader({ fullname: personalDetails.fullname })
 
   // Personal details assertions
   await moveDetailPage.checkPersonalDetails(personalDetails)
 })
 
 test('Police to Court with existing person', async t => {
+  const personalDetails = await createPersonFixture()
+
   // PNC lookup
-  await createMovePage.fillInPncSearch(pncNumber)
+  await createMovePage.fillInPncSearch(personalDetails.police_national_computer)
   await page.submitForm()
 
   // PNC lookup results
-  await createMovePage.checkPersonLookupResults(1, pncNumber)
-  await createMovePage.selectSearchResults(fullname)
+  await createMovePage.checkPersonLookupResults(
+    1,
+    personalDetails.police_national_computer
+  )
+  await createMovePage.selectSearchResults(personalDetails.fullname)
   await page.submitForm()
 
   // Move details
@@ -95,13 +99,13 @@ test('Police to Court with existing person', async t => {
 
   // Confirmation page
   await createMovePage.checkConfirmationStep({
-    fullname,
+    fullname: personalDetails.fullname,
     location: moveDetails.to_location_court_appearance,
   })
-  await t.click(Selector('a').withExactText(fullname))
+  await t.click(Selector('a').withExactText(personalDetails.fullname))
 
   // Move detail assertions
-  await moveDetailPage.checkHeader({ fullname })
+  await moveDetailPage.checkHeader({ fullname: personalDetails.fullname })
 
   // Personal details assertions
   await moveDetailPage.checkPersonalDetails(personalDetails)
@@ -116,9 +120,7 @@ test('Police to Prison (recall) with new person', async t => {
     .click(createMovePage.steps.personLookup.nodes.moveSomeoneNew)
 
   // Personal details
-  const personalDetails = await createMovePage.fillInPersonalDetails({
-    pncNumber,
-  })
+  const personalDetails = await createMovePage.fillInPersonalDetails()
   await page.submitForm()
 
   // Move details
@@ -134,16 +136,14 @@ test('Police to Prison (recall) with new person', async t => {
   await page.submitForm()
 
   // Confirmation page
-  const fullname = `${personalDetails.text.last_name}, ${personalDetails.text.first_names}`.toUpperCase()
-
   await createMovePage.checkConfirmationStep({
-    fullname,
+    fullname: personalDetails.fullname,
     location: 'Prison',
   })
-  await t.click(Selector('a').withExactText(fullname))
+  await t.click(Selector('a').withExactText(personalDetails.fullname))
 
   // Move detail assertions
-  await moveDetailPage.checkHeader({ fullname })
+  await moveDetailPage.checkHeader({ fullname: personalDetails.fullname })
 
   // Personal details assertions
   await moveDetailPage.checkPersonalDetails(personalDetails)

--- a/test/e2e/move.new.prison.test.js
+++ b/test/e2e/move.new.prison.test.js
@@ -1,0 +1,80 @@
+import { Selector } from 'testcafe'
+
+import { newMove } from './_routes'
+import { prisonUser } from './roles'
+import { page, moveDetailPage, createMovePage } from './pages'
+import { createPersonFixture } from './helpers'
+
+fixture('New move from Prison').beforeEach(async t => {
+  await t.useRole(prisonUser).navigateTo(newMove)
+})
+
+test('Prison to Court with unfound person', async t => {
+  const searchTerm = 'UNKNOWN_PRISONER'
+
+  // PNC lookup
+  await createMovePage.fillInPrisonNumberSearch(searchTerm)
+  await page.submitForm()
+
+  // PNC lookup results
+  await createMovePage.checkPersonLookupResults(0, searchTerm)
+
+  await t.expect(page.nodes.submitButton.exists).notOk()
+
+  await t
+    .expect(
+      createMovePage.steps.personLookupResults.nodes.searchAgainLink.exists
+    )
+    .ok()
+
+  await t.click(createMovePage.steps.personLookupResults.nodes.searchAgainLink)
+
+  await t
+    .expect(page.getCurrentUrl())
+    .contains('/move/new/person-lookup-prison-number')
+})
+
+test('Prison to Court with existing person', async t => {
+  const personalDetails = await createPersonFixture()
+
+  // PNC lookup
+  await createMovePage.fillInPrisonNumberSearch(personalDetails.prison_number)
+  await page.submitForm()
+
+  // PNC lookup results
+  await createMovePage.checkPersonLookupResults(
+    1,
+    personalDetails.prison_number
+  )
+  await createMovePage.selectSearchResults(personalDetails.fullname)
+  await page.submitForm()
+
+  // Move details
+  const moveDetails = await createMovePage.fillInMoveDetails('Court')
+  await page.submitForm()
+
+  // Court information
+  await createMovePage.fillInCourtInformation()
+  await page.submitForm()
+
+  // Risk information
+  await createMovePage.fillInReleaseStatus()
+  await page.submitForm()
+
+  // Health information
+  await createMovePage.fillInSpecialVehicle()
+  await page.submitForm()
+
+  // Confirmation page
+  await createMovePage.checkConfirmationStep({
+    fullname: personalDetails.fullname,
+    location: moveDetails.to_location_court_appearance,
+  })
+  await t.click(Selector('a').withExactText(personalDetails.fullname))
+
+  // Move detail assertions
+  await moveDetailPage.checkHeader(personalDetails)
+
+  // Personal details assertions
+  await moveDetailPage.checkPersonalDetails(personalDetails)
+})

--- a/test/e2e/move.new.stc.test.js
+++ b/test/e2e/move.new.stc.test.js
@@ -1,0 +1,61 @@
+import { Selector } from 'testcafe'
+
+import { newMove } from './_routes'
+import { stcUser } from './roles'
+import { page, moveDetailPage, createMovePage } from './pages'
+
+fixture('New move from Secure Training Centre (STC)').beforeEach(async t => {
+  await t.useRole(stcUser).navigateTo(newMove)
+})
+
+test('Secure Training Centre to Court with new person', async t => {
+  // PNC lookup
+  await t
+    .expect(page.getCurrentUrl())
+    .contains('/move/new/person-lookup-pnc')
+    .click(createMovePage.steps.personLookup.nodes.noIdentifierLink)
+    .click(createMovePage.steps.personLookup.nodes.moveSomeoneNew)
+
+  // Personal details
+  const personalDetails = await createMovePage.fillInPersonalDetails()
+  await page.submitForm()
+
+  // Move details
+  const moveDetails = await createMovePage.fillInMoveDetails('Court')
+  await page.submitForm()
+
+  // Court information
+  await createMovePage.fillInCourtInformation()
+  await page.submitForm()
+
+  // Risk information
+  await createMovePage.fillInRiskInformation()
+  await page.submitForm()
+
+  // Health information
+  await createMovePage.fillInHealthInformation()
+  await page.submitForm()
+
+  // Documents upload
+  const files = ['a-random-text-file.txt', 'boy-the-cat.jpg', 'leo-the-cat.png']
+  await createMovePage.fillInDocumentUploads(files)
+  await createMovePage.checkDocumentUploads(files)
+  await page.submitForm()
+
+  // Confirmation page
+  const fullname = `${personalDetails.text.last_name}, ${personalDetails.text.first_names}`.toUpperCase()
+
+  await createMovePage.checkConfirmationStep({
+    fullname,
+    location: moveDetails.to_location_court_appearance,
+  })
+  await t.click(Selector('a').withExactText(fullname))
+
+  // Move detail assertions
+  await moveDetailPage.checkHeader({ fullname })
+
+  // Personal details assertions
+  await moveDetailPage.checkPersonalDetails(personalDetails)
+
+  // TODO: Check files are present
+})

--- a/test/e2e/move.new.stc.test.js
+++ b/test/e2e/move.new.stc.test.js
@@ -43,16 +43,15 @@ test('Secure Training Centre to Court with new person', async t => {
   await page.submitForm()
 
   // Confirmation page
-  const fullname = `${personalDetails.text.last_name}, ${personalDetails.text.first_names}`.toUpperCase()
 
   await createMovePage.checkConfirmationStep({
-    fullname,
+    fullname: personalDetails.fullname,
     location: moveDetails.to_location_court_appearance,
   })
-  await t.click(Selector('a').withExactText(fullname))
+  await t.click(Selector('a').withExactText(personalDetails.fullname))
 
   // Move detail assertions
-  await moveDetailPage.checkHeader({ fullname })
+  await moveDetailPage.checkHeader({ fullname: personalDetails.fullname })
 
   // Personal details assertions
   await moveDetailPage.checkPersonalDetails(personalDetails)

--- a/test/e2e/pages/create-move.js
+++ b/test/e2e/pages/create-move.js
@@ -38,6 +38,18 @@ class CreateMovePage extends Page {
           searchAgainLink: Selector('a').withText('Search again'),
         },
       },
+      personalDetails: {
+        nodes: {
+          ethnicity: Selector('#ethnicity'),
+        },
+      },
+      moveDetails: {
+        nodes: {
+          to_location_court_appearance: Selector(
+            '#to_location_court_appearance'
+          ),
+        },
+      },
       documents: {
         nodes: {
           uploadList: Selector('.app-multi-file-upload__list'),
@@ -111,7 +123,9 @@ class CreateMovePage extends Page {
     return {
       ...textFields,
       fullname: `${person.last_name}, ${person.first_names}`.toUpperCase(),
-      ethnicity: await selectAutocompleteOption('Ethnicity').then(getInnerText),
+      ethnicity: await selectAutocompleteOption(
+        this.steps.personalDetails.nodes.ethnicity
+      ),
       gender: await selectFieldsetOption(
         'Gender',
         faker.random.arrayElement(['Male', 'Female'])
@@ -129,12 +143,26 @@ class CreateMovePage extends Page {
     await t.expect(this.getCurrentUrl()).contains('/move/new/move-details')
     await selectFieldsetOption('Move to', moveType)
 
+    let values = {}
+    switch (moveType) {
+      case 'Court':
+        values = {
+          to_location_court_appearance: await selectAutocompleteOption(
+            this.steps.moveDetails.nodes.to_location_court_appearance
+          ),
+        }
+        break
+      case 'Prison recall':
+        values = await fillInForm({
+          additional_information: faker.lorem.sentence(6),
+        })
+        break
+    }
+
     return {
-      to_location_court_appearance:
-        moveType === 'Court'
-          ? await selectAutocompleteOption('Name of court').then(getInnerText)
-          : moveType,
+      move_type: moveType,
       date_type: await selectFieldsetOption('Date', 'Today').then(getInnerText),
+      ...values,
     }
   }
 

--- a/test/e2e/pages/create-move.js
+++ b/test/e2e/pages/create-move.js
@@ -22,6 +22,7 @@ class CreateMovePage extends Page {
           pncNumberSearch: Selector(
             'input[name="filter.police_national_computer"]'
           ),
+          prisonNumberSearch: Selector('input[name="filter.prison_number"]'),
           noIdentifierLink: Selector('summary').withText(
             'I don’t have this number'
           ),
@@ -34,6 +35,7 @@ class CreateMovePage extends Page {
         nodes: {
           searchSummary: Selector('h2.govuk-heading-m'),
           moveSomeoneNew: Selector('a').withText('move someone else'),
+          searchAgainLink: Selector('a').withText('Search again'),
         },
       },
       documents: {
@@ -67,6 +69,21 @@ class CreateMovePage extends Page {
       .selectText(this.steps.personLookup.nodes.pncNumberSearch)
       .pressKey('delete')
       .typeText(this.steps.personLookup.nodes.pncNumberSearch, searchTerm)
+  }
+
+  /**
+   * Fill in prison number search
+   *
+   * @param {String} searchTerm - Search term to enter
+   * @returns {Promise<FormDetails>}
+   */
+  fillInPrisonNumberSearch(searchTerm) {
+    return t
+      .expect(this.getCurrentUrl())
+      .contains('/move/new/person-lookup-prison-number')
+      .selectText(this.steps.personLookup.nodes.prisonNumberSearch)
+      .pressKey('delete')
+      .typeText(this.steps.personLookup.nodes.prisonNumberSearch, searchTerm)
   }
 
   /**
@@ -142,6 +159,20 @@ class CreateMovePage extends Page {
   }
 
   /**
+   * Fill in release status
+   *
+   * @returns {Promise}
+   */
+  async fillInReleaseStatus() {
+    await t.expect(this.getCurrentUrl()).contains('/move/new/release-status')
+
+    return selectFieldsetOption(
+      'Is there a reason this person should not be released?',
+      'No'
+    )
+  }
+
+  /**
    * Fill in health information
    *
    * @returns {Promise}
@@ -150,6 +181,20 @@ class CreateMovePage extends Page {
     await t
       .expect(this.getCurrentUrl())
       .contains('/move/new/health-information')
+
+    return selectFieldsetOption(
+      'Does this person need to travel in a special vehicle?',
+      'No'
+    )
+  }
+
+  /**
+   * Fill in special vehicle
+   *
+   * @returns {Promise}
+   */
+  async fillInSpecialVehicle() {
+    await t.expect(this.getCurrentUrl()).contains('/move/new/special-vehicle')
 
     return selectFieldsetOption(
       'Does this person need to travel in a special vehicle?',

--- a/test/e2e/pages/move-detail.js
+++ b/test/e2e/pages/move-detail.js
@@ -1,6 +1,8 @@
+import { forEach } from 'lodash'
 import { Selector, t } from 'testcafe'
 
 import Page from './page'
+import filters from '../../../config/nunjucks/filters'
 
 class MoveDetailPage extends Page {
   constructor() {
@@ -37,26 +39,34 @@ class MoveDetailPage extends Page {
       .contains(content, 'Content contains text')
   }
 
-  checkPersonalDetails({ text, gender, ethnicity } = {}) {
-    return t
-      .expect(
-        this.getDlDefinitionByKey(
-          this.nodes.personalDetailsSummary,
-          'PNC number'
-        )
-      )
-      .eql(text.police_national_computer)
-      .expect(
-        this.getDlDefinitionByKey(this.nodes.personalDetailsSummary, 'Gender')
-      )
-      .eql(gender)
-      .expect(
-        this.getDlDefinitionByKey(
-          this.nodes.personalDetailsSummary,
-          'Ethnicity'
-        )
-      )
-      .eql(ethnicity)
+  async checkPersonalDetails({
+    police_national_computer: pncNumber,
+    prison_number: prisonNumber,
+    date_of_birth: dateOfBirth,
+    gender,
+    ethnicity,
+  } = {}) {
+    const labelMap = {
+      'PNC number': pncNumber,
+      'Prison number': prisonNumber,
+      'Date of birth': dateOfBirth
+        ? `${filters.formatDate(dateOfBirth)} (Age ${filters.calculateAge(
+            dateOfBirth
+          )})`
+        : undefined,
+      Gender: gender,
+      Ethnicity: ethnicity,
+    }
+
+    forEach(labelMap, async (value, key) => {
+      if (value) {
+        await t
+          .expect(
+            this.getDlDefinitionByKey(this.nodes.personalDetailsSummary, key)
+          )
+          .eql(value)
+      }
+    })
   }
 }
 

--- a/test/e2e/roles.js
+++ b/test/e2e/roles.js
@@ -26,3 +26,10 @@ export const stcUser = Role(home, async t => {
     .typeText('#password', E2E.ROLES.STC.password)
     .pressKey('enter')
 })
+
+export const prisonUser = Role(home, async t => {
+  await t
+    .typeText('#username', E2E.ROLES.PRISON.username)
+    .typeText('#password', E2E.ROLES.PRISON.password)
+    .pressKey('enter')
+})

--- a/test/e2e/smoke.test.js
+++ b/test/e2e/smoke.test.js
@@ -1,5 +1,5 @@
 import { movesByDay } from './_routes'
-import { policeUser, stcUser, supplierUser } from './roles'
+import { policeUser, stcUser, prisonUser, supplierUser } from './roles'
 import { page, movesDashboardPage } from './pages'
 
 const users = [
@@ -13,6 +13,12 @@ const users = [
     name: 'STC user',
     role: stcUser,
     username: 'End-to-End Test STC',
+    homeButton: movesDashboardPage.nodes.createMoveButton,
+  },
+  {
+    name: 'Prison user',
+    role: prisonUser,
+    username: 'End-to-End Test Prison',
     homeButton: movesDashboardPage.nodes.createMoveButton,
   },
   {


### PR DESCRIPTION
This change includes a further refactor of the end-to-end test suite to allow us to create fixtures more easily and re-use more of the code across different journeys.

It also fixes a few bugs that were spotted within existing libraries whilst running these new scenarios.

If it's easier these can be split out into a separate PR...