### PR TITLE
[P4-1306] Allow message component to be focusable

### DIFF
--- a/common/components/message/_message.scss
+++ b/common/components/message/_message.scss
@@ -14,7 +14,7 @@ $_message-border-width: 5px;
   }
 
   &:focus {
-    outline: none;
+    outline: $govuk-focus-width solid $govuk-focus-colour;
   }
 
   * {

--- a/common/components/message/message.js
+++ b/common/components/message/message.js
@@ -1,5 +1,12 @@
 function Message($module) {
   this.cacheEls($module)
+
+  this.defaults = {
+    isDismissable: this.$module.hasAttribute('data-allow-dismiss'),
+    isFocused: this.$module.hasAttribute('data-focus'),
+  }
+
+  this.settings = this.defaults
 }
 
 Message.prototype = {
@@ -13,10 +20,17 @@ Message.prototype = {
 
   render: function() {
     this.appendClose(this.$module)
+
+    if (this.settings.isFocused) {
+      this.$module.focus()
+    }
   },
 
   appendClose: function($element) {
-    if ($element.className.indexOf('error') !== -1) {
+    if (
+      $element.className.indexOf('error') !== -1 ||
+      !this.settings.isDismissable
+    ) {
       return
     }
 

--- a/common/components/message/message.yaml
+++ b/common/components/message/message.yaml
@@ -3,6 +3,14 @@ params:
   type: string
   required: false
   description: Classes to add to the parent element.
+- name: allowDismiss
+  type: boolean
+  required: false
+  description: Whether to allow the message to be dismissed. Default is `true`
+- name: focusOnload
+  type: boolean
+  required: false
+  description: Whether to focus the element on page load. Default is `false`
 - name: title
   type: object
   required: true
@@ -65,6 +73,13 @@ examples:
     data:
       allowDismiss: false
       title:
-        html: A message heading
+        html: Cannot be dismissed
+      content:
+        html: Containing some <strong>extra content</strong>.
+  - name: focused on load
+    data:
+      focusOnload: true
+      title:
+        html: Focused on page load
       content:
         html: Containing some <strong>extra content</strong>.

--- a/common/components/message/template.njk
+++ b/common/components/message/template.njk
@@ -1,9 +1,18 @@
 {% set element = params.element | default('div') %}
 {% set allowDismiss = params.allowDismiss | default(true) %}
+{% set focusOnload = params.focusOnload | default(false) %}
 
-<{{ element }} class="app-message{% if params.classes %} {{ params.classes }}{% endif %}"{% if allowDismiss %} data-module="app-message"{% endif %} tabindex="-1" role="alert">
+<{{ element }}
+  class="app-message{% if params.classes %} {{ params.classes }}{% endif %}"
+  data-module="app-message"
+  {% if allowDismiss %} data-allow-dismiss{% endif %}
+  {% if focusOnload %} data-focus{% endif %}
+  tabindex="-1"
+  role="alert"
+  aria-labelledby="app-message__heading"
+  >
   {% if params.title.html or params.title.text %}
-    <h2 class="app-message__heading">
+    <h2 class="app-message__heading" id="app-message__heading">
       {{ params.title.html | safe if params.title.html else params.title.text }}
     </h2>
   {% endif %}

--- a/common/components/message/template.test.js
+++ b/common/components/message/template.test.js
@@ -30,6 +30,14 @@ describe('Message component', function() {
     it('should render module data attribute', function() {
       expect($component.attr('data-module')).to.equal('app-message')
     })
+
+    it('should render dismissable attribute', function() {
+      expect($component.attr('data-allow-dismiss')).to.exist
+    })
+
+    it('should not render focus attribute', function() {
+      expect($component.attr('data-focus')).not.to.exist
+    })
   })
 
   context('with classes', function() {
@@ -155,12 +163,22 @@ describe('Message component', function() {
     })
 
     context('when dismiss is prevented', function() {
-      it('should render unescaped html', function() {
+      it('should not render dismissable attribute', function() {
         const $ = renderComponentHtmlToCheerio(
           'message',
           examples['without dismiss']
         )
-        expect($('.app-message').attr('data-module')).to.be.undefined
+        expect($('.app-message').attr('data-allow-dismiss')).not.to.exist
+      })
+    })
+
+    context('when focus on load is set', function() {
+      it('should render focus attribute', function() {
+        const $ = renderComponentHtmlToCheerio(
+          'message',
+          examples['focused on load']
+        )
+        expect($('.app-message').attr('data-focus')).to.exist
       })
     })
   })


### PR DESCRIPTION
## Proposed changes

This introduces the ability to focus the message component using
a configuration item. If this is enabled the element will be focused on page
load. This will help improve accessibility as assistive technologies like
screenreaders will read this content first.

It also includes an update to the style to show the focused state when the element
is focused.

## Screenshots

### Before

![image](https://user-images.githubusercontent.com/3327997/79851463-405b3c00-83bd-11ea-9d15-97742f58cfe8.png)

### After

![image](https://user-images.githubusercontent.com/3327997/79851420-33d6e380-83bd-11ea-8432-1f45818dc1d0.png)
