### PR TITLE
[P4-1154] Capture hearing time and court case

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ It will also start a new deployment specific [job on CircleCI](https://app.circl
 | E2E_SUPPLIER_PASSWORD | Supplier user password used for acceptance testing | |
 | LOCATIONS_BATCH_SIZE | Maximum number of location IDs to send in one request when requesting moves for all locations | 40 |
 | FEATURE_FLAG_IMAGES | Whether to display images from the API. If set to false, it will always show the fallback image | false |
+| FEATURE_FLAG_PRISON_COURT_HEARINGS | Whether to display the court hearings step from Prison locations | false |
 
 ### Development specific
 

--- a/app/move/controllers/confirmation.js
+++ b/app/move/controllers/confirmation.js
@@ -2,7 +2,7 @@ const { filter, get, map, reject } = require('lodash')
 
 function confirmation(req, res) {
   const {
-    hearings,
+    court_hearings: courtHearings,
     move_type: moveType,
     to_location: toLocation,
   } = res.locals.move
@@ -11,8 +11,14 @@ function confirmation(req, res) {
     suppliers && suppliers.length
       ? map(suppliers, 'name')
       : [req.t('supplier_fallback')]
-  const savedHearings = map(filter(hearings, 'saved_to_nomis'), 'case_number')
-  const unsavedHearings = map(reject(hearings, 'saved_to_nomis'), 'case_number')
+  const savedHearings = map(
+    filter(courtHearings, 'saved_to_nomis'),
+    'case_number'
+  )
+  const unsavedHearings = map(
+    reject(courtHearings, 'saved_to_nomis'),
+    'case_number'
+  )
 
   const locals = {
     supplierNames,

--- a/app/move/controllers/confirmation.test.js
+++ b/app/move/controllers/confirmation.test.js
@@ -165,7 +165,7 @@ describe('Move controllers', function() {
       beforeEach(function() {
         res.locals.move = {
           ...mockMove,
-          hearings: [
+          court_hearings: [
             {
               case_number: 'S72525',
               saved_to_nomis: true,

--- a/app/move/controllers/create/court-hearings.js
+++ b/app/move/controllers/create/court-hearings.js
@@ -81,6 +81,15 @@ class CourtHearingsController extends CreateBaseController {
       next(error)
     }
   }
+
+  // TODO: Remove once court hearings are fully released
+  canAccessCourtHearings(isEnabled) {
+    return req => {
+      return (
+        req.sessionModel.get('from_location_type') === 'prison' && isEnabled
+      )
+    }
+  }
 }
 
 module.exports = CourtHearingsController

--- a/app/move/controllers/create/court-hearings.js
+++ b/app/move/controllers/create/court-hearings.js
@@ -1,0 +1,86 @@
+const { find, pick } = require('lodash')
+const { formatISO, parseISO } = require('date-fns')
+
+const CreateBaseController = require('./base')
+const personService = require('../../../../common/services/person')
+const courtHearingService = require('../../../../common/services/court-hearing')
+const componentService = require('../../../../common/services/component')
+const presenters = require('../../../../common/presenters')
+
+class CourtHearingsController extends CreateBaseController {
+  middlewareSetup() {
+    super.middlewareSetup()
+    this.use(this.setCourtCaseItems)
+  }
+
+  async setCourtCaseItems(req, res, next) {
+    const person = req.sessionModel.get('person') || {}
+
+    if (!person.id) {
+      return next()
+    }
+
+    try {
+      const courtCases = await personService.getCourtCases(person.id)
+      const {
+        court_hearing__court_case: courtCaseField,
+      } = req.form.options.fields
+
+      courtCaseField.items = courtCases.map(courtCase => {
+        const card = presenters.courtCaseToCardComponent(courtCase)
+        return {
+          html: componentService.getComponent('appCard', card),
+          value: courtCase.nomis_case_id.toString(),
+        }
+      })
+
+      req.courtCases = courtCases
+
+      next()
+    } catch (error) {
+      // TODO: Handle different error cases better, ie invalid Prison number
+      next()
+    }
+  }
+
+  async saveValues(req, res, next) {
+    // TODO: Remove once we support creating hearings without a case
+    if (req.form.values.has_court_case === 'false') {
+      return next()
+    }
+
+    const moveDate = req.sessionModel.get('date')
+    const {
+      court_hearing__comments: comments,
+      court_hearing__court_case: courtCaseId,
+      court_hearing__start_time: startTime,
+    } = req.form.values
+    const courtCase = find(req.courtCases, {
+      id: courtCaseId,
+    })
+
+    try {
+      const whitelistedCaseAttributes = pick(courtCase, [
+        'nomis_case_id',
+        'nomis_case_status',
+        'case_number',
+        'case_type',
+        'case_start_date',
+      ])
+      const hearingDatetime = parseISO(`${moveDate}T${startTime}`)
+      const courtHearing = await courtHearingService.create({
+        ...whitelistedCaseAttributes,
+        comments,
+        start_time: formatISO(hearingDatetime),
+      })
+
+      req.form.values.court_hearings = [courtHearing]
+
+      super.saveValues(req, res, next)
+    } catch (error) {
+      next(error)
+    }
+  }
+}
+
+module.exports = CourtHearingsController

--- a/app/move/controllers/create/court-hearings.test.js
+++ b/app/move/controllers/create/court-hearings.test.js
@@ -286,4 +286,64 @@ describe('Move controllers', function() {
       })
     })
   })
+
+  describe('#canAccessCourtHearings()', function() {
+    let req
+
+    beforeEach(function() {
+      req = {
+        sessionModel: {
+          get: sinon.stub(),
+        },
+      }
+    })
+
+    context('when feature is enabled', function() {
+      const isEnabled = true
+
+      context('when from location type is prison', function() {
+        beforeEach(function() {
+          req.sessionModel.get.withArgs('from_location_type').returns('prison')
+        })
+
+        it('should return true', function() {
+          expect(controller.canAccessCourtHearings(isEnabled)(req)).to.be.true
+        })
+      })
+
+      context('when from location type is not a prison', function() {
+        beforeEach(function() {
+          req.sessionModel.get.withArgs('from_location_type').returns('police')
+        })
+
+        it('should return false', function() {
+          expect(controller.canAccessCourtHearings(isEnabled)(req)).to.be.false
+        })
+      })
+    })
+
+    context('when feature is not enabled', function() {
+      const isEnabled = false
+
+      context('when from location type is prison', function() {
+        beforeEach(function() {
+          req.sessionModel.get.withArgs('from_location_type').returns('prison')
+        })
+
+        it('should return false', function() {
+          expect(controller.canAccessCourtHearings(isEnabled)(req)).to.be.false
+        })
+      })
+
+      context('when from location type is not a prison', function() {
+        beforeEach(function() {
+          req.sessionModel.get.withArgs('from_location_type').returns('police')
+        })
+
+        it('should return false', function() {
+          expect(controller.canAccessCourtHearings(isEnabled)(req)).to.be.false
+        })
+      })
+    })
+  })
 })

--- a/app/move/controllers/create/court-hearings.test.js
+++ b/app/move/controllers/create/court-hearings.test.js
@@ -1,0 +1,289 @@
+const timezoneMock = require('timezone-mock')
+
+const CreateBaseController = require('./base')
+const Controller = require('./court-hearings')
+
+const presenters = require('../../../../common/presenters')
+const componentService = require('../../../../common/services/component')
+const personService = require('../../../../common/services/person')
+const courtHearingService = require('../../../../common/services/court-hearing')
+
+const controller = new Controller({ route: '/' })
+
+const mockPerson = {
+  id: 'b695d0f0-af8e-4b97-891e-92020d6820b9',
+  first_names: 'Steve Jones',
+  last_name: 'Bloggs',
+}
+const mockCourtCases = [
+  {
+    id: 'T20167984',
+    nomis_case_id: 'T20167984',
+    nomis_case_status: 'ACTIVE',
+    case_start_date: '2016-11-14',
+    case_type: 'Adult',
+    case_number: 'T20167984',
+    location: {
+      title: 'Snaresbrook Crown Court',
+    },
+  },
+  {
+    id: 'T20177984',
+    nomis_case_id: 'T20177984',
+    nomis_case_status: 'ACTIVE',
+    case_start_date: '2018-11-14',
+    case_type: 'Adult',
+    case_number: 'T20177984',
+    location: {
+      title: 'Luton Crown Court',
+    },
+  },
+]
+
+describe('Move controllers', function() {
+  describe('Hearing details controller', function() {
+    describe('#middlewareSetup()', function() {
+      beforeEach(function() {
+        sinon.stub(CreateBaseController.prototype, 'middlewareSetup')
+        sinon.stub(controller, 'use')
+        sinon.stub(controller, 'setCourtCaseItems')
+
+        controller.middlewareSetup()
+      })
+
+      it('should call parent method', function() {
+        expect(CreateBaseController.prototype.middlewareSetup).to.have.been
+          .calledOnce
+      })
+
+      it('should call setCourtCaseItems middleware', function() {
+        expect(controller.use.firstCall).to.have.been.calledWith(
+          controller.setCourtCaseItems
+        )
+      })
+
+      it('should call correct number of middleware', function() {
+        expect(controller.use.callCount).to.equal(1)
+      })
+    })
+
+    describe('#setCourtCaseItems()', function() {
+      let req, nextSpy
+
+      beforeEach(function() {
+        sinon.stub(personService, 'getCourtCases')
+        sinon.stub(componentService, 'getComponent').returnsArg(0)
+        sinon.stub(presenters, 'courtCaseToCardComponent').returnsArg(0)
+        req = {
+          form: {
+            options: {
+              fields: {
+                court_hearing__court_case: {
+                  items: [],
+                },
+              },
+            },
+          },
+          sessionModel: {
+            get: sinon.stub(),
+          },
+        }
+        nextSpy = sinon.spy()
+      })
+
+      context('without person ID', function() {
+        beforeEach(async function() {
+          await controller.setCourtCaseItems(req, {}, nextSpy)
+        })
+
+        it('should not person service', function() {
+          expect(personService.getCourtCases).not.to.be.called
+        })
+
+        it('should not set court case items', function() {
+          expect(
+            req.form.options.fields.court_hearing__court_case.items
+          ).to.deep.equal([])
+        })
+
+        it('should call next', function() {
+          expect(nextSpy).to.be.calledOnceWithExactly()
+        })
+      })
+
+      context('with person ID', function() {
+        beforeEach(function() {
+          req.sessionModel.get.withArgs('person').returns(mockPerson)
+        })
+
+        context('when getCourtCases rejects', function() {
+          const mockError = new Error('Mock error')
+
+          beforeEach(async function() {
+            personService.getCourtCases.rejects(mockError)
+            await controller.setCourtCaseItems(req, {}, nextSpy)
+          })
+
+          it('should not set court case items', function() {
+            expect(
+              req.form.options.fields.court_hearing__court_case.items
+            ).to.deep.equal([])
+          })
+
+          it('should call next without error', function() {
+            expect(nextSpy).to.be.calledOnceWithExactly()
+          })
+        })
+
+        context('when getCourtCases resolves', function() {
+          beforeEach(async function() {
+            personService.getCourtCases.resolves(mockCourtCases)
+            await controller.setCourtCaseItems(req, {}, nextSpy)
+          })
+
+          it('should set people items property', function() {
+            expect(
+              req.form.options.fields.court_hearing__court_case.items
+            ).to.deep.equal([
+              {
+                value: mockCourtCases[0].nomis_case_id,
+                html: 'appCard',
+              },
+              {
+                value: mockCourtCases[1].nomis_case_id,
+                html: 'appCard',
+              },
+            ])
+          })
+
+          it('should call presenter correct number of times', function() {
+            expect(presenters.courtCaseToCardComponent.callCount).to.equal(2)
+          })
+
+          it('should call presenter correctly', function() {
+            expect(
+              presenters.courtCaseToCardComponent.firstCall
+            ).to.be.calledWithExactly(mockCourtCases[0])
+            expect(
+              presenters.courtCaseToCardComponent.secondCall
+            ).to.be.calledWithExactly(mockCourtCases[1])
+          })
+
+          it('should call component service correct number of times', function() {
+            expect(componentService.getComponent.callCount).to.equal(2)
+          })
+
+          it('should call component service correctly', function() {
+            expect(
+              componentService.getComponent.firstCall
+            ).to.be.calledWithExactly('appCard', mockCourtCases[0])
+            expect(
+              componentService.getComponent.secondCall
+            ).to.be.calledWithExactly('appCard', mockCourtCases[1])
+          })
+
+          it('should call next', function() {
+            expect(nextSpy).to.be.calledOnceWithExactly()
+          })
+        })
+      })
+    })
+
+    describe('#saveValues()', function() {
+      let req, nextSpy
+      const mockDate = '2020-05-15'
+
+      beforeEach(function() {
+        timezoneMock.register('UTC')
+        sinon.stub(courtHearingService, 'create')
+        req = {
+          courtCases: mockCourtCases,
+          form: {
+            values: {
+              court_hearing__comments: 'Hearings comments',
+              court_hearing__court_case: mockCourtCases[0].id,
+              court_hearing__start_time: '10:00',
+            },
+          },
+          sessionModel: {
+            get: sinon
+              .stub()
+              .withArgs('date')
+              .returns(mockDate),
+          },
+        }
+        nextSpy = sinon.spy()
+      })
+
+      afterEach(function() {
+        timezoneMock.unregister()
+      })
+
+      context('when not associated with a court case', function() {
+        beforeEach(async function() {
+          req.form.values.has_court_case = 'false'
+          await controller.saveValues(req, {}, nextSpy)
+        })
+
+        it('should not set court hearings', function() {
+          expect(req.form.values).not.to.contain.property('court_hearings')
+        })
+
+        it('should call next without error', function() {
+          expect(nextSpy).to.be.calledOnceWithExactly()
+        })
+      })
+
+      context('when associated with a court case', function() {
+        context('when court hearing service rejects', function() {
+          const mockError = new Error('Mock error')
+
+          beforeEach(async function() {
+            courtHearingService.create.rejects(mockError)
+            await controller.saveValues(req, {}, nextSpy)
+          })
+
+          it('should not set court hearings', function() {
+            expect(req.form.values).not.to.contain.property('court_hearings')
+          })
+
+          it('should call next with error', function() {
+            expect(nextSpy).to.be.calledOnceWithExactly(mockError)
+          })
+        })
+
+        context('when court hearing service resolves', function() {
+          const mockResponse = {
+            id: 'ea7dfa93-b0d9-491f-8d18-0c5f32a08eeb',
+            type: 'court_hearings',
+          }
+
+          beforeEach(async function() {
+            courtHearingService.create.resolves(mockResponse)
+            await controller.saveValues(req, {}, nextSpy)
+          })
+
+          it('should send correct data to court hearings service', function() {
+            expect(courtHearingService.create).to.be.calledOnceWithExactly({
+              nomis_case_id: mockCourtCases[0].nomis_case_id,
+              nomis_case_status: mockCourtCases[0].nomis_case_status,
+              case_number: mockCourtCases[0].case_number,
+              case_type: mockCourtCases[0].case_type,
+              case_start_date: mockCourtCases[0].case_start_date,
+              comments: req.form.values.court_hearing__comments,
+              start_time: '2020-05-15T10:00:00Z',
+            })
+          })
+
+          it('should add court_hearings to form values', function() {
+            expect(req.form.values).to.contain.property('court_hearings')
+          })
+
+          it('should set court hearings service response to form values', function() {
+            expect(req.form.values.court_hearings).to.deep.equal([mockResponse])
+          })
+        })
+      })
+    })
+  })
+})

--- a/app/move/controllers/create/index.js
+++ b/app/move/controllers/create/index.js
@@ -1,25 +1,27 @@
 const Assessment = require('./assessment')
 const Base = require('./base')
+const CourtHearings = require('./court-hearings')
+const Document = require('./document')
 const MoveDate = require('./move-date')
 const MoveDetails = require('./move-details')
-const PersonalDetails = require('./personal-details')
-const Save = require('./save')
-const Person = require('./person')
-const PersonSearch = require('./person-search')
 const PersonSearchResults = require('./person-search-results')
-const Document = require('./document')
+const PersonSearch = require('./person-search')
+const Person = require('./person')
+const PersonalDetails = require('./personal-details')
 const PrisonTransferReason = require('./prison-transfer-reason')
+const Save = require('./save')
 
 module.exports = {
   Assessment,
   Base,
+  CourtHearings,
+  Document,
   MoveDate,
   MoveDetails,
-  PersonalDetails,
-  Save,
-  Person,
-  PersonSearch,
   PersonSearchResults,
-  Document,
+  PersonSearch,
+  Person,
+  PersonalDetails,
   PrisonTransferReason,
+  Save,
 }

--- a/app/move/controllers/view.js
+++ b/app/move/controllers/view.js
@@ -19,12 +19,16 @@ module.exports = function view(req, res) {
     personalDetailsSummary: presenters.personToSummaryListComponent(person),
     tagList: presenters.assessmentToTagList(person.assessment_answers),
     assessment: presenters.assessmentByCategory(person.assessment_answers),
-    courtHearings: sortBy(move.hearings, 'start_time').map(hearing => {
-      return {
-        ...hearing,
-        summaryList: presenters.courtHearingToSummaryListComponent(hearing),
+    courtHearings: sortBy(move.court_hearings, 'start_time').map(
+      courtHearing => {
+        return {
+          ...courtHearing,
+          summaryList: presenters.courtHearingToSummaryListComponent(
+            courtHearing
+          ),
+        }
       }
-    }),
+    ),
     courtSummary: presenters.assessmentToSummaryListComponent(
       person.assessment_answers,
       'court'

--- a/app/move/controllers/view.test.js
+++ b/app/move/controllers/view.test.js
@@ -8,7 +8,7 @@ const mockMove = {
     assessment_answers: [],
   },
   documents: [],
-  hearings: [
+  court_hearings: [
     {
       id: '1',
       start_time: '2020-10-20T13:00:00+00:00',
@@ -171,7 +171,7 @@ describe('Move controllers', function() {
 
       it('should call courtHearingToSummaryListComponent for each hearing', function() {
         expect(presenters.courtHearingToSummaryListComponent).to.be.callCount(
-          mockMove.hearings.length
+          mockMove.court_hearings.length
         )
       })
 

--- a/app/move/fields/create.js
+++ b/app/move/fields/create.js
@@ -1,6 +1,7 @@
 const { cloneDeep } = require('lodash')
 
-const { date } = require('../formatters')
+const { date, time: timeFormatter } = require('../formatters')
+const { time: timeValidator } = require('../validators')
 
 const personSearchFilter = {
   validate: 'required',
@@ -389,6 +390,90 @@ module.exports = {
     label: {
       text: 'fields::date_to.label',
       classes: 'govuk-label--s',
+    },
+  },
+  has_court_case: {
+    validate: 'required',
+    component: 'govukRadios',
+    name: 'has_court_case',
+    fieldset: {
+      legend: {
+        text: 'fields::has_court_case.label',
+        classes: 'govuk-visually-hidden govuk-fieldset__legend--m',
+      },
+    },
+    items: [
+      {
+        id: 'has_court_case',
+        value: 'true',
+        text: 'fields::has_court_case.items.yes.label',
+        conditional: [
+          'court_hearing__court_case',
+          'court_hearing__start_time',
+          'court_hearing__comments',
+        ],
+      },
+      {
+        value: 'false',
+        text: 'fields::has_court_case.items.no.label',
+      },
+    ],
+  },
+  court_hearing__start_time: {
+    id: 'court_hearing__start_time',
+    name: 'court_hearing__start_time',
+    validate: ['required', timeValidator],
+    formatter: [timeFormatter],
+    component: 'govukInput',
+    classes: 'govuk-input--width-10',
+    autocomplete: 'off',
+    skip: true,
+    label: {
+      html: 'fields::court_hearing__start_time.label',
+      classes: 'govuk-label--s',
+    },
+    hint: {
+      text: 'fields::court_hearing__start_time.hint',
+    },
+    dependent: {
+      field: 'has_court_case',
+      value: 'true',
+    },
+  },
+  court_hearing__court_case: {
+    name: 'court_hearing__court_case',
+    validate: 'required',
+    component: 'govukRadios',
+    items: [],
+    skip: true,
+    fieldset: {
+      legend: {
+        text: 'fields::court_hearing__court_case.label',
+        classes: 'govuk-fieldset__legend--s',
+      },
+    },
+    hint: {
+      text: 'fields::court_hearing__court_case.hint',
+    },
+    dependent: {
+      field: 'has_court_case',
+      value: 'true',
+    },
+  },
+  court_hearing__comments: {
+    id: 'court_hearing__comments',
+    name: 'court_hearing__comments',
+    skip: true,
+    rows: 3,
+    component: 'govukTextarea',
+    classes: 'govuk-input--width-20',
+    label: {
+      text: 'fields::court_hearing__comments.label',
+      classes: 'govuk-label--s',
+    },
+    dependent: {
+      field: 'has_court_case',
+      value: 'true',
     },
   },
   // risk information

--- a/app/move/steps/create.js
+++ b/app/move/steps/create.js
@@ -10,6 +10,7 @@ const {
   PrisonTransferReason,
   Save,
 } = require('../controllers/create')
+const { FEATURE_FLAGS } = require('../../../config')
 
 const personSearchStep = {
   controller: PersonSearch,
@@ -161,7 +162,18 @@ module.exports = {
       {
         field: 'move_type',
         value: 'court_appearance',
-        next: 'court-information',
+        next: [
+          {
+            // TODO: Remove function call once court hearings are fully released and replace with what is below
+            fn: CourtHearings.prototype.canAccessCourtHearings(
+              FEATURE_FLAGS.PRISON_COURT_HEARINGS
+            ),
+            // field: 'from_location_type',
+            // value: 'prison',
+            next: 'hearing-details',
+          },
+          'court-information',
+        ],
       },
       {
         field: 'from_location_type',

--- a/app/move/steps/create.js
+++ b/app/move/steps/create.js
@@ -1,13 +1,14 @@
 const {
-  PersonalDetails,
   Assessment,
+  CourtHearings,
+  Document,
   MoveDate,
   MoveDetails,
-  Save,
   PersonSearch,
   PersonSearchResults,
-  Document,
+  PersonalDetails,
   PrisonTransferReason,
+  Save,
 } = require('../controllers/create')
 
 const personSearchStep = {
@@ -232,6 +233,17 @@ module.exports = {
       'risk-information',
     ],
     fields: ['solicitor', 'interpreter', 'other_court'],
+  },
+  '/hearing-details': {
+    controller: CourtHearings,
+    pageTitle: 'moves::steps.hearing_details.heading',
+    next: ['release-status'],
+    fields: [
+      'has_court_case',
+      'court_hearing__start_time',
+      'court_hearing__court_case',
+      'court_hearing__comments',
+    ],
   },
   '/risk-information': {
     ...riskStep,

--- a/app/move/views/confirmation.njk
+++ b/app/move/views/confirmation.njk
@@ -60,6 +60,16 @@
         }) }}
       {% endif %}
 
+      {# TODO: Remove once we support creating hearings without a case #}
+      {% if move.from_location.location_type == 'prison' and move.to_location.location_type == 'court' and not move.court_hearings.length %}
+        {{ govukWarningText({
+          text: t("moves::confirmation.saved_to_nomis", {
+            context: "failed"
+          }),
+          iconFallbackText: "Warning"
+        }) }}
+      {% endif %}
+
       <p>
         <a href="{{ MOVES_URL }}">
           {{ t("actions::back_to_dashboard") }}

--- a/common/assets/scss/overrides/_all.scss
+++ b/common/assets/scss/overrides/_all.scss
@@ -1,4 +1,5 @@
 @import "buttons";
 @import "font-corrections";
+@import "govuk-frontend";
 @import "positioning";
 @import "visibility";

--- a/common/assets/scss/overrides/_govuk-frontend.scss
+++ b/common/assets/scss/overrides/_govuk-frontend.scss
@@ -1,0 +1,7 @@
+// required to allow the card component to be nested
+// and to use the full width of the container
+//
+// previous value - display: inline-block;
+.govuk-radios__label {
+  display: block;
+}

--- a/common/components/card/_card.scss
+++ b/common/components/card/_card.scss
@@ -44,6 +44,11 @@
 .app-card__title {
   @include govuk-font($size: 19, $weight: bold);
   margin: 0;
+
+  .govuk-checkboxes &,
+  .govuk-radios & {
+    margin-top: 8px;
+  }
 }
 
 .app-card__content {

--- a/common/lib/api-client/models.js
+++ b/common/lib/api-client/models.js
@@ -31,6 +31,10 @@ module.exports = {
         jsonApi: 'hasMany',
         type: 'documents',
       },
+      court_hearings: {
+        jsonApi: 'hasMany',
+        type: 'court_hearings',
+      },
     },
   },
   image: {
@@ -66,6 +70,22 @@ module.exports = {
       location: {
         jsonApi: 'hasOne',
         type: 'locations',
+      },
+    },
+  },
+  court_hearing: {
+    attributes: {
+      start_time: '',
+      case_number: '',
+      case_type: '',
+      case_start_date: '',
+      comments: '',
+      nomis_case_id: '',
+      nomis_hearing_id: '',
+      saved_to_nomis: '',
+      move: {
+        jsonApi: 'hasOne',
+        type: 'moves',
       },
     },
   },

--- a/common/lib/api-client/models.js
+++ b/common/lib/api-client/models.js
@@ -56,6 +56,19 @@ module.exports = {
       },
     },
   },
+  court_case: {
+    attributes: {
+      nomis_case_id: '',
+      nomis_case_status: '',
+      case_start_date: '',
+      case_type: '',
+      case_number: '',
+      location: {
+        jsonApi: 'hasOne',
+        type: 'locations',
+      },
+    },
+  },
   gender: {
     attributes: {
       key: '',

--- a/common/lib/api-client/models.test.js
+++ b/common/lib/api-client/models.test.js
@@ -46,6 +46,18 @@ const testCases = {
       args: '1',
     },
   ],
+  court_case: [
+    {
+      method: 'find',
+      httpMock: 'get',
+      mockPath: '/1',
+      args: '1',
+    },
+    {
+      method: 'findAll',
+      httpMock: 'get',
+    },
+  ],
   gender: [
     {
       method: 'findAll',

--- a/common/lib/api-client/models.test.js
+++ b/common/lib/api-client/models.test.js
@@ -58,6 +58,13 @@ const testCases = {
       httpMock: 'get',
     },
   ],
+  court_hearing: [
+    {
+      method: 'create',
+      httpMock: 'post',
+      args: {},
+    },
+  ],
   gender: [
     {
       method: 'findAll',

--- a/common/presenters/court-case-to-card-component.js
+++ b/common/presenters/court-case-to-card-component.js
@@ -1,0 +1,35 @@
+const { filter } = require('lodash')
+
+const i18n = require('../../config/i18n')
+const filters = require('../../config/nunjucks/filters')
+
+function courtCaseToCardComponent({
+  location = {},
+  case_start_date: startDate,
+  case_type: caseType,
+  case_number: caseNumber,
+}) {
+  const metaItems = [
+    {
+      label: i18n.t('moves::court_case.items.start_date.label'),
+      text: filters.formatDate(startDate),
+    },
+    {
+      label: i18n.t('moves::court_case.items.case_type.label'),
+      text: caseType,
+    },
+  ]
+  const title =
+    caseNumber + (location && location.title ? ` at ${location.title}` : '')
+
+  return {
+    meta: {
+      items: filter(metaItems, 'text'),
+    },
+    title: {
+      text: title,
+    },
+  }
+}
+
+module.exports = courtCaseToCardComponent

--- a/common/presenters/court-case-to-card-component.test.js
+++ b/common/presenters/court-case-to-card-component.test.js
@@ -1,0 +1,120 @@
+const courtCaseToCardComponent = require('./court-case-to-card-component')
+
+const i18n = require('../../config/i18n')
+const filters = require('../../config/nunjucks/filters')
+
+const mockCourtCase = {
+  nomis_case_id: 'T20167984',
+  nomis_case_status: 'ACTIVE',
+  case_start_date: '2016-11-14',
+  case_type: 'Adult',
+  case_number: 'T20167984',
+  location: {
+    title: 'Snaresbrook Crown Court',
+  },
+}
+
+describe('Presenters', function() {
+  describe('#courtCaseToCardComponent()', function() {
+    let transformedResponse
+
+    beforeEach(function() {
+      sinon.stub(i18n, 't').returnsArg(0)
+      sinon.stub(filters, 'formatDate').returnsArg(0)
+    })
+
+    context('with mock court case', function() {
+      beforeEach(function() {
+        transformedResponse = courtCaseToCardComponent(mockCourtCase)
+      })
+
+      describe('response', function() {
+        it('should contain a title', function() {
+          expect(transformedResponse).to.have.property('title')
+          expect(transformedResponse.title).to.deep.equal({
+            text: 'T20167984 at Snaresbrook Crown Court',
+          })
+        })
+
+        it('should format date', function() {
+          expect(filters.formatDate).to.be.calledOnceWithExactly(
+            mockCourtCase.case_start_date
+          )
+        })
+
+        it('should contain correct meta data', function() {
+          expect(transformedResponse).to.have.property('meta')
+          expect(transformedResponse.meta).to.deep.equal({
+            items: [
+              {
+                label: 'moves::court_case.items.start_date.label',
+                text: mockCourtCase.case_start_date,
+              },
+              {
+                label: 'moves::court_case.items.case_type.label',
+                text: mockCourtCase.case_type,
+              },
+            ],
+          })
+        })
+      })
+
+      describe('translations', function() {
+        it('should translate age label', function() {
+          expect(i18n.t.getCall(0)).to.be.calledWithExactly(
+            'moves::court_case.items.start_date.label'
+          )
+        })
+
+        it('should translate date of birth label', function() {
+          expect(i18n.t.getCall(1)).to.be.calledWithExactly(
+            'moves::court_case.items.case_type.label'
+          )
+        })
+      })
+    })
+
+    context('without location', function() {
+      beforeEach(function() {
+        const mockCourtCaseWithoutLocation = {
+          ...mockCourtCase,
+        }
+        delete mockCourtCaseWithoutLocation.location
+
+        transformedResponse = courtCaseToCardComponent(
+          mockCourtCaseWithoutLocation
+        )
+      })
+
+      describe('response', function() {
+        it('title should only contain case number', function() {
+          expect(transformedResponse).to.have.property('title')
+          expect(transformedResponse.title).to.deep.equal({
+            text: 'T20167984',
+          })
+        })
+      })
+    })
+
+    context('without null location', function() {
+      beforeEach(function() {
+        const mockCourtCaseWithoutLocation = {
+          ...mockCourtCase,
+          location: null,
+        }
+        transformedResponse = courtCaseToCardComponent(
+          mockCourtCaseWithoutLocation
+        )
+      })
+
+      describe('response', function() {
+        it('title should only contain case number', function() {
+          expect(transformedResponse).to.have.property('title')
+          expect(transformedResponse.title).to.deep.equal({
+            text: 'T20167984',
+          })
+        })
+      })
+    })
+  })
+})

--- a/common/presenters/index.js
+++ b/common/presenters/index.js
@@ -2,6 +2,7 @@ const assessmentAnswerToTag = require('./assessment-answer-to-tag')
 const assessmentToTagList = require('./assessment-to-tag-list')
 const assessmentToSummaryListComponent = require('./assessment-to-summary-list-component')
 const assessmentByCategory = require('./assessment-by-category')
+const courtCaseToCardComponent = require('./court-case-to-card-component')
 const courtHearingToSummaryListComponent = require('./court-hearing-to-summary-list-component')
 const moveToCardComponent = require('./move-to-card-component')
 const moveToMetaListComponent = require('./move-to-meta-list-component')
@@ -16,6 +17,7 @@ module.exports = {
   assessmentToTagList,
   assessmentToSummaryListComponent,
   assessmentByCategory,
+  courtCaseToCardComponent,
   courtHearingToSummaryListComponent,
   moveToCardComponent,
   moveToMetaListComponent,

--- a/common/services/court-hearing.js
+++ b/common/services/court-hearing.js
@@ -1,0 +1,11 @@
+const apiClient = require('../lib/api-client')()
+
+const courtHearingService = {
+  create(data) {
+    return apiClient
+      .create('court_hearing', data)
+      .then(response => response.data)
+  },
+}
+
+module.exports = courtHearingService

--- a/common/services/court-hearing.test.js
+++ b/common/services/court-hearing.test.js
@@ -1,0 +1,38 @@
+const courtHearingService = require('./court-hearing')
+const apiClient = require('../lib/api-client')()
+
+const mockCourtHearing = {
+  start_time: '2020-10-20T13:00:00+00:00',
+  case_number: 'T18725',
+  case_start_date: '2019-10-08T10:30:00+00:00',
+  case_type: 'Adult',
+  comments: 'Distinctio accusantium enim libero eligendi est.',
+}
+
+describe('Court Hearing Service', function() {
+  describe('#create()', function() {
+    const mockData = {
+      name: 'Steve Bloggs',
+    }
+    const mockResponse = {
+      data: mockCourtHearing,
+    }
+    let courtHearing
+
+    beforeEach(async function() {
+      sinon.stub(apiClient, 'create').resolves(mockResponse)
+      courtHearing = await courtHearingService.create(mockData)
+    })
+
+    it('should call create method with data', function() {
+      expect(apiClient.create).to.be.calledOnceWithExactly(
+        'court_hearing',
+        mockData
+      )
+    })
+
+    it('should return court hearing', function() {
+      expect(courtHearing).to.deep.equal(mockResponse.data)
+    })
+  })
+})

--- a/common/services/index.js
+++ b/common/services/index.js
@@ -1,8 +1,10 @@
+const courtHearing = require('./court-hearing')
 const move = require('./move')
 const person = require('./person')
 const referenceData = require('./reference-data')
 
 module.exports = {
+  courtHearing,
   move,
   person,
   referenceData,

--- a/common/services/person.js
+++ b/common/services/person.js
@@ -86,6 +86,18 @@ const personService = {
       .then(response => response.data.url)
   },
 
+  getCourtCases(personId) {
+    if (!personId) {
+      return Promise.reject(new Error('No ID supplied'))
+    }
+
+    return apiClient
+      .one('person', personId)
+      .all('court_case')
+      .get()
+      .then(response => response.data)
+  },
+
   getByIdentifiers(identifiers) {
     const filter = mapKeys(identifiers, (value, key) => `filter[${key}]`)
 

--- a/common/services/person.test.js
+++ b/common/services/person.test.js
@@ -561,6 +561,51 @@ describe('Person Service', function() {
     })
   })
 
+  describe('#getCourtCases()', function() {
+    const mockId = 'b695d0f0-af8e-4b97-891e-92020d6820b9'
+    const mockResponse = {
+      data: [
+        {
+          id: 'T20167984',
+        },
+        {
+          id: 'T20177984',
+        },
+      ],
+    }
+    let imageUrl
+
+    beforeEach(async function() {
+      sinon.stub(apiClient, 'one').returnsThis()
+      sinon.stub(apiClient, 'all').returnsThis()
+      sinon.stub(apiClient, 'get').resolves(mockResponse)
+    })
+
+    context('without ID', function() {
+      it('should reject with error', function() {
+        return expect(personService.getCourtCases()).to.be.rejectedWith(
+          'No ID supplied'
+        )
+      })
+    })
+
+    context('with ID', function() {
+      beforeEach(async function() {
+        imageUrl = await personService.getCourtCases(mockId)
+      })
+
+      it('should call correct api client methods', function() {
+        expect(apiClient.one).to.be.calledOnceWithExactly('person', mockId)
+        expect(apiClient.all).to.be.calledOnceWithExactly('court_case')
+        expect(apiClient.get).to.be.calledOnceWithExactly()
+      })
+
+      it('should return image url property', function() {
+        expect(imageUrl).to.deep.equal(mockResponse.data)
+      })
+    })
+  })
+
   describe('#getByIdentifiers()', function() {
     const mockResponse = {
       data: [mockPerson],

--- a/config/index.js
+++ b/config/index.js
@@ -124,6 +124,8 @@ module.exports = {
   LOCATIONS_BATCH_SIZE: process.env.LOCATIONS_BATCH_SIZE || 40,
   FEATURE_FLAGS: {
     IMAGES: process.env.FEATURE_FLAG_IMAGES,
+    // TODO: Remove once court hearings are fully released
+    PRISON_COURT_HEARINGS: process.env.FEATURE_FLAG_PRISON_COURT_HEARINGS,
   },
   E2E: {
     BASE_URL: process.env.E2E_BASE_URL || BASE_URL,

--- a/locales/en/fields.json
+++ b/locales/en/fields.json
@@ -102,6 +102,28 @@
   "time_due": {
     "label": "Time due"
   },
+  "has_court_case": {
+    "label": "Associated court case",
+    "items": {
+      "yes": {
+        "label": "Yes"
+      },
+      "no": {
+        "label": "No"
+      }
+    }
+  },
+  "court_hearing__start_time": {
+    "label": "Time of first hearing",
+    "hint": "We only require the time of the earliest hearing to book the move"
+  },
+  "court_hearing__court_case": {
+    "label": "What court case is this move for?",
+    "hint": "The case must exist in NOMIS to appear here"
+  },
+  "court_hearing__comments": {
+    "label": "Give details (optional)"
+  },
   "risk": {
     "label": "Add risk information",
     "hint": "Select all that apply"

--- a/locales/en/moves.json
+++ b/locales/en/moves.json
@@ -185,5 +185,15 @@
   },
   "agreement_status": {
     "heading": "Has this move been agreed with receiving prison?"
+  },
+  "court_case": {
+    "items": {
+      "start_date": {
+        "label": "Start date"
+      },
+      "case_type": {
+        "label": "Case type"
+      }
+    }
   }
 }

--- a/locales/en/moves.json
+++ b/locales/en/moves.json
@@ -59,6 +59,9 @@
     "move_details": {
       "heading": "Where is this person moving?"
     },
+    "hearing_details": {
+      "heading": "Is this move associated with a court case?"
+    },
     "court_information": {
       "heading": "Is there information for the court?"
     },

--- a/test/e2e/move.new.prison.test.js
+++ b/test/e2e/move.new.prison.test.js
@@ -1,5 +1,6 @@
 import { Selector } from 'testcafe'
 
+import { FEATURE_FLAGS } from '../../config'
 import { newMove } from './_routes'
 import { ocaUser, prisonUser } from './_roles'
 import { createPersonFixture } from './_helpers'
@@ -55,7 +56,13 @@ test('With existing person', async t => {
   await page.submitForm()
 
   // Court information
-  const courtInformation = await createMovePage.fillInCourtInformation()
+  // TODO: Remove this logic when we release the journey to all users
+  let courtHearings, courtInformation
+  if (FEATURE_FLAGS.PRISON_COURT_HEARINGS) {
+    courtHearings = await createMovePage.fillInCourtHearings()
+  } else {
+    courtInformation = await createMovePage.fillInCourtInformation()
+  }
   await page.submitForm()
 
   // Risk information
@@ -80,7 +87,11 @@ test('With existing person', async t => {
   await moveDetailPage.checkPersonalDetails(personalDetails)
 
   // Check assessment
-  await moveDetailPage.checkCourtInformation(courtInformation)
+  if (FEATURE_FLAGS.PRISON_COURT_HEARINGS) {
+    await moveDetailPage.checkCourtHearings(courtHearings)
+  } else {
+    await moveDetailPage.checkCourtInformation(courtInformation)
+  }
   await moveDetailPage.checkRiskInformation(riskInformation)
   await moveDetailPage.checkHealthInformation(healthInformation)
 })

--- a/test/e2e/pages/create-move.js
+++ b/test/e2e/pages/create-move.js
@@ -54,6 +54,7 @@ class CreateMovePage extends Page {
       specialVehicleRadio: Selector('[name="special_vehicle__explicit"]'),
       notToBeReleased: Selector('#not_to_be_released'),
       notToBeReleasedRadio: Selector('[name="not_to_be_released__explicit"]'),
+      hasCourtCase: Selector('[name="has_court_case"]'),
     }
 
     this.steps = {
@@ -301,6 +302,23 @@ class CreateMovePage extends Page {
     }
 
     return fillInForm(fields)
+  }
+
+  /**
+   * Fill in court hearings
+   *
+   * @returns {Promise}
+   */
+  async fillInCourtHearings() {
+    await t.expect(this.getCurrentUrl()).contains('/move/new/hearing-details')
+
+    return fillInForm({
+      hasCourtCase: {
+        selector: this.fields.hasCourtCase,
+        value: 'No',
+        type: 'radio',
+      },
+    })
   }
 
   /**

--- a/test/e2e/pages/move-detail.js
+++ b/test/e2e/pages/move-detail.js
@@ -29,6 +29,9 @@ class MoveDetailPage extends Page {
       noCourtInformationMessage: Selector('.app-message').withText(
         'No information for the court'
       ),
+      noCourtHearingsMessage: Selector('.app-message').withText(
+        'No court hearings'
+      ),
       riskInformation: Selector('#main-content h2')
         .withText('Risk information')
         .sibling('.app-panel'),
@@ -78,6 +81,15 @@ class MoveDetailPage extends Page {
       Gender: gender,
       Ethnicity: ethnicity,
     })
+  }
+
+  checkCourtHearings({ hasCourtCase } = {}) {
+    if (hasCourtCase === 'No') {
+      return t.expect(this.nodes.noCourtHearingsMessage.exists).ok()
+    }
+
+    // TODO: Write further assertions for when a move does have a court case
+    return t.expect(this.nodes.noCourtHearingsMessage.exists).not.ok()
   }
 
   checkCourtInformation({

--- a/test/fixtures/api-client/court_case.find.json
+++ b/test/fixtures/api-client/court_case.find.json
@@ -1,0 +1,34 @@
+{
+  "data": {
+    "id": "007f6aa0-7d82-4bf1-9191-2e27235d0f76",
+    "type": "court_cases",
+    "attributes": {
+      "nomis_case_id": "T20167984",
+      "nomis_case_status": "ACTIVE",
+      "case_start_date": "2016-11-14",
+      "case_type": "Adult",
+      "case_number": "T20167984"
+    },
+    "relationships": {
+      "location": {
+        "data": {
+          "id": "870c1142-cb71-4e3b-82b0-217fda895a1a",
+          "type": "locations"
+        }
+      }
+    }
+  },
+  "included": [
+    {
+      "id": "870c1142-cb71-4e3b-82b0-217fda895a1a",
+      "type": "locations",
+      "attributes": {
+        "key": "durham_crown_court",
+        "title": "Durham Crown Court",
+        "location_type": "court",
+        "nomis_agency_id": null,
+        "disabled_at": null
+      }
+    }
+  ]
+}

--- a/test/fixtures/api-client/court_case.findAll.json
+++ b/test/fixtures/api-client/court_case.findAll.json
@@ -1,0 +1,104 @@
+{
+  "data": [
+    {
+      "id": "007f6aa0-7d82-4bf1-9191-2e27235d0f76",
+      "type": "court_cases",
+      "attributes": {
+        "nomis_case_id": "T20167984",
+        "nomis_case_status": "ACTIVE",
+        "case_start_date": "2016-11-14",
+        "case_type": "Adult",
+        "case_number": "T20167984"
+      },
+      "relationships": {
+        "location": {
+          "data": {
+            "id": "870c1142-cb71-4e3b-82b0-217fda895a1a",
+            "type": "locations"
+          }
+        }
+      }
+    },
+    {
+      "id": "0194fe97-fa7e-49f5-b109-e1db6fee2190",
+      "type": "court_cases",
+      "attributes": {
+        "nomis_case_id": "T30391985",
+        "nomis_case_status": "ACTIVE",
+        "case_start_date": "2018-10-10",
+        "case_type": "Adult",
+        "case_number": "T30391985"
+      },
+      "relationships": {
+        "location": {
+          "data": {
+            "id": "870c1142-cb71-4e3b-82b0-217fda895a1a",
+            "type": "locations"
+          }
+        }
+      }
+    },
+    {
+      "id": "04a177a2-b899-425d-90ec-47f61cc5cc2d",
+      "type": "court_cases",
+      "attributes": {
+        "nomis_case_id": "T10123991",
+        "nomis_case_status": "ACTIVE",
+        "case_start_date": "2017-04-19",
+        "case_type": "Adult",
+        "case_number": "T10123991"
+      },
+      "relationships": {
+        "location": {
+          "data": {
+            "id": "3374c092-8080-4dd3-82c6-3621cbcecc33",
+            "type": "locations"
+          }
+        }
+      }
+    }
+  ],
+  "included": [
+    {
+      "id": "870c1142-cb71-4e3b-82b0-217fda895a1a",
+      "type": "locations",
+      "attributes": {
+        "key": "durham_crown_court",
+        "title": "Durham Crown Court",
+        "location_type": "court",
+        "nomis_agency_id": null,
+        "disabled_at": null
+      }
+    },
+    {
+      "id": "3374c092-8080-4dd3-82c6-3621cbcecc33",
+      "type": "locations",
+      "attributes": {
+        "key": "warrington_crown_court",
+        "title": "Warrington Crown Court",
+        "location_type": "court",
+        "nomis_agency_id": null,
+        "disabled_at": null
+      }
+    }
+  ],
+  "links": {
+    "self": "http://localhost:5000/api/v1/court_cases?page%5Bnumber%5D=1&page%5Bsize%5D=20",
+    "first": "http://localhost:5000/api/v1/court_cases?page%5Bnumber%5D=1&page%5Bsize%5D=20",
+    "prev": null,
+    "next": "http://localhost:5000/api/v1/court_cases?page%5Bnumber%5D=2&page%5Bsize%5D=20",
+    "last": "http://localhost:5000/api/v1/court_cases?page%5Bnumber%5D=25&page%5Bsize%5D=20"
+  },
+  "meta": {
+    "pagination": {
+      "per_page": 20,
+      "total_pages": 1,
+      "total_objects": 3,
+      "links": {
+        "first": "/api/v1/court_cases?page=1",
+        "last": "/api/v1/court_cases?page=25",
+        "next": "/api/v1/court_cases?page=2"
+      }
+    }
+  }
+}

--- a/test/fixtures/api-client/court_hearing.create.json
+++ b/test/fixtures/api-client/court_hearing.create.json
@@ -1,0 +1,22 @@
+{
+  "data": {
+    "id": "007f6aa0-7d82-4bf1-9191-2e27235d0f76",
+    "type": "court_hearings",
+    "attributes": {
+      "start_time": "2020-10-20T13:00:00+00:00",
+      "case_number": "T18725",
+      "case_start_date": "2019-10-08T10:30:00+00:00",
+      "case_type": "Adult",
+      "comments": "Distinctio accusantium enim libero eligendi est.",
+      "nomis_case_id": "3918461",
+      "nomis_hearing_id": "20167984",
+      "saved_to_nomis": "true"
+    },
+    "relationships": {
+      "move": {
+        "data": null
+      }
+    }
+  },
+  "included": []
+}

--- a/test/fixtures/api-client/move.find.json
+++ b/test/fixtures/api-client/move.find.json
@@ -48,6 +48,18 @@
             "type": "documents"
           }
         ]
+      },
+      "court_hearings": {
+        "data": [
+          {
+            "id": "76e00bf9-55f6-4ea5-b018-2c47d060caf5",
+            "type": "court_hearings"
+          },
+          {
+            "id": "3ef88a47-6f1f-5b9b-b2fc-c0fe42cb0c92",
+            "type": "court_hearings"
+          }
+        ]
       }
     }
   },
@@ -177,6 +189,34 @@
         "content_type": "image/png",
         "filesize": "290 KB",
         "url": "http://example-document/url"
+      }
+    },
+    {
+      "id": "76e00bf9-55f6-4ea5-b018-2c47d060caf5",
+      "type": "court_hearings",
+      "attributes": {
+        "start_time": "2020-10-20T13:00:00+00:00",
+        "case_number": "T18725",
+        "case_start_date": "2019-10-08T10:30:00+00:00",
+        "case_type": "Adult",
+        "comments": "Distinctio accusantium enim libero eligendi est.",
+        "nomis_case_id": "3918461",
+        "nomis_hearing_id": "20167984",
+        "saved_to_nomis": "true"
+      }
+    },
+    {
+      "id": "3ef88a47-6f1f-5b9b-b2fc-c0fe42cb0c92",
+      "type": "court_hearings",
+      "attributes": {
+        "start_time": "2020-108-12T09:00:00+00:00",
+        "case_number": "T109625",
+        "case_start_date": "2018-08-08T10:30:00+00:00",
+        "case_type": "Adult",
+        "comments": "Distinctio ano enim libero eligendi est.",
+        "nomis_case_id": "195710123",
+        "nomis_hearing_id": "0919381",
+        "saved_to_nomis": "false"
       }
     }
   ]

--- a/test/fixtures/api-client/move.findAll.json
+++ b/test/fixtures/api-client/move.findAll.json
@@ -49,6 +49,18 @@
               "type": "documents"
             }
           ]
+        },
+        "court_hearings": {
+          "data": [
+            {
+              "id": "76e00bf9-55f6-4ea5-b018-2c47d060caf5",
+              "type": "court_hearings"
+            },
+            {
+              "id": "3ef88a47-6f1f-5b9b-b2fc-c0fe42cb0c92",
+              "type": "court_hearings"
+            }
+          ]
         }
       }
     },
@@ -97,6 +109,14 @@
               "type": "documents"
             }
           ]
+        },
+        "court_hearings": {
+          "data": [
+            {
+              "id": "76e00bf9-55f6-4ea5-b018-2c47d060caf5",
+              "type": "court_hearings"
+            }
+          ]
         }
       }
     },
@@ -139,6 +159,9 @@
           }
         },
         "documents": {
+          "data": []
+        },
+        "court_hearings": {
           "data": []
         }
       }
@@ -192,6 +215,18 @@
               "type": "documents"
             }
           ]
+        },
+        "court_hearings": {
+          "data": [
+            {
+              "id": "76e00bf9-55f6-4ea5-b018-2c47d060caf5",
+              "type": "court_hearings"
+            },
+            {
+              "id": "3ef88a47-6f1f-5b9b-b2fc-c0fe42cb0c92",
+              "type": "court_hearings"
+            }
+          ]
         }
       }
     },
@@ -234,6 +269,9 @@
           }
         },
         "documents": {
+          "data": []
+        },
+        "court_hearings": {
           "data": []
         }
       }
@@ -287,6 +325,18 @@
               "type": "documents"
             }
           ]
+        },
+        "court_hearings": {
+          "data": [
+            {
+              "id": "76e00bf9-55f6-4ea5-b018-2c47d060caf5",
+              "type": "court_hearings"
+            },
+            {
+              "id": "3ef88a47-6f1f-5b9b-b2fc-c0fe42cb0c92",
+              "type": "court_hearings"
+            }
+          ]
         }
       }
     },
@@ -335,6 +385,14 @@
               "type": "documents"
             }
           ]
+        },
+        "court_hearings": {
+          "data": [
+            {
+              "id": "3ef88a47-6f1f-5b9b-b2fc-c0fe42cb0c92",
+              "type": "court_hearings"
+            }
+          ]
         }
       }
     },
@@ -377,6 +435,9 @@
           }
         },
         "documents": {
+          "data": []
+        },
+        "court_hearings": {
           "data": []
         }
       }
@@ -430,6 +491,18 @@
               "type": "documents"
             }
           ]
+        },
+        "court_hearings": {
+          "data": [
+            {
+              "id": "76e00bf9-55f6-4ea5-b018-2c47d060caf5",
+              "type": "court_hearings"
+            },
+            {
+              "id": "3ef88a47-6f1f-5b9b-b2fc-c0fe42cb0c92",
+              "type": "court_hearings"
+            }
+          ]
         }
       }
     },
@@ -476,6 +549,14 @@
             {
               "id": "b3da96e8-ffbd-4b09-9de1-b09130980aaf",
               "type": "documents"
+            }
+          ]
+        },
+        "court_hearings": {
+          "data": [
+            {
+              "id": "76e00bf9-55f6-4ea5-b018-2c47d060caf5",
+              "type": "court_hearings"
             }
           ]
         }
@@ -530,6 +611,18 @@
               "type": "documents"
             }
           ]
+        },
+        "court_hearings": {
+          "data": [
+            {
+              "id": "76e00bf9-55f6-4ea5-b018-2c47d060caf5",
+              "type": "court_hearings"
+            },
+            {
+              "id": "3ef88a47-6f1f-5b9b-b2fc-c0fe42cb0c92",
+              "type": "court_hearings"
+            }
+          ]
         }
       }
     },
@@ -572,6 +665,9 @@
           }
         },
         "documents": {
+          "data": []
+        },
+        "court_hearings": {
           "data": []
         }
       }
@@ -621,6 +717,14 @@
               "type": "documents"
             }
           ]
+        },
+        "court_hearings": {
+          "data": [
+            {
+              "id": "76e00bf9-55f6-4ea5-b018-2c47d060caf5",
+              "type": "court_hearings"
+            }
+          ]
         }
       }
     },
@@ -663,6 +767,9 @@
           }
         },
         "documents": {
+          "data": []
+        },
+        "court_hearings": {
           "data": []
         }
       }
@@ -710,6 +817,14 @@
             {
               "id": "4c613f24-e218-4e3c-afa3-c371893269f5",
               "type": "documents"
+            }
+          ]
+        },
+        "court_hearings": {
+          "data": [
+            {
+              "id": "3ef88a47-6f1f-5b9b-b2fc-c0fe42cb0c92",
+              "type": "court_hearings"
             }
           ]
         }
@@ -764,6 +879,18 @@
               "type": "documents"
             }
           ]
+        },
+        "court_hearings": {
+          "data": [
+            {
+              "id": "76e00bf9-55f6-4ea5-b018-2c47d060caf5",
+              "type": "court_hearings"
+            },
+            {
+              "id": "3ef88a47-6f1f-5b9b-b2fc-c0fe42cb0c92",
+              "type": "court_hearings"
+            }
+          ]
         }
       }
     },
@@ -816,6 +943,18 @@
               "type": "documents"
             }
           ]
+        },
+        "court_hearings": {
+          "data": [
+            {
+              "id": "76e00bf9-55f6-4ea5-b018-2c47d060caf5",
+              "type": "court_hearings"
+            },
+            {
+              "id": "3ef88a47-6f1f-5b9b-b2fc-c0fe42cb0c92",
+              "type": "court_hearings"
+            }
+          ]
         }
       }
     },
@@ -858,6 +997,9 @@
           }
         },
         "documents": {
+          "data": []
+        },
+        "court_hearings": {
           "data": []
         }
       }
@@ -911,6 +1053,18 @@
               "type": "documents"
             }
           ]
+        },
+        "court_hearings": {
+          "data": [
+            {
+              "id": "76e00bf9-55f6-4ea5-b018-2c47d060caf5",
+              "type": "court_hearings"
+            },
+            {
+              "id": "3ef88a47-6f1f-5b9b-b2fc-c0fe42cb0c92",
+              "type": "court_hearings"
+            }
+          ]
         }
       }
     },
@@ -961,6 +1115,18 @@
             {
               "id": "b3da96e8-ffbd-4b09-9de1-b09130980aaf",
               "type": "documents"
+            }
+          ]
+        },
+        "court_hearings": {
+          "data": [
+            {
+              "id": "76e00bf9-55f6-4ea5-b018-2c47d060caf5",
+              "type": "court_hearings"
+            },
+            {
+              "id": "3ef88a47-6f1f-5b9b-b2fc-c0fe42cb0c92",
+              "type": "court_hearings"
             }
           ]
         }
@@ -2722,6 +2888,34 @@
         "content_type": "image/png",
         "filesize": "290 KB",
         "url": "http://example-document/url-another"
+      }
+    },
+    {
+      "id": "76e00bf9-55f6-4ea5-b018-2c47d060caf5",
+      "type": "court_hearings",
+      "attributes": {
+        "start_time": "2020-10-20T13:00:00+00:00",
+        "case_number": "T18725",
+        "case_start_date": "2019-10-08T10:30:00+00:00",
+        "case_type": "Adult",
+        "comments": "Distinctio accusantium enim libero eligendi est.",
+        "nomis_case_id": "3918461",
+        "nomis_hearing_id": "20167984",
+        "saved_to_nomis": "true"
+      }
+    },
+    {
+      "id": "3ef88a47-6f1f-5b9b-b2fc-c0fe42cb0c92",
+      "type": "court_hearings",
+      "attributes": {
+        "start_time": "2020-108-12T09:00:00+00:00",
+        "case_number": "T109625",
+        "case_start_date": "2018-08-08T10:30:00+00:00",
+        "case_type": "Adult",
+        "comments": "Distinctio ano enim libero eligendi est.",
+        "nomis_case_id": "195710123",
+        "nomis_hearing_id": "0919381",
+        "saved_to_nomis": "false"
       }
     }
   ],


### PR DESCRIPTION
## Proposed changes

This introduces a new step for capturing court case and hearing details for Prison to Court moves.

This is the first stage of P4-1154 to be able to retrieve a list of cases and store them in the form journey. It relies on [#354](https://github.com/ministryofjustice/hmpps-book-secure-move-api/pull/354) from the API to work.

It may also require further changes to store the hearing data in the correct format to send to the API. But those changes can come later rather than continue to block these changes.

**Note:** It hasn't been added into the journey logic yet so its not accessible by any existing users or on the demo link.

## Screenshots

### Without a court location

![localhost_3001_move_new_hearing-details (5)](https://user-images.githubusercontent.com/3327997/78378374-c5c2ac00-75c8-11ea-8cb0-4bb2f51b8697.png)

### With a court location

![localhost_3001_move_new_hearing-details (6)](https://user-images.githubusercontent.com/3327997/78378366-c3605200-75c8-11ea-85a3-84c1e19d32fb.png)
