### PR TITLE
[P4-1108] Add message to confirmation page with sync status

### DIFF
--- a/app/move/controllers/confirmation.js
+++ b/app/move/controllers/confirmation.js
@@ -7,15 +7,15 @@ function confirmation(req, res) {
     to_location: toLocation,
   } = res.locals.move
   const suppliers = get(res.locals, 'move.from_location.suppliers')
-  const supplierName =
+  const supplierNames =
     suppliers && suppliers.length
-      ? map(suppliers, 'name').join(' and ')
-      : req.t('supplier_fallback')
+      ? map(suppliers, 'name')
+      : [req.t('supplier_fallback')]
   const savedHearings = map(filter(hearings, 'saved_to_nomis'), 'case_number')
   const unsavedHearings = map(reject(hearings, 'saved_to_nomis'), 'case_number')
 
   const locals = {
-    supplierName,
+    supplierNames,
     savedHearings,
     unsavedHearings,
     location:

--- a/app/move/controllers/confirmation.js
+++ b/app/move/controllers/confirmation.js
@@ -1,15 +1,23 @@
-const { get, map } = require('lodash')
+const { filter, get, map, reject } = require('lodash')
 
 function confirmation(req, res) {
-  const { move_type: moveType, to_location: toLocation } = res.locals.move
+  const {
+    hearings,
+    move_type: moveType,
+    to_location: toLocation,
+  } = res.locals.move
   const suppliers = get(res.locals, 'move.from_location.suppliers')
   const supplierName =
     suppliers && suppliers.length
       ? map(suppliers, 'name').join(' and ')
       : req.t('supplier_fallback')
+  const savedHearings = map(filter(hearings, 'saved_to_nomis'), 'case_number')
+  const unsavedHearings = map(reject(hearings, 'saved_to_nomis'), 'case_number')
 
   const locals = {
     supplierName,
+    savedHearings,
+    unsavedHearings,
     location:
       moveType === 'prison_recall'
         ? req.t('fields::move_type.items.prison_recall.label')

--- a/app/move/controllers/confirmation.test.js
+++ b/app/move/controllers/confirmation.test.js
@@ -50,6 +50,18 @@ describe('Move controllers', function() {
       it('should translate supplier fallback key', function() {
         expect(req.t).to.have.been.calledOnceWithExactly('supplier_fallback')
       })
+
+      it('should use empty array for saved hearings', function() {
+        const params = res.render.args[0][1]
+        expect(params).to.have.property('savedHearings')
+        expect(params.savedHearings).to.deep.equal([])
+      })
+
+      it('should use empty array for unsaved hearings', function() {
+        const params = res.render.args[0][1]
+        expect(params).to.have.property('unsavedHearings')
+        expect(params.unsavedHearings).to.deep.equal([])
+      })
     })
 
     describe('with move_type "prison_recall"', function() {
@@ -143,6 +155,71 @@ describe('Move controllers', function() {
         const params = res.render.args[0][1]
         expect(params).to.have.property('supplierName')
         expect(params.supplierName).to.equal('Supplier one and Supplier two')
+      })
+    })
+
+    describe('with hearings', function() {
+      beforeEach(function() {
+        res.locals.move = {
+          ...mockMove,
+          hearings: [
+            {
+              case_number: 'S72525',
+              saved_to_nomis: true,
+            },
+            {
+              case_number: 'T43406',
+              saved_to_nomis: false,
+            },
+            {
+              case_number: 'S67301',
+              saved_to_nomis: false,
+            },
+            {
+              case_number: 'T15222',
+              saved_to_nomis: true,
+            },
+            {
+              case_number: 'T45483',
+              saved_to_nomis: false,
+            },
+            {
+              case_number: 'T30532',
+              saved_to_nomis: false,
+            },
+          ],
+        }
+
+        controller(req, res)
+      })
+
+      it('should contain correct number of saved hearings', function() {
+        const params = res.render.args[0][1]
+        expect(params).to.have.property('savedHearings')
+        expect(params.savedHearings.length).to.equal(2)
+      })
+
+      it('should contain correct case numbers in saved hearings', function() {
+        const params = res.render.args[0][1]
+        expect(params).to.have.property('savedHearings')
+        expect(params.savedHearings).to.deep.equal(['S72525', 'T15222'])
+      })
+
+      it('should contain correct number of unsaved hearings', function() {
+        const params = res.render.args[0][1]
+        expect(params).to.have.property('unsavedHearings')
+        expect(params.unsavedHearings.length).to.equal(4)
+      })
+
+      it('should contain correct case numbers in unsaved hearings', function() {
+        const params = res.render.args[0][1]
+        expect(params).to.have.property('unsavedHearings')
+        expect(params.unsavedHearings).to.deep.equal([
+          'T43406',
+          'S67301',
+          'T45483',
+          'T30532',
+        ])
       })
     })
   })

--- a/app/move/controllers/confirmation.test.js
+++ b/app/move/controllers/confirmation.test.js
@@ -43,8 +43,8 @@ describe('Move controllers', function() {
 
       it('should use supplier fallback as supplier name', function() {
         const params = res.render.args[0][1]
-        expect(params).to.have.property('supplierName')
-        expect(params.supplierName).to.equal('supplier_fallback')
+        expect(params).to.have.property('supplierNames')
+        expect(params.supplierNames).to.deep.equal(['supplier_fallback'])
       })
 
       it('should translate supplier fallback key', function() {
@@ -100,8 +100,8 @@ describe('Move controllers', function() {
 
       it('should use supplier fallback as supplier name', function() {
         const params = res.render.args[0][1]
-        expect(params).to.have.property('supplierName')
-        expect(params.supplierName).to.equal('supplier_fallback')
+        expect(params).to.have.property('supplierNames')
+        expect(params.supplierNames).to.deep.equal(['supplier_fallback'])
       })
 
       it('should translate supplier fallback key', function() {
@@ -125,10 +125,10 @@ describe('Move controllers', function() {
         controller(req, res)
       })
 
-      it('should use first supplier name as supplier param', function() {
+      it('should only contain first supplier in supplier param', function() {
         const params = res.render.args[0][1]
-        expect(params).to.have.property('supplierName')
-        expect(params.supplierName).to.equal('Supplier one')
+        expect(params).to.have.property('supplierNames')
+        expect(params.supplierNames).to.deep.equal(['Supplier one'])
       })
     })
 
@@ -151,10 +151,13 @@ describe('Move controllers', function() {
         controller(req, res)
       })
 
-      it('should join supplier names as supplier param', function() {
+      it('should contain all supplier names as supplier param', function() {
         const params = res.render.args[0][1]
-        expect(params).to.have.property('supplierName')
-        expect(params.supplierName).to.equal('Supplier one and Supplier two')
+        expect(params).to.have.property('supplierNames')
+        expect(params.supplierNames).to.deep.equal([
+          'Supplier one',
+          'Supplier two',
+        ])
       })
     })
 

--- a/app/move/views/confirmation.njk
+++ b/app/move/views/confirmation.njk
@@ -38,6 +38,28 @@
         }) | safe }}
       </p>
 
+      {% if savedHearings|length %}
+        {{ govukInsetText({
+          html: t("moves::confirmation.saved_to_nomis", {
+            name: move.person.fullname | upper,
+            date: move.date | formatDateWithDay,
+            cases: savedHearings | oxfordJoin,
+            count: savedHearings.length
+          })
+        }) }}
+      {% endif %}
+
+      {% if unsavedHearings|length %}
+        {{ govukWarningText({
+          text: t("moves::confirmation.saved_to_nomis", {
+            context: "failed",
+            cases: unsavedHearings | oxfordJoin,
+            count: unsavedHearings.length
+          }),
+          iconFallbackText: "Warning"
+        }) }}
+      {% endif %}
+
       <p>
         <a href="{{ MOVES_URL }}">
           {{ t("actions::back_to_dashboard") }}

--- a/app/move/views/confirmation.njk
+++ b/app/move/views/confirmation.njk
@@ -34,7 +34,7 @@
           name: move.person.fullname | upper,
           location: location,
           date: move.date | formatDateWithDay,
-          supplier: supplierName
+          supplier: supplierNames | oxfordJoin
         }) | safe }}
       </p>
 

--- a/config/nunjucks/filters.js
+++ b/config/nunjucks/filters.js
@@ -167,6 +167,33 @@ function formatTime(value) {
   return `${hours}${minutes}${suffix}`
 }
 
+/**
+ * Join a list of items using commas and `and` as
+ * the final join
+ *
+ * @param  {Array} an array of items to join
+ * @param  {String} last delimiter to use
+ * @return {String} items joined using commas and the last delimiter
+ * @example {{ ["one","two","three"] | oxfordJoin }}
+ */
+function oxfordJoin(arr = [], lastDelimiter = 'and') {
+  if (arr.length === 0) {
+    return ''
+  }
+
+  if (arr.length === 1) {
+    return arr[0]
+  }
+
+  if (arr.length === 2) {
+    // joins all with "and" but no commas
+    return arr.join(` ${lastDelimiter} `)
+  }
+
+  // joins all with commas, but last one gets ", and" (oxford comma!)
+  return `${arr.slice(0, -1).join(', ')}, ${lastDelimiter} ${arr.slice(-1)}`
+}
+
 module.exports = {
   formatDate,
   formatDateRange,
@@ -178,4 +205,5 @@ module.exports = {
   kebabcase: kebabCase,
   startCase,
   pluralize,
+  oxfordJoin,
 }

--- a/config/nunjucks/filters.test.js
+++ b/config/nunjucks/filters.test.js
@@ -438,4 +438,66 @@ describe('Nunjucks filters', function() {
       })
     })
   })
