### PR TITLE
[P4-1306] Provide better user feedback when a move conflict occurs

### DIFF
--- a/app/move/controllers/create/save.js
+++ b/app/move/controllers/create/save.js
@@ -1,4 +1,4 @@
-const { omit, capitalize, flatten, values, some } = require('lodash')
+const { get, omit, capitalize, flatten, values, some } = require('lodash')
 
 const analytics = require('../../../../common/lib/analytics')
 const courtHearingService = require('../../../../common/services/court-hearing')
@@ -105,6 +105,20 @@ class SaveController extends CreateBaseController {
     } catch (err) {
       next(err)
     }
+  }
+
+  errorHandler(err, req, res, next) {
+    const apiErrorCode = get(err, 'errors[0].code')
+
+    if (err.statusCode === 422 && apiErrorCode === 'taken') {
+      const existingMoveId = get(err, 'errors[0].meta.existing_id')
+
+      return res.render('move/views/create/save-conflict', {
+        existingMoveId,
+      })
+    }
+
+    super.errorHandler(err, req, res, next)
   }
 }
 

--- a/app/move/steps/create.js
+++ b/app/move/steps/create.js
@@ -116,6 +116,7 @@ module.exports = {
     next: 'prison-transfer-reason',
   },
   '/move-date': {
+    editable: true,
     pageTitle: 'moves::steps.move_date.heading',
     next: [
       {
@@ -158,6 +159,7 @@ module.exports = {
     next: 'agreement-status',
   },
   '/move-details': {
+    editable: true,
     controller: MoveDetails,
     template: 'move-details',
     pageTitle: 'moves::steps.move_details.heading',

--- a/app/move/views/create/save-conflict.njk
+++ b/app/move/views/create/save-conflict.njk
@@ -1,0 +1,49 @@
+{% extends "layouts/two-column.njk" %}
+
+{% block pageTitle %}
+  {{ t("validation::page_title_prefix") }}: {{ t("validation::move_conflict.heading") }}
+{% endblock %}
+
+{% block beforeContent %}
+  {{ super() }}
+
+  {% if backLink and not options.hideBackLink %}
+    {{ govukBackLink({
+      text: t("actions::back"),
+      href: backLink
+    }) }}
+  {% endif %}
+{% endblock %}
+
+{% block contentHeader %}
+  {% set errorMsg %}
+    <p class="govuk-!-margin-top-4">
+      {{ t("validation::move_conflict.message", {
+        href: "/move/" + existingMoveId,
+        name: values.person.fullname | upper,
+        location: values.to_location.title,
+        date: values.date | formatDateWithDay
+      }) | safe }}
+    </p>
+
+    {# TODO: Find way to get correct "move details" #}
+    <p class="govuk-!-margin-top-2">
+      {{ t("validation::move_conflict.instructions", {
+        date_href: "move-date/edit",
+        location_href: "move-details/edit"
+      }) | safe }}
+    </p>
+  {% endset %}
+
+  {{ appMessage({
+    focusOnload: true,
+    classes: "app-message--error",
+    title: {
+      text: t("validation::move_conflict.heading")
+    },
+    content: {
+      html: errorMsg
+    }
+  }) }}
+{% endblock %}
+

--- a/locales/en/validation.json
+++ b/locales/en/validation.json
@@ -11,6 +11,11 @@
   "before": "must be in the past",
   "default": "is required",
   "generic": "something went wrong",
+  "move_conflict": {
+    "heading": "This move cannot be created",
+    "message": "A move <a href=\"{{href}}\">already exists</a> for <strong>{{name}}</strong> to <strong>{{location}}</strong> on <strong>{{date}}</strong>.",
+    "instructions": "If you still need to move this person try <a href=\"{{date_href}}\">changing the date</a> or <a href=\"{{location_href}}\">the destination</a>."
+  },
   "LIMIT_FILE_SIZE": "must be smaller than 50MB",
   "LIMIT_PART_COUNT": "has too many parts",
   "LIMIT_FILE_COUNT": "has too mamy files",


### PR DESCRIPTION
## Proposed changes

This fix handles `422` errors during move creation where the reason code
is `taken`.

This means that the user is trying to create a duplicate
move (same to and from location, date and person) which the service
doesn't currently allow.

We now provide the user with better feedback that this is what has
happened and a link to the existing move, as well as options to change
the date or location if they still want to create a move for that person.

**Note:** Depends on #442 

## Screencapture

### Changing the date

<kbd><img src="https://user-images.githubusercontent.com/3327997/79869820-e4eb7700-83d9-11ea-90ee-9465ffa9d0d9.gif"></kbd>

<kbd><img src="https://user-images.githubusercontent.com/3327997/79870188-82df4180-83da-11ea-8942-5b92ec86d079.gif"></kbd>

### Changing the destination

## Screenshots

### Before

<kbd><img src="https://user-images.githubusercontent.com/3327997/79868844-71953580-83d8-11ea-8ced-e52774284e0f.png"></kbd>

### After

<kbd><img src="https://user-images.githubusercontent.com/3327997/79875500-a78ae780-83e1-11ea-9432-98333c67fa90.png"></kbd>
