### PR TITLE
Move saving of court hearings to end of create journey

### DIFF
--- a/common/services/court-hearing.js
+++ b/common/services/court-hearing.js
@@ -1,9 +1,22 @@
+const { mapValues, pickBy } = require('lodash')
+
 const apiClient = require('../lib/api-client')()
 
 const courtHearingService = {
+  format(data) {
+    const relationships = ['move']
+
+    return mapValues(pickBy(data), (value, key) => {
+      if (relationships.includes(key) && typeof value === 'string') {
+        return { id: value }
+      }
+      return value
+    })
+  },
+
   create(data) {
     return apiClient
-      .create('court_hearing', data)
+      .create('court_hearing', courtHearingService.format(data))
       .then(response => response.data)
   },
 }

--- a/common/services/court-hearing.test.js
+++ b/common/services/court-hearing.test.js
@@ -10,6 +10,81 @@ const mockCourtHearing = {
 }
 
 describe('Court Hearing Service', function() {
+  describe('#format()', function() {
+    const mockMoveId = 'b695d0f0-af8e-4b97-891e-92020d6820b9'
+
+    context('when relationship field is string', function() {
+      let formatted
+
+      beforeEach(async function() {
+        formatted = await courtHearingService.format({
+          date: '2010-10-10',
+          move: mockMoveId,
+        })
+      })
+
+      it('should format as relationship object', function() {
+        expect(formatted.move).to.deep.equal({
+          id: mockMoveId,
+        })
+      })
+
+      it('should not affect non relationship fields', function() {
+        expect(formatted.date).to.equal('2010-10-10')
+      })
+    })
+
+    context('when relationship field is not a string', function() {
+      let formatted
+
+      beforeEach(async function() {
+        formatted = await courtHearingService.format({
+          date: '2010-10-10',
+          move: {
+            id: mockMoveId,
+          },
+        })
+      })
+
+      it('should return its original value', function() {
+        expect(formatted.move).to.deep.equal({
+          id: mockMoveId,
+        })
+      })
+
+      it('should not affect non relationship fields', function() {
+        expect(formatted.date).to.equal('2010-10-10')
+      })
+    })
+
+    context('with falsey values', function() {
+      let formatted
+
+      beforeEach(async function() {
+        formatted = await courtHearingService.format({
+          date: '2010-10-10',
+          move: {
+            id: mockMoveId,
+          },
+          empty_string: '',
+          false: false,
+          undefined: undefined,
+          empty_array: [],
+        })
+      })
+
+      it('should remove falsey values', function() {
+        expect(formatted).to.deep.equal({
+          date: '2010-10-10',
+          move: {
+            id: mockMoveId,
+          },
+          empty_array: [],
+        })
+      })
+    })
+  })
+
   describe('#create()', function() {
     const mockData = {
       name: 'Steve Bloggs',


### PR DESCRIPTION
## Proposed changes

### Why

Court hearings were previously being saved after the court hearings
step. But this meant they were being sent without a move ID, which is
required to be able to save that hearing to NOMIS.

### What

This change moves that logic until after the creation of a move so that the move ID can
be sent as part of the court hearing. This allows it to be created in NOMIS and associates
that court hearing with the move.