### PR TITLE
fix: Visually hide date fieldset legend

### DIFF
--- a/app/move/fields/create.js
+++ b/app/move/fields/create.js
@@ -307,7 +307,7 @@ module.exports = {
     fieldset: {
       legend: {
         text: 'fields::date_type.label',
-        classes: 'govuk-fieldset__legend--m',
+        classes: 'govuk-visually-hidden govuk-fieldset__legend--m',
       },
     },
     items: [


### PR DESCRIPTION
This change ensures the step now behaves more consistently with other
steps that only have one question. It's also the pattern suggested
on the GOV.UK Design System when asking only one question on a page.

## Before

![image](https://user-images.githubusercontent.com/3327997/78378889-8183db80-75c9-11ea-9a6d-461edf3a6a13.png)

## After

![image](https://user-images.githubusercontent.com/3327997/78378779-6022ef80-75c9-11ea-8ed1-25f4e55672a5.png)
