### PR TITLE
[P4-1236] Display hearings on move detail page

### DIFF
--- a/app/move/controllers/view.js
+++ b/app/move/controllers/view.js
@@ -1,3 +1,5 @@
+const { sortBy } = require('lodash')
+
 const presenters = require('../../../common/presenters')
 
 module.exports = function view(req, res) {
@@ -17,6 +19,12 @@ module.exports = function view(req, res) {
     personalDetailsSummary: presenters.personToSummaryListComponent(person),
     tagList: presenters.assessmentToTagList(person.assessment_answers),
     assessment: presenters.assessmentByCategory(person.assessment_answers),
+    courtHearings: sortBy(move.hearings, 'start_time').map(hearing => {
+      return {
+        ...hearing,
+        summaryList: presenters.courtHearingToSummaryListComponent(hearing),
+      }
+    }),
     courtSummary: presenters.assessmentToSummaryListComponent(
       person.assessment_answers,
       'court'

--- a/app/move/controllers/view.test.js
+++ b/app/move/controllers/view.test.js
@@ -8,6 +8,33 @@ const mockMove = {
     assessment_answers: [],
   },
   documents: [],
+  hearings: [
+    {
+      id: '1',
+      start_time: '2020-10-20T13:00:00+00:00',
+      case_number: 'T12345',
+    },
+    {
+      id: '2',
+      start_time: '2020-10-20T20:00:00+00:00',
+      case_number: 'S12345',
+    },
+    {
+      id: '3',
+      start_time: '2020-10-20T09:00:00+00:00',
+      case_number: 'S67890',
+    },
+    {
+      id: '4',
+      start_time: '2020-10-20T16:30:00+00:00',
+      case_number: 'T001144',
+    },
+    {
+      id: '5',
+      start_time: '2020-10-20T11:20:00+00:00',
+      case_number: 'T66992277',
+    },
+  ],
 }
 
 describe('Move controllers', function() {
@@ -20,6 +47,9 @@ describe('Move controllers', function() {
       sinon.stub(presenters, 'assessmentToTagList').returnsArg(0)
       sinon.stub(presenters, 'assessmentByCategory').returnsArg(0)
       sinon.stub(presenters, 'assessmentToSummaryListComponent').returnsArg(0)
+      sinon
+        .stub(presenters, 'courtHearingToSummaryListComponent')
+        .callsFake(hearing => `summaryList__${hearing.id}`)
 
       req = {
         t: sinon.stub().returnsArg(0),
@@ -95,6 +125,53 @@ describe('Move controllers', function() {
         ).to.be.calledOnceWithExactly(
           mockMove.person.assessment_answers,
           'court'
+        )
+      })
+
+      it('should contain court hearings param', function() {
+        const params = res.render.args[0][1]
+        expect(params).to.have.property('courtHearings')
+      })
+
+      it('should order court hearings by start time', function() {
+        const params = res.render.args[0][1]
+        expect(params.courtHearings).to.deep.equal([
+          {
+            id: '3',
+            start_time: '2020-10-20T09:00:00+00:00',
+            case_number: 'S67890',
+            summaryList: 'summaryList__3',
+          },
+          {
+            id: '5',
+            start_time: '2020-10-20T11:20:00+00:00',
+            case_number: 'T66992277',
+            summaryList: 'summaryList__5',
+          },
+          {
+            id: '1',
+            start_time: '2020-10-20T13:00:00+00:00',
+            case_number: 'T12345',
+            summaryList: 'summaryList__1',
+          },
+          {
+            id: '4',
+            start_time: '2020-10-20T16:30:00+00:00',
+            case_number: 'T001144',
+            summaryList: 'summaryList__4',
+          },
+          {
+            id: '2',
+            start_time: '2020-10-20T20:00:00+00:00',
+            case_number: 'S12345',
+            summaryList: 'summaryList__2',
+          },
+        ])
+      })
+
+      it('should call courtHearingToSummaryListComponent for each hearing', function() {
+        expect(presenters.courtHearingToSummaryListComponent).to.be.callCount(
+          mockMove.hearings.length
         )
       })
 

--- a/app/move/views/_includes/assessment.njk
+++ b/app/move/views/_includes/assessment.njk
@@ -52,19 +52,61 @@
 {% endfor %}
 
 {% if move.to_location.location_type == 'court' %}
-  <h2 class="govuk-heading-m govuk-!-margin-bottom-2 govuk-!-margin-top-7">
-    {{ t("moves::assessment.categories.court.heading") }}
-  </h2>
+  {% if move.from_location.location_type == 'prison' and not courtSummary.rows.length %}
+    <h2 class="govuk-heading-m govuk-!-margin-bottom-2 govuk-!-margin-top-7">
+      {{ t("moves::detail.court_hearings.heading", {
+        context: "with_count" if courtHearings.length > 1,
+        count: courtHearings.length
+      }) }}
+    </h2>
 
-  {% if courtSummary.rows | length %}
-    {{ govukSummaryList(courtSummary) }}
+    {% if courtHearings.length %}
+      {% for courtHearing in courtHearings %}
+        {% if courtHearings.length > 1 %}
+          <h3 class="govuk-heading-s govuk-!-margin-bottom-2 govuk-!-margin-top-6">
+            {{ t("moves::detail.court_hearings.subheading", {
+              context: "with_index",
+              index: loop.index
+            }) }}
+          </h3>
+        {% endif %}
+
+        {{ govukSummaryList(courtHearing.summaryList) }}
+
+        {% if not courtHearing.saved_to_nomis %}
+          {{ govukWarningText({
+            text: t("moves::detail.court_hearings.nomis_failed", {
+              context: "with_index" if courtHearings.length > 1,
+              index: loop.index
+            }),
+            iconFallbackText: "Warning"
+          }) }}
+        {% endif %}
+      {% endfor %}
+    {% else %}
+      {{ appMessage({
+        classes: "app-message--muted",
+        allowDismiss: false,
+        content: {
+          html: t("moves::detail.court_hearings.empty")
+        }
+      }) }}
+    {% endif %}
   {% else %}
-    {{ appMessage({
-      classes: "app-message--muted",
-      allowDismiss: false,
-      content: {
-        html: t("moves::assessment.categories.court.empty")
-      }
-    }) }}
+    <h2 class="govuk-heading-m govuk-!-margin-bottom-2 govuk-!-margin-top-7">
+      {{ t("moves::assessment.categories.court.heading") }}
+    </h2>
+
+    {% if courtSummary.rows | length %}
+      {{ govukSummaryList(courtSummary) }}
+    {% else %}
+      {{ appMessage({
+        classes: "app-message--muted",
+        allowDismiss: false,
+        content: {
+          html: t("moves::assessment.categories.court.empty")
+        }
+      }) }}
+    {% endif %}
   {% endif %}
 {% endif %}

--- a/common/presenters/court-hearing-to-summary-list-component.js
+++ b/common/presenters/court-hearing-to-summary-list-component.js
@@ -1,0 +1,60 @@
+const i18n = require('../../config/i18n')
+const filters = require('../../config/nunjucks/filters')
+
+module.exports = function courtHearingsToSummaryListComponent({
+  comments,
+  start_time: startTime,
+  case_number: caseNumber,
+  case_type: caseType,
+  case_start_date: caseStartDate,
+} = {}) {
+  const startedOn = i18n.t('moves::detail.court_hearing.started_on', {
+    datetime: filters.formatDate(caseStartDate, 'yyyy-MM-dd'),
+    datestring: filters.formatDate(caseStartDate),
+  })
+  const startedOnString = caseStartDate ? ` (${startedOn})` : ''
+
+  const rows = [
+    {
+      key: {
+        text: i18n.t('moves::detail.court_hearing.time_of_hearing'),
+      },
+      value: {
+        html: startTime
+          ? `<time datetime="${startTime}">${filters.formatTime(
+              startTime
+            )}</time>`
+          : undefined,
+      },
+    },
+    {
+      key: {
+        text: i18n.t('moves::detail.court_hearing.case_number'),
+      },
+      value: {
+        html: caseNumber ? caseNumber + startedOnString : undefined,
+      },
+    },
+    {
+      key: {
+        text: i18n.t('moves::detail.court_hearing.case_type'),
+      },
+      value: {
+        text: caseType,
+      },
+    },
+    {
+      key: {
+        text: i18n.t('moves::detail.court_hearing.comments'),
+      },
+      value: {
+        text: comments,
+      },
+    },
+  ]
+
+  return {
+    classes: 'govuk-!-margin-bottom-2',
+    rows: rows.filter(row => row.value.text || row.value.html),
+  }
+}

--- a/common/presenters/court-hearing-to-summary-list-component.test.js
+++ b/common/presenters/court-hearing-to-summary-list-component.test.js
@@ -1,0 +1,235 @@
+const courtHearingsToSummaryListComponent = require('./court-hearing-to-summary-list-component')
+
+const i18n = require('../../config/i18n')
+const filters = require('../../config/nunjucks/filters')
+
+const mockHearing = {
+  start_time: '2020-10-20T13:00:00+00:00',
+  case_number: 'T18725',
+  case_start_date: '2019-10-08T10:30:00+00:00',
+  case_type: 'Adult',
+  comments: 'Distinctio accusantium enim libero eligendi est.',
+}
+
+describe('Presenters', function() {
+  describe('#courtHearingsToSummaryListComponent()', function() {
+    const mockDateLong = '18 Jun 1960'
+    const mockDateShort = '1960-06-18'
+    const mockTime = '9am'
+
+    beforeEach(function() {
+      sinon.stub(i18n, 't').returnsArg(0)
+      sinon.stub(filters, 'formatDate').returns(mockDateLong)
+      sinon.stub(filters, 'formatTime').returns(mockTime)
+      filters.formatDate
+        .withArgs(mockHearing.case_start_date, 'yyyy-MM-dd')
+        .returns(mockDateShort)
+    })
+
+    context('with a mock person object', function() {
+      let transformedResponse
+
+      beforeEach(function() {
+        transformedResponse = courtHearingsToSummaryListComponent(mockHearing)
+      })
+
+      describe('response', function() {
+        it('should contain classes property', function() {
+          expect(transformedResponse).to.have.property('classes')
+          expect(transformedResponse.classes).to.equal(
+            'govuk-!-margin-bottom-2'
+          )
+        })
+
+        it('should contain correct number of rows', function() {
+          expect(transformedResponse).to.have.property('rows')
+          expect(transformedResponse.rows.length).to.equal(4)
+        })
+
+        it('should contain hearing time', function() {
+          const row = transformedResponse.rows[0]
+
+          expect(row).to.deep.equal({
+            key: { text: 'moves::detail.court_hearing.time_of_hearing' },
+            value: {
+              html: `<time datetime="${mockHearing.start_time}">${mockTime}</time>`,
+            },
+          })
+        })
+
+        it('should case number', function() {
+          const row = transformedResponse.rows[1]
+
+          expect(row).to.deep.equal({
+            key: { text: 'moves::detail.court_hearing.case_number' },
+            value: {
+              html: `${mockHearing.case_number} (moves::detail.court_hearing.started_on)`,
+            },
+          })
+        })
+
+        it('should case type', function() {
+          const row = transformedResponse.rows[2]
+
+          expect(row).to.deep.equal({
+            key: { text: 'moves::detail.court_hearing.case_type' },
+            value: {
+              text: mockHearing.case_type,
+            },
+          })
+        })
+
+        it('should contain comments', function() {
+          const row = transformedResponse.rows[3]
+
+          expect(row).to.deep.equal({
+            key: { text: 'moves::detail.court_hearing.comments' },
+            value: { text: mockHearing.comments },
+          })
+        })
+      })
+
+      describe('translation', function() {
+        it('should send correct values to `started on` translation', function() {
+          expect(i18n.t).to.be.calledWith(
+            'moves::detail.court_hearing.started_on',
+            {
+              datetime: mockDateShort,
+              datestring: mockDateLong,
+            }
+          )
+        })
+      })
+    })
+
+    context('with no input values', function() {
+      let transformedResponse
+
+      beforeEach(function() {
+        transformedResponse = courtHearingsToSummaryListComponent()
+      })
+
+      describe('response', function() {
+        it('should contain classes property', function() {
+          expect(transformedResponse).to.have.property('classes')
+          expect(transformedResponse.classes).to.equal(
+            'govuk-!-margin-bottom-2'
+          )
+        })
+
+        it('should contain correct number of rows', function() {
+          expect(transformedResponse).to.have.property('rows')
+          expect(transformedResponse.rows.length).to.equal(0)
+        })
+      })
+    })
+
+    context('with empty object', function() {
+      let transformedResponse
+
+      beforeEach(function() {
+        transformedResponse = courtHearingsToSummaryListComponent({})
+      })
+
+      describe('response', function() {
+        it('should contain classes property', function() {
+          expect(transformedResponse).to.have.property('classes')
+          expect(transformedResponse.classes).to.equal(
+            'govuk-!-margin-bottom-2'
+          )
+        })
+
+        it('should contain correct number of rows', function() {
+          expect(transformedResponse).to.have.property('rows')
+          expect(transformedResponse.rows.length).to.equal(0)
+        })
+      })
+    })
+
+    context('with no case start date', function() {
+      let transformedResponse
+
+      beforeEach(function() {
+        transformedResponse = courtHearingsToSummaryListComponent({
+          start_time: '2020-10-20T13:00:00+00:00',
+          case_number: 'T18725',
+          case_type: 'Youth',
+          comments: 'Distinctio accusantium enim libero eligendi est.',
+        })
+      })
+
+      describe('response', function() {
+        it('should return only case number', function() {
+          const row = transformedResponse.rows[1]
+
+          expect(row).to.deep.equal({
+            key: { text: 'moves::detail.court_hearing.case_number' },
+            value: { html: mockHearing.case_number },
+          })
+        })
+
+        it('should contain correct number of rows', function() {
+          expect(transformedResponse).to.have.property('rows')
+          expect(transformedResponse.rows.length).to.equal(4)
+        })
+      })
+    })
+
+    context('with no case number but a case start date', function() {
+      let transformedResponse
+
+      beforeEach(function() {
+        transformedResponse = courtHearingsToSummaryListComponent({
+          start_time: '2020-10-20T13:00:00+00:00',
+          case_start_date: '2019-10-08T10:30:00+00:00',
+          comments: 'Distinctio accusantium enim libero eligendi est.',
+        })
+      })
+
+      describe('response', function() {
+        it('should contain correct number of rows', function() {
+          expect(transformedResponse).to.have.property('rows')
+          expect(transformedResponse.rows.length).to.equal(2)
+        })
+
+        it('should not contain case number row', function() {
+          const row1 = transformedResponse.rows[0]
+          const row2 = transformedResponse.rows[1]
+
+          expect(row1.key.text).to.equal(
+            'moves::detail.court_hearing.time_of_hearing'
+          )
+          expect(row2.key.text).to.equal('moves::detail.court_hearing.comments')
+        })
+      })
+    })
+
+    context('with no start time', function() {
+      let transformedResponse
+
+      beforeEach(function() {
+        transformedResponse = courtHearingsToSummaryListComponent({
+          case_number: 'T18725',
+          comments: 'Distinctio accusantium enim libero eligendi est.',
+        })
+      })
+
+      describe('response', function() {
+        it('should contain correct number of rows', function() {
+          expect(transformedResponse).to.have.property('rows')
+          expect(transformedResponse.rows.length).to.equal(2)
+        })
+
+        it('should not contain hearing time row', function() {
+          const row1 = transformedResponse.rows[0]
+          const row2 = transformedResponse.rows[1]
+
+          expect(row1.key.text).to.equal(
+            'moves::detail.court_hearing.case_number'
+          )
+          expect(row2.key.text).to.equal('moves::detail.court_hearing.comments')
+        })
+      })
+    })
+  })
+})

--- a/common/presenters/index.js
+++ b/common/presenters/index.js
@@ -2,6 +2,7 @@ const assessmentAnswerToTag = require('./assessment-answer-to-tag')
 const assessmentToTagList = require('./assessment-to-tag-list')
 const assessmentToSummaryListComponent = require('./assessment-to-summary-list-component')
 const assessmentByCategory = require('./assessment-by-category')
+const courtHearingToSummaryListComponent = require('./court-hearing-to-summary-list-component')
 const moveToCardComponent = require('./move-to-card-component')
 const moveToMetaListComponent = require('./move-to-meta-list-component')
 const personToCardComponent = require('./person-to-card-component')
@@ -16,6 +17,7 @@ module.exports = {
   assessmentToTagList,
   assessmentToSummaryListComponent,
   assessmentByCategory,
+  courtHearingToSummaryListComponent,
   moveToCardComponent,
   moveToMetaListComponent,
   personToCardComponent,

--- a/locales/en/moves.json
+++ b/locales/en/moves.json
@@ -137,6 +137,16 @@
   },
   "detail": {
     "page_title": "Move details for {{name}}",
+    "court_hearings": {
+      "heading": "Court hearing",
+      "heading_plural": "Court hearings",
+      "heading_with_count": "Court hearings ({{count}})",
+      "subheading": "Hearing",
+      "subheading_with_index": "Hearing {{index}}",
+      "empty": "No court hearings",
+      "nomis_failed": "A court date for this hearing could not be added to NOMIS — check it was added manually",
+      "nomis_failed_with_index": "A court date for hearing {{index}} could not be added to NOMIS — check it was added manually"
+    },
     "court_hearing": {
       "time_of_hearing": "Time of hearing",
       "case_number": "Case number",

--- a/locales/en/moves.json
+++ b/locales/en/moves.json
@@ -136,7 +136,14 @@
     }
   },
   "detail": {
-    "page_title": "Move details for {{name}}"
+    "page_title": "Move details for {{name}}",
+    "court_hearing": {
+      "time_of_hearing": "Time of hearing",
+      "case_number": "Case number",
+      "started_on": "started on <time datetime=\"{{datetime}}\">{{datestring}}</time>",
+      "case_type": "Case type",
+      "comments": "Comments"
+    }
   },
   "cancel": {
     "steps": {


### PR DESCRIPTION
## Proposed changes

This change adds hearings to the display of hearings on the move detail page. It uses the GOV.UK Summary List component to display the information for a hearing and will not display any rows that don't have a value.

It also changes the display slightly based on the number of hearings. If there is only one hearing it condenses the display of numbers and uses a singular heading.

#### NOMIS status

If a court date was not created in NOMIS during the creation of the move it will display a warning message to check manually that the court date has been created.

## Screenshots

### With one hearing

<kbd><img src="https://user-images.githubusercontent.com/3327997/78900431-bfbc4780-7a6e-11ea-9899-f8b383782f32.png"></kbd>

### With multiple hearings

<kbd><img src="https://user-images.githubusercontent.com/3327997/78900104-46245980-7a6e-11ea-8dc7-d52cb6e7d7c2.png"></kbd>

### With no hearings

<kbd><img src="https://user-images.githubusercontent.com/3327997/78803478-f898e580-79b6-11ea-86d3-c18317de30ae.png"></kbd>
