### PR TITLE
[P4-1224] fix: Prevent field helper mutating properties

### DIFF
--- a/app/move/fields/create.js
+++ b/app/move/fields/create.js
@@ -1,3 +1,5 @@
+const { cloneDeep } = require('lodash')
+
 const { date } = require('../formatters')
 
 const personSearchFilter = {
@@ -125,7 +127,7 @@ const dateField = {
 module.exports = {
   // Person search
   'filter.police_national_computer': {
-    ...personSearchFilter,
+    ...cloneDeep(personSearchFilter),
     id: 'filter.police_national_computer',
     name: 'filter.police_national_computer',
     label: {
@@ -134,7 +136,7 @@ module.exports = {
     },
   },
   'filter.prison_number': {
-    ...personSearchFilter,
+    ...cloneDeep(personSearchFilter),
     id: 'filter.prison_number',
     name: 'filter.prison_number',
     label: {
@@ -197,7 +199,7 @@ module.exports = {
     autocomplete: 'off',
   },
   date_of_birth: {
-    ...dateField,
+    ...cloneDeep(dateField),
     validate: [...dateField.validate, 'before'],
     label: {
       text: 'fields::date_of_birth.label',
@@ -251,7 +253,7 @@ module.exports = {
   // move details
   to_location: {},
   move_type: {
-    ...moveType,
+    ...cloneDeep(moveType),
     items: [
       {
         id: 'move_type',
@@ -268,7 +270,7 @@ module.exports = {
     ],
   },
   move_type__police: {
-    ...moveType,
+    ...cloneDeep(moveType),
     items: [
       {
         id: 'move_type',
@@ -328,7 +330,7 @@ module.exports = {
     ],
   },
   date_custom: {
-    ...dateField,
+    ...cloneDeep(dateField),
     validate: [...dateField.validate, 'after'],
     skip: true,
     dependent: {
@@ -343,7 +345,7 @@ module.exports = {
     },
   },
   date_from: {
-    ...dateField,
+    ...cloneDeep(dateField),
     validate: [...dateField.validate, 'after'],
     id: 'date_from',
     name: 'date_from',
@@ -375,7 +377,7 @@ module.exports = {
     ],
   },
   date_to: {
-    ...dateField,
+    ...cloneDeep(dateField),
     skip: true,
     validate: [...dateField.validate, 'after'],
     dependent: {
@@ -390,31 +392,31 @@ module.exports = {
     },
   },
   // risk information
-  violent: assessmentQuestionComments,
-  escape: assessmentQuestionComments,
-  hold_separately: assessmentQuestionComments,
-  self_harm: assessmentQuestionComments,
-  concealed_items: assessmentQuestionComments,
-  other_risks: requiredAssessmentQuestionComments,
+  violent: cloneDeep(assessmentQuestionComments),
+  escape: cloneDeep(assessmentQuestionComments),
+  hold_separately: cloneDeep(assessmentQuestionComments),
+  self_harm: cloneDeep(assessmentQuestionComments),
+  concealed_items: cloneDeep(assessmentQuestionComments),
+  other_risks: cloneDeep(requiredAssessmentQuestionComments),
   not_to_be_released: {
-    ...requiredAssessmentQuestionComments,
+    ...cloneDeep(requiredAssessmentQuestionComments),
     explicit: true,
   },
   // health information
-  special_diet_or_allergy: assessmentQuestionComments,
-  health_issue: assessmentQuestionComments,
-  medication: assessmentQuestionComments,
-  wheelchair: assessmentQuestionComments,
-  pregnant: assessmentQuestionComments,
-  other_health: requiredAssessmentQuestionComments,
+  special_diet_or_allergy: cloneDeep(assessmentQuestionComments),
+  health_issue: cloneDeep(assessmentQuestionComments),
+  medication: cloneDeep(assessmentQuestionComments),
+  wheelchair: cloneDeep(assessmentQuestionComments),
+  pregnant: cloneDeep(assessmentQuestionComments),
+  other_health: cloneDeep(requiredAssessmentQuestionComments),
   special_vehicle: {
-    ...requiredAssessmentQuestionComments,
+    ...cloneDeep(requiredAssessmentQuestionComments),
     explicit: true,
   },
   // court information
-  solicitor: assessmentQuestionComments,
-  interpreter: assessmentQuestionComments,
-  other_court: requiredAssessmentQuestionComments,
+  solicitor: cloneDeep(assessmentQuestionComments),
+  interpreter: cloneDeep(assessmentQuestionComments),
+  other_court: cloneDeep(requiredAssessmentQuestionComments),
   documents: {
     id: 'documents',
     name: 'documents',

--- a/common/helpers/field.js
+++ b/common/helpers/field.js
@@ -1,4 +1,12 @@
-const { cloneDeep, concat, fromPairs, get, set, compact } = require('lodash')
+const {
+  cloneDeep,
+  compact,
+  concat,
+  fromPairs,
+  get,
+  mapValues,
+  set,
+} = require('lodash')
 
 const componentService = require('../services/component')
 const i18n = require('../../config/i18n')
@@ -194,7 +202,7 @@ function insertItemConditional({ key, field }) {
 }
 
 function populateAssessmentFields(currentFields, questions) {
-  const fields = cloneDeep(currentFields)
+  const fields = mapValues(currentFields, field => cloneDeep(field))
   const implicitQuestions = questions.filter(
     ({ key }) => fields[key] && !fields[key].explicit
   )

--- a/common/helpers/field.test.js
+++ b/common/helpers/field.test.js
@@ -1080,8 +1080,13 @@ describe('Form helpers', function() {
     })
 
     context('with both implicit and explicit fields', function() {
+      const mockImplicitField = {
+        skip: true,
+        implicit: true,
+      }
       const mockFields = {
-        special_diet_or_allergy: {},
+        special_diet_or_allergy: mockImplicitField,
+        special_vehicle: mockImplicitField,
         medication: {
           explicit: true,
         },
@@ -1103,6 +1108,12 @@ describe('Form helpers', function() {
               text: 'Special diet or allergy',
               key: 'special_diet_or_allergy',
               conditional: 'special_diet_or_allergy',
+            },
+            {
+              value: '1a73d31a-8dd4-47b6-90a0-15ce4e332539',
+              text: 'Requires special vehicle',
+              key: 'special_vehicle',
+              conditional: 'special_vehicle',
             },
           ],
           fieldset: {
@@ -1147,10 +1158,26 @@ describe('Form helpers', function() {
           },
           explicit: true,
         })
+        expect(fields.special_diet_or_allergy).to.deep.equal({
+          skip: true,
+          implicit: true,
+          dependent: {
+            field: 'health',
+            value: 'e6faaf20-3072-4a65-91f7-93d52b16260f',
+          },
+        })
+        expect(fields.special_vehicle).to.deep.equal({
+          skip: true,
+          implicit: true,
+          dependent: {
+            field: 'health',
+            value: '1a73d31a-8dd4-47b6-90a0-15ce4e332539',
+          },
+        })
       })
 
       it('should return the correct number of fields', function() {
-        expect(Object.keys(fields).length).to.equal(4)
+        expect(Object.keys(fields).length).to.equal(5)
       })
     })
 


### PR DESCRIPTION
This helper method was mutating the original field and assigning
the dependent property. This meant in the case where lots of fields
existed, each field got the value of the last item.

This change creates a copy and re-assigns the field rather than
adding a property to the original field object.