### PR TITLE
Update mocha configuration method

### DIFF
--- a/.mocharc.js
+++ b/.mocharc.js
@@ -1,0 +1,9 @@
+module.exports = {
+  ui: 'bdd',
+  recursive: true,
+  require: 'test/unit/common.js',
+  file: [
+    'test/unit/component-helpers.js',
+    'test/unit/global-helpers.js',
+  ],
+}

--- a/package.json
+++ b/package.json
@@ -189,7 +189,7 @@
     "release:github": "conventional-github-releaser -p angular",
     "release:tags": "git push --follow-tags origin HEAD:master",
     "start": "node start.js",
-    "test": "NODE_ENV=test LOG_LEVEL=silent mocha './app/**/*.test.js' './common/**/*.test.js' './config/**/*.test.js' --opts ./test/unit/mocha.opts",
+    "test": "NODE_ENV=test LOG_LEVEL=silent mocha './app/**/*.test.js' './common/**/*.test.js' './config/**/*.test.js'",
     "test-e2e:chrome": "testcafe chrome test/e2e/*.test.js",
     "test-e2e:ci": "npm run test-e2e:chrome -- --color --reporter spec,xunit:reports/testcafe/results-chrome.xml",
     "test-e2e:local": "E2E_BASE_URL='' npm run test-e2e:chrome -- --debug-on-fail",

--- a/test/unit/mocha.opts
+++ b/test/unit/mocha.opts
@@ -1,5 +1,0 @@
-test/unit/component-helpers.js
-test/unit/global-helpers.js
---require test/unit/common.js
---ui bdd
---recursive


### PR DESCRIPTION
## Proposed changes

As of v6.0.0 mocha now supports [configuration files](https://mochajs.org/#configuring-mocha-nodejs) and will likely
deprecate the use of [mocha.opts](https://mochajs.org/#mochaopts) in future releases.

This change updates the way we configure mocha to be ready for any
future deprecations.