### PR TITLE
Update consistency of "requested" language

### DIFF
--- a/app/move/controllers/create/base.js
+++ b/app/move/controllers/create/base.js
@@ -20,7 +20,7 @@ class CreateBaseController extends FormWizardController {
     const steps = Object.keys(req.form.options.steps)
     const lastStep = steps[steps.length - 1]
     const buttonText = nextStep.includes(lastStep)
-      ? 'actions::schedule_move'
+      ? 'actions::request_move'
       : 'actions::continue'
 
     req.form.options.buttonText = req.form.options.buttonText || buttonText

--- a/app/move/controllers/create/base.test.js
+++ b/app/move/controllers/create/base.test.js
@@ -132,7 +132,7 @@ describe('Move controllers', function() {
 
           it('should set cancel url correctly', function() {
             expect(req.form.options.buttonText).to.equal(
-              'actions::schedule_move'
+              'actions::request_move'
             )
           })
 

--- a/app/move/views/confirmation.njk
+++ b/app/move/views/confirmation.njk
@@ -1,7 +1,7 @@
 {% extends "layouts/base.njk" %}
 
 {% block customGtagConfig %}
-  gtag('set', {'page_title': 'Move scheduled'});
+  gtag('set', {'page_title': 'Move requested'});
 {% endblock %}
 
 {% block pageTitle %}
@@ -20,8 +20,8 @@
 
       {{ govukPanel({
         classes: "govuk-!-margin-bottom-7",
-        titleText: t("moves::confirmation.panel.heading", { context: move.status }),
-        html: t("moves::confirmation.panel.content", {
+        titleText: t("messages::create_move.success.heading", { context: move.status }),
+        html: t("messages::create_move.success.content", {
           context: move.status,
           moveReference: move.reference
         })

--- a/locales/en/actions.json
+++ b/locales/en/actions.json
@@ -9,7 +9,7 @@
   "back": "Back",
   "back_to_dashboard": "$t(actions::back) to dashboard",
   "back_to_move": "$t(actions::back) to move",
-  "schedule_move": "Schedule move",
+  "request_move": "Request move",
   "search": "Search",
   "search_again": "Search again",
   "continue": "Continue",

--- a/locales/en/errors.json
+++ b/locales/en/errors.json
@@ -17,7 +17,7 @@
   },
   "missing_prereq": {
     "heading": "Journey expired",
-    "heading_create_move": "This move has been scheduled",
+    "heading_create_move": "This move has been requested",
     "content": "Your journey has been completed.",
     "content_create_move": "You can view upcoming moves or create a new move from the dashboard."
   },

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -1,8 +1,9 @@
 {
   "create_move": {
     "success": {
-      "title": "Move scheduled",
-      "content": "Move for <strong>{{name}}</strong> to <strong>{{location}}</strong> on <strong>{{date}}</strong> has been scheduled."
+      "heading": "Move requested",
+      "heading_proposed": "Move sent for review",
+      "content": "Move reference<br><strong>{{moveReference}}</strong>"
     }
   }
 }

--- a/locales/en/moves.json
+++ b/locales/en/moves.json
@@ -130,7 +130,7 @@
     "outgoing_moves_with_date": "Outgoing moves for {{date}}",
     "cancelled_moves": "{{count}} cancelled moves",
     "move_to": "Move to",
-    "no_results": "No moves scheduled",
+    "no_results": "No moves requested",
     "single_moves": "Single moves",
     "single_moves_no_results": "No moves proposed",
     "filter": {
@@ -173,14 +173,9 @@
     }
   },
   "confirmation": {
-    "page_title": "Move scheduled for {{name}}",
+    "page_title": "Move requested for {{name}}",
     "page_title_proposed": "Move sent for {{name}}",
-    "panel": {
-      "heading": "Move scheduled",
-      "heading_proposed": "Move sent for review",
-      "content": "Reference number<br><strong>{{moveReference}}</strong>"
-    },
-    "detail": "The move for <strong><a href=\"{{href}}\">{{name}}</a></strong> to <strong>{{location}}</strong> on <strong>{{date}}</strong> has been scheduled with {{supplier}}.",
+    "detail": "The move for <strong><a href=\"{{href}}\">{{name}}</a></strong> to <strong>{{location}}</strong> on <strong>{{date}}</strong> has been requested with {{supplier}}.",
     "detail_proposed": "The move for <strong><a href=\"{{href}}\">{{name}}</a></strong> to <strong>{{location}}</strong> has been sent to the Population Management Unit (PMU) for review.",
     "saved_to_nomis": "<p>A court date for case number <strong>{{cases}}</strong> on <strong>{{date}}</strong> has been added to NOMIS.</p><p>If this person has more than one hearing you will need to add any extra court dates.</p>",
     "saved_to_nomis_plural": "<p>Court dates for case numbers <strong>{{cases}}</strong> on <strong>{{date}}</strong> have been added to NOMIS.</p>",


### PR DESCRIPTION
## Proposed changes

The statuses for a move were recently updated. We used to refer to a
move as "Scheduled" when it was created, but with the introduction of
different states for a supplier this term was changed to "Requested".

Currently we use a mix of the two terms which could be confusing to users.

This change ensures we have consistency in terminology and updates
any existing references to "Scheduled" to be "Requested".

## Screenshots

### Before

Notice the inconsistency between "Scheduled" and "Requested" in the submit button, the confirmation banner and the status indicators on the move detail and dashboard.

There was also inconsistency with "Reference number" and "Move reference" between the confirmation banner and the dashboard and move detail pages.

<kbd><img src="https://user-images.githubusercontent.com/3327997/79864038-ab623e00-83d0-11ea-807c-04e369ac5a5f.png"></kbd>

<kbd><img src="https://user-images.githubusercontent.com/3327997/79863782-3e4ea880-83d0-11ea-90f2-285702f1844d.png"></kbd>

<kbd><img src="https://user-images.githubusercontent.com/3327997/79863804-4ad30100-83d0-11ea-80ac-d91fa132e8f8.png"></kbd>

<kbd><img src="https://user-images.githubusercontent.com/3327997/79864234-098f2100-83d1-11ea-967a-5f2c80365775.png"></kbd>

### After

Now has improved consistency between the term used in all parts of the service.

<kbd><img src="https://user-images.githubusercontent.com/3327997/79863968-8ff73300-83d0-11ea-841b-04b41ceb8c9d.png"></kbd>

<kbd><img src="https://user-images.githubusercontent.com/3327997/79863872-663e0c00-83d0-11ea-80b9-f91c4484dd39.png"></kbd>

<kbd><img src="https://user-images.githubusercontent.com/3327997/79863804-4ad30100-83d0-11ea-80ac-d91fa132e8f8.png"></kbd>

<kbd><img src="https://user-images.githubusercontent.com/3327997/79864234-098f2100-83d1-11ea-967a-5f2c80365775.png"></kbd>