### PR TITLE
fix: [P4-1041] Extend service timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@ It will also start a new deployment specific [job on CircleCI](https://app.circl
 | AUTH_PROVIDER_KEY **(required)** | Client key provided by the OAuth2 provider for user authentication | |
 | AUTH_PROVIDER_SECRET **(required)** | Client secret provided by the OAuth2 provider for user authentication | |
 | AUTH_PROVIDER_URL **(required)** | Base URL for the auth provider server | |
+| AUTH_EXPIRY_MARGIN | How close the user authentication should be to expiring before refreshing it | `300` (5 minutes) |
 | NOMIS_ELITE2_API_URL **(required)** | Base URL for the NOMIS Elite 2 API, without trailing slash | |
 | SERVER_HOST **(required)** | The (accessible) hostname (and port) of the listening web server. Used by [Grant](https://github.com/simov/grant) to construct redirect URLs after OAuth authentication. For example `localhost:3000` | |
 | FEEDBACK_URL | URL for the feedback link in the phase banner at the top of the page. If empty, the link will not be displayed. | |

--- a/app/auth/middleware.js
+++ b/app/auth/middleware.js
@@ -6,7 +6,6 @@ const { decodeAccessToken } = require('../../common/lib/access-token')
 
 function processAuthResponse() {
   return async function middleware(req, res, next) {
-    // const { grant, originalRequestUrl, currentLocation } = req.session
     const accessToken = get(req.session, 'grant.response.access_token')
 
     if (!accessToken) {
@@ -22,7 +21,7 @@ function processAuthResponse() {
         getFullname(accessToken),
       ])
 
-      const previousSession = req.session
+      const previousSession = { ...req.session }
 
       req.session.regenerate(error => {
         if (error) {

--- a/app/auth/middleware.js
+++ b/app/auth/middleware.js
@@ -6,7 +6,7 @@ const { decodeAccessToken } = require('../../common/lib/access-token')
 
 function processAuthResponse() {
   return async function middleware(req, res, next) {
-    const { originalRequestUrl, currentLocation } = req.session
+    // const { grant, originalRequestUrl, currentLocation } = req.session
     const accessToken = get(req.session, 'grant.response.access_token')
 
     if (!accessToken) {
@@ -22,18 +22,28 @@ function processAuthResponse() {
         getFullname(accessToken),
       ])
 
+      const previousSession = req.session
+
       req.session.regenerate(error => {
         if (error) {
           return next(error)
         }
-
         req.session.authExpiry = decodedAccessToken.exp
-        req.session.currentLocation = currentLocation
-        req.session.originalRequestUrl = originalRequestUrl
         req.session.user = new User({
           fullname,
           locations,
           roles: decodedAccessToken.authorities,
+        })
+
+        // copy any previous session properties ignoring grant or any that already exist
+        Object.keys(previousSession).forEach(key => {
+          if (req.session[key]) {
+            return
+          }
+          if (key === 'grant') {
+            return
+          }
+          req.session[key] = previousSession[key]
         })
 
         next()

--- a/app/auth/middleware.test.js
+++ b/app/auth/middleware.test.js
@@ -199,7 +199,7 @@ describe('Authentication middleware', function() {
           })
 
           it('does not copy grant property', function() {
-            expect(req.session.grant).to.equal(undefined)
+            expect(req.session).not.to.contain.property('grant')
           })
 
           it('calls the next action', function() {

--- a/app/auth/middleware.test.js
+++ b/app/auth/middleware.test.js
@@ -41,6 +41,8 @@ describe('Authentication middleware', function() {
           originalRequestUrl: '/test',
           currentLocation: '1234567890',
           regenerate: sinon.stub(),
+          anotherKey: 'abc',
+          grant: 'grantObject',
         },
       }
     })
@@ -190,6 +192,14 @@ describe('Authentication middleware', function() {
 
           it('sets the location in the session', function() {
             expect(req.session.currentLocation).to.equal('1234567890')
+          })
+
+          it('copies additional properties in the session', function() {
+            expect(req.session.anotherKey).to.equal('abc')
+          })
+
+          it('does not copy grant property', function() {
+            expect(req.session.grant).to.equal(undefined)
           })
 
           it('calls the next action', function() {

--- a/app/moves/middleware.test.js
+++ b/app/moves/middleware.test.js
@@ -651,7 +651,7 @@ describe('Moves middleware', function() {
         moveService.getMovesCount.restore()
       })
       it('sets res.locals.moveTypeNavigation', function() {
-        expect(res.locals).to.deep.equal({
+        expect({ ...res.locals }).to.deep.equal({
           dateRange: ['2010-09-03', '2010-09-10'],
           moveTypeNavigation: [
             {

--- a/common/components/multi-file-upload/multi-file-upload.js
+++ b/common/components/multi-file-upload/multi-file-upload.js
@@ -125,9 +125,10 @@ MultiFileUpload.prototype = {
           row.classList.remove('dz-success')
           row.classList.add('dz-error')
           row.querySelector('[data-dz-errormessage]').innerHTML = errorMessage
-          const buttons = row
-            .closest('.app-multi-file-upload__list')
-            .querySelectorAll('button[name="delete"]')
+
+          const buttons = this.dropzone.previewsContainer.querySelectorAll(
+            'button[data-dz-remove]'
+          )
           const actions = [...buttons]
           actions.forEach(action => {
             action.style.visibility = 'hidden'

--- a/common/components/multi-file-upload/multi-file-upload.js
+++ b/common/components/multi-file-upload/multi-file-upload.js
@@ -116,7 +116,24 @@ MultiFileUpload.prototype = {
           row.parentNode.removeChild(row)
           this.render()
         })
-        .catch(() => false)
+        .catch(error => {
+          let errorMessage = 'could not be deleted'
+          if (error.response && error.response.data) {
+            errorMessage = error.response.data
+          }
+          const row = target.closest('.dz-success')
+          row.classList.remove('dz-success')
+          row.classList.add('dz-error')
+          row.querySelector('[data-dz-errormessage]').innerHTML = errorMessage
+          const buttons = document.querySelectorAll(
+            '.govuk-summary-list__actions button'
+          )
+          const actions = [...buttons]
+          actions.forEach(action => {
+            action.style.visibility = 'hidden'
+          })
+          return false
+        })
     }
   },
 

--- a/common/components/multi-file-upload/multi-file-upload.js
+++ b/common/components/multi-file-upload/multi-file-upload.js
@@ -125,9 +125,9 @@ MultiFileUpload.prototype = {
           row.classList.remove('dz-success')
           row.classList.add('dz-error')
           row.querySelector('[data-dz-errormessage]').innerHTML = errorMessage
-          const buttons = document.querySelectorAll(
-            '.govuk-summary-list__actions button'
-          )
+          const buttons = row
+            .closest('.app-multi-file-upload__list')
+            .querySelectorAll('button[name="delete"]')
           const actions = [...buttons]
           actions.forEach(action => {
             action.style.visibility = 'hidden'

--- a/common/components/multi-file-upload/template.njk
+++ b/common/components/multi-file-upload/template.njk
@@ -29,7 +29,7 @@
 
       {{ govukButton({
         html: deleteLabel,
-        classes: "govuk-button--secondary govuk-!-margin-bottom-0 js-upload-delete",
+        classes: "govuk-button--secondary govuk-!-margin-bottom-0",
         name: "delete",
         attributes: { "data-dz-remove": "" },
         value: params.id

--- a/common/middleware/ensure-authenticated.js
+++ b/common/middleware/ensure-authenticated.js
@@ -9,13 +9,33 @@ function _isExpired(authExpiry) {
 module.exports = function ensureAuthenticated({
   provider,
   whitelist = [],
+  expiryMargin = 5 * 60,
 } = {}) {
   return (req, res, next) => {
-    if (whitelist.includes(req.url) || !_isExpired(req.session.authExpiry)) {
+    let authExpiry = req.session.authExpiry
+    if (req.method === 'GET') {
+      authExpiry -= expiryMargin
+    }
+    if (whitelist.includes(req.url) || !_isExpired(authExpiry)) {
       return next()
     }
 
     req.session.originalRequestUrl = req.originalUrl
+    if (req.method === 'POST') {
+      let errorKey
+      const contentType = req.header('content-type')
+      if (contentType.startsWith('multipart/form-data')) {
+        errorKey = 'MULTIPART_FAILED_AUTH'
+      } else if (req.xhr) {
+        errorKey = 'DELETE_FAILED_AUTH'
+      }
+      if (errorKey) {
+        res.status(401)
+        const errorString = req.t(`validation::${errorKey}`)
+        return res.send(errorString)
+      }
+      req.session.originalRequestBody = req.body
+    }
     res.redirect(`/connect/${provider}`)
   }
 }

--- a/common/middleware/ensure-authenticated.js
+++ b/common/middleware/ensure-authenticated.js
@@ -9,11 +9,11 @@ function _isExpired(authExpiry) {
 module.exports = function ensureAuthenticated({
   provider,
   whitelist = [],
-  expiryMargin = 5 * 60,
+  expiryMargin,
 } = {}) {
   return (req, res, next) => {
     let authExpiry = req.session.authExpiry
-    if (req.method === 'GET') {
+    if (req.method === 'GET' && expiryMargin) {
       authExpiry -= expiryMargin
     }
     if (whitelist.includes(req.url) || !_isExpired(authExpiry)) {
@@ -21,19 +21,20 @@ module.exports = function ensureAuthenticated({
     }
 
     req.session.originalRequestUrl = req.originalUrl
+
     if (req.method === 'POST') {
-      let errorKey
       const contentType = req.header('content-type')
-      if (contentType.startsWith('multipart/form-data')) {
-        errorKey = 'MULTIPART_FAILED_AUTH'
-      } else if (req.xhr) {
-        errorKey = 'DELETE_FAILED_AUTH'
+      const isMultipart = contentType.startsWith('multipart/form-data;')
+      if (isMultipart || req.xhr) {
+        const error = new Error(
+          req.t('validation::AUTH_EXPIRED', {
+            context: isMultipart ? 'MULTIPART' : '',
+          })
+        )
+        error.statusCode = 422
+        return next(error)
       }
-      if (errorKey) {
-        res.status(401)
-        const errorString = req.t(`validation::${errorKey}`)
-        return res.send(errorString)
-      }
+
       req.session.originalRequestBody = req.body
     }
     res.redirect(`/connect/${provider}`)

--- a/common/middleware/ensure-body-processed.js
+++ b/common/middleware/ensure-body-processed.js
@@ -1,0 +1,13 @@
+module.exports = function ensureBodyProcessed(authMountpoint = '/auth') {
+  return (req, res, next) => {
+    if (!req.url.startsWith(authMountpoint)) {
+      const originalBody = req.session.originalRequestBody
+      if (originalBody) {
+        delete req.session.originalRequestBody
+        req.body = originalBody
+        req.method = 'POST'
+      }
+    }
+    next()
+  }
+}

--- a/common/middleware/errors.js
+++ b/common/middleware/errors.js
@@ -22,6 +22,13 @@ function _getMessage(error) {
     }
   }
 
+  if (error.statusCode === 422) {
+    return {
+      heading: 'errors::unprocessable_entity.heading',
+      content: 'errors::unprocessable_entity.content',
+    }
+  }
+
   return {
     heading: 'errors::default.heading',
     content: 'errors::default.content',
@@ -43,7 +50,11 @@ function catchAll(showStackTrace = false) {
       return next(error)
     }
 
-    logger[statusCode === 404 ? 'info' : 'error'](error)
+    logger[statusCode < 500 ? 'info' : 'error'](error)
+
+    if (req.xhr) {
+      return res.status(statusCode).send(error.message)
+    }
 
     res.status(statusCode).render('error', {
       error,

--- a/common/middleware/errors.js
+++ b/common/middleware/errors.js
@@ -1,37 +1,21 @@
 const logger = require('../../config/logger')
 
 function _getMessage(error) {
+  let errorLookup = 'default'
+
   if (error.code === 'EBADCSRFTOKEN') {
-    return {
-      heading: 'errors::tampered_with.heading',
-      content: 'errors::tampered_with.content',
-    }
-  }
-
-  if (error.statusCode === 404) {
-    return {
-      heading: 'errors::not_found.heading',
-      content: 'errors::not_found.content',
-    }
-  }
-
-  if (error.statusCode === 403 || error.statusCode === 401) {
-    return {
-      heading: 'errors::unauthorized.heading',
-      content: 'errors::unauthorized.content',
-    }
-  }
-
-  if (error.statusCode === 422) {
-    return {
-      heading: 'errors::unprocessable_entity.heading',
-      content: 'errors::unprocessable_entity.content',
-    }
+    errorLookup = 'tampered_with'
+  } else if (error.statusCode === 404) {
+    errorLookup = 'not_found'
+  } else if (error.statusCode === 403 || error.statusCode === 401) {
+    errorLookup = 'unauthorized'
+  } else if (error.statusCode === 422) {
+    errorLookup = 'unprocessable_entity'
   }
 
   return {
-    heading: 'errors::default.heading',
-    content: 'errors::default.content',
+    heading: `errors::${errorLookup}.heading`,
+    content: `errors::${errorLookup}.content`,
   }
 }
 
@@ -44,12 +28,11 @@ function notFound(req, res, next) {
 
 function catchAll(showStackTrace = false) {
   return function errors(error, req, res, next) {
-    const statusCode = error.statusCode || 500
-
     if (res.headersSent) {
       return next(error)
     }
 
+    const statusCode = error.statusCode || 500
     logger[statusCode < 500 ? 'info' : 'error'](error)
 
     if (req.xhr) {

--- a/common/middleware/process-original-request-body.js
+++ b/common/middleware/process-original-request-body.js
@@ -1,4 +1,4 @@
-module.exports = function ensureBodyProcessed(authMountpoint = '/auth') {
+module.exports = function processOriginalRequestBody(authMountpoint = '/auth') {
   return (req, res, next) => {
     if (!req.url.startsWith(authMountpoint)) {
       const originalBody = req.session.originalRequestBody

--- a/common/middleware/process-original-request-body.test.js
+++ b/common/middleware/process-original-request-body.test.js
@@ -1,0 +1,96 @@
+const ensureBodyProcessed = require('./process-original-request-body')
+
+const sessionWithOriginalRequestBody = () => ({
+  originalRequestBody: {
+    foo: 'bar',
+  },
+})
+
+describe('Body processing after reauthentication middleware', function() {
+  describe('#ensureBodyProcessed()', function() {
+    let res, nextSpy
+
+    beforeEach(function() {
+      nextSpy = sinon.spy()
+      res = {
+        redirect: sinon.spy(),
+      }
+    })
+    context('when originalRequestBody is present in session', function() {
+      const req = {
+        url: '/foo',
+        session: sessionWithOriginalRequestBody(),
+      }
+
+      beforeEach(function() {
+        ensureBodyProcessed()(req, res, nextSpy)
+      })
+
+      it('should set the request body to the originalRequestBody', function() {
+        expect(req.body).to.deep.equal({ foo: 'bar' })
+      })
+
+      it('should set the request method to POST', function() {
+        expect(req.method).to.equal('POST')
+      })
+
+      it('should call next', function() {
+        expect(nextSpy).to.be.calledOnceWithExactly()
+      })
+
+      it('should not redirect', function() {
+        expect(res.redirect).not.to.be.called
+      })
+    })
+
+    context('when no originalRequestBody is present in session', function() {
+      const req = {
+        url: '/foo',
+        session: {},
+      }
+
+      beforeEach(function() {
+        ensureBodyProcessed()(req, res, nextSpy)
+      })
+
+      it('should leave request body unchanged', function() {
+        expect(req.body).to.equal(undefined)
+      })
+
+      it('should leave the request method unchanged', function() {
+        expect(req.method).to.equal(undefined)
+      })
+
+      it('should call next', function() {
+        expect(nextSpy).to.be.calledOnceWithExactly()
+      })
+
+      it('should not redirect', function() {
+        expect(res.redirect).not.to.be.called
+      })
+    })
+
+    context('when an auth route is matched', function() {
+      const req = {
+        url: '/myauth/callback',
+        session: sessionWithOriginalRequestBody(),
+      }
+
+      beforeEach(function() {
+        ensureBodyProcessed('/myauth')(req, res, nextSpy)
+      })
+
+      it('should leave request body unchanged', function() {
+        expect(req.body).to.equal(undefined)
+      })
+
+      it('should call next', function() {
+        expect(nextSpy).to.be.calledOnceWithExactly()
+      })
+
+      it('should not redirect', function() {
+        expect(res.redirect).not.to.be.called
+      })
+    })
+  })
+})

--- a/config/index.js
+++ b/config/index.js
@@ -17,6 +17,7 @@ const SESSION = {
   TTL: process.env.SESSION_TTL || 60 * 30 * 1000, // 30 mins
   DB: process.env.SESSION_DB_INDEX || 0,
 }
+const AUTH_EXPIRY_MARGIN = process.env.AUTH_EXPIRY_MARGIN || 5 * 60 // 5 minutes
 
 function _authUrl(path) {
   return AUTH_BASE_URL ? new URL(path, AUTH_BASE_URL).href : ''
@@ -26,6 +27,7 @@ module.exports = {
   IS_DEV,
   IS_PRODUCTION,
   SESSION,
+  AUTH_EXPIRY_MARGIN,
   SERVER_HOST,
   PORT: process.env.PORT || 3000,
   LOG_LEVEL: process.env.LOG_LEVEL || (IS_DEV ? 'debug' : 'error'),

--- a/config/index.js
+++ b/config/index.js
@@ -17,7 +17,6 @@ const SESSION = {
   TTL: process.env.SESSION_TTL || 60 * 30 * 1000, // 30 mins
   DB: process.env.SESSION_DB_INDEX || 0,
 }
-const AUTH_EXPIRY_MARGIN = process.env.AUTH_EXPIRY_MARGIN || 5 * 60 // 5 minutes
 
 function _authUrl(path) {
   return AUTH_BASE_URL ? new URL(path, AUTH_BASE_URL).href : ''
@@ -27,7 +26,7 @@ module.exports = {
   IS_DEV,
   IS_PRODUCTION,
   SESSION,
-  AUTH_EXPIRY_MARGIN,
+  AUTH_EXPIRY_MARGIN: process.env.AUTH_EXPIRY_MARGIN || 5 * 60, // 5 minutes
   SERVER_HOST,
   PORT: process.env.PORT || 3000,
   LOG_LEVEL: process.env.LOG_LEVEL || (IS_DEV ? 'debug' : 'error'),

--- a/locales/en/errors.json
+++ b/locales/en/errors.json
@@ -28,5 +28,9 @@
   "unauthorized": {
     "heading": "You don’t have permission to view this page",
     "content": "If you think you should have access please contact the support team."
+  },
+  "unprocessable_entity": {
+    "heading": "We could not process the request",
+    "content": "Try again in a few moments."
   }
 }

--- a/locales/en/validation.json
+++ b/locales/en/validation.json
@@ -19,6 +19,6 @@
   "LIMIT_FIELD_COUNT": "includes too many fields",
   "LIMIT_UNEXPECTED_FILE": "must include expected file types",
   "API_DOCUMENT_STORAGE_FAILED": "could not be uploaded – try again",
-  "MULTIPART_FAILED_AUTH": "could not be uploaded. Please reload the page and try again",
-  "DELETE_FAILED_AUTH": "could not be deleted. Please reload the page and try again"
+  "AUTH_EXPIRED": "could not be deleted. Please reload the page and try again",
+  "AUTH_EXPIRED_MULTIPART": "could not be uploaded. Please reload the page and try again"
 }

--- a/locales/en/validation.json
+++ b/locales/en/validation.json
@@ -18,5 +18,7 @@
   "LIMIT_FIELD_VALUE": "must include a shorter field value",
   "LIMIT_FIELD_COUNT": "includes too many fields",
   "LIMIT_UNEXPECTED_FILE": "must include expected file types",
-  "API_DOCUMENT_STORAGE_FAILED": "could not be uploaded – try again"
+  "API_DOCUMENT_STORAGE_FAILED": "could not be uploaded – try again",
+  "MULTIPART_FAILED_AUTH": "could not be uploaded. Please reload the page and try again",
+  "DELETE_FAILED_AUTH": "could not be deleted. Please reload the page and try again"
 }

--- a/server.js
+++ b/server.js
@@ -30,7 +30,7 @@ const ensureCurrentLocation = require('./common/middleware/ensure-current-locati
 const errorHandlers = require('./common/middleware/errors')
 const checkSession = require('./common/middleware/check-session')
 const ensureAuthenticated = require('./common/middleware/ensure-authenticated')
-const ensureBodyProcessed = require('./common/middleware/ensure-body-processed')
+const processOriginalRequestBody = require('./common/middleware/process-original-request-body')
 const locals = require('./common/middleware/locals')
 const router = require('./app/router')
 const healthcheckApp = require('./app/healthcheck')
@@ -146,7 +146,7 @@ app.use(
 app.use(helmet())
 
 // Ensure body processed after reauthentication
-app.use(ensureBodyProcessed())
+app.use(processOriginalRequestBody())
 
 // Routing
 app.use(router)

--- a/server.js
+++ b/server.js
@@ -30,6 +30,7 @@ const ensureCurrentLocation = require('./common/middleware/ensure-current-locati
 const errorHandlers = require('./common/middleware/errors')
 const checkSession = require('./common/middleware/check-session')
 const ensureAuthenticated = require('./common/middleware/ensure-authenticated')
+const ensureBodyProcessed = require('./common/middleware/ensure-body-processed')
 const locals = require('./common/middleware/locals')
 const router = require('./app/router')
 const healthcheckApp = require('./app/healthcheck')
@@ -133,6 +134,7 @@ app.use(
   ensureAuthenticated({
     provider: config.DEFAULT_AUTH_PROVIDER,
     whitelist: config.AUTH_WHITELIST_URLS,
+    expiryMargin: config.AUTH_EXPIRY_MARGIN,
   })
 )
 app.use(
@@ -142,6 +144,9 @@ app.use(
   })
 )
 app.use(helmet())
+
+// Ensure body processed after reauthentication
+app.use(ensureBodyProcessed())
 
 // Routing
 app.use(router)


### PR DESCRIPTION
Problem
-------

After successfully reauthenticating a user, the user's session is regenerated. Unfortunately this had the side-effect of losing all the info that HMPO form wizard has stored resulting in the user seeing a session timeout message (or for xhr requests, the cryptic 'Server returned code 0')

Even if the HMPO form wizard was not being lost, the reauthentication redirect would have the effect of causing any posted information to be dropped.

Ideally a new token could just be requested using the refresh token rather than redirecting the user, but the HMPPS OAuth server does not support refresh tokens for the type of grant we require.

Fix
---

- Copy properties from previous session to new one
- Stash POST body (if any) in `req.session.originalRequestBody` when redirecting to /connect/$provider route
- Return 401 for request types that cannot be handled
  - when content-type is `multipart/formdata` (as we can't store the uploaded file)
  - when request is an `xhr` request (since the xhr runs afoul of cross-site concerns)
- Update request's body and method if `req.session.originalRequestBody` is present after successful reauthentication
- Refresh the auth token if the request method is 'GET' and the token is about to expire (see AUTH_EXPIRY_MARGIN env var)

Handling 401 errors
--------------------

Upload failed

![upload-auth-expired_mov](https://user-images.githubusercontent.com/4856/77750486-c8972d00-701b-11ea-9dfe-54a464608a2b.png)

Delete failed

![delete-auth-expired_mov](https://user-images.githubusercontent.com/4856/77750439-b2896c80-701b-11ea-9ca5-a26e3473d106.png)

Additionally suppresses the delete buttons

Potential enhancements
------------

This should cover the vast majority of cases, but if we find users are still getting stung by it, we could look into

- Automatically refresh the page and display a flash message afterwards
  (I did implement this to show Andy, but we both felt it would be more confusing to the user)
- Add ability to countdown to expiry on the client-side and prompt user to stay "logged in" when expiry is (or is about to be) reached
- Store the uploaded files temporarily (non-trivial)
- Stash and deal with xhr changes (non-trivial)
- Use a refresh token if possible (trivial but dependent on OAuth server changes)

Env vars
--------

Add  `AUTH_EXPIRY_MARGIN` to determine how much time should remain for the auth token to expire before attempting to refresh it. Defaults to 300 seconds (ie 5 minutes)






### Checklist

- [x] If adding new environment variables, they have been documented in the [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md)
- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
