### PR TITLE
feat: Allow API cache to be controlled by environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,8 @@ It will also start a new deployment specific [job on CircleCI](https://app.circl
 | API_AUTH_PATH **(required)** | Path to which OAuth2 access token requests should be sent | |
 | API_CLIENT_ID **(required)** | Client ID used to authenticate with the backend API | |
 | API_SECRET **(required)** | Client secret used to authenticate with the backend API | |
+| API_CACHE_EXPIRY | The expiry time of cached API request (in seconds) | 7 days |
+| API_DISABLE_CACHE | Whether to disable caching of API requests | false |
 | AUTH_PROVIDER_KEY **(required)** | Client key provided by the OAuth2 provider for user authentication | |
 | AUTH_PROVIDER_SECRET **(required)** | Client secret provided by the OAuth2 provider for user authentication | |
 | AUTH_PROVIDER_URL **(required)** | Base URL for the auth provider server | |

--- a/common/lib/api-client/index.js
+++ b/common/lib/api-client/index.js
@@ -19,7 +19,13 @@ module.exports = function() {
 
   instance.replaceMiddleware('errors', errors)
   instance.replaceMiddleware('POST', post(FILE_UPLOADS.MAX_FILE_SIZE))
-  instance.replaceMiddleware('axios-request', request(API.CACHE_EXPIRY))
+  instance.replaceMiddleware(
+    'axios-request',
+    request({
+      cacheExpiry: API.CACHE_EXPIRY,
+      disableCache: API.DISABLE_CACHE,
+    })
+  )
   instance.insertMiddlewareBefore('axios-request', requestTimeout(API.TIMEOUT))
   instance.insertMiddlewareBefore('axios-request', auth)
 

--- a/common/lib/api-client/middleware/request.js
+++ b/common/lib/api-client/middleware/request.js
@@ -15,7 +15,7 @@ function cacheResponse(key, expiry) {
   }
 }
 
-function requestMiddleware(expiry = 60) {
+function requestMiddleware({ cacheExpiry = 60, disableCache = false } = {}) {
   return {
     name: 'axios-request',
     req: async function req(payload) {
@@ -27,7 +27,7 @@ function requestMiddleware(expiry = 60) {
       }`
       const cacheModel = get(models, `${req.model}.options.cache`)
 
-      if (!cacheModel || req.params.cache === false) {
+      if (!cacheModel || req.params.cache === false || disableCache) {
         debug('Uncached')
         return jsonApi.axios(req)
       }
@@ -37,7 +37,7 @@ function requestMiddleware(expiry = 60) {
         .then(response => {
           if (!response) {
             debug('From cache (uncached)')
-            return jsonApi.axios(req).then(cacheResponse(key, expiry))
+            return jsonApi.axios(req).then(cacheResponse(key, cacheExpiry))
           }
 
           debug('From cache (cached)')

--- a/config/index.js
+++ b/config/index.js
@@ -43,7 +43,8 @@ module.exports = {
     CLIENT_ID: process.env.API_CLIENT_ID,
     SECRET: process.env.API_SECRET,
     TIMEOUT: 30000, // in milliseconds
-    CACHE_EXPIRY: 60 * 60 * 24 * 7, // in seconds (7 days)
+    CACHE_EXPIRY: process.env.API_CACHE_EXPIRY || 60 * 60 * 24 * 7, // in seconds (7 days)
+    DISABLE_CACHE: process.env.API_DISABLE_CACHE,
   },
   PLACEHOLDER_IMAGES: {
     PERSON: 'images/person-fallback.png',


### PR DESCRIPTION
## Proposed changes

This change introduces environment variable support for API cache.

It adds support for:

- cache to be completely disabled, which can be useful during
development or debugging
- the expiry time to be changed per environment, can be useful to have
shorter expiry on staging/development environments

### Checklist

- [x] If adding new environment variables, they have been documented in the [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md)