+
+  describe('#oxfordJoin()', function() {
+    context('by default', function() {
+      context('with no items', function() {
+        it('should return empty string', function() {
+          const joined = filters.oxfordJoin([])
+          expect(joined).to.equal('')
+        })
+      })
+
+      context('with one item', function() {
+        it('should return item', function() {
+          const joined = filters.oxfordJoin(['one'])
+          expect(joined).to.equal('one')
+        })
+      })
+
+      context('with two items', function() {
+        it('should join with `and`', function() {
+          const joined = filters.oxfordJoin(['one', 'two'])
+          expect(joined).to.equal('one and two')
+        })
+      })
+
+      context('with multiple items', function() {
+        it('should join with comma and `and`', function() {
+          const joined = filters.oxfordJoin(['one', 'two', 'three'])
+          expect(joined).to.equal('one, two, and three')
+        })
+      })
+    })
+
+    context('with custom delimiter', function() {
+      context('with no items', function() {
+        it('should return empty string', function() {
+          const joined = filters.oxfordJoin([], 'or')
+          expect(joined).to.equal('')
+        })
+      })
+
+      context('with one item', function() {
+        it('should return item', function() {
+          const joined = filters.oxfordJoin(['one'], 'or')
+          expect(joined).to.equal('one')
+        })
+      })
+
+      context('with two items', function() {
+        it('should join with `or`', function() {
+          const joined = filters.oxfordJoin(['one', 'two'], 'or')
+          expect(joined).to.equal('one or two')
+        })
+      })
+
+      context('with multiple items', function() {
+        it('should join with comma and `or`', function() {
+          const joined = filters.oxfordJoin(['one', 'two', 'three'], 'or')
+          expect(joined).to.equal('one, two, or three')
+        })
+      })
+    })
+  })
 })

