### PR TITLE
fix: Use fallback config when creating Redis store

### DIFF
--- a/common/lib/api-client/middleware/request.js
+++ b/common/lib/api-client/middleware/request.js
@@ -1,12 +1,12 @@
 const { get } = require('lodash')
 const debug = require('debug')('app:api-client')
 
-const redisStore = require('../../../../config/redis-store')()
+const redisStore = require('../../../../config/redis-store')
 const models = require('../models')
 
 function cacheResponse(key, expiry) {
   return async response => {
-    await redisStore.client.setexAsync(
+    await redisStore().client.setexAsync(
       key,
       expiry,
       JSON.stringify(response.data)
@@ -32,17 +32,19 @@ function requestMiddleware(expiry = 60) {
         return jsonApi.axios(req)
       }
 
-      return redisStore.client.getAsync(key).then(response => {
-        if (!response) {
-          debug('From cache (uncached)')
-          return jsonApi.axios(req).then(cacheResponse(key, expiry))
-        }
+      return redisStore()
+        .client.getAsync(key)
+        .then(response => {
+          if (!response) {
+            debug('From cache (uncached)')
+            return jsonApi.axios(req).then(cacheResponse(key, expiry))
+          }
 
-        debug('From cache (cached)')
-        return {
-          data: JSON.parse(response),
-        }
-      })
+          debug('From cache (cached)')
+          return {
+            data: JSON.parse(response),
+          }
+        })
     },
   }
 }

--- a/config/redis-store.js
+++ b/config/redis-store.js
@@ -3,15 +3,19 @@ const session = require('express-session')
 const RedisStore = require('connect-redis')(session)
 const bluebird = require('bluebird')
 
+const { REDIS } = require('./')
+const logger = require('./logger')
+
+const defaultOptions = {
+  ...REDIS.SESSION,
+  logErrors: logger.error,
+}
+
 let store
 
-module.exports = function redisStore(options) {
+module.exports = function redisStore(options = defaultOptions) {
   if (store) {
     return store
-  }
-
-  if (!options) {
-    return
   }
 
   const client = redis.createClient(options)

--- a/server.js
+++ b/server.js
@@ -19,13 +19,9 @@ const Sentry = require('@sentry/node')
 // Local dependencies
 const config = require('./config')
 const configPaths = require('./config/paths')
-const logger = require('./config/logger')
 const i18n = require('./config/i18n')
 const nunjucks = require('./config/nunjucks')
-const redisStore = require('./config/redis-store')({
-  ...config.REDIS.SESSION,
-  logErrors: error => logger.error(error),
-})
+const redisStore = require('./config/redis-store')
 const ensureCurrentLocation = require('./common/middleware/ensure-current-location')
 const errorHandlers = require('./common/middleware/errors')
 const checkSession = require('./common/middleware/check-session')
@@ -96,7 +92,7 @@ app.use(cookieParser())
 app.use(responseTime())
 app.use(
   session({
-    store: redisStore,
+    store: redisStore(),
     secret: config.SESSION.SECRET,
     name: config.SESSION.NAME,
     saveUninitialized: false,


### PR DESCRIPTION
## Proposed changes

This fix moves the config into the redis store library so that if
it is created without config, it will use the settings from the config
file.

This means the load order is less important when creating the client.

It also means that it can be used elsewhere without needing to pass in
the configuration, for example, without end-to-end tests.