### PR TITLE
[P4-1237] Ensure court information is only displayed when appropriate

### DIFF
--- a/app/move/views/_includes/assessment.njk
+++ b/app/move/views/_includes/assessment.njk
@@ -51,18 +51,20 @@
   {% endfor %}
 {% endfor %}
 
-<h2 class="govuk-heading-m govuk-!-margin-bottom-2 govuk-!-margin-top-7">
-  {{ t("moves::assessment.categories.court.heading") }}
-</h2>
+{% if move.to_location.location_type == 'court' %}
+  <h2 class="govuk-heading-m govuk-!-margin-bottom-2 govuk-!-margin-top-7">
+    {{ t("moves::assessment.categories.court.heading") }}
+  </h2>
 
-{% if courtSummary.rows | length %}
-  {{ govukSummaryList(courtSummary) }}
-{% else %}
-  {{ appMessage({
-    classes: "app-message--muted",
-    allowDismiss: false,
-    content: {
-      html: t("moves::assessment.categories.court.empty")
-    }
-  }) }}
+  {% if courtSummary.rows | length %}
+    {{ govukSummaryList(courtSummary) }}
+  {% else %}
+    {{ appMessage({
+      classes: "app-message--muted",
+      allowDismiss: false,
+      content: {
+        html: t("moves::assessment.categories.court.empty")
+      }
+    }) }}
+  {% endif %}
 {% endif %}

--- a/test/e2e/move.new.police.test.js
+++ b/test/e2e/move.new.police.test.js
@@ -159,6 +159,13 @@ test('Police to Prison (recall) with new person', async t => {
 
   // Personal details assertions
   await moveDetailPage.checkPersonalDetails(personalDetails)
+
+  // Check assessment
+  await t
+    .expect(moveDetailPage.nodes.courtInformationHeading.exists)
+    .notOk()
+    .expect(moveDetailPage.nodes.courtInformation.exists)
+    .notOk()
 })
 
 fixture('Cancel move from Police Custody').beforeEach(async t => {

--- a/test/e2e/pages/move-detail.js
+++ b/test/e2e/pages/move-detail.js
@@ -20,6 +20,12 @@ class MoveDetailPage extends Page {
       personalDetailsSummary: Selector(
         '#main-content .govuk-grid-column-two-thirds dl.govuk-summary-list'
       ),
+      courtInformationHeading: Selector('#main-content h2').withText(
+        'Information for the court'
+      ),
+      courtInformation: Selector('#main-content h2')
+        .withText('Information for the court')
+        .sibling('dl'),
     }
   }
 


### PR DESCRIPTION
## Proposed changes

This change ensures that the court information section is only displayed on the move detail page when the move is to a court location.

Previously we would show the court section for all types of moves, but for Police to Prison or Prison to Prison moves for example, we will no longer need to display this information.

## Screenshots

### Before

<kbd><img src="https://user-images.githubusercontent.com/3327997/78652995-657a8580-78ba-11ea-8a0e-e8bc1b988e79.png"></kbd>

### After

<kbd><img src="https://user-images.githubusercontent.com/3327997/78652957-5693d300-78ba-11ea-8acb-e38eac1063cc.png"></kbd>
