### PR TITLE
[P4-1154] Capture hearing time and court case setup

### DIFF
--- a/app/move/formatters.js
+++ b/app/move/formatters.js
@@ -6,6 +6,10 @@ const formatters = {
     const parsedDate = chrono.en_GB.parseDate(value)
     return parsedDate ? formatDate(parsedDate, format) : value
   },
+  time(value, format = 'HH:mm') {
+    const parsedDate = chrono.en_GB.parseDate(value)
+    return parsedDate ? formatDate(parsedDate, format) : value
+  },
 }
 
 module.exports = formatters

--- a/app/move/formatters.test.js
+++ b/app/move/formatters.test.js
@@ -44,4 +44,44 @@ describe('Formatters', function() {
       })
     })
   })
+
+  describe('#time()', function() {
+    context('when input value is a valid time', function() {
+      context('with default time format', function() {
+        it('should return formatted time', function() {
+          const time = formatters.time('5:00')
+          expect(time).to.equal('05:00')
+        })
+
+        it('should return formatted time', function() {
+          const time = formatters.time('5am')
+          expect(time).to.equal('05:00')
+        })
+
+        it('should return formatted time', function() {
+          const time = formatters.time('22:00')
+          expect(time).to.equal('22:00')
+        })
+
+        it('should return formatted time', function() {
+          const time = formatters.time('10pm')
+          expect(time).to.equal('22:00')
+        })
+      })
+
+      context('with custom date format', function() {
+        it('should return custom date format', function() {
+          const time = formatters.time('10:00', "H:mmaaaaa'm")
+          expect(time).to.equal('10:00am')
+        })
+      })
+    })
+
+    context('when input value is not a valid time', function() {
+      it('should return input value', function() {
+        const time = formatters.time('not-a-date')
+        expect(time).to.equal('not-a-date')
+      })
+    })
+  })
 })

--- a/app/move/validators.js
+++ b/app/move/validators.js
@@ -1,0 +1,13 @@
+const { Controller } = require('hmpo-form-wizard')
+
+module.exports = {
+  time(value) {
+    return (
+      value === '' ||
+      Controller.validators.regex(
+        value,
+        /^([0-9]|0[0-9]|1[0-9]|2[0-3]):([0-5][0-9]) ?([AaPp][Mm])?$/
+      )
+    )
+  },
+}

--- a/app/move/validators.test.js
+++ b/app/move/validators.test.js
@@ -1,0 +1,48 @@
+const validators = require('./validators')
+
+describe('Validators', function() {
+  describe('#time()', function() {
+    describe('invalid values', function() {
+      const inputs = [
+        10,
+        null,
+        '10',
+        '25:00',
+        '10:65',
+        'asdf',
+        '10:00a',
+        '9:00p',
+        '9pm',
+        '7am',
+        'midnight',
+        'midday',
+      ]
+
+      inputs.forEach(i => {
+        it(`test for: "${i}"`, function() {
+          expect(validators.time(i)).not.to.be.ok
+        })
+      })
+    })
+
+    describe('valid values', function() {
+      const inputs = [
+        '',
+        '9:00am',
+        '9:00pm',
+        '9:00',
+        '10:00',
+        '10:30',
+        '10:00am',
+        '10:00pm',
+        '22:00',
+      ]
+
+      inputs.forEach(i => {
+        it(`test for: "${i}"`, function() {
+          expect(validators.time(i)).to.be.ok
+        })
+      })
+    })
+  })
+})

--- a/common/helpers/field.js
+++ b/common/helpers/field.js
@@ -1,4 +1,4 @@
-const { cloneDeep, fromPairs, get, set } = require('lodash')
+const { cloneDeep, concat, fromPairs, get, set, compact } = require('lodash')
 
 const componentService = require('../services/component')
 const i18n = require('../../config/i18n')
@@ -59,17 +59,27 @@ function renderConditionalFields([key, field], index, obj) {
     {
       ...field,
       items: field.items.map(item => {
-        const fieldName = item.conditional
-        const field = fields[fieldName]
+        const conditionalFields = concat([], item.conditional)
 
-        if (!field) {
+        const components = conditionalFields.map(conditionalField => {
+          const field = fields[conditionalField]
+
+          if (!field) {
+            return
+          }
+
+          return componentService.getComponent(field.component, {
+            ...field,
+            id: conditionalField,
+            name: conditionalField,
+          })
+        })
+
+        if (!compact(components).length) {
           return item
         }
 
-        const params = { ...field, id: fieldName, name: fieldName }
-        const html = componentService.getComponent(params.component, params)
-
-        return { ...item, conditional: { html } }
+        return { ...item, conditional: { html: components.join('') } }
       }),
     },
   ]

--- a/common/helpers/field.test.js
+++ b/common/helpers/field.test.js
@@ -260,6 +260,94 @@ describe('Form helpers', function() {
           ])
         })
       })