--- a/locales/en/moves.json
+++ b/locales/en/moves.json
@@ -159,7 +159,11 @@
       "content": "Reference number<br><strong>{{moveReference}}</strong>"
     },
     "detail": "The move for <strong><a href=\"{{href}}\">{{name}}</a></strong> to <strong>{{location}}</strong> on <strong>{{date}}</strong> has been scheduled with {{supplier}}.",
-    "detail_proposed": "The move for <strong><a href=\"{{href}}\">{{name}}</a></strong> to <strong>{{location}}</strong> has been sent to the Population Management Unit (PMU) for review."
+    "detail_proposed": "The move for <strong><a href=\"{{href}}\">{{name}}</a></strong> to <strong>{{location}}</strong> has been sent to the Population Management Unit (PMU) for review.",
+    "saved_to_nomis": "<p>A court date for case number <strong>{{cases}}</strong> on <strong>{{date}}</strong> has been added to NOMIS.</p><p>If this person has more than one hearing you will need to add any extra court dates.</p>",
+    "saved_to_nomis_plural": "<p>Court dates for case numbers <strong>{{cases}}</strong> on <strong>{{date}}</strong> have been added to NOMIS.</p>",
+    "saved_to_nomis_failed": "You need to add this court date to NOMIS as it could not be added.",
+    "saved_to_nomis_failed_plural": "You need to add court dates to NOMIS for {{cases}} as they could not be added."
   },
   "agreement_status": {
     "heading": "Has this move been agreed with receiving prison?"


### PR DESCRIPTION
## Proposed changes

This change involves adding messages to the confirmation page of creating a new move to display whether the relevant information has been added to NOMIS or not.

The two scenarios use distinctly different components to draw more attention to the case where something needs to be done.

It also has basic handling for when multiple hearings are supported when creating a move - it will join case numbers using commas and the word "and".

**Note:** This only applies to moves from a Prison to a Court

#### Todo

- [x] Use correct values from API to determine whether a move has court hearings
- [x] Use correct value from API to determine if hearings were created in NOMIS
- [x] Update screenshots

## What it looks like

### If hearing (court date) was created in NOMIS

- Message to user to say has been added successfully (includes date and case number)
- Includes content to add further hearings to NOMIS

<kbd><img src="https://user-images.githubusercontent.com/3327997/78820274-69e49280-79cf-11ea-945d-5b7814e2a55d.png"></kbd>

<kbd><img src="https://user-images.githubusercontent.com/3327997/78820229-589b8600-79cf-11ea-9d97-7a1443a56d1d.png"></kbd>

### If hearing (court date) was not created in NOMIS

- Warning message to say it was not added and the user needs to add it themselves

<kbd><img src="https://user-images.githubusercontent.com/3327997/78820037-1114fa00-79cf-11ea-9bc1-785ba28a63fe.png"></kbd>

<kbd><img src="https://user-images.githubusercontent.com/3327997/78820101-29851480-79cf-11ea-84df-084ec3ab8048.png"></kbd>