### PR TITLE
[P4-1108] feat: Use supplier name in confirmation message

### DIFF
--- a/app/move/controllers/confirmation.js
+++ b/app/move/controllers/confirmation.js
@@ -1,7 +1,15 @@
+const { get, map } = require('lodash')
+
 function confirmation(req, res) {
   const { move_type: moveType, to_location: toLocation } = res.locals.move
+  const suppliers = get(res.locals, 'move.from_location.suppliers')
+  const supplierName =
+    suppliers && suppliers.length
+      ? map(suppliers, 'name').join(' and ')
+      : req.t('supplier_fallback')
 
   const locals = {
+    supplierName,
     location:
       moveType === 'prison_recall'
         ? req.t('fields::move_type.items.prison_recall.label')

--- a/app/move/controllers/confirmation.test.js
+++ b/app/move/controllers/confirmation.test.js
@@ -9,18 +9,22 @@ const mockMove = {
 
 describe('Move controllers', function() {
   describe('#confirmation()', function() {
-    describe('with move_type "court_appearance"', function() {
-      let req, res
+    let req, res
 
+    beforeEach(function() {
+      req = {
+        t: sinon.stub().returnsArg(0),
+      }
+      res = {
+        render: sinon.spy(),
+        locals: {
+          move: mockMove,
+        },
+      }
+    })
+
+    context('by default', function() {
       beforeEach(function() {
-        req = {}
-        res = {
-          render: sinon.spy(),
-          locals: {
-            move: mockMove,
-          },
-        }
-
         controller(req, res)
       })
 
@@ -31,46 +35,114 @@ describe('Move controllers', function() {
         expect(template).to.equal('move/views/confirmation')
       })
 
-      it('should contain a location param', function() {
+      it('should use to location title as location', function() {
         const params = res.render.args[0][1]
         expect(params).to.have.property('location')
         expect(params.location).to.equal(mockMove.to_location.title)
       })
+
+      it('should use supplier fallback as supplier name', function() {
+        const params = res.render.args[0][1]
+        expect(params).to.have.property('supplierName')
+        expect(params.supplierName).to.equal('supplier_fallback')
+      })
+
+      it('should translate supplier fallback key', function() {
+        expect(req.t).to.have.been.calledOnceWithExactly('supplier_fallback')
+      })
     })
 
     describe('with move_type "prison_recall"', function() {
-      let req, res
-
       beforeEach(function() {
-        req = {
-          t: sinon.stub().returnsArg(0),
+        res.locals.move = {
+          ...mockMove,
+          move_type: 'prison_recall',
         }
-        res = {
-          render: sinon.spy(),
-          locals: {
-            move: {
-              ...mockMove,
-              move_type: 'prison_recall',
-            },
+
+        controller(req, res)
+      })
+
+      it('should use translation key as location', function() {
+        const params = res.render.args[0][1]
+        expect(params).to.have.property('location')
+        expect(params.location).to.equal(
+          'fields::move_type.items.prison_recall.label'
+        )
+        expect(req.t.secondCall).to.have.been.calledWithExactly(
+          'fields::move_type.items.prison_recall.label'
+        )
+      })
+    })
+
+    describe('with empty supplier', function() {
+      beforeEach(function() {
+        res.locals.move = {
+          ...mockMove,
+          from_location: {
+            suppliers: [],
           },
         }
 
         controller(req, res)
       })
 
-      it('should render confirmation template', function() {
-        const template = res.render.args[0][0]
-
-        expect(res.render.calledOnce).to.be.true
-        expect(template).to.equal('move/views/confirmation')
+      it('should use supplier fallback as supplier name', function() {
+        const params = res.render.args[0][1]
+        expect(params).to.have.property('supplierName')
+        expect(params.supplierName).to.equal('supplier_fallback')
       })
 
-      it('should pass correct values to location translation', function() {
+      it('should translate supplier fallback key', function() {
+        expect(req.t).to.have.been.calledOnceWithExactly('supplier_fallback')
+      })
+    })
+
+    describe('with one supplier', function() {
+      beforeEach(function() {
+        res.locals.move = {
+          ...mockMove,
+          from_location: {
+            suppliers: [
+              {
+                name: 'Supplier one',
+              },
+            ],
+          },
+        }
+
+        controller(req, res)
+      })
+
+      it('should use first supplier name as supplier param', function() {
         const params = res.render.args[0][1]
-        expect(params).to.have.property('location')
-        expect(req.t.firstCall).to.have.been.calledWithExactly(
-          'fields::move_type.items.prison_recall.label'
-        )
+        expect(params).to.have.property('supplierName')
+        expect(params.supplierName).to.equal('Supplier one')
+      })
+    })
+
+    describe('with multiple suppliers', function() {
+      beforeEach(function() {
+        res.locals.move = {
+          ...mockMove,
+          from_location: {
+            suppliers: [
+              {
+                name: 'Supplier one',
+              },
+              {
+                name: 'Supplier two',
+              },
+            ],
+          },
+        }
+
+        controller(req, res)
+      })
+
+      it('should join supplier names as supplier param', function() {
+        const params = res.render.args[0][1]
+        expect(params).to.have.property('supplierName')
+        expect(params.supplierName).to.equal('Supplier one and Supplier two')
       })
     })
   })

--- a/app/move/views/confirmation.njk
+++ b/app/move/views/confirmation.njk
@@ -24,12 +24,14 @@
         })
       }) }}
 
-      <p>{{ t("moves::confirmation.detail", {
+      <p>
+        {{ t("moves::confirmation.detail", {
           href: "/move/" + move.id,
           name: move.person.fullname | upper,
           location: location,
-          date: move.date | formatDateWithDay
-          }) | safe }}
+          date: move.date | formatDateWithDay,
+          supplier: supplierName
+        }) | safe }}
       </p>
 
       <p>

--- a/locales/en/default.json
+++ b/locales/en/default.json
@@ -2,6 +2,7 @@
   "feedback_link": "Give us feedback",
   "age": "Age",
   "age_with_date_of_birth": "{{date_of_birth}} (Age {{age}})",
+  "supplier_fallback": "the supplier",
   "primary_navigation": {
     "upcoming_moves": "Upcoming moves",
     "single_moves": "Single moves"

--- a/locales/en/moves.json
+++ b/locales/en/moves.json
@@ -155,7 +155,7 @@
       "heading": "Move scheduled",
       "content": "Reference number<br><strong>{{moveReference}}</strong>"
     },
-    "detail": "The move for <strong><a href=\"{{href}}\">{{name}}</a></strong> to <strong>{{location}}</strong> on <strong>{{date}}</strong> has been scheduled."
+    "detail": "The move for <strong><a href=\"{{href}}\">{{name}}</a></strong> to <strong>{{location}}</strong> on <strong>{{date}}</strong> has been scheduled with {{supplier}}."
   },
   "agreement_status": {
     "heading": "Has this move been agreed with receiving prison?"


### PR DESCRIPTION
This adds the ability to display the supplier that serves that location
on the confirmation page.

If there are no suppliers mapped it uses a fallback.

This change is linked to #404 but has been separated so that it can be merged to avoid conflicts.

## What it looks like

### With known supplier

![image](https://user-images.githubusercontent.com/3327997/78013272-28544780-733e-11ea-83e9-75184a87ba2f.png)

### With unknown supplier

![image](https://user-images.githubusercontent.com/3327997/78013219-12df1d80-733e-11ea-8ff5-787d28c7e363.png)