+
+      context('when conditional is an array', function() {
+        const field = [
+          'field',
+          {
+            name: 'field',
+            items: [
+              {
+                value: '31b90233-7043-4633-8055-f24854545ead',
+                text: 'Item one',
+                conditional: [
+                  'conditional_field_one',
+                  'conditional_field_two',
+                  'unknown_field',
+                ],
+              },
+              {
+                value: '31b90233-7043-4633-8055-f24854545eac',
+                text: 'Item two',
+              },
+            ],
+          },
+        ]
+        const fields = [
+          ...field,
+          [
+            'conditional_field_one',
+            {
+              component: 'govukInput',
+              classes: 'input-classes',
+            },
+          ],
+          [
+            'conditional_field_two',
+            {
+              component: 'govukTextarea',
+              classes: 'input-classes',
+            },
+          ],
+        ]
+        let response
+
+        beforeEach(function() {
+          response = renderConditionalFields(field, 0, fields)
+        })
+
+        it('should call component service for each item', function() {
+          expect(componentService.getComponent).to.be.calledTwice
+        })
+
+        it('should call component service with correct args', function() {
+          expect(
+            componentService.getComponent.firstCall
+          ).to.be.calledWithExactly('govukInput', {
+            component: 'govukInput',
+            classes: 'input-classes',
+            id: 'conditional_field_one',
+            name: 'conditional_field_one',
+          })
+        })
+
+        it('should call component service with correct args', function() {
+          expect(
+            componentService.getComponent.secondCall
+          ).to.be.calledWithExactly('govukTextarea', {
+            component: 'govukTextarea',
+            classes: 'input-classes',
+            id: 'conditional_field_two',
+            name: 'conditional_field_two',
+          })
+        })
+
+        it('should render conditional content', function() {
+          expect(response[1].items).to.deep.equal([
+            {
+              value: '31b90233-7043-4633-8055-f24854545ead',
+              text: 'Item one',
+              conditional: {
+                html: 'govukInputgovukTextarea',
+              },
+            },
+            {
+              value: '31b90233-7043-4633-8055-f24854545eac',
+              text: 'Item two',
+            },
+          ])
+        })
+      })
     })
   })
 

--- a/config/nunjucks/filters.js
+++ b/config/nunjucks/filters.js
@@ -12,6 +12,7 @@ const {
 } = require('date-fns')
 const { kebabCase, startCase } = require('lodash')
 const pluralize = require('pluralize')
+const chrono = require('chrono-node')
 
 const { DATE_FORMATS } = require('../index')
 
@@ -127,7 +128,7 @@ function calculateAge(value) {
  * @example {{ "2000-01-01T14:00:00Z" | formatTime }}
  */
 function formatTime(value) {
-  const parsedDate = parseISO(value)
+  const parsedDate = chrono.en_GB.parseDate(value)
 
   if (!value || !isValidDate(parsedDate)) {
     return value

--- a/config/nunjucks/filters.test.js
+++ b/config/nunjucks/filters.test.js
@@ -258,40 +258,35 @@ describe('Nunjucks filters', function() {
   describe('#formatTime()', function() {
     context('when given an invalid datetime', function() {
       it('should return input value', function() {
-        const age = filters.formatTime('2010-45-5')
-        expect(age).to.equal('2010-45-5')
+        const time = filters.formatTime('2010-45-5')
+        expect(time).to.equal('2010-45-5')
       })
 
       it('should return input value', function() {
-        const age = filters.formatTime('not a date')
-        expect(age).to.equal('not a date')
+        const time = filters.formatTime('not a date')
+        expect(time).to.equal('not a date')
       })
     })
 
     context('when given falsey values', function() {
       it('should return input value', function() {
-        const age = filters.formatTime(undefined)
-        expect(age).to.be.undefined
+        const time = filters.formatTime(undefined)
+        expect(time).to.be.undefined
       })
 
       it('should return input value', function() {
-        const age = filters.formatTime(null)
-        expect(age).to.equal(null)
+        const time = filters.formatTime(null)
+        expect(time).to.equal(null)
       })
 
       it('should return input value', function() {
-        const age = filters.formatTime(false)
-        expect(age).to.equal(false)
+        const time = filters.formatTime(false)
+        expect(time).to.equal(false)
       })
 
       it('should return input value', function() {
-        const age = filters.formatTime(0)
-        expect(age).to.equal(0)
-      })
-
-      it('should return input value', function() {
-        const age = filters.formatTime('')
-        expect(age).to.equal('')
+        const time = filters.formatTime('')
+        expect(time).to.equal('')
       })
     })
 
@@ -368,6 +363,16 @@ describe('Nunjucks filters', function() {
         it('should return correct format', function() {
           const time = filters.formatTime('2000-06-01T01:00:00Z')
           expect(time).to.equal('1am')
+        })
+
+        it('should return correct format', function() {
+          const time = filters.formatTime('10:00')
+          expect(time).to.equal('10am')
+        })
+
+        it('should return correct format', function() {
+          const time = filters.formatTime('22:00')
+          expect(time).to.equal('10pm')
         })
       })
 

--- a/locales/en/validation.json
+++ b/locales/en/validation.json
@@ -6,6 +6,7 @@
   "required": "cannot be blank",
   "numeric": "can only contain numbers",
   "date": "must be a valid date",
+  "time": "must be a valid time, for example 12:00 or 12pm",
   "after": "must be in the future",
   "before": "must be in the past",
   "default": "is required",


### PR DESCRIPTION
This PR contains a number of changes related to capturing hearing time for Prison to Court moves.

That change required some extension to existing libraries like formatters, validators and filters.

The major change is currently blocked by some API changes that it requires first so these changes are being split into a separate PR so that they can be merged now.

See #398 for the changes related to the create move journey.