### PR TITLE
Revert "refactor: Allow images to be controlled by env var"

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,7 +230,6 @@ It will also start a new deployment specific [job on CircleCI](https://app.circl
 | E2E_SUPPLIER_USERNAME | Supplier user username used for acceptance testing | |
 | E2E_SUPPLIER_PASSWORD | Supplier user password used for acceptance testing | |
 | LOCATIONS_BATCH_SIZE | Maximum number of location IDs to send in one request when requesting moves for all locations | 40 |
-| FEATURE_FLAG_IMAGES | Whether to display images from the API. If set to false, it will always show the fallback image | false |
 | FEATURE_FLAG_PRISON_COURT_HEARINGS | Whether to display the court hearings step from Prison locations | false |
 
 ### Development specific

--- a/app/person/controllers.js
+++ b/app/person/controllers.js
@@ -4,14 +4,8 @@ const personService = require('../../common/services/person')
 const nunjucksGlobals = require('../../config/nunjucks/globals')
 
 module.exports = {
-  image: (fallbackImage, showImages = false) => {
+  image: fallbackImage => {
     return async (req, res) => {
-      const imagePath = nunjucksGlobals.getAssetPath(fallbackImage)
-
-      if (!showImages) {
-        return res.redirect(imagePath)
-      }
-
       try {
         const imageUrl = await personService.getImageUrl(req.params.personId)
         const response = await axios.get(imageUrl, {
@@ -23,6 +17,7 @@ module.exports = {
         })
         res.end(response.data, 'binary')
       } catch (error) {
+        const imagePath = nunjucksGlobals.getAssetPath(fallbackImage)
         res.redirect(imagePath)
       }
     }

--- a/app/person/controllers.test.js
+++ b/app/person/controllers.test.js
@@ -29,31 +29,10 @@ describe('Person app', function() {
       }
     })
 
-    context('when set to not show images', function() {
-      beforeEach(async function() {
-        personService.getImageUrl.rejects(new Error())
-        await controllers.image(placeholderImage)(req, res)
-      })
-
-      it('should not call res.end', function() {
-        expect(res.end).not.to.be.called
-      })
-
-      it('should get placeholder image from manifest', function() {
-        expect(nunjucksGlobals.getAssetPath).to.be.calledOnceWithExactly(
-          placeholderImage
-        )
-      })
-
-      it('should redirect to placeholder images', function() {
-        expect(res.redirect).to.be.calledOnceWithExactly(manifestImagePath)
-      })
-    })
-
     context('when person service errors', function() {
       beforeEach(async function() {
         personService.getImageUrl.rejects(new Error())
-        await controllers.image(placeholderImage, true)(req, res)
+        await controllers.image(placeholderImage)(req, res)
       })
 
       it('should not call res.end', function() {
@@ -81,7 +60,7 @@ describe('Person app', function() {
       context('when axios errors', function() {
         beforeEach(async function() {
           axios.get.rejects(new Error())
-          await controllers.image(placeholderImage, true)(req, res)
+          await controllers.image(placeholderImage)(req, res)
         })
 
         it('should not call res.end', function() {
@@ -111,7 +90,7 @@ describe('Person app', function() {
 
         beforeEach(async function() {
           axios.get.resolves(mockResponse)
-          await controllers.image(placeholderImage, true)(req, res)
+          await controllers.image(placeholderImage)(req, res)
         })
 
         it('should set headers', function() {

--- a/app/person/index.js
+++ b/app/person/index.js
@@ -2,15 +2,12 @@
 const router = require('express').Router()
 
 // Local dependencies
-const { PLACEHOLDER_IMAGES, FEATURE_FLAGS } = require('../../config')
+const { PLACEHOLDER_IMAGES } = require('../../config')
 
 const { image } = require('./controllers')
 
 // Define routes
-router.get(
-  '/:personId/image',
-  image(PLACEHOLDER_IMAGES.PERSON, FEATURE_FLAGS.IMAGES)
-)
+router.get('/:personId/image', image(PLACEHOLDER_IMAGES.PERSON))
 
 // Export
 module.exports = {

--- a/config/index.js
+++ b/config/index.js
@@ -124,7 +124,6 @@ module.exports = {
   },
   LOCATIONS_BATCH_SIZE: process.env.LOCATIONS_BATCH_SIZE || 40,
   FEATURE_FLAGS: {
-    IMAGES: process.env.FEATURE_FLAG_IMAGES,
     // TODO: Remove once court hearings are fully released
     PRISON_COURT_HEARINGS: process.env.FEATURE_FLAG_PRISON_COURT_HEARINGS,
   },


### PR DESCRIPTION
This change undoes the introduction of a feature flag to toggle the loading of images.

It was done whilst there was a bug in the API so that we could quickly switch it on or off in
production whilst it was being debugged. It's not working fully. We'd rather not have lots of
feature flag toggles all around the app so this code is being removed to tidy up some of that
tech debt.

This reverts commit 8141bb2babcba3cf86a95b345bbd9cbf7a1e36a2.

### Checklist

- [x] If adding new environment variables, they have been documented in the [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md)
