### PR TITLE
chore: Temporarily hide the primary navigation

### DIFF
--- a/common/templates/layouts/base.njk
+++ b/common/templates/layouts/base.njk
@@ -92,14 +92,15 @@
       }
     ]
   }) }}
+
   {% block primaryNavigation %}
-    {{ mojPrimaryNavigation({
+    {# {{ mojPrimaryNavigation({
       label: 'Primary navigation',
       items: [{
         text: t("default::primary_navigation.single_moves") if CURRENT_LOCATION and canAccess("moves:view:proposed") else t("default::primary_navigation.upcoming_moves"),
         href: '/moves'
       }]
-    }) }}
+    }) }} #}
   {% endblock %}
 {% endblock %}
 


### PR DESCRIPTION
There are some more changes that need to be made to the navigation for
it to be in a fully releasable state but we would like to release
some other changes from master so this change temporarily removes
it from the template.