### PR TITLE
Fix end-to-end tests

### DIFF
--- a/app/move/steps/create.js
+++ b/app/move/steps/create.js
@@ -33,7 +33,14 @@ const moveDetailsStep = {
     {
       field: 'from_location_type',
       value: 'prison',
-      next: 'move-date-range',
+      next: [
+        {
+          field: 'to_location_type',
+          value: 'prison',
+          next: 'move-date-range',
+        },
+        'move-date',
+      ],
     },
     'move-date',
   ],

--- a/test/e2e/move.new.prison.test.js
+++ b/test/e2e/move.new.prison.test.js
@@ -53,6 +53,10 @@ test('Prison to Court with existing person', async t => {
   const moveDetails = await createMovePage.fillInMoveDetails('Court')
   await page.submitForm()
 
+  // Move date
+  await createMovePage.fillInDate()
+  await page.submitForm()
+
   // Court information
   await createMovePage.fillInCourtInformation()
   await page.submitForm()

--- a/test/e2e/move.new.stc.test.js
+++ b/test/e2e/move.new.stc.test.js
@@ -24,6 +24,10 @@ test('Secure Training Centre to Court with new person', async t => {
   const moveDetails = await createMovePage.fillInMoveDetails('Court')
   await page.submitForm()
 
+  // Move date
+  await createMovePage.fillInDate()
+  await page.submitForm()
+
   // Court information
   await createMovePage.fillInCourtInformation()
   await page.submitForm()


### PR DESCRIPTION
This fixes 2 issues that are causing the end-to-end tests to fail:

- Date range step is shown to all prison journeys
- End-to-end tests for STC and Prison don't cater for separate move date step