### PR TITLE
[NOJIRA] Fix end to end test and confirmation page for proposed moves

### DIFF
--- a/app/move/views/confirmation.njk
+++ b/app/move/views/confirmation.njk
@@ -5,7 +5,9 @@
 {% endblock %}
 
 {% block pageTitle %}
-  {{ t("moves::confirmation.page_title", { name: move.person.fullname | upper }) }}
+  {{ t("moves::confirmation.page_title", {
+    context: move.status,
+    name: move.person.fullname | upper }) }}
 {% endblock %}
 
 {% block beforeContent %}
@@ -18,14 +20,16 @@
 
       {{ govukPanel({
         classes: "govuk-!-margin-bottom-7",
-        titleText: t("moves::confirmation.panel.heading"),
+        titleText: t("moves::confirmation.panel.heading", { context: move.status }),
         html: t("moves::confirmation.panel.content", {
+          context: move.status,
           moveReference: move.reference
         })
       }) }}
 
       <p>
         {{ t("moves::confirmation.detail", {
+          context: move.status,
           href: "/move/" + move.id,
           name: move.person.fullname | upper,
           location: location,

--- a/locales/en/moves.json
+++ b/locales/en/moves.json
@@ -152,11 +152,14 @@
   },
   "confirmation": {
     "page_title": "Move scheduled for {{name}}",
+    "page_title_proposed": "Move sent for {{name}}",
     "panel": {
       "heading": "Move scheduled",
+      "heading_proposed": "Move sent for review",
       "content": "Reference number<br><strong>{{moveReference}}</strong>"
     },
-    "detail": "The move for <strong><a href=\"{{href}}\">{{name}}</a></strong> to <strong>{{location}}</strong> on <strong>{{date}}</strong> has been scheduled with {{supplier}}."
+    "detail": "The move for <strong><a href=\"{{href}}\">{{name}}</a></strong> to <strong>{{location}}</strong> on <strong>{{date}}</strong> has been scheduled with {{supplier}}.",
+    "detail_proposed": "The move for <strong><a href=\"{{href}}\">{{name}}</a></strong> to <strong>{{location}}</strong> has been sent to the Population Management Unit (PMU) for review."
   },
   "agreement_status": {
     "heading": "Has this move been agreed with receiving prison?"

--- a/test/e2e/pages/create-move.js
+++ b/test/e2e/pages/create-move.js
@@ -159,9 +159,11 @@ class CreateMovePage extends Page {
         })
         break
       case 'Prison':
-        values = await selectAutocompleteOption(
-          this.steps.moveDetails.nodes.to_location_prison
-        )
+        values = {
+          to_location_prison: await selectAutocompleteOption(
+            this.steps.moveDetails.nodes.to_location_prison
+          ),
+        }
         break
     }
 


### PR DESCRIPTION
The text on the confirmation page is different between scheduled and proposed moves.

### Proposed
<img width="1037" alt="Screenshot 2020-04-08 at 17 23 55" src="https://user-images.githubusercontent.com/853989/78808932-10c03300-79be-11ea-865a-1ce0b0000491.png">


### Scheduled 

<img width="848" alt="Screenshot 2020-04-08 at 17 03 47" src="https://user-images.githubusercontent.com/853989/78806958-4e6f8c80-79bb-11ea-9056-86e73fe4c5a7.png">

Also: fixed broken e2e test.

### Checklist

- [x] If adding new environment variables, they have been documented in the [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md)
- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
