### PR TITLE
[NOJIRA] fix: Navigation displays wrong label

### DIFF
--- a/app/locations/views/locations.njk
+++ b/app/locations/views/locations.njk
@@ -1,5 +1,7 @@
 {% extends "layouts/base.njk" %}
 
+{% block primaryNavigation %}{% endblock %}
+
 {% block organisationSwitcher %}{% endblock %}
 
 {% block pageTitle %}

--- a/common/templates/layouts/base.njk
+++ b/common/templates/layouts/base.njk
@@ -92,13 +92,15 @@
       }
     ]
   }) }}
-  {{ mojPrimaryNavigation({
-    label: 'Primary navigation',
-    items: [{
-      text: t("default::primary_navigation.single_moves") if CURRENT_LOCATION and CURRENT_LOCATION.location_type === 'prison' else t("default::primary_navigation.upcoming_moves"),
-      href: '/moves'
-    }]
-  }) }}
+  {% block primaryNavigation %}
+    {{ mojPrimaryNavigation({
+      label: 'Primary navigation',
+      items: [{
+        text: t("default::primary_navigation.single_moves") if CURRENT_LOCATION and canAccess("moves:view:proposed") else t("default::primary_navigation.upcoming_moves"),
+        href: '/moves'
+      }]
+    }) }}
+  {% endblock %}
 {% endblock %}
 
 {% block beforeContent %}


### PR DESCRIPTION
This PR:
- fixes the wrong label in the primary navigation, as it was determined by location only and not permissions
- removes the primary navigation in the location template, as it's too early to determine its link


### Checklist

- [x] If adding new environment variables, they have been documented in the [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md)
- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
