### PR TITLE
[P4 1309] Generic table for allocations and moves

### DIFF
--- a/app/allocations/middleware.js
+++ b/app/allocations/middleware.js
@@ -32,7 +32,7 @@ const allocationsMiddleware = {
     res.locals.allocationsSummary = [
       {
         active: false,
-        label: req.t('allocations::dashboard.label'),
+        label: req.t('allocations::dashboard.labels.single_requests'),
         href: `/allocations/week/${getDateFromParams(req)}/`,
         value,
       },

--- a/app/allocations/middleware.test.js
+++ b/app/allocations/middleware.test.js
@@ -35,7 +35,7 @@ describe('#setAllocationsSummary', function() {
     expect(locals.allocationsSummary).to.deep.equal([
       {
         active: false,
-        label: 'allocations::dashboard.label',
+        label: 'allocations::dashboard.labels.single_requests',
         href: '/allocations/week/2020-01-01/',
         value: 18,
       },

--- a/app/moves/controllers/list-by-status.js
+++ b/app/moves/controllers/list-by-status.js
@@ -5,12 +5,7 @@ module.exports = function list(req, res) {
   const template = 'moves/views/list-by-status'
   const locals = {
     pageTitle: 'moves::dashboard.single_moves',
-    moves: movesByRangeAndStatus.map(
-      presenters.moveToCardComponent({
-        showMeta: false,
-        showTags: false,
-      })
-    ),
+    ...presenters.movesToTable(movesByRangeAndStatus),
   }
 
   res.render(template, locals)

--- a/app/moves/views/list-by-status.njk
+++ b/app/moves/views/list-by-status.njk
@@ -18,9 +18,10 @@
 
 {% block pageContent %}
 {% if moves.length %}
-  {% for move in moves %}
-    {{ appCard(move) }}
-  {% endfor %}
+  {{ govukTable({
+    rows: moves,
+    head: movesHeads
+  }) }}
 {% else %}
     {{ appMessage({
       classes: "app-message--muted govuk-!-margin-top-7",

--- a/common/assets/scss/application.scss
+++ b/common/assets/scss/application.scss
@@ -26,6 +26,7 @@ $govuk-font-family: "Inter", system-ui, sans-serif;
 @import "govuk-frontend/govuk/components/select/select.scss";
 @import "govuk-frontend/govuk/components/skip-link/skip-link.scss";
 @import "govuk-frontend/govuk/components/summary-list/summary-list.scss";
+@import "govuk-frontend/govuk/components/table/table.scss";
 @import "govuk-frontend/govuk/components/textarea/textarea.scss";
 @import "govuk-frontend/govuk/components/warning-text/warning-text.scss";
 

--- a/common/lib/api-client/models.js
+++ b/common/lib/api-client/models.js
@@ -180,4 +180,25 @@ module.exports = {
       filesize: '',
     },
   },
+  allocation: {
+    attributes: {
+      from_location: {
+        jsonApi: 'hasOne',
+        type: 'locations',
+      },
+      to_location: {
+        jsonApi: 'hasOne',
+        type: 'locations',
+      },
+      date: '',
+      prisoner_category: '',
+      sentence_length: '',
+      complex_cases: [],
+      moves_count: 0,
+      complete_in_full: '', // boolean
+      other_criteria: '',
+      created_at: '',
+      updated_at: '',
+    },
+  },
 }

--- a/common/lib/api-client/models.js
+++ b/common/lib/api-client/models.js
@@ -15,6 +15,10 @@ module.exports = {
       date: '',
       date_from: '',
       date_to: '',
+      prison_transfer_reason: {
+        jsonApi: 'hasOne',
+        type: 'prison_transfer_reasons',
+      },
       person: {
         jsonApi: 'hasOne',
         type: 'people',

--- a/common/lib/api-client/models.test.js
+++ b/common/lib/api-client/models.test.js
@@ -107,6 +107,12 @@ const testCases = {
       args: '1',
     },
   ],
+  allocation: [
+    {
+      method: 'findAll',
+      httpMock: 'get',
+    },
+  ],
 }
 
 const client = proxyquire('./', {

--- a/common/presenters/index.js
+++ b/common/presenters/index.js
@@ -9,6 +9,9 @@ const moveToMetaListComponent = require('./move-to-meta-list-component')
 const moveTypesToFilterComponent = require('./move-type-for-filter')
 const movesByToLocation = require('./moves-by-to-location')
 const movesToCSV = require('./moves-to-csv')
+const movesToTable = require('./moves-to-table')
+const objectToTableHead = require('./object-to-table-head')
+const objectToTableRow = require('./object-to-table-row')
 const personToCardComponent = require('./person-to-card-component')
 const personToSummaryListComponent = require('./person-to-summary-list-component')
 
@@ -26,4 +29,7 @@ module.exports = {
   movesByToLocation,
   movesToCSV,
   moveTypesToFilterComponent,
+  objectToTableHead,
+  objectToTableRow,
+  movesToTable,
 }

--- a/common/presenters/moves-to-table.js
+++ b/common/presenters/moves-to-table.js
@@ -1,0 +1,44 @@
+const i18n = require('../../config/i18n')
+const filters = require('../../config/nunjucks/filters')
+
+const objectToTableHead = require('./object-to-table-head')
+const objectToTableRow = require('./object-to-table-row')
+
+const tableConfig = [
+  {
+    head: i18n.t('name'),
+    attributes: {
+      attributes: {
+        scope: 'row',
+      },
+    },
+    row: data => {
+      return `<a href="/move/${data.id}">${data.person.fullname}</a> (${data.person.identifiers[0].value})`
+    },
+  },
+  {
+    head: i18n.t('moves::dashboard.created_at'),
+    row: data => filters.formatDate(data.created_at),
+  },
+  {
+    head: i18n.t('moves::dashboard.move_to'),
+    row: 'to_location.title',
+  },
+  {
+    head: i18n.t('date'),
+    row: data => filters.formatDateRange([data.date_from, data.date_to]),
+  },
+  {
+    head: i18n.t('moves::dashboard.move_type'),
+    row: 'prison_transfer_reason',
+  },
+]
+
+function movesToTable(movesByRangeAndStatus) {
+  return {
+    movesHeads: tableConfig.map(objectToTableHead),
+    moves: movesByRangeAndStatus.map(objectToTableRow(tableConfig)),
+  }
+}
+
+module.exports = movesToTable

--- a/common/presenters/moves-to-table.test.js
+++ b/common/presenters/moves-to-table.test.js
@@ -1,0 +1,165 @@
+const i18n = require('../../config/i18n')
+
+const mockMoves = [
+  {
+    id: 'acba3ad5-a8d3-4b95-9e48-121dafb3babe',
+    type: 'moves',
+    reference: 'TEW5896J',
+    status: 'proposed',
+    updated_at: '2020-04-20T11:48:53+01:00',
+    created_at: '2020-04-20T11:48:53+01:00',
+    prison_transfer_reason: 'MAPPA',
+    time_due: null,
+    date: null,
+    move_type: 'prison_transfer',
+    date_from: '2020-09-28',
+    date_to: '2020-10-28',
+    person: {
+      id: '746ad25b-9d6b-4159-ba45-d4a62936c48d',
+      type: 'people',
+      first_names: 'JOHN',
+      last_name: 'DOE',
+      identifiers: [
+        {
+          identifier_type: 'police_national_computer',
+          value: '17/522710A',
+        },
+        {
+          identifier_type: 'prison_number',
+          value: 'A5075DA',
+        },
+      ],
+      fullname: 'DOE, JOHN',
+    },
+    from_location: {
+      id: '54d1c8c3-699e-4198-9218-f923a7f18149',
+      type: 'locations',
+      key: 'wyi',
+      title: 'WETHERBY (HMPYOI)',
+      location_type: 'prison',
+    },
+    to_location: {
+      id: 'cb0c3a4d-011a-47e5-9dca-05a418047cfd',
+      type: 'locations',
+      key: 'ali',
+      title: 'ALBANY (HMP)',
+      location_type: 'prison',
+    },
+  },
+  {
+    id: '394f107e-da78-45d4-900c-c95717179f68',
+    type: 'moves',
+    reference: 'UYN4638F',
+    status: 'proposed',
+    updated_at: '2020-04-21T10:56:02+01:00',
+    created_at: '2020-04-21T10:56:02+01:00',
+    prison_transfer_reason: 'Compassionate',
+    time_due: null,
+    date: null,
+    move_type: 'prison_transfer',
+    date_from: '2020-05-01',
+    date_to: null,
+    person: {
+      id: '746ad25b-9d6b-4159-ba45-d4a62936c54s',
+      type: 'people',
+      first_names: 'JANE',
+      last_name: 'DOE',
+      identifiers: [
+        {
+          identifier_type: 'police_national_computer',
+          value: '17/522710W',
+        },
+        {
+          identifier_type: 'prison_number',
+          value: 'A5075DY',
+        },
+      ],
+      fullname: 'DOE, JANE',
+    },
+    from_location: {
+      id: '54d1c8c3-699e-4198-9218-f923a7f18149',
+      type: 'locations',
+      key: 'wyi',
+      title: 'WETHERBY (HMPYOI)',
+    },
+    to_location: {
+      id: 'b7fd1648-ddbc-4c9c-9221-05d67d182488',
+      type: 'locations',
+      key: 'hmp_northallerton',
+      title: 'HMP Northallerton',
+    },
+  },
+]
+const presenter = require('./moves-to-table')
+describe('#movesToTable', function() {
+  let output
+  beforeEach(function() {
+    output = presenter([])
+  })
+  it('returns an object with movesHeads', function() {
+    expect(output.movesHeads).to.exist
+    expect(output.movesHeads).to.be.an('array')
+  })
+  it('returns an object with moves', function() {
+    expect(output.moves).to.exist
+    expect(output.moves).to.be.an('array')
+  })
+  describe('its behaviour', function() {
+    let output
+    beforeEach(function() {
+      output = presenter(mockMoves)
+      sinon.stub(i18n, 't').returnsArg(0)
+    })
+    it('returns html with composite name on the first cell', function() {
+      expect(output.moves[0][0]).to.deep.equal({
+        html:
+          '<a href="/move/acba3ad5-a8d3-4b95-9e48-121dafb3babe">DOE, JOHN</a> (17/522710A)',
+        attributes: {
+          scope: 'row',
+        },
+      })
+    })
+    it('returns html with createdAt on the second cell', function() {
+      expect(output.moves[0][1]).to.deep.equal({
+        html: '20 Apr 2020',
+      })
+    })
+    it('returns toLocation on the third cell', function() {
+      expect(output.moves[0][2]).to.deep.equal({
+        html: 'ALBANY (HMP)',
+      })
+    })
+    it('returns the date range on the fourth cell', function() {
+      expect(output.moves[0][3]).to.deep.equal({
+        html: '28 Sep to 28 Oct 2020',
+      })
+    })
+    it('returns the move type on the fifth cell', function() {
+      expect(output.moves[0][4]).to.deep.equal({
+        html: 'MAPPA',
+      })
+    })
+    it('returns a row per record', function() {
+      expect(output.moves.length).to.equal(2)
+    })
+    it('returns one head row with all the cells', function() {
+      expect(output.movesHeads).to.deep.equal([
+        {
+          html: 'Name',
+        },
+        {
+          html: 'Created at',
+        },
+        {
+          html: 'Move to',
+        },
+        {
+          html: 'Date',
+        },
+        {
+          html: 'Move type',
+        },
+      ])
+    })
+  })
+})

--- a/common/presenters/object-to-table-head.js
+++ b/common/presenters/object-to-table-head.js
@@ -1,0 +1,6 @@
+function objectToTableHead(schemaEl) {
+  return {
+    html: schemaEl.head,
+  }
+}
+module.exports = objectToTableHead

--- a/common/presenters/object-to-table-head.test.js
+++ b/common/presenters/object-to-table-head.test.js
@@ -1,0 +1,24 @@
+const schemaExample = [
+  {
+    head: 'Move type',
+    row: 'prison_transfer_reason',
+  },
+  {
+    head: 'Age',
+    row: 'age',
+  },
+]
+const presenter = require('./object-to-table-head')
+describe('table head presenter', function() {
+  it('returns the heading specified', function() {
+    const output = schemaExample.map(presenter)
+    expect(output).to.deep.equal([
+      {
+        html: 'Move type',
+      },
+      {
+        html: 'Age',
+      },
+    ])
+  })
+})

--- a/common/presenters/object-to-table-row.js
+++ b/common/presenters/object-to-table-row.js
@@ -1,0 +1,25 @@
+const { get, isFunction } = require('lodash')
+function objectToTableRow(schema) {
+  return function(data) {
+    return schema.map(schemaProp => {
+      let html
+      const prop = schemaProp.row
+      if (isFunction(prop)) {
+        html = prop(data)
+      } else if (Array.isArray(prop)) {
+        html = prop
+          .map(singleProp => {
+            return get(data, singleProp)
+          })
+          .join(' ')
+      } else {
+        html = get(data, prop)
+      }
+      return {
+        html,
+        ...schemaProp.attributes,
+      }
+    })
+  }
+}
+module.exports = objectToTableRow

--- a/common/presenters/object-to-table-row.test.js
+++ b/common/presenters/object-to-table-row.test.js
@@ -1,0 +1,115 @@
+const dataExample = [
+  {
+    name: 'John',
+    surname: 'Doe',
+    created_at: '2020-10-10',
+    details: {
+      risk: 'violent',
+    },
+  },
+]
+const presenter = require('./object-to-table-row')
+describe('the presenter for the table rows', function() {
+  context('when the property passed to it is described by a path', function() {
+    it('returns a non nested path', function() {
+      const output = dataExample.map(
+        presenter([
+          {
+            row: 'name',
+          },
+        ])
+      )
+      expect(output).to.deep.equal([
+        [
+          {
+            html: 'John',
+          },
+        ],
+      ])
+    })
+    it('returns a nested path', function() {
+      const output = dataExample.map(
+        presenter([
+          {
+            row: 'details.risk',
+          },
+        ])
+      )
+      expect(output).to.deep.equal([
+        [
+          {
+            html: 'violent',
+          },
+        ],
+      ])
+    })
+  })
+  context(
+    'when the property passed to it is described by an array',
+    function() {
+      it('concatenates the various elements', function() {
+        const output = dataExample.map(
+          presenter([
+            {
+              row: ['name', 'surname'],
+            },
+          ])
+        )
+        expect(output).to.deep.equal([
+          [
+            {
+              html: 'John Doe',
+            },
+          ],
+        ])
+      })
+    }
+  )
+  context(
+    'when the property passed to it is described by a function',
+    function() {
+      it('returns the output of the function', function() {
+        const output = dataExample.map(
+          presenter([
+            {
+              row: data => {
+                return `<ul><li>${data.name}</li><li>${data.created_at}</li></ul>`
+              },
+            },
+          ])
+        )
+        expect(output).to.deep.equal([
+          [
+            {
+              html: '<ul><li>John</li><li>2020-10-10</li></ul>',
+            },
+          ],
+        ])
+      })
+    }
+  )
+  context('with multiple cells', function() {
+    it('returns an object with all the data for the cells', function() {
+      const output = dataExample.map(
+        presenter([
+          {
+            row: 'name',
+          },
+          {
+            row: 'details.risk',
+          },
+        ])
+      )
+      expect(output).to.deep.equal([
+        [
+          {
+            html: 'John',
+          },
+          {
+            html: 'violent',
+          },
+        ],
+      ])
+    })
+  })
+})

--- a/common/templates/layouts/base.njk
+++ b/common/templates/layouts/base.njk
@@ -15,6 +15,7 @@
 {% from "govuk/components/summary-list/macro.njk"      import govukSummaryList %}
 {% from "govuk/components/textarea/macro.njk"          import govukTextarea %}
 {% from "govuk/components/warning-text/macro.njk"      import govukWarningText %}
+{% from "govuk/components/table/macro.njk"             import govukTable %}
 
 {% from "moj/components/organisation-switcher/macro.njk" import mojOrganisationSwitcher %}
 {% from "moj/components/primary-navigation/macro.njk" import mojPrimaryNavigation %}

--- a/config/nunjucks/filters.js
+++ b/config/nunjucks/filters.js
@@ -49,6 +49,9 @@ function formatDateRange(dateRange) {
   if (!Array.isArray(dateRange) || dateRange.length !== 2) {
     return dateRange
   }
+  if (!dateRange[1]) {
+    return dateRange[0]
+  }
   const parsedDates = dateRange.map(date => {
     return isDate(date) ? date : parseISO(date)
   })

--- a/config/nunjucks/filters.test.js
+++ b/config/nunjucks/filters.test.js
@@ -152,6 +152,9 @@ describe('Nunjucks filters', function() {
       it('returns a string if passed a string', function() {
         expect(formatDateRange('10/10/2019')).to.equal('10/10/2019')
       })
+      it('accepts a null second date', function() {
+        expect(formatDateRange(['10/10/2019', null])).to.equal('10/10/2019')
+      })
       it('returns other unexpected things if passed to it', function() {
         expect(formatDateRange({ time: '1' })).to.deep.equal({ time: '1' })
         expect(formatDateRange(['2010-10-10'])).to.deep.equal(['2010-10-10'])

--- a/locales/en/allocations.json
+++ b/locales/en/allocations.json
@@ -1,5 +1,6 @@
 {
   "dashboard": {
-    "heading": "Allocations"
+    "heading": "Allocations",
+    "labels": { "single_requests": "single requests" }
   }
 }

--- a/locales/en/default.json
+++ b/locales/en/default.json
@@ -1,7 +1,9 @@
 {
   "feedback_link": "Give us feedback",
   "age": "Age",
+  "name": "Name",
   "from": "From",
+  "date": "Date",
   "age_with_date_of_birth": "{{date_of_birth}} (Age {{age}})",
   "supplier_fallback": "the supplier",
   "opens_new_window": "Opens in a new window",

--- a/locales/en/moves.json
+++ b/locales/en/moves.json
@@ -133,6 +133,8 @@
     "no_results": "No moves requested",
     "single_moves": "Single moves",
     "single_moves_no_results": "No moves proposed",
+    "created_at": "Created at",
+    "move_type": "Move type",
     "filter": {
       "proposed": "proposed",
       "approved": "approved",

--- a/test/fixtures/api-client/allocation.findAll.json
+++ b/test/fixtures/api-client/allocation.findAll.json
@@ -1,0 +1,80 @@
+{
+  "data": [
+    {
+      "id": "0e180146-d911-49d8-a62e-63ea5cec7ba5",
+      "type": "allocations",
+      "attributes": {
+        "moves_count": 2,
+        "date": "2020-04-20",
+        "created_at": "2020-04-20T10:44:37+01:00",
+        "updated_at": "2020-04-20T10:44:37+01:00",
+        "prisoner_category": "c",
+        "sentence_length": "short",
+        "complex_cases": null,
+        "complete_in_full": true,
+        "other_criteria": null
+      },
+      "relationships": {
+        "from_location": {
+          "data": {
+            "id": "8387e205-97d1-4023-83c5-4f16f0c479d0",
+            "type": "locations"
+          }
+        },
+        "to_location": {
+          "data": {
+            "id": "9efd0df4-70b2-411f-8df8-8bb09b2eafe0",
+            "type": "locations"
+          }
+        }
+      }
+    }
+  ],
+  "included": [
+    {
+      "id": "8387e205-97d1-4023-83c5-4f16f0c479d0",
+      "type": "locations",
+      "attributes": {
+        "key": "kmi",
+        "title": "KIRKHAM (HMP)",
+        "location_type": "prison",
+        "nomis_agency_id": "KMI",
+        "can_upload_documents": false,
+        "disabled_at": null,
+        "suppliers": []
+      }
+    },
+    {
+      "id": "9efd0df4-70b2-411f-8df8-8bb09b2eafe0",
+      "type": "locations",
+      "attributes": {
+        "key": "nmi",
+        "title": "NOTTINGHAM (HMP)",
+        "location_type": "prison",
+        "nomis_agency_id": "NMI",
+        "can_upload_documents": false,
+        "disabled_at": null,
+        "suppliers": []
+      }
+    }
+  ],
+  "links": {
+    "self": "http://localhost:5000/api/v1/allocations?filter%5Bdate_from%5D=2020-04-20&filter%5Bdate_to%5D=2020-04-26&page%5Bnumber%5D=1&page%5Bsize%5D=1&per_page=1",
+    "first": "http://localhost:5000/api/v1/allocations?filter%5Bdate_from%5D=2020-04-20&filter%5Bdate_to%5D=2020-04-26&page%5Bnumber%5D=1&page%5Bsize%5D=1&per_page=1",
+    "prev": null,
+    "next": "http://localhost:5000/api/v1/allocations?filter%5Bdate_from%5D=2020-04-20&filter%5Bdate_to%5D=2020-04-26&page%5Bnumber%5D=2&page%5Bsize%5D=1&per_page=1",
+    "last": "http://localhost:5000/api/v1/allocations?filter%5Bdate_from%5D=2020-04-20&filter%5Bdate_to%5D=2020-04-26&page%5Bnumber%5D=14&page%5Bsize%5D=1&per_page=1"
+  },
+  "meta": {
+    "pagination": {
+      "per_page": 10,
+      "total_pages": 1,
+      "total_objects": 1,
+      "links": {
+        "first": "/api/v1/allocations",
+        "last": "/api/v1/allocations",
+        "next": "/api/v1/allocations"
+      }
+    }
+  }
+}

--- a/test/fixtures/api-client/move.find.json
+++ b/test/fixtures/api-client/move.find.json
@@ -16,7 +16,8 @@
       "move_type": "court_appearance",
       "move_agreed": false,
       "move_agreed_by": null,
-      "additional_information": null
+      "additional_information": null,
+      "prison_transfer_reason": null
     },
     "relationships": {
       "person": {

--- a/test/fixtures/api-client/move.findAll.json
+++ b/test/fixtures/api-client/move.findAll.json
@@ -17,7 +17,8 @@
         "move_type": "court_appearance",
         "move_agreed": null,
         "move_agreed_by": null,
-        "additional_information": null
+        "additional_information": null,
+        "prison_transfer_reason": null
       },
       "relationships": {
         "person": {
@@ -81,7 +82,8 @@
         "move_type": "court_appearance",
         "move_agreed": null,
         "move_agreed_by": null,
-        "additional_information": null
+        "additional_information": null,
+        "prison_transfer_reason": null
       },
       "relationships": {
         "person": {
@@ -137,7 +139,8 @@
         "move_type": "court_appearance",
         "move_agreed": null,
         "move_agreed_by": null,
-        "additional_information": null
+        "additional_information": null,
+        "prison_transfer_reason": null
       },
       "relationships": {
         "person": {
@@ -183,7 +186,8 @@
         "move_type": "prison_transfer",
         "move_agreed": false,
         "move_agreed_by": null,
-        "additional_information": null
+        "additional_information": null,
+        "prison_transfer_reason": null
       },
       "relationships": {
         "person": {
@@ -247,7 +251,8 @@
         "move_type": "court_appearance",
         "move_agreed": null,
         "move_agreed_by": null,
-        "additional_information": null
+        "additional_information": null,
+        "prison_transfer_reason": null
       },
       "relationships": {
         "person": {
@@ -293,7 +298,8 @@
         "move_type": "court_appearance",
         "move_agreed": null,
         "move_agreed_by": null,
-        "additional_information": null
+        "additional_information": null,
+        "prison_transfer_reason": null
       },
       "relationships": {
         "person": {
@@ -357,7 +363,8 @@
         "move_type": "court_appearance",
         "move_agreed": null,
         "move_agreed_by": null,
-        "additional_information": null
+        "additional_information": null,
+        "prison_transfer_reason": null
       },
       "relationships": {
         "person": {
@@ -413,7 +420,8 @@
         "move_type": "court_appearance",
         "move_agreed": null,
         "move_agreed_by": null,
-        "additional_information": null
+        "additional_information": null,
+        "prison_transfer_reason": null
       },
       "relationships": {
         "person": {
@@ -459,7 +467,8 @@
         "move_type": "court_appearance",
         "move_agreed": null,
         "move_agreed_by": null,
-        "additional_information": null
+        "additional_information": null,
+        "prison_transfer_reason": null
       },
       "relationships": {
         "person": {
@@ -523,7 +532,8 @@
         "move_type": "court_appearance",
         "move_agreed": null,
         "move_agreed_by": null,
-        "additional_information": null
+        "additional_information": null,
+        "prison_transfer_reason": null
       },
       "relationships": {
         "person": {
@@ -579,7 +589,8 @@
         "move_type": "court_appearance",
         "move_agreed": null,
         "move_agreed_by": null,
-        "additional_information": null
+        "additional_information": null,
+        "prison_transfer_reason": null
       },
       "relationships": {
         "person": {
@@ -643,7 +654,8 @@
         "move_type": "court_appearance",
         "move_agreed": null,
         "move_agreed_by": null,
-        "additional_information": null
+        "additional_information": null,
+        "prison_transfer_reason": null
       },
       "relationships": {
         "person": {
@@ -689,7 +701,8 @@
         "move_type": "court_appearance",
         "move_agreed": null,
         "move_agreed_by": null,
-        "additional_information": null
+        "additional_information": null,
+        "prison_transfer_reason": null
       },
       "relationships": {
         "person": {
@@ -745,7 +758,8 @@
         "move_type": "court_appearance",
         "move_agreed": null,
         "move_agreed_by": null,
-        "additional_information": null
+        "additional_information": null,
+        "prison_transfer_reason": null
       },
       "relationships": {
         "person": {
@@ -791,7 +805,8 @@
         "move_type": "prison_transfer",
         "move_agreed": true,
         "move_agreed_by": "Steve Rogers",
-        "additional_information": null
+        "additional_information": null,
+        "prison_transfer_reason": null
       },
       "relationships": {
         "person": {
@@ -847,7 +862,8 @@
         "move_type": "court_appearance",
         "move_agreed": null,
         "move_agreed_by": null,
-        "additional_information": null
+        "additional_information": null,
+        "prison_transfer_reason": null
       },
       "relationships": {
         "person": {
@@ -911,7 +927,8 @@
         "move_type": "court_appearance",
         "move_agreed": null,
         "move_agreed_by": null,
-        "additional_information": null
+        "additional_information": null,
+        "prison_transfer_reason": null
       },
       "relationships": {
         "person": {
@@ -975,7 +992,8 @@
         "move_type": "court_appearance",
         "move_agreed": null,
         "move_agreed_by": null,
-        "additional_information": null
+        "additional_information": null,
+        "prison_transfer_reason": null
       },
       "relationships": {
         "person": {
@@ -1021,7 +1039,8 @@
         "move_type": "prison_transfer",
         "move_agreed": true,
         "move_agreed_by": "John Doe",
-        "additional_information": null
+        "additional_information": null,
+        "prison_transfer_reason": null
       },
       "relationships": {
         "person": {
@@ -1085,7 +1104,8 @@
         "move_type": "court_appearance",
         "move_agreed": null,
         "move_agreed_by": null,
-        "additional_information": null
+        "additional_information": null,
+        "prison_transfer_reason": null
       },
       "relationships": {
         "person": {


### PR DESCRIPTION
<img width="1028" alt="Screenshot 2020-04-21 at 11 51 12" src="https://user-images.githubusercontent.com/853989/79857915-6c2eef80-83c6-11ea-808c-a20908e2b409.png">

This PR represents a first iteration of the table component, with no pagination nor sorting. I have used the OCA journey to mount it since the PMU dashboard is not ready yet.
A couple of things:
- this PR has unearthed a previously unnoticed bug: the reason for move is not saved correctly. I will investigate the reason
- The default output of the date range filter when passed only one date is different from the format of the single date formatter (you can notice the difference in the second row of the screenshot). This may need to be addressed separately.
- I have kept the table presenter very generic for it to work for both moves and allocations, and I am sure this will cause discussion, since therefore most of the presentational behaviour is handled by the config attached in the controller. If that seems unsavoury, I can move the config elsewhere as an intermediate layer between controller and presenter.

This PR contains also a couple of things that I have done to make the API request for allocations work, since it's now available in a branch.



### Checklist

- [x] If adding new environment variables, they have been documented in the [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md)
- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
