### PR TITLE
Handle moves with no court hearings

### DIFF
--- a/app/move/controllers/create/save.js
+++ b/app/move/controllers/create/save.js
@@ -35,7 +35,7 @@ class SaveController extends CreateBaseController {
           assessment_answers: data.assessment,
         }),
         // create hearings
-        ...data.court_hearings.map(hearing =>
+        ...(data.court_hearings || []).map(hearing =>
           courtHearingService.create({
             ...hearing,
             move: move.id,


### PR DESCRIPTION
Currently when a move is created without the court hearings step
the property that is mapped doesn't exist which meant the map would
fail.

This change ensures that if the property doesn't exist is creates a
fallback array.