### PR TITLE
[P4-1212]: feat: Dashboard for the OCA journey

### DIFF
--- a/app/moves/controllers/dashboard.js
+++ b/app/moves/controllers/dashboard.js
@@ -1,4 +1,3 @@
-module.exports = function list(req, res) {
-  const template = 'moves/views/dashboard'
-  res.render(template, res.locals)
+module.exports = function dashboard(req, res) {
+  res.render('moves/views/dashboard')
 }

--- a/app/moves/controllers/dashboard.js
+++ b/app/moves/controllers/dashboard.js
@@ -1,5 +1,3 @@
-// const presenters = require('../../../common/presenters')
-
 module.exports = function list(req, res) {
   const template = 'moves/views/dashboard'
   res.render(template, res.locals)

--- a/app/moves/controllers/dashboard.js
+++ b/app/moves/controllers/dashboard.js
@@ -1,0 +1,6 @@
+// const presenters = require('../../../common/presenters')
+
+module.exports = function list(req, res) {
+  const template = 'moves/views/dashboard'
+  res.render(template, res.locals)
+}

--- a/app/moves/controllers/index.js
+++ b/app/moves/controllers/index.js
@@ -1,8 +1,10 @@
+const dashboard = require('./dashboard')
 const download = require('./download')
 const list = require('./list')
 const listByStatus = require('./list-by-status')
 
 module.exports = {
+  dashboard,
   download,
   list,
   listByStatus,

--- a/app/moves/index.js
+++ b/app/moves/index.js
@@ -15,8 +15,7 @@ const {
   setMovesByDateAndLocation,
   setMovesByDateRangeAndStatus,
   setMovesByDateAllLocations,
-  setTotalMoves,
-  setTranslatedMoveTypes,
+  setDashboardMoveSummary,
 } = require('./middleware')
 
 const uuidRegex =
@@ -33,7 +32,7 @@ router.use('^([^.]+)$', saveUrl)
 // Define routes
 router.get('/', redirectBaseUrl)
 router.get(
-  '/:period(week|day)/:date',
+  '/:period(week|day)/:date/:view(outgoing)',
   protectRoute('moves:view:all'),
   setMovesByDateAllLocations,
   setPagination,
@@ -42,38 +41,36 @@ router.get(
 router.get(
   `/:period(week|day)/:date/:locationId(${uuidRegex})`,
   protectRoute('moves:view:by_location'),
+  protectRoute('moves:view:proposed'),
+  setMoveTypeNavigation,
+  setDashboardMoveSummary,
+  setPagination,
+  dashboard
+)
+router.get(
+  `/:period(week|day)/:date/:locationId(${uuidRegex})/:view(outgoing)`,
+  protectRoute('moves:view:by_location'),
   setMovesByDateAndLocation,
   setPagination,
   list
-)
-router.get(
-  `/:period(week|day)/:date/:locationId(${uuidRegex})/:view(dashboard)`,
-  protectRoute('moves:view:by_location'),
-  protectRoute('moves:view:proposed'),
-  setMoveTypeNavigation,
-  setTotalMoves,
-  setTranslatedMoveTypes,
-  setPagination,
-  dashboard
 )
 router.get(
   `/:period(week|day)/:date/:locationId(${uuidRegex})/:status(proposed|requested,accepted,completed|rejected)`,
   protectRoute('moves:view:by_location'),
   protectRoute('moves:view:proposed'),
   setMoveTypeNavigation,
-  setTranslatedMoveTypes,
   setMovesByDateRangeAndStatus,
   setPagination,
   listByStatus
 )
 router.get(
-  '/:period(week|day)/:date/download.:extension(csv|json)',
+  '/:period(week|day)/:date/:view(outgoing)/download.:extension(csv|json)',
   protectRoute('moves:download:all'),
   setMovesByDateAllLocations,
   download
 )
 router.get(
-  `/:period(week|day)/:date/:locationId(${uuidRegex})/download.:extension(csv|json)`,
+  `/:period(week|day)/:date/:locationId(${uuidRegex})/:view(outgoing)/download.:extension(csv|json)`,
   protectRoute('moves:download:by_location'),
   setMovesByDateAndLocation,
   download

--- a/app/moves/index.js
+++ b/app/moves/index.js
@@ -3,7 +3,7 @@ const router = require('express').Router()
 
 // Local dependencies
 const { protectRoute } = require('../../common/middleware/permissions')
-const { download, list, listByStatus } = require('./controllers')
+const { dashboard, download, list, listByStatus } = require('./controllers')
 const {
   redirectBaseUrl,
   saveUrl,
@@ -15,6 +15,8 @@ const {
   setMovesByDateAndLocation,
   setMovesByDateRangeAndStatus,
   setMovesByDateAllLocations,
+  setTotalMoves,
+  setTranslatedMoveTypes,
 } = require('./middleware')
 
 const uuidRegex =
@@ -45,10 +47,21 @@ router.get(
   list
 )
 router.get(
+  `/:period(week|day)/:date/:locationId(${uuidRegex})/:view(dashboard)`,
+  protectRoute('moves:view:by_location'),
+  protectRoute('moves:view:proposed'),
+  setMoveTypeNavigation,
+  setTotalMoves,
+  setTranslatedMoveTypes,
+  setPagination,
+  dashboard
+)
+router.get(
   `/:period(week|day)/:date/:locationId(${uuidRegex})/:status(proposed|requested,accepted,completed|rejected)`,
   protectRoute('moves:view:by_location'),
   protectRoute('moves:view:proposed'),
   setMoveTypeNavigation,
+  setTranslatedMoveTypes,
   setMovesByDateRangeAndStatus,
   setPagination,
   listByStatus

--- a/app/moves/middleware.js
+++ b/app/moves/middleware.js
@@ -1,5 +1,5 @@
 const { format } = require('date-fns')
-const { find, get, chunk, cloneDeep } = require('lodash')
+const { find, get, chunk, cloneDeep, reject } = require('lodash')
 
 const permissions = require('../../common/middleware/permissions')
 
@@ -47,11 +47,10 @@ const movesMiddleware = {
         'moves:view:proposed',
         userPermissions
       )
-      return res.redirect(
-        `${req.baseUrl}/day/${today}/${currentLocation}/${
-          canViewProposedMoves ? 'proposed' : ''
-        }`
-      )
+      const url = canViewProposedMoves
+        ? `${req.baseUrl}/week/${today}/${currentLocation}/dashboard`
+        : `${req.baseUrl}/day/${today}/${currentLocation}/`
+      return res.redirect(url)
     }
 
     return res.redirect(`${req.baseUrl}/day/${today}`)
@@ -88,7 +87,7 @@ const movesMiddleware = {
     next()
   },
   setPagination: (req, res, next) => {
-    const { locationId = '', period, status } = req.params
+    const { locationId = '', period, status, view } = req.params
     const today = format(new Date(), dateFormat)
     const baseDate = getDateFromParams(req)
     const interval = period === 'week' ? 7 : 1
@@ -97,12 +96,12 @@ const movesMiddleware = {
     const nextPeriod = getPeriod(baseDate, interval)
 
     const locationInUrl = locationId ? `/${locationId}` : ''
-    const statusInUrl = status ? `/${status}` : ''
+    const viewInUrl = status || view ? `/${status || view}` : ''
 
     res.locals.pagination = {
-      todayUrl: `${req.baseUrl}/${period}/${today}${locationInUrl}${statusInUrl}`,
-      nextUrl: `${req.baseUrl}/${period}/${nextPeriod}${locationInUrl}${statusInUrl}`,
-      prevUrl: `${req.baseUrl}/${period}/${previousPeriod}${locationInUrl}${statusInUrl}`,
+      todayUrl: `${req.baseUrl}/${period}/${today}${locationInUrl}${viewInUrl}`,
+      nextUrl: `${req.baseUrl}/${period}/${nextPeriod}${locationInUrl}${viewInUrl}`,
+      prevUrl: `${req.baseUrl}/${period}/${previousPeriod}${locationInUrl}${viewInUrl}`,
     }
 
     next()
@@ -116,9 +115,8 @@ const movesMiddleware = {
           return moveService
             .getMovesCount({ dateRange, status: moveType.filter, locationId })
             .then(count => {
-              const { label } = moveType
               return {
-                label,
+                ...moveType,
                 value: count,
                 active: moveType.filter === req.params.status,
                 href: `${req.baseUrl}/${period}/${date}${
@@ -126,13 +124,42 @@ const movesMiddleware = {
                 }/${moveType.filter}`,
               }
             })
-            .then(presenters.moveTypesToFilterComponent)
         })
       )
       next()
     } catch (error) {
       next(error)
     }
+  },
+  setTotalMoves: (req, res, next) => {
+    if (!get(res, 'locals.moveTypeNavigation')) {
+      return next()
+    }
+    const totalMoves = {
+      label: 'moves::dashboard.filter.total',
+      filter: 'total',
+      href: find(res.locals.moveTypeNavigation, { filter: 'proposed' }).href,
+    }
+    totalMoves.value = res.locals.moveTypeNavigation.reduce(
+      (accumulator, moveType) => {
+        return (accumulator += moveType.value)
+      },
+      0
+    )
+    res.locals.moveTypeNavigation = reject(res.locals.moveTypeNavigation, {
+      filter: 'proposed',
+    })
+    res.locals.moveTypeNavigation.unshift(totalMoves)
+    next()
+  },
+  setTranslatedMoveTypes(req, res, next) {
+    if (!get(res, 'locals.moveTypeNavigation')) {
+      return next()
+    }
+    res.locals.moveTypeNavigation = presenters.moveTypesToFilterComponent(
+      res.locals.moveTypeNavigation
+    )
+    next()
   },
   setMovesByDateAndLocation: async (req, res, next) => {
     const { dateRange, fromLocationId } = res.locals

--- a/app/moves/views/dashboard.njk
+++ b/app/moves/views/dashboard.njk
@@ -1,0 +1,9 @@
+{% extends "./_layout.njk" %}
+
+{% block headerGridColumnClass %}govuk-grid-column-full{% endblock %}
+
+{% block headerActions %}
+  {{ appFilter({
+    items: moveTypeNavigation
+  }) }}
+{% endblock %}

--- a/app/moves/views/dashboard.njk
+++ b/app/moves/views/dashboard.njk
@@ -1,9 +1,10 @@
 {% extends "./_layout.njk" %}
 
-{% block headerGridColumnClass %}govuk-grid-column-full{% endblock %}
+{% block headerGridColumnClass %}govuk-grid-column-full view-dashboard{% endblock %}
 
 {% block headerActions %}
   {{ appFilter({
-    items: moveTypeNavigation
+    items: moveTypeNavigation,
+    classes: "app-filter--stacked"
   }) }}
 {% endblock %}

--- a/app/moves/views/dashboard.njk
+++ b/app/moves/views/dashboard.njk
@@ -1,10 +1,10 @@
 {% extends "./_layout.njk" %}
 
-{% block headerGridColumnClass %}govuk-grid-column-full view-dashboard{% endblock %}
+{% block headerGridColumnClass %}govuk-grid-column-full{% endblock %}
 
 {% block headerActions %}
   {{ appFilter({
-    items: moveTypeNavigation,
+    items: dashboardMoveSummary,
     classes: "app-filter--stacked"
   }) }}
 {% endblock %}

--- a/common/components/filter/_filter.scss
+++ b/common/components/filter/_filter.scss
@@ -75,3 +75,46 @@
 .app-filter__label {
   text-decoration: underline;
 }
+
+.app-filter--stacked {
+  .app-filter__list {
+    flex-direction: column;
+  }
+  .app-filter__list-item {
+    margin-bottom: govuk-spacing(1);
+  }
+  .app-filter__list-item:not(:first-of-type) {
+    border-color: govuk-colour('light-grey');
+    .app-filter__link {
+      background-color: govuk-colour('light-grey');
+      .app-filter__value {
+        text-decoration: underline;
+        display: inline-block;
+        font: inherit;
+      }
+      &:link,
+      &:active,
+      &:visited {
+        color: govuk-colour('blue');
+      }
+
+      &:hover {
+        color: govuk-colour('black');
+      }
+
+      &:focus {
+        background-color: govuk-colour('yellow');
+        color: govuk-colour('black');
+      }
+    }
+    @include govuk-media-query($until: 370px) {
+      min-height: auto;
+    }
+  }
+  .app-filter__list-item:first-of-type {
+    min-height: 110px;
+  }
+  .app-filter__link {
+    height: auto;
+  }
+}

--- a/common/components/filter/filter.yaml
+++ b/common/components/filter/filter.yaml
@@ -25,10 +25,15 @@ params:
             type: string
             required: false
             description: the content of the small text inside the link
+          - name: classes
+            type: string
+            required: false
+            description: the css class applied to the container
 
 examples:
   - name: default
     data:
+      classes: 'app-filter-stacked'
       items:
         - active: false
           href: /moves/proposed

--- a/common/components/filter/template.njk
+++ b/common/components/filter/template.njk
@@ -1,4 +1,4 @@
-<nav class="app-filter">
+<nav class="app-filter {{ params.classes if params.classes }}">
   <ul class="app-filter__list">
     {% for item in params.items %}
       <li class="app-filter__list-item {{ 'app-filter__list-item--active' if item.active }}">

--- a/common/components/filter/template.test.js
+++ b/common/components/filter/template.test.js
@@ -57,6 +57,11 @@ describe('Results component', function() {
       expect(valueSpan.length).to.equal(1)
       expect(valueSpan.html()).to.equal('Moves proposed')
     })
+    it('incorporates the classes passed to it', function() {
+      expect(component.get(0).attribs.class).to.equal(
+        'app-filter app-filter-stacked'
+      )
+    })
   })
   context('without value', function() {
     let component, items, $

--- a/common/presenters/move-type-for-filter.js
+++ b/common/presenters/move-type-for-filter.js
@@ -1,9 +1,9 @@
 const i18n = require('../../config/i18n')
-const { cloneDeep } = require('lodash')
 
-function moveTypesToFilterComponent(item) {
-  const moveType = cloneDeep(item)
-  moveType.label = i18n.t(item.label)
-  return moveType
+function moveTypesToFilterComponent(items) {
+  return items.map(item => {
+    item.label = i18n.t(item.label)
+    return item
+  })
 }
 module.exports = moveTypesToFilterComponent

--- a/common/presenters/move-type-for-filter.js
+++ b/common/presenters/move-type-for-filter.js
@@ -1,9 +1,7 @@
 const i18n = require('../../config/i18n')
 
-function moveTypesToFilterComponent(items) {
-  return items.map(item => {
-    item.label = i18n.t(item.label)
-    return item
-  })
+function moveTypesToFilterComponent(item) {
+  item.label = i18n.t(item.label)
+  return item
 }
 module.exports = moveTypesToFilterComponent

--- a/common/presenters/move-type-for-filter.test.js
+++ b/common/presenters/move-type-for-filter.test.js
@@ -2,34 +2,22 @@ const i18n = require('../../config/i18n')
 const presenter = require('./move-type-for-filter')
 
 describe('move type for filter', function() {
-  const testItems = [
-    {
-      id: 1,
-      label: 'a',
-    },
-    {
-      id: 2,
-      label: 'b',
-    },
-  ]
+  const testItem = {
+    id: 1,
+    label: 'a',
+  }
   let output
   beforeEach(function() {
     sinon.stub(i18n, 't').returns('__translated__')
-    output = presenter(testItems)
+    output = presenter(testItem)
   })
   it('translates the label of every item', function() {
-    expect(i18n.t).to.have.been.calledTwice
+    expect(i18n.t).to.have.been.calledOnce
   })
   it('returns the items so modified', function() {
-    expect(output).to.deep.equal([
-      {
-        id: 1,
-        label: '__translated__',
-      },
-      {
-        id: 2,
-        label: '__translated__',
-      },
-    ])
+    expect(output).to.deep.equal({
+      id: 1,
+      label: '__translated__',
+    })
   })
 })

--- a/common/presenters/move-type-for-filter.test.js
+++ b/common/presenters/move-type-for-filter.test.js
@@ -1,0 +1,35 @@
+const i18n = require('../../config/i18n')
+const presenter = require('./move-type-for-filter')
+
+describe('move type for filter', function() {
+  const testItems = [
+    {
+      id: 1,
+      label: 'a',
+    },
+    {
+      id: 2,
+      label: 'b',
+    },
+  ]
+  let output
+  beforeEach(function() {
+    sinon.stub(i18n, 't').returns('__translated__')
+    output = presenter(testItems)
+  })
+  it('translates the label of every item', function() {
+    expect(i18n.t).to.have.been.calledTwice
+  })
+  it('returns the items so modified', function() {
+    expect(output).to.deep.equal([
+      {
+        id: 1,
+        label: '__translated__',
+      },
+      {
+        id: 2,
+        label: '__translated__',
+      },
+    ])
+  })
+})

--- a/config/nunjucks/filters.js
+++ b/config/nunjucks/filters.js
@@ -1,5 +1,7 @@
 const {
+  differenceInDays,
   format,
+  isThisWeek,
   isToday,
   isTomorrow,
   isYesterday,
@@ -13,8 +15,12 @@ const {
 const { kebabCase, startCase } = require('lodash')
 const pluralize = require('pluralize')
 const chrono = require('chrono-node')
+const i18n = require('../i18n')
 
 const { DATE_FORMATS } = require('../index')
+const weekOptions = {
+  weekStartsOn: 1,
+}
 
 /**
  * Formats a date into the desired string format
@@ -46,6 +52,16 @@ function formatDateRange(dateRange) {
     return isDate(date) ? date : parseISO(date)
   })
   const [startDate, endDate] = parsedDates
+  if (
+    isThisWeek(startDate, weekOptions) &&
+    differenceInDays(endDate, startDate) === 6
+  ) {
+    return i18n.t('actions::current_week')
+  }
+  return _formatAnyDateRange(startDate, endDate)
+}
+
+function _formatAnyDateRange(startDate, endDate) {
   const displayMonth = isSameMonth(startDate, endDate) ? '' : ' MMM'
   const displayYear = isSameYear(startDate, endDate) ? '' : ' yyyy'
   const formattedStartDay = format(startDate, `d${displayMonth}${displayYear}`)

--- a/config/nunjucks/filters.test.js
+++ b/config/nunjucks/filters.test.js
@@ -1,5 +1,6 @@
 const proxyquire = require('proxyquire')
 const timezoneMock = require('timezone-mock')
+const { startOfWeek, endOfWeek } = require('date-fns')
 
 const filters = proxyquire('./filters', {
   '../index': {
@@ -190,6 +191,22 @@ describe('Nunjucks filters', function() {
         ).to.equal('1 to 10 Nov 2019')
       })
     })
+    context(
+      'when both start date and end date are on the current week ',
+      function() {
+        const weekOpts = {
+          weekStartsOn: 1,
+        }
+        it('returns "this week"', function() {
+          expect(
+            formatDateRange([
+              startOfWeek(new Date(), weekOpts),
+              endOfWeek(new Date(), weekOpts),
+            ])
+          ).to.equal('This week')
+        })
+      }
+    )
   })
 
   describe('#calculateAge()', function() {

--- a/config/nunjucks/filters.test.js
+++ b/config/nunjucks/filters.test.js
@@ -1,6 +1,7 @@
 const proxyquire = require('proxyquire')
 const timezoneMock = require('timezone-mock')
 const { startOfWeek, endOfWeek } = require('date-fns')
+const i18n = require('../i18n')
 
 const filters = proxyquire('./filters', {
   '../index': {
@@ -197,13 +198,16 @@ describe('Nunjucks filters', function() {
         const weekOpts = {
           weekStartsOn: 1,
         }
+        before(function() {
+          sinon.stub(i18n, 't').returnsArg(0)
+        })
         it('returns "this week"', function() {
           expect(
             formatDateRange([
               startOfWeek(new Date(), weekOpts),
               endOfWeek(new Date(), weekOpts),
             ])
-          ).to.equal('This week')
+          ).to.equal('actions::current_week')
         })
       }
     )

--- a/locales/en/moves.json
+++ b/locales/en/moves.json
@@ -131,7 +131,8 @@
     "filter": {
       "proposed": "proposed",
       "approved": "approved",
-      "rejected": "rejected"
+      "rejected": "rejected",
+      "total": "total"
     }
   },
   "detail": {

--- a/locales/en/moves.json
+++ b/locales/en/moves.json
@@ -132,7 +132,7 @@
       "proposed": "proposed",
       "approved": "approved",
       "rejected": "rejected",
-      "total": "total"
+      "total": "single requests"
     }
   },
   "detail": {


### PR DESCRIPTION
This is the dashboard for the OCA journey. For now allowances are not included, as agreed with Andrew.
The existing URLs for the moves now acquire the suffix `/outgoing`, in preparation from when we will have `/incoming` as well. The current "default" view per location url is now taken by the dashboard.

Each box in the filter of the dashboard links to the corresponding filtered view; however, `total` links to `proposed`.

Please note before merging this that this changes the behaviour of the existing public website.

No e-2-e tests were harmed in the making of this change.


![image](https://user-images.githubusercontent.com/853989/78006722-42d5f300-7335-11ea-94be-04c3d34bbf15.png)


### Default moves view to which the *OCA* user with a location is redirected:
<img width="427" alt="Screenshot 2020-04-01 at 17 14 22" src="https://user-images.githubusercontent.com/853989/78160958-9e3ed880-743c-11ea-8713-00ab372f26a2.png">

### Default moves view to which the *non-OCA* user with a location is redirected:
<img width="438" alt="Screenshot 2020-04-01 at 17 15 23" src="https://user-images.githubusercontent.com/853989/78160909-90895300-743c-11ea-972c-fc66513d26e7.png">



### Checklist

- [x] If adding new environment variables, they have been documented in the [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md)
- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
