### PR TITLE
[P4-1111] Show status of NOMIS

### DIFF
--- a/common/middleware/errors.js
+++ b/common/middleware/errors.js
@@ -1,3 +1,5 @@
+const { get } = require('lodash')
+
 const logger = require('../../config/logger')
 
 function _getMessage(error) {
@@ -39,10 +41,14 @@ function catchAll(showStackTrace = false) {
       return res.status(statusCode).send(error.message)
     }
 
+    const locationType = get(res.locals, 'CURRENT_LOCATION.location_type')
+    const showNomisMessage = locationType === 'prison' && statusCode === 500
+
     res.status(statusCode).render('error', {
       error,
       statusCode,
       showStackTrace,
+      showNomisMessage,
       message: _getMessage(error),
     })
   }

--- a/common/templates/error.njk
+++ b/common/templates/error.njk
@@ -1,9 +1,17 @@
 {% extends "layouts/base.njk" %}
 
+{% block primaryNavigation %}{% endblock %}
+
+{% block organisationSwitcher %}{% endblock %}
+
 {% block content %}
   <h1 class="govuk-heading-xl">{{ t(message.heading) }}</h1>
 
   <p>{{ t(message.content) }}</p>
+
+  {% if showNomisMessage %}
+    <p>{{ t("errors::nomis_status_message") }}</p>
+  {% endif %}
 
   {% if showStackTrace %}
     <dl class="app-stack-trace">

--- a/locales/en/errors.json
+++ b/locales/en/errors.json
@@ -32,5 +32,6 @@
   "unprocessable_entity": {
     "heading": "We could not process the request",
     "content": "Try again in a few moments."
-  }
+  },
+  "nomis_status_message": "The problem may be related to NOMIS being unavailable."
 }


### PR DESCRIPTION
This change adds a message to the error page for prison locations to communicate that the problem may be with NOMIS.

This is an MVP solution for now. We didn't want to go down the route of monitoring live uptime of NOMIS as our reliance is still quite minimal.

## What it looks like

![localhost_3001_trigger-error](https://user-images.githubusercontent.com/3327997/78234653-5fa62e00-74cf-11ea-9c78-675adf6d30f1.png)
