### PR TITLE
[P4-1306] Extend permissions to determine permitted destinations

### DIFF
--- a/app/move/controllers/create/move-details.js
+++ b/app/move/controllers/create/move-details.js
@@ -1,4 +1,4 @@
-const { mapKeys, set } = require('lodash')
+const { get, map, omitBy, set } = require('lodash')
 
 const fieldHelpers = require('../../../../common/helpers/field')
 const referenceDataHelpers = require('../../../../common/helpers/reference-data')
@@ -9,9 +9,9 @@ const CreateBaseController = require('./base')
 class MoveDetailsController extends CreateBaseController {
   middlewareSetup() {
     super.middlewareSetup()
-    this.use(this.setMoveType)
+    this.use(this.setMoveTypes)
     this.use(this.setLocationItems('court', 'to_location_court_appearance'))
-    this.use(this.setLocationItems('prison', 'to_location_prison'))
+    this.use(this.setLocationItems('prison', 'to_location_prison_transfer'))
   }
 
   setLocationItems(locationType, fieldName) {
@@ -41,11 +41,25 @@ class MoveDetailsController extends CreateBaseController {
     }
   }
 
-  setMoveType(req, res, next) {
-    // This is to ensure any custom move types keep the
-    // same key that is used in this controller
-    req.form.options.fields = mapKeys(req.form.options.fields, (value, key) =>
-      key.includes('move_type') ? 'move_type' : key
+  setMoveTypes(req, res, next) {
+    const permittedMoveTypes = get(req.session, 'user.permissions', [])
+      .filter(permission => permission.includes('move:create:'))
+      .map(permission => permission.replace('move:create:', ''))
+    const existingItems = req.form.options.fields.move_type.items
+    const permittedItems = existingItems.filter(item =>
+      permittedMoveTypes.includes(item.value)
+    )
+    const removedConditionals = map(
+      existingItems.filter(item => !permittedMoveTypes.includes(item.value)),
+      'conditional'
+    )
+
+    // update move_type with only permitted items
+    set(req, 'form.options.fields.move_type.items', permittedItems)
+
+    // remove any conditionals fields that are no longer needed
+    req.form.options.fields = omitBy(req.form.options.fields, (value, key) =>
+      removedConditionals.includes(key)
     )
 
     next()

--- a/app/move/fields/create.js
+++ b/app/move/fields/create.js
@@ -13,18 +13,6 @@ const personSearchFilter = {
   autocomplete: 'off',
 }
 
-const moveType = {
-  validate: 'required',
-  component: 'govukRadios',
-  name: 'move_type',
-  fieldset: {
-    legend: {
-      text: 'fields::move_type.label',
-      classes: 'govuk-fieldset__legend--m',
-    },
-  },
-}
-
 const assessmentQuestionComments = {
   skip: true,
   rows: 3,
@@ -123,13 +111,6 @@ const dateField = {
   hint: {
     text: 'fields::date.hint',
   },
-}
-
-const moveTypeCourtAppearance = {
-  id: 'move_type',
-  value: 'court_appearance',
-  text: 'fields::move_type.items.court_appearance.label',
-  conditional: 'to_location_court_appearance',
 }
 
 module.exports = {
@@ -261,24 +242,27 @@ module.exports = {
   // move details
   to_location: {},
   move_type: {
-    ...cloneDeep(moveType),
-    items: [{ ...moveTypeCourtAppearance }],
-  },
-  move_type__prison_to_prison: {
-    ...cloneDeep(moveType),
-    items: [
-      { ...moveTypeCourtAppearance },
-      {
-        value: 'prison',
-        text: 'fields::move_type.items.prison.label',
-        conditional: 'to_location_prison',
+    validate: 'required',
+    component: 'govukRadios',
+    name: 'move_type',
+    fieldset: {
+      legend: {
+        text: 'fields::move_type.label',
+        classes: 'govuk-fieldset__legend--m',
       },
-    ],
-  },
-  move_type__police: {
-    ...cloneDeep(moveType),
+    },
     items: [
-      { ...moveTypeCourtAppearance },
+      {
+        id: 'move_type',
+        value: 'court_appearance',
+        text: 'fields::move_type.items.court_appearance.label',
+        conditional: 'to_location_court_appearance',
+      },
+      {
+        value: 'prison_transfer',
+        text: 'fields::move_type.items.prison_transfer.label',
+        conditional: 'to_location_prison_transfer',
+      },
       {
         value: 'prison_recall',
         text: 'fields::move_type.items.prison_recall.label',
@@ -289,7 +273,7 @@ module.exports = {
   to_location_court_appearance: toLocationType('court_appearance', {
     validate: 'required',
   }),
-  to_location_prison: toLocationType('prison', {
+  to_location_prison_transfer: toLocationType('prison_transfer', {
     validate: 'required',
   }),
   additional_information: {

--- a/app/move/steps/create.js
+++ b/app/move/steps/create.js
@@ -27,27 +27,6 @@ const personSearchStep = {
   ],
 }
 
-const moveDetailsStep = {
-  controller: MoveDetails,
-  template: 'move-details',
-  pageTitle: 'moves::steps.move_details.heading',
-  next: [
-    {
-      field: 'from_location_type',
-      value: 'prison',
-      next: [
-        {
-          field: 'to_location_type',
-          value: 'prison',
-          next: 'move-date-range',
-        },
-        'move-date',
-      ],
-    },
-    'move-date',
-  ],
-}
-
 const riskStep = {
   controller: Assessment,
   assessmentCategory: 'risk',
@@ -112,19 +91,6 @@ module.exports = {
         value: true,
         next: 'personal-details',
       },
-      {
-        field: 'from_location_type',
-        value: 'police',
-        next: 'move-details-police',
-      },
-      {
-        fn: req => {
-          return req.session.user.permissions.includes(
-            'move:create:prison_to_prison'
-          )
-        },
-        next: 'move-details-prison-to-prison',
-      },
       'move-details',
     ],
     fields: ['people'],
@@ -132,14 +98,7 @@ module.exports = {
   '/personal-details': {
     controller: PersonalDetails,
     pageTitle: 'moves::steps.personal_details.heading',
-    next: [
-      {
-        field: 'from_location_type',
-        value: 'police',
-        next: 'move-details-police',
-      },
-      'move-details',
-    ],
+    next: 'move-details',
     fields: [
       'police_national_computer',
       'last_name',
@@ -199,30 +158,29 @@ module.exports = {
     next: 'agreement-status',
   },
   '/move-details': {
-    ...moveDetailsStep,
+    controller: MoveDetails,
+    template: 'move-details',
+    pageTitle: 'moves::steps.move_details.heading',
+    next: [
+      {
+        field: 'from_location_type',
+        value: 'prison',
+        next: [
+          {
+            field: 'to_location_type',
+            value: 'prison',
+            next: 'move-date-range',
+          },
+          'move-date',
+        ],
+      },
+      'move-date',
+    ],
     fields: [
-      'to_location',
       'move_type',
-      'to_location_prison',
-      'to_location_court_appearance',
-    ],
-  },
-  '/move-details-prison-to-prison': {
-    ...moveDetailsStep,
-    fields: [
       'to_location',
-      'move_type__prison_to_prison',
-      'to_location_prison',
       'to_location_court_appearance',
-    ],
-  },
-  '/move-details-police': {
-    ...moveDetailsStep,
-    fields: [
-      'to_location',
-      'move_type__police',
-      'to_location_prison_recall',
-      'to_location_court_appearance',
+      'to_location_prison_transfer',
       'additional_information',
     ],
   },

--- a/common/lib/permissions.js
+++ b/common/lib/permissions.js
@@ -3,6 +3,24 @@ const policePermissions = [
   'moves:download',
   'move:view',
   'move:create',
+  'move:create:court_appearance',
+  'move:create:prison_recall',
+  'move:cancel',
+]
+const secureChildrensHomePermissions = [
+  'moves:view:outgoing',
+  'moves:download',
+  'move:view',
+  'move:create',
+  'move:create:court_appearance',
+  'move:cancel',
+]
+const secureTrainingCentrePermissions = [
+  'moves:view:outgoing',
+  'moves:download',
+  'move:view',
+  'move:create',
+  'move:create:court_appearance',
   'move:cancel',
 ]
 const supplierPermissions = [
@@ -16,6 +34,7 @@ const prisonPermissions = [
   'moves:download',
   'move:view',
   'move:create',
+  'move:create:court_appearance',
   'move:cancel',
 ]
 const ocaPermissions = [
@@ -24,14 +43,15 @@ const ocaPermissions = [
   'moves:download',
   'move:view',
   'move:create',
-  'move:create:prison_to_prison',
+  'move:create:court_appearance',
+  'move:create:prison_transfer',
 ]
 const pmuPermissions = ['allocations:view', 'allocation:create']
 
 const permissionsByRole = {
   ROLE_PECS_POLICE: policePermissions,
-  ROLE_PECS_SCH: policePermissions,
-  ROLE_PECS_STC: policePermissions,
+  ROLE_PECS_SCH: secureChildrensHomePermissions,
+  ROLE_PECS_STC: secureTrainingCentrePermissions,
   ROLE_PECS_PRISON: prisonPermissions,
   ROLE_PECS_HMYOI: prisonPermissions,
   ROLE_PECS_OCA: ocaPermissions,

--- a/common/lib/user.test.js
+++ b/common/lib/user.test.js
@@ -102,6 +102,8 @@ describe('User class', function() {
           'moves:download',
           'move:view',
           'move:create',
+          'move:create:court_appearance',
+          'move:create:prison_recall',
           'move:cancel',
         ])
       })
@@ -118,6 +120,7 @@ describe('User class', function() {
           'moves:download',
           'move:view',
           'move:create',
+          'move:create:court_appearance',
           'move:cancel',
         ])
       })
@@ -134,6 +137,7 @@ describe('User class', function() {
           'moves:download',
           'move:view',
           'move:create',
+          'move:create:court_appearance',
           'move:cancel',
         ])
       })
@@ -150,6 +154,7 @@ describe('User class', function() {
           'moves:download',
           'move:view',
           'move:create',
+          'move:create:court_appearance',
           'move:cancel',
         ])
       })
@@ -166,6 +171,7 @@ describe('User class', function() {
           'moves:download',
           'move:view',
           'move:create',
+          'move:create:court_appearance',
           'move:cancel',
         ])
       })
@@ -183,7 +189,8 @@ describe('User class', function() {
           'moves:download',
           'move:view',
           'move:create',
-          'move:create:prison_to_prison',
+          'move:create:court_appearance',
+          'move:create:prison_transfer',
         ])
       })
     })
@@ -211,6 +218,8 @@ describe('User class', function() {
           'ROLE_PECS_SUPPLIER',
           'ROLE_PECS_STC',
           'ROLE_PECS_SCH',
+          'ROLE_PECS_OCA',
+          'ROLE_PECS_PMU',
           'ROLE_PECS_HMYOI',
         ])
       })
@@ -221,8 +230,15 @@ describe('User class', function() {
           'moves:download',
           'move:view',
           'move:create',
+          'move:create:court_appearance',
+          'move:create:prison_recall',
           'move:cancel',
           'moves:view:all',
+          'moves:view:dashboard',
+          'moves:view:proposed',
+          'move:create:prison_transfer',
+          'allocations:view',
+          'allocation:create',
         ])
       })
     })

--- a/locales/en/fields.json
+++ b/locales/en/fields.json
@@ -56,7 +56,7 @@
     "label": "Move to",
     "short_label": "To",
     "items": {
-      "prison": {
+      "prison_transfer": {
         "label": "Prison"
       },
       "prison_recall": {
@@ -73,7 +73,7 @@
   "to_location_court_appearance": {
     "label": "Name of court"
   },
-  "to_location_prison": {
+  "to_location_prison_transfer": {
     "label": "Name of prison"
   },
   "additional_information": {


### PR DESCRIPTION
This refactor moves some of the existing logic from the steps object
to one of the controllers.

It moves the logic for determining which destinations a user can send
a person to. That logic has had to be based on permissions to some extent
which meant creating various different "steps" and using the [Form Wizard
forking logic](https://github.com/UKHomeOffice/passports-form-wizard#next-steps) to handle that.

This caused a problem when trying to introduce the ability to go back
and make a change to the move details when there is a conflict as there
isn't one step to direct a user to.

The existing logic also meant transforming the name of one of the fields
to not break the logic within the process method of the lifecycle.

This change uses permissions to determine which types of move a user can
create and builds the move type options from there. This allows us to link
to one step if making changes and reduces some of the complexity in the
steps and fields configurations.