### PR TITLE
Add read-only field component

### DIFF
--- a/common/components/read-only-field/macro.njk
+++ b/common/components/read-only-field/macro.njk
@@ -1,0 +1,3 @@
+{% macro appReadOnlyField(params) %}
+  {%- include "./template.njk" -%}
+{% endmacro %}

--- a/common/components/read-only-field/read-only-field.yaml
+++ b/common/components/read-only-field/read-only-field.yaml
@@ -1,0 +1,73 @@
+params:
+- name: classes
+  type: string
+  required: false
+  description: Classes to add to the parent element.
+- name: name
+  type: string
+  required: true
+  description: Field name.
+- name: value
+  type: string
+  required: true
+  description: Field value.
+- name: noHidden
+  type: boolean
+  required: false
+  description: Whether to include a hidden field.
+- name: label
+  type: object
+  required: false
+  description: Options for the caption.
+  params:
+  - name: text
+    type: string
+    required: true
+    description: If `html` is set, this is not required. Text to use within the label. If `html` is provided, the `text` argument will be ignored.
+  - name: html
+    type: string
+    required: true
+    description: If `text` is set, this is not required. HTML to use within the label. If `html` is provided, the `text` argument will be ignored.
+  - name: classes
+    type: string
+    required: false
+    description: Classes to add to the label element.
+- name: items
+  type: array
+  required: false
+  description: Array of components.
+
+examples:
+  - name: default
+    data:
+      label:
+        text: Display text
+      value: Display value
+  - name: with html
+    data:
+      label:
+        html: Display html
+        text: Display text
+      vale: Display value
+  - name: with classes
+    data:
+      label:
+        classes: heading-class
+        text: Display text
+      value: Display value
+      classes: display-class
+  - name: with name
+    data:
+      label:
+        text: Display text
+      value: Display value
+      name: display
+  - name: with items
+    data:
+      label:
+        text: Display text
+      value: Display value
+      items:
+        - component: govukDetails
+          summaryHtml: summaryText
+          html: detailsText

--- a/common/components/read-only-field/template.njk
+++ b/common/components/read-only-field/template.njk
@@ -1,0 +1,18 @@
+{% from "govuk/components/details/macro.njk" import govukDetails %}
+
+<div class="app-read-only-field govuk-form-group {%- if params.classes %} {{ params.classes }}{% endif %}">
+  {% if params.name %}
+    <input type="hidden" name="{{ params.name }}" value="{{ params.value }}">
+  {% endif %}
+  <h2 class="app-read-only-field__heading govuk-label {%- if params.label.classes %} {{ params.label.classes }}{% endif %}">
+    {% if params.label.html %}{{ params.label.html | safe }}{% else %}{{ params.label.text }}{% endif %}
+  </h2>
+  <p class="app-read-only-field__value govuk-body">{{ params.value }}</p>
+  {% if params.items %}
+    <div class="app-read-only-field__items">
+      {% for item in params.items %}
+        {{ callAsMacro(item.component)(item) }}
+      {% endfor %}
+    </div>
+  {% endif %}
+</div>

