### PR TITLE
Update deprecated uuid/v4 import

### DIFF
--- a/common/lib/analytics.js
+++ b/common/lib/analytics.js
@@ -1,4 +1,4 @@
-const uuidv4 = require('uuid/v4')
+const { v4: uuidv4 } = require('uuid')
 const axios = require('axios')
 const { ANALYTICS: { GA_ID } = {} } = require('../../config')
 

--- a/common/lib/analytics.test.js
+++ b/common/lib/analytics.test.js
@@ -27,7 +27,9 @@ describe('Analytics', function() {
 
       beforeEach(function() {
         analytics = proxyquire('./analytics', {
-          'uuid/v4': () => mockUUID,
+          uuid: {
+            v4: () => mockUUID,
+          },
           '../../config': {
             ANALYTICS: {
               GA_ID: mockGaID,


### PR DESCRIPTION
## Proposed changes

This change updates the way uuid v4 is imported as since v7 in
the uuid package the method we use is no longer supported.