### PR TITLE
fix(e2e): Update selector used in end-to-end tests

### DIFF
--- a/test/e2e/pages/create-move.js
+++ b/test/e2e/pages/create-move.js
@@ -25,7 +25,7 @@ class CreateMovePage extends Page {
       gender: Selector('[name="gender"]'),
       moveType: Selector('[name="move_type"]'),
       courtLocation: Selector('#to_location_court_appearance'),
-      prisonLocation: Selector('#to_location_prison'),
+      prisonLocation: Selector('#to_location_prison_transfer'),
       additionalInformation: Selector('#additional_information'),
       dateType: Selector('[name="date_type"]'),
       dateFrom: Selector('#date_from'),


### PR DESCRIPTION
The way move details is constructed changed and this test wasn't
updated at the same time.

This updates the selector so they will now pass.