--- a/common/components/read-only-field/template.test.js
+++ b/common/components/read-only-field/template.test.js
@@ -1,0 +1,192 @@
+const {
+  renderComponentHtmlToCheerio,
+  getExamples,
+} = require('../../../test/unit/component-helpers')
+
+const examples = getExamples('read-only-field')
+const getComponent = example => {
+  const $ = renderComponentHtmlToCheerio('read-only-field', examples[example])
+  return $('.app-read-only-field')
+}
+
+describe('Read only field component', function() {
+  describe('default', function() {
+    let $component
+
+    beforeEach(function() {
+      $component = getComponent('default')
+    })
+
+    context('when rendering component', function() {
+      it('should create the expected element', function() {
+        expect($component.get(0).tagName).to.equal('div')
+      })
+      it('should add the default class', function() {
+        expect($component.hasClass('govuk-form-group')).to.be.true
+      })
+    })
+
+    context('when rendering heading', function() {
+      let $heading
+
+      beforeEach(function() {
+        $heading = $component.find('.app-read-only-field__heading')
+      })
+      it('should create the expected element', function() {
+        expect($heading.get(0).tagName).to.equal('h2')
+      })
+      it('should add the default class', function() {
+        expect($heading.hasClass('govuk-label')).to.be.true
+      })
+      it('should output heading', function() {
+        expect($heading.text().trim()).to.equal('Display text')
+      })
+    })
+
+    context('when rendering value', function() {
+      let $value
+
+      beforeEach(function() {
+        $value = $component.find('.app-read-only-field__value')
+      })
+      it('should create the expected element', function() {
+        expect($value.get(0).tagName).to.equal('p')
+      })
+      it('should add the default class', function() {
+        expect($value.hasClass('govuk-body')).to.be.true
+      })
+      it('should output heading', function() {
+        expect($value.text().trim()).to.equal('Display value')
+      })
+    })
+
+    context('when rendering hidden input', function() {
+      let $hidden
+
+      beforeEach(function() {
+        $hidden = $component.find('[type=hidden]')
+      })
+
+      it('should omit it', function() {
+        expect($hidden.get(0)).to.not.exist
+      })
+    })
+
+    context('when rendering nested items', function() {
+      let $items
+
+      beforeEach(function() {
+        $items = $component.find('.app-read-only-field__items')
+      })
+
+      it('should omit it', function() {
+        expect($items.get(0)).to.not.exist
+      })
+    })
+  })
+
+  describe('with html', function() {
+    let $component
+
+    beforeEach(function() {
+      $component = getComponent('with html')
+    })
+
+    context('when rendering heading', function() {
+      let $heading
+
+      beforeEach(function() {
+        $heading = $component.find('.app-read-only-field__heading')
+      })
+
+      it('should prefer html value for heading', function() {
+        expect($heading.text().trim()).to.equal('Display html')
+      })
+    })
+  })
+
+  describe('with classes', function() {
+    let $component
+
+    beforeEach(function() {
+      $component = getComponent('with classes')
+    })
+
+    context('when rendering component', function() {
+      it('should add the custom class', function() {
+        expect($component.hasClass('display-class')).to.be.true
+      })
+    })
+
+    context('when rendering heading', function() {
+      let $heading
+
+      beforeEach(function() {
+        $heading = $component.find('.app-read-only-field__heading')
+      })
+
+      it('should add the custom class', function() {
+        expect($heading.hasClass('heading-class')).to.be.true
+      })
+    })
+  })
+
+  describe('with name', function() {
+    let $component
+
+    beforeEach(function() {
+      $component = getComponent('with name')
+    })
+
+    context('when rendering hidden input', function() {
+      let $hidden
+
+      beforeEach(function() {
+        $hidden = $component.find('[type=hidden]')
+      })
+
+      it('should add the expected name', function() {
+        expect($hidden.attr('name')).to.equal('display')
+      })
+
+      it('should add the expected value', function() {
+        expect($hidden.attr('value')).to.equal('Display value')
+      })
+    })
+  })
+
+  describe('with items', function() {
+    let $component
+
+    beforeEach(function() {
+      $component = getComponent('with items')
+    })
+
+    context('when rendering items', function() {
+      let $items
+      let summaryText
+      let detailsText
+
+      beforeEach(function() {
+        $items = $component.find('.app-read-only-field__items')
+        summaryText = $items
+          .find('.govuk-details__summary-text')
+          .text()
+          .trim()
+        detailsText = $items
+          .find('.govuk-details__text')
+          .text()
+          .trim()
+      })
+
+      it('should wrap the items', function() {
+        expect($items.length).to.equal(1)
+      })
+
+      it('should output the items', function() {
+        expect(summaryText).to.equal('summaryText')
+        expect(detailsText).to.equal('detailsText')
+      })
+    })
+  })
+})

--- a/common/templates/layouts/base.njk
+++ b/common/templates/layouts/base.njk
@@ -29,6 +29,7 @@
 {% from "multi-file-upload/macro.njk" import appMultiFileUpload %}
 {% from "pagination/macro.njk"        import appPagination %}
 {% from "panel/macro.njk"             import appPanel %}
+{% from "read-only-field/macro.njk"   import appReadOnlyField %}
 {% from "tag/macro.njk"               import appTag %}
 {% from "time/macro.njk"              import appTime %}
 

--- a/test/unit/component-helpers.js
+++ b/test/unit/component-helpers.js
@@ -5,16 +5,23 @@ const cheerio = require('cheerio')
 const yaml = require('js-yaml')
 const nunjucks = require('nunjucks')
 
+const templateGlobals = require('../../config/nunjucks/globals')
 const configPaths = require('../../config/paths')
+
 const views = [
   configPaths.components,
   configPaths.govukFrontend,
   configPaths.mojFrontend,
 ]
 
-nunjucks.configure(views, {
+const nunjucksEnvironment = nunjucks.configure(views, {
   trimBlocks: true,
   lstripBlocks: true,
+})
+
+// Global variables
+Object.keys(templateGlobals).forEach(global => {
+  nunjucksEnvironment.addGlobal(global, templateGlobals[global])
 })
 
 /**


### PR DESCRIPTION
Display the value of a field rather than allow the user to edit it.

Optionally output further additional components (just details for now).

Read-only
![Personal_details_-_update_move](https://user-images.githubusercontent.com/4856/79975761-66eba680-8493-11ea-93a8-18b324fef276.png)


### Checklist

- [x] If adding new environment variables, they have been documented in the [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md)
- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
