### PR TITLE
feature - Add ability to update moves

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,7 @@ It will also start a new deployment specific [job on CircleCI](https://app.circl
 | E2E_SUPPLIER_PASSWORD | Supplier user password used for acceptance testing | |
 | LOCATIONS_BATCH_SIZE | Maximum number of location IDs to send in one request when requesting moves for all locations | 40 |
 | FEATURE_FLAG_PRISON_COURT_HEARINGS | Whether to display the court hearings step from Prison locations | false |
+| FEATURE_FLAG_EDITABILITY | Whether to enable page views where moves can be updated | |
 
 ### Development specific
 

--- a/app/move/controllers/create/assessment.test.js
+++ b/app/move/controllers/create/assessment.test.js
@@ -181,6 +181,7 @@ describe('Move controllers', function() {
           },
         ])
         req = {
+          getPerson: sinon.stub(),
           form: {
             options: {
               assessmentCategory: 'risk',
@@ -190,9 +191,6 @@ describe('Move controllers', function() {
                 escape: {},
               },
             },
-          },
-          sessionModel: {
-            get: sinon.stub(),
           },
         }
         res = {
@@ -208,7 +206,7 @@ describe('Move controllers', function() {
 
         context('with answers in the list of keys', function() {
           beforeEach(function() {
-            req.sessionModel.get.withArgs('person').returns({
+            req.getPerson.returns({
               assessment_answers: [
                 {
                   category: 'risk',
@@ -257,7 +255,7 @@ describe('Move controllers', function() {
 
         context('with answers not in the list of keys', function() {
           beforeEach(function() {
-            req.sessionModel.get.withArgs('person').returns({
+            req.getPerson.returns({
               assessment_answers: [
                 {
                   category: 'risk',
@@ -299,7 +297,7 @@ describe('Move controllers', function() {
 
         context('with non imported answers', function() {
           beforeEach(function() {
-            req.sessionModel.get.withArgs('person').returns({
+            req.getPerson.returns({
               assessment_answers: [
                 {
                   category: 'risk',
@@ -337,7 +335,7 @@ describe('Move controllers', function() {
         'when the step does not include previous assessment keys',
         function() {
           beforeEach(function() {
-            req.sessionModel.get.withArgs('person').returns({
+            req.getPerson.returns({
               assessment_answers: [],
             })
             controller.setPreviousAssessment(req, res, nextSpy)

--- a/app/move/controllers/create/base.js
+++ b/app/move/controllers/create/base.js
@@ -9,10 +9,30 @@ class CreateBaseController extends FormWizardController {
 
   middlewareLocals() {
     super.middlewareLocals()
+    this.use(this.setModels)
     this.use(this.setButtonText)
     this.use(this.setCancelUrl)
     this.use(this.setMoveSummary)
     this.use(this.setJourneyTimer)
+  }
+
+  _addModelMethods(req) {
+    req.getMove = () => req.models.move || {}
+    req.getMoveId = () => req.getMove().id
+    req.getPerson = () => req.models.person || {}
+    req.getPersonId = () => req.getPerson().id
+  }
+
+  _setModels(req) {
+    req.models.move = req.sessionModel.toJSON()
+    req.models.person = req.sessionModel.get('person')
+  }
+
+  setModels(req, res, next) {
+    req.models = req.models || {}
+    this._setModels(req)
+    this._addModelMethods(req)
+    next()
   }
 
   setButtonText(req, res, next) {
@@ -53,14 +73,14 @@ class CreateBaseController extends FormWizardController {
 
   setMoveSummary(req, res, next) {
     const currentLocation = req.session.currentLocation
-    const sessionModel = req.sessionModel.toJSON()
+    const move = req.getMove()
     const moveSummary = presenters.moveToMetaListComponent({
-      ...sessionModel,
+      ...move,
       from_location: currentLocation,
     })
 
-    res.locals.person = sessionModel.person
-    res.locals.moveSummary = sessionModel.move_type ? moveSummary : {}
+    res.locals.person = req.getPerson()
+    res.locals.moveSummary = move.move_type ? moveSummary : {}
 
     next()
   }

--- a/app/move/controllers/create/personal-details.js
+++ b/app/move/controllers/create/personal-details.js
@@ -1,4 +1,4 @@
-const { get, set } = require('lodash')
+const { set } = require('lodash')
 
 const fieldHelpers = require('../../../../common/helpers/field')
 const referenceDataHelpers = require('../../../../common/helpers/reference-data')
@@ -56,7 +56,7 @@ class PersonalDetailsController extends CreateBaseController {
 
   async saveValues(req, res, next) {
     try {
-      const id = get(req.sessionModel.get('person'), 'id')
+      const id = req.getPersonId()
 
       req.form.values.person = await this.savePerson(id, req.form.values)
       super.saveValues(req, res, next)

--- a/app/move/controllers/create/personal-details.test.js
+++ b/app/move/controllers/create/personal-details.test.js
@@ -205,9 +205,8 @@ describe('Move controllers', function() {
           form: {
             values: {},
           },
-          sessionModel: {
-            get: sinon.stub(),
-          },
+          getPerson: sinon.stub(),
+          getPersonId: sinon.stub(),
         }
       })
 
@@ -215,7 +214,8 @@ describe('Move controllers', function() {
         context('with a new person', function() {
           beforeEach(async function() {
             sinon.stub(controller, 'savePerson').resolves(personMock)
-            req.sessionModel.get.withArgs('person').returns(personMock)
+            req.getPerson.returns(personMock)
+            req.getPersonId.returns(personMock.id)
 
             await controller.saveValues(req, {}, nextSpy)
           })
@@ -241,7 +241,7 @@ describe('Move controllers', function() {
         context('with a pre-existing person', function() {
           beforeEach(async function() {
             sinon.stub(controller, 'savePerson').resolves(personMock)
-            req.sessionModel.get.withArgs('person').returns(undefined)
+            req.getPerson.returns(undefined)
 
             await controller.saveValues(req, {}, nextSpy)
           })

--- a/app/move/controllers/index.js
+++ b/app/move/controllers/index.js
@@ -1,11 +1,13 @@
 const Cancel = require('./cancel')
 const confirmation = require('./confirmation')
 const create = require('./create')
+const update = require('./update')
 const view = require('./view')
 
 module.exports = {
   Cancel,
   create,
   view,
+  update,
   confirmation,
 }

--- a/app/move/controllers/update/assessment.js
+++ b/app/move/controllers/update/assessment.js
@@ -1,0 +1,71 @@
+const { pick } = require('lodash')
+
+const personService = require('../../../../common/services/person')
+const Assessment = require('../create/assessment')
+
+const UpdateBase = require('./base')
+
+const compare = (a, b) => {
+  const key = 'assessment_question_id'
+  if (a[key] < b[key]) {
+    return -1
+  }
+  if (a[key] > b[key]) {
+    return 1
+  }
+}
+const getAnswerKeys = answers => {
+  return answers
+    .map(x => pick(x, ['key', 'assessment_question_id', 'comments']))
+    .sort(compare)
+}
+
+class UpdateAssessmentController extends UpdateBase {
+  middlewareLocals() {
+    super.middlewareLocals()
+    this.use(this.setPreviousAssessment)
+  }
+
+  async saveValues(req, res, next) {
+    try {
+      const personId = req.getPersonId()
+      const person = req.getPerson()
+      const assessments = person.assessment_answers || []
+      const fieldKeys = Object.keys(req.form.options.fields)
+
+      const previousAssessments = assessments.filter(
+        ({ key }) => !fieldKeys.includes(key)
+      )
+
+      const newAssessments = this.getAssessments(req, res)
+      const updatedAssessments = [
+        ...previousAssessments,
+        ...newAssessments,
+      ].sort(compare)
+      // TODO: keep all existing NOMIS alerts
+      // answer.nomis_alert_code
+      // TODO: filter out requested answers
+      // 'not_to_be_released', 'special_vehicle'))
+      // TODO: don't set assessments if not from prison?
+      // fromLocationType !== 'prison'
+
+      const originalKeys = getAnswerKeys(assessments)
+      const updatedKeys = getAnswerKeys(updatedAssessments)
+
+      if (JSON.stringify(originalKeys) !== JSON.stringify(updatedKeys)) {
+        await personService.update({
+          id: personId,
+          assessment_answers: updatedAssessments,
+        })
+      }
+
+      next()
+    } catch (error) {
+      next(error)
+    }
+  }
+}
+
+UpdateBase.mixin(UpdateAssessmentController, Assessment)
+
+module.exports = UpdateAssessmentController

--- a/app/move/controllers/update/assessment.test.js
+++ b/app/move/controllers/update/assessment.test.js
@@ -1,0 +1,289 @@
+const personService = require('../../../../common/services/person')
+const CreateAssessment = require('../create/assessment')
+
+const MixinProto = CreateAssessment.prototype
+const AssessmentController = require('./assessment')
+const UpdateBaseController = require('./base')
+
+// TODO: figure out how to proxyquire lodash without breaking it elsewhere
+
+const controller = new AssessmentController({ route: '/' })
+const ownProto = Object.getPrototypeOf(controller)
+
+describe('Move controllers', function() {
+  describe('Update assessment controller', function() {
+    it('should extend UpdateBaseController', function() {
+      expect(Object.getPrototypeOf(ownProto)).to.equal(
+        UpdateBaseController.prototype
+      )
+    })
+
+    describe('When mixing in create controller', function() {
+      it('should copy configure from CreateAssessment', function() {
+        expect(controller.configure).to.exist.and.equal(MixinProto.configure)
+      })
+
+      it('should copy setPreviousAssessment from CreateAssessment', function() {
+        expect(controller.setPreviousAssessment).to.exist.and.equal(
+          MixinProto.setPreviousAssessment
+        )
+      })
+
+      it('should copy getAssessments from CreateAssessment', function() {
+        expect(controller.getAssessments).to.exist.and.equal(
+          MixinProto.getAssessments
+        )
+      })
+
+      it('should not copy saveValues from CreateAssessment', function() {
+        expect(controller.saveValues).to.exist.and.not.be.equal(
+          MixinProto.saveValues
+        )
+      })
+
+      it('should only have the expected methods of its own', function() {
+        const ownMethods = ['saveValues']
+        const mixedinMethods = Object.getOwnPropertyNames(MixinProto)
+        const ownProps = Object.getOwnPropertyNames(ownProto).filter(
+          prop => !mixedinMethods.includes(prop) || ownMethods.includes(prop)
+        )
+        expect(ownProps).to.deep.equal(ownMethods)
+      })
+    })
+
+    describe('#middlewareLocals()', function() {
+      beforeEach(function() {
+        sinon.stub(UpdateBaseController.prototype, 'middlewareLocals')
+        sinon.stub(controller, 'use')
+
+        controller.middlewareLocals()
+      })
+
+      it('should call parent method', function() {
+        expect(UpdateBaseController.prototype.middlewareLocals).to.have.been
+          .calledOnce
+      })
+
+      it('should call set previous assessment method', function() {
+        expect(controller.use.firstCall).to.have.been.calledWithExactly(
+          controller.setPreviousAssessment
+        )
+      })
+
+      it('should call correct number of middleware', function() {
+        expect(controller.use).to.be.callCount(1)
+      })
+    })
+
+    describe('#saveValues', function() {
+      let req
+      const res = {}
+      let nextSpy
+      beforeEach(function() {
+        sinon.stub(personService, 'update').resolves()
+        req = {
+          getPersonId: sinon.stub().returns('#personId'),
+          getPerson: sinon.stub().returns({
+            id: '#personId',
+            assessment_answers: [
+              {
+                title: 'Violent',
+                comments: '#original_value',
+                created_at: '2020-04-10',
+                expires_at: null,
+                assessment_question_id: 'af8cfc67-757c-4019-9d5e-618017de1617',
+                category: 'risk',
+                key: 'violent',
+                nomis_alert_type: null,
+                nomis_alert_code: null,
+                nomis_alert_type_description: null,
+                nomis_alert_description: null,
+                imported_from_nomis: null,
+              },
+            ],
+          }),
+          form: {
+            values: {
+              violent: '#original_value',
+              escape: '',
+              hold_separately: '',
+              self_harm: '',
+              concealed_items: '',
+              other_risks: '',
+              risk: ['af8cfc67-757c-4019-9d5e-618017de1617'],
+            },
+            options: {
+              fields: {
+                violent: {},
+                escape: {},
+                hold_separately: {},
+                self_harm: {},
+                concealed_items: {},
+                other_risks: {},
+              },
+            },
+          },
+          questions: [
+            {
+              id: 'af8cfc67-757c-4019-9d5e-618017de1617',
+              type: 'assessment_questions',
+              key: 'violent',
+              category: 'risk',
+            },
+            {
+              id: 'f2db9a8f-a5a9-40cf-875b-d1f5f62b2497',
+              type: 'assessment_questions',
+              key: 'escape',
+              category: 'risk',
+            },
+            {
+              id: '8f38efb0-36c1-4a56-8c66-3b72c9525f92',
+              type: 'assessment_questions',
+              key: 'hold_separately',
+              category: 'risk',
+            },
+            {
+              id: '4e7e54b4-a40c-488f-bdff-c6b2268ca4eb',
+              type: 'assessment_questions',
+              key: 'self_harm',
+              category: 'risk',
+            },
+            {
+              id: '56826f64-da5d-42eb-b360-131e60bcc3d3',
+              type: 'assessment_questions',
+              key: 'concealed_items',
+              category: 'risk',
+            },
+            {
+              id: '4e37ac1a-a461-45a8-bca9-f0e994d3105e',
+              type: 'assessment_questions',
+              key: 'other_risks',
+              category: 'risk',
+            },
+            {
+              id: '3a661bc8-5536-43e9-bcea-0a4d9651a175',
+              type: 'assessment_questions',
+              key: 'not_for_release',
+              category: 'risk',
+            },
+            {
+              id: 'bafcde0b-46e9-44b2-ad20-de3644256a42',
+              type: 'assessment_questions',
+              key: 'not_to_be_released',
+              category: 'risk',
+            },
+          ],
+        }
+        nextSpy = sinon.spy()
+      })
+
+      context('When assessment answers are unchanged', function() {
+        it('should not update the person data', async function() {
+          await controller.saveValues(req, res, nextSpy)
+          expect(personService.update).to.not.be.called
+        })
+      })
+
+      context('When assessment answers have changed', function() {
+        beforeEach(function() {
+          req.form.values.violent = '#violent'
+        })
+        it('should update the person data', async function() {
+          await controller.saveValues(req, res, nextSpy)
+          expect(personService.update).to.be.calledOnceWithExactly({
+            assessment_answers: [
+              {
+                assessment_question_id: 'af8cfc67-757c-4019-9d5e-618017de1617',
+                comments: '#violent',
+                key: 'violent',
+              },
+            ],
+            id: '#personId',
+          })
+        })
+      })
+
+      context('When assessment comment has been deleted', function() {
+        beforeEach(function() {
+          req.form.values.violent = ''
+        })
+        it('should remove the comment from the assessment answer', async function() {
+          await controller.saveValues(req, res, nextSpy)
+          expect(personService.update).to.be.calledOnceWithExactly({
+            assessment_answers: [
+              {
+                assessment_question_id: 'af8cfc67-757c-4019-9d5e-618017de1617',
+                comments: '',
+                key: 'violent',
+              },
+            ],
+            id: '#personId',
+          })
+        })
+      })
+
+      context('When assessment item is checked', function() {
+        beforeEach(function() {
+          req.form.values.risk.push('56826f64-da5d-42eb-b360-131e60bcc3d3')
+          req.form.values.risk.push('4e7e54b4-a40c-488f-bdff-c6b2268ca4eb')
+        })
+        it('should add the assessment answer and order the assessments', async function() {
+          await controller.saveValues(req, res, nextSpy)
+          expect(personService.update).to.be.calledOnceWithExactly({
+            assessment_answers: [
+              {
+                assessment_question_id: '4e7e54b4-a40c-488f-bdff-c6b2268ca4eb',
+                comments: '',
+                key: 'self_harm',
+              },
+              {
+                assessment_question_id: '56826f64-da5d-42eb-b360-131e60bcc3d3',
+                comments: '',
+                key: 'concealed_items',
+              },
+              {
+                assessment_question_id: 'af8cfc67-757c-4019-9d5e-618017de1617',
+                comments: '#original_value',
+                key: 'violent',
+              },
+            ],
+            id: '#personId',
+          })
+        })
+      })
+
+      context('When there were no assessment answers originally', function() {
+        beforeEach(function() {
+          req.getPerson.returns({ id: '#personId' })
+        })
+        it('should update the person data', async function() {
+          await controller.saveValues(req, res, nextSpy)
+          expect(personService.update).to.be.calledOnceWithExactly({
+            assessment_answers: [
+              {
+                assessment_question_id: 'af8cfc67-757c-4019-9d5e-618017de1617',
+                comments: '#original_value',
+                key: 'violent',
+              },
+            ],
+            id: '#personId',
+          })
+        })
+      })
+
+      context('When person API fails', function() {
+        const err = new Error()
+        beforeEach(function() {
+          req.form.values.violent = '#changeme'
+          personService.update.throws(err)
+        })
+        it('should call next with the error thrown', async function() {
+          try {
+            await controller.saveValues(req, res, nextSpy)
+          } catch (error) {}
+          expect(nextSpy).to.be.calledOnceWithExactly(err)
+        })
+      })
+    })
+  })
+})

--- a/app/move/controllers/update/base.js
+++ b/app/move/controllers/update/base.js
@@ -1,0 +1,108 @@
+const { get, keys } = require('lodash')
+
+const personService = require('../../../../common/services/person')
+const CreateBaseController = require('../create/base')
+
+class UpdateBaseController extends CreateBaseController {
+  middlewareLocals() {
+    super.middlewareLocals()
+    this.use(this.setNextStep)
+    this.use(this.setInitialStep)
+  }
+
+  _setModels(req) {
+    const res = req.res
+    req.models.move = res.locals.move
+    req.models.person = req.models.move.person
+  }
+
+  getBaseUrl(req) {
+    const moveId = req.getMoveId()
+    return `/move/${moveId}`
+  }
+
+  setCancelUrl(req, res, next) {
+    res.locals.cancelUrl = this.getBaseUrl(req)
+    next()
+  }
+
+  setNextStep(req, res, next) {
+    const nextUrl = this.getBaseUrl(req)
+    req.form.options.next = nextUrl
+    next()
+  }
+
+  setInitialStep(req, res, next) {
+    let initialStep = false
+    const referrer = req.get('referrer')
+    if (!referrer) {
+      initialStep = true
+    } else {
+      const { pathname } = new URL(referrer)
+      if (pathname === this.getBaseUrl(req)) {
+        initialStep = true
+      }
+    }
+    req.initialStep = initialStep
+    next()
+  }
+
+  protectReadOnlyFields(req, values) {
+    const fields = req.form.options.fields
+    Object.keys(fields).forEach(key => {
+      const field = fields[key]
+      if (field.readOnly && values[key] !== undefined && values[key] !== null) {
+        fields[key] = {
+          ...field,
+          ...field.updateComponent,
+          value: values[key],
+        }
+      }
+    })
+  }
+
+  getErrors(req, res) {
+    if (req.initialStep) {
+      return {}
+    }
+    return super.getErrors(req, res)
+  }
+
+  getValues(req, res, callback) {
+    return super.getValues(req, res, (err, values) => {
+      if (err) {
+        return callback(err)
+      }
+
+      try {
+        if (req.initialStep) {
+          values = this.getUpdateValues(req)
+        }
+        this.protectReadOnlyFields(req, values)
+      } catch (error) {
+        return callback(error)
+      }
+
+      callback(null, values)
+    })
+  }
+
+  getUpdateValues(req, res) {
+    const person = req.getPerson()
+    const fields = keys(get(req, 'form.options.fields'))
+    return personService.unformat(person, fields)
+  }
+}
+
+UpdateBaseController.mixin = function mixin(controller, mixinController) {
+  const controllerMethods = Object.getOwnPropertyNames(controller.prototype)
+  Object.getOwnPropertyNames(mixinController.prototype)
+    .filter(key => key !== 'prototype')
+    .forEach(key => {
+      if (!controllerMethods.includes(key)) {
+        controller.prototype[key] = mixinController.prototype[key]
+      }
+    })
+}
+
+module.exports = UpdateBaseController

--- a/app/move/controllers/update/base.test.js
+++ b/app/move/controllers/update/base.test.js
@@ -1,0 +1,570 @@
+const FormController = require('hmpo-form-wizard').Controller
+const { cloneDeep } = require('lodash')
+
+const personService = require('../../../../common/services/person')
+const CreateBaseController = require('../create/base')
+const BaseProto = CreateBaseController.prototype
+
+const UpdateBaseController = require('./base')
+
+const controller = new UpdateBaseController({ route: '/' })
+
+describe('Move controllers', function() {
+  describe('Update base controller', function() {
+    describe('#middlewareChecks()', function() {
+      it('should inherit middlewareChecks from CreateBaseController', function() {
+        expect(controller.middlewareChecks).to.exist.and.equal(
+          BaseProto.middlewareChecks
+        )
+      })
+    })
+
+    describe('#middlewareLocals()', function() {
+      it('should not inherit middlewareLocals from CreateBaseController', function() {
+        expect(controller.middlewareLocals).to.exist.and.not.equal(
+          BaseProto.middlewareLocals
+        )
+      })
+    })
+
+    describe('#setButtonText()', function() {
+      it('should inherit setButtonText from CreateBaseController', function() {
+        expect(controller.setButtonText).to.exist.and.equal(
+          BaseProto.setButtonText
+        )
+      })
+    })
+
+    describe('#setMoveSummary()', function() {
+      it('should inherit setMoveSummary from CreateBaseController', function() {
+        expect(controller.setMoveSummary).to.exist.and.equal(
+          BaseProto.setMoveSummary
+        )
+      })
+    })
+
+    describe('#setJourneyTimer()', function() {
+      it('should inherit setJourneyTimer from CreateBaseController', function() {
+        expect(controller.setJourneyTimer).to.exist.and.equal(
+          BaseProto.setJourneyTimer
+        )
+      })
+    })
+
+    describe('#checkCurrentLocation()', function() {
+      it('should inherit checkCurrentLocation from CreateBaseController', function() {
+        expect(controller.checkCurrentLocation).to.exist.and.equal(
+          BaseProto.checkCurrentLocation
+        )
+      })
+    })
+
+    describe('#middlewareLocals()', function() {
+      beforeEach(function() {
+        sinon.stub(BaseProto, 'middlewareLocals')
+        sinon.stub(controller, 'use')
+
+        controller.middlewareLocals()
+      })
+
+      it('should call parent method', function() {
+        expect(BaseProto.middlewareLocals).to.have.been.calledOnce
+      })
+
+      it('should call set next step method', function() {
+        expect(controller.use.getCall(0)).to.have.been.calledWithExactly(
+          controller.setNextStep
+        )
+      })
+
+      it('should call correct number of additional middleware', function() {
+        expect(controller.use).to.be.callCount(2)
+      })
+    })
+
+    describe('#setCancelUrl()', function() {
+      let req = {}
+      let res, nextSpy
+
+      beforeEach(function() {
+        nextSpy = sinon.spy()
+        req = {
+          getMoveId: sinon.stub().returns('moveId'),
+        }
+        res = {
+          locals: {
+            moveId: '#moveId',
+          },
+        }
+        controller.setCancelUrl(req, res, nextSpy)
+      })
+
+      it('should set cancel url correctly', function() {
+        expect(res.locals.cancelUrl).to.equal('/move/moveId')
+      })
+
+      it('should call next', function() {
+        expect(nextSpy).to.be.calledOnceWithExactly()
+      })
+    })
+
+    describe('#setNextStep()', function() {
+      let req = {}
+      let nextSpy
+      const res = {}
+
+      beforeEach(function() {
+        nextSpy = sinon.spy()
+        req = {
+          form: {
+            options: {},
+          },
+        }
+        controller.getBaseUrl = sinon.stub().returns('/move/moveId')
+        controller.setNextStep(req, res, nextSpy)
+      })
+
+      it('should set form options next step', function() {
+        expect(req.form.options.next).to.equal('/move/moveId')
+      })
+
+      it('should call next', function() {
+        expect(nextSpy).to.be.calledOnceWithExactly()
+      })
+    })
+
+    describe('#getUpdateValues()', function() {
+      const req = {
+        form: {
+          options: {
+            fields: {
+              field1: {},
+              field2: {},
+            },
+          },
+        },
+      }
+      const person = { id: '#personId' }
+      const values = { foo: 'bar' }
+
+      beforeEach(function() {
+        req.getPerson = sinon.stub().returns(person)
+        sinon.stub(personService, 'unformat').returns(values)
+      })
+
+      it('should return updated values', function() {
+        expect(controller.getUpdateValues(req)).to.equal(values)
+      })
+
+      context('When a valid ', function() {
+        this.beforeEach(function() {
+          controller.getUpdateValues(req)
+        })
+        it('should get person data', function() {
+          expect(req.getPerson).to.be.calledOnceWithExactly()
+        })
+        it('should get person data', function() {
+          expect(personService.unformat).to.be.calledOnceWithExactly(person, [
+            'field1',
+            'field2',
+          ])
+        })
+      })
+    })
+
+    describe('#setInitialStep()', function() {
+      let req
+      let nextSpy
+      const res = {}
+      beforeEach(function() {
+        req = {
+          get: sinon.stub(),
+        }
+        controller.getBaseUrl = sinon.stub().returns('/baseUrl')
+        nextSpy = sinon.stub()
+      })
+
+      it('should invoke the next middleware', function() {
+        controller.setInitialStep(req, res, nextSpy)
+        expect(nextSpy).to.be.calledOnceWithExactly()
+      })
+
+      context('when there is no referrer', function() {
+        it('should set initialStep to true', function() {
+          controller.setInitialStep(req, res, nextSpy)
+          expect(req.initialStep).to.be.true
+        })
+      })
+
+      context('when referrer is the base page', function() {
+        beforeEach(function() {
+          req.get.withArgs('referrer').returns('http://example.com/baseUrl')
+          controller.setInitialStep(req, res, nextSpy)
+        })
+
+        it('should set initialStep to true', function() {
+          expect(req.initialStep).to.be.true
+        })
+      })
+
+      context('when the referrer is anything else', function() {
+        beforeEach(function() {
+          req.get.withArgs('referrer').returns('http://example.com/someUrl')
+          controller.setInitialStep(req, res, nextSpy)
+        })
+
+        it('should not set initialStep to true', function() {
+          expect(req.initialStep).to.not.be.true
+        })
+      })
+    })
+
+    describe('#_setModels()', function() {
+      let req
+      const mockSession = {
+        id: '#move',
+        person: {
+          id: '#person',
+        },
+      }
+      beforeEach(function() {
+        req = {
+          models: {},
+          res: {
+            locals: {
+              move: mockSession,
+            },
+          },
+        }
+        controller._setModels(req)
+      })
+
+      it('should add move model to req', function() {
+        expect(req.models.move).to.deep.equal(mockSession)
+      })
+
+      it('should add person model to req', function() {
+        expect(req.models.person).to.deep.equal(mockSession.person)
+      })
+    })
+
+    describe('#mixin', function() {
+      class BaseSource {
+        baseMethod() {
+          return 'BaseSource'
+        }
+      }
+      class BaseTarget extends BaseSource {
+        baseMethod() {
+          return 'BaseTarget'
+        }
+      }
+      class ControllerSource extends BaseSource {
+        superMethod() {
+          return 'ControllerSource - superMethod'
+        }
+
+        thisMethod() {
+          return 'ControllerSource - thisMethod'
+        }
+
+        superMethodSource() {
+          return super.baseMethod()
+        }
+
+        thisMethodSource() {
+          return this.baseMethod()
+        }
+      }
+      class ControllerTarget extends BaseTarget {
+        superMethod() {
+          return super.baseMethod()
+        }
+
+        thisMethod() {
+          return this.baseMethod()
+        }
+
+        superMethodTarget() {
+          return super.baseMethod()
+        }
+
+        thisMethodTarget() {
+          return this.baseMethod()
+        }
+      }
+      UpdateBaseController.mixin(ControllerTarget, ControllerSource)
+
+      const SourceProto = ControllerSource.prototype
+      const TargetProto = ControllerTarget.prototype
+      const controller = new ControllerTarget()
+
+      context('When method exists only in target controller', function() {
+        it('should leave it untouched', function() {
+          expect(TargetProto.superMethodTarget).to.exist
+          expect(TargetProto.thisMethodTarget).to.exist
+          expect(SourceProto.superMethodTarget).to.not.exist
+          expect(SourceProto.thisMethodTarget).to.not.exist
+        })
+
+        it('should resolve `this` to extended class', function() {
+          expect(controller.thisMethodTarget()).to.equal('BaseTarget')
+        })
+
+        it('should resolve `super` to extended class', function() {
+          expect(controller.superMethodTarget()).to.equal('BaseTarget')
+        })
+      })
+
+      context('When method exists in both controllers', function() {
+        it('should leave it untouched', function() {
+          expect(TargetProto.superMethod).to.exist
+          expect(SourceProto.superMethod).to.exist
+          expect(TargetProto.superMethod).to.not.equal(SourceProto.superMethod)
+          expect(TargetProto.thisMethod).to.exist
+          expect(SourceProto.thisMethod).to.exist
+          expect(TargetProto.thisMethod).to.not.equal(SourceProto.thisMethod)
+        })
+
+        it('should resolve `this` to extended class', function() {
+          expect(controller.thisMethod()).to.equal('BaseTarget')
+        })
+
+        it('should resolve `super` to extended class', function() {
+          expect(controller.superMethod()).to.equal('BaseTarget')
+        })
+      })
+
+      context('When method exists only in source controller', function() {
+        it('should append it to target', function() {
+          expect(TargetProto.superMethodSource).to.exist
+          expect(TargetProto.superMethodSource).to.equal(
+            SourceProto.superMethodSource
+          )
+          expect(TargetProto.thisMethodSource).to.exist
+          expect(TargetProto.thisMethodSource).to.equal(
+            SourceProto.thisMethodSource
+          )
+        })
+
+        it('should resolve `this` to extended class', function() {
+          expect(controller.thisMethodSource()).to.equal('BaseTarget')
+        })
+
+        it('should resolve `super` to mixed-in class', function() {
+          expect(controller.superMethodSource()).to.equal('BaseSource')
+        })
+      })
+    })
+  })
+
+  describe('#getErrors()', function() {
+    let getErrorsStub
+    let req
+    let res
+
+    beforeEach(function() {
+      getErrorsStub = sinon.stub(BaseProto, 'getErrors')
+      req = {}
+      res = {}
+    })
+
+    context('when req.initialStep is false', function() {
+      it('should call the parent getErrors method', function() {
+        controller.getErrors(req, res)
+        expect(getErrorsStub).to.be.calledOnceWithExactly(req, res)
+      })
+    })
+
+    context('when req.initialStep is true', function() {
+      beforeEach(function() {
+        req.initialStep = true
+      })
+
+      it('should not call the parent getErrors method', function() {
+        controller.getErrors(req, res)
+        expect(getErrorsStub).to.not.be.called
+      })
+
+      it('should return an empty object', function() {
+        expect(controller.getErrors(req, res)).to.deep.equal({})
+      })
+    })
+  })
+
+  describe('#getValues()', function() {
+    let getValuesStub
+    let callback
+    let req
+    let res
+
+    beforeEach(function() {
+      callback = sinon.spy()
+      sinon.stub(controller, 'getUpdateValues').returns({ baz: 'tastic' })
+      sinon.stub(controller, 'protectReadOnlyFields')
+      getValuesStub = sinon.stub(FormController.prototype, 'getValues')
+      getValuesStub.callsFake((req, res, valuesCallback) => {
+        valuesCallback(null, { foo: 'bar' })
+      })
+      req = {
+        form: {
+          options: {},
+        },
+      }
+      res = {
+        locals: {},
+      }
+    })
+
+    context('when req.initialStep is false', function() {
+      it('should not call the getUpdateValues method', function() {
+        controller.getValues(req, res, callback)
+        expect(controller.getUpdateValues).to.not.be.called
+      })
+
+      it('should call the protectReadOnlyFields method with the correct args', function() {
+        controller.getValues(req, res, callback)
+        expect(controller.protectReadOnlyFields).to.be.calledOnceWithExactly(
+          req,
+          {
+            foo: 'bar',
+          }
+        )
+      })
+
+      it('should invoke the callback', function() {
+        controller.getValues(req, res, callback)
+        expect(callback).to.be.calledOnceWithExactly(null, { foo: 'bar' })
+      })
+    })
+
+    context('when req.initialStep is true', function() {
+      beforeEach(function() {
+        req.initialStep = true
+      })
+      it('should call the getUpdateValues method with the correct args', function() {
+        controller.getValues(req, res, callback)
+        expect(controller.getUpdateValues).to.be.calledOnceWithExactly(req)
+      })
+      it('should call the protectReadOnlyFields method with the correct args', function() {
+        controller.getValues(req, res, callback)
+        expect(controller.protectReadOnlyFields).to.be.calledOnceWithExactly(
+          req,
+          {
+            baz: 'tastic',
+          }
+        )
+      })
+
+      it('should invoke the callback with the correct args', function() {
+        controller.getValues(req, res, callback)
+        expect(callback).to.be.calledOnceWithExactly(null, {
+          baz: 'tastic',
+        })
+      })
+    })
+
+    context('when super.getUpdateValues passes an error', function() {
+      let err
+      beforeEach(function() {
+        err = new Error()
+        getValuesStub.callsFake((req, res, valuesCallback) => {
+          valuesCallback(err, { foo: 'bar' })
+        })
+      })
+
+      it('should invoke the callback with the error', function() {
+        controller.getValues(req, res, callback)
+        expect(callback).to.be.calledOnceWithExactly(err)
+      })
+    })
+
+    context('when this.getUpdateValues throws an error', function() {
+      let err
+      beforeEach(function() {
+        req.initialStep = true
+        req.form.options.update = true
+        err = new Error()
+        controller.getUpdateValues.restore()
+        sinon.stub(controller, 'getUpdateValues').throws(err)
+      })
+
+      it('should invoke the callback with the error', function() {
+        controller.getValues(req, res, callback)
+        expect(callback).to.be.calledOnceWithExactly(err)
+      })
+    })
+  })
+
+  describe('#getUpdateValues()', function() {
+    const req = {}
+    beforeEach(function() {
+      req.getPerson = sinon.stub()
+    })
+    context('when default getUpdateValues method invoked', function() {
+      it('should return an empty object', function() {
+        const values = controller.getUpdateValues(req, {})
+        expect(values).to.deep.equal({})
+      })
+    })
+  })
+
+  describe('#protectReadOnlyFields()', function() {
+    const unprotectedComponent = {
+      component: 'a',
+      prop: false,
+      updateComponent: {
+        component: 'b',
+        prop: true,
+        anotherProp: true,
+      },
+    }
+    const protectedComponent = cloneDeep(unprotectedComponent)
+    protectedComponent.readOnly = true
+
+    const fields = {
+      unprotected: cloneDeep(unprotectedComponent),
+      protectedUndef: cloneDeep(protectedComponent),
+      protectedNull: cloneDeep(protectedComponent),
+      protected: cloneDeep(protectedComponent),
+    }
+    let req
+    const values = {
+      unprotected: 'unprotected-value',
+      protectedNull: null,
+      protected: 'protected-value',
+    }
+    beforeEach(function() {
+      req = {
+        form: {
+          options: {
+            fields: cloneDeep(fields),
+          },
+        },
+      }
+    })
+
+    it('should leave unprotected fields unchanged', function() {
+      controller.protectReadOnlyFields(req, values)
+      const { unprotected } = req.form.options.fields
+      expect(unprotected).to.deep.equal(fields.unprotected)
+    })
+    it('should leave protected fields that have no value unchanged', function() {
+      controller.protectReadOnlyFields(req, values)
+      const { protectedUndef } = req.form.options.fields
+      expect(protectedUndef).to.deep.equal(fields.protectedUndef)
+    })
+    it('should leave protected fields that have null value unchanged', function() {
+      controller.protectReadOnlyFields(req, values)
+      const { protectedNull } = req.form.options.fields
+      expect(protectedNull).to.deep.equal(fields.protectedNull)
+    })
+    it('should update component of protected fields that have a value', function() {
+      controller.protectReadOnlyFields(req, values)
+      const { protected: protectedField } = req.form.options.fields
+      expect(protectedField.component).to.equal('b')
+      expect(protectedField).to.have.property('prop', true)
+      expect(protectedField).to.have.property('anotherProp', true)
+    })
+  })
+})

--- a/app/move/controllers/update/index.js
+++ b/app/move/controllers/update/index.js
@@ -1,0 +1,11 @@
+const Assessment = require('./assessment')
+const MoveDate = require('./move-date')
+const MoveDetails = require('./move-details')
+const PersonalDetails = require('./personal-details')
+
+module.exports = {
+  Assessment,
+  MoveDate,
+  MoveDetails,
+  PersonalDetails,
+}

--- a/app/move/controllers/update/move-date.js
+++ b/app/move/controllers/update/move-date.js
@@ -1,0 +1,55 @@
+const { get, pick } = require('lodash')
+
+const moveService = require('../../../../common/services/move')
+const { formatDate } = require('../../../../config/nunjucks/filters')
+const CreateMoveDateController = require('../create/move-date')
+
+const UpdateBase = require('./base')
+
+class UpdateMoveDetailsController extends UpdateBase {
+  getUpdateValues(req, res) {
+    const move = req.getMove()
+    if (!move) {
+      return {}
+    }
+
+    const values = {}
+    values.date_type = 'custom'
+    const dateFormat = 'yyyy-MM-dd'
+    const dates = {
+      [formatDate(res.locals.TODAY, dateFormat)]: 'today',
+      [formatDate(res.locals.TOMORROW, dateFormat)]: 'tomorrow',
+    }
+    if (dates[move.date]) {
+      values.date_type = dates[move.date]
+    }
+    if (values.date_type === 'custom') {
+      values.date_custom = formatDate(move.date)
+    }
+
+    return values
+  }
+
+  async saveValues(req, res, next) {
+    try {
+      const id = req.getMoveId()
+      const data = {
+        ...pick(get(req, 'form.values'), ['date', 'date_type', 'date_custom']),
+        id,
+      }
+
+      if (req.getMove().date !== data.date) {
+        await moveService.update(data)
+      }
+
+      // no need to call super
+      next()
+    } catch (error) {
+      next(error)
+    }
+  }
+}
+
+UpdateBase.mixin(UpdateMoveDetailsController, CreateMoveDateController)
+
+module.exports = UpdateMoveDetailsController

--- a/app/move/controllers/update/move-date.test.js
+++ b/app/move/controllers/update/move-date.test.js
@@ -1,0 +1,177 @@
+const moveService = require('../../../../common/services/move')
+const CreateMoveDate = require('../create/move-date')
+
+const UpdateBaseController = require('./base')
+const MoveDateController = require('./move-date')
+
+const MixinProto = CreateMoveDate.prototype
+
+const controller = new MoveDateController({ route: '/' })
+const ownProto = Object.getPrototypeOf(controller)
+
+describe('Move controllers', function() {
+  describe('Update move details controller', function() {
+    it('should extend UpdateBaseController', function() {
+      expect(Object.getPrototypeOf(ownProto)).to.equal(
+        UpdateBaseController.prototype
+      )
+    })
+
+    describe('When mixing in create controller', function() {
+      it('should copy middlewareSetup from CreateMoveDate', function() {
+        expect(controller.middlewareSetup).to.exist.and.equal(
+          MixinProto.middlewareSetup
+        )
+      })
+
+      it('should copy setDateType from CreateMoveDate', function() {
+        expect(controller.setDateType).to.exist.and.equal(
+          MixinProto.setDateType
+        )
+      })
+
+      it('should copy process from CreateMoveDate', function() {
+        expect(controller.process).to.exist.and.equal(MixinProto.process)
+      })
+
+      it('should copy successHandler from CreateMoveDate', function() {
+        expect(controller.successHandler).to.exist.and.equal(
+          MixinProto.successHandler
+        )
+      })
+
+      it('should only have the expected methods of its own', function() {
+        const ownMethods = ['getUpdateValues', 'saveValues']
+        const mixedinMethods = Object.getOwnPropertyNames(MixinProto)
+        const ownProps = Object.getOwnPropertyNames(ownProto).filter(
+          prop => !mixedinMethods.includes(prop) || ownMethods.includes(prop)
+        )
+        expect(ownProps).to.deep.equal(ownMethods)
+      })
+    })
+
+    describe('#getUpdateValues', function() {
+      const today = '2019-10-02'
+      const tomorrow = '2019-10-03'
+      let req = {}
+      const res = {
+        locals: {
+          TODAY: today,
+          TOMORROW: tomorrow,
+        },
+      }
+      beforeEach(function() {
+        req = {
+          form: {
+            values: {
+              date: '2019-10-04',
+            },
+          },
+          getMove: sinon.stub(),
+        }
+      })
+
+      context('When no move exists', function() {
+        it('should return an empty object', function() {
+          expect(controller.getUpdateValues(req, res)).to.deep.equal({})
+        })
+      })
+
+      context('When a move exists without a move type', function() {
+        const move = { id: '#move', date: '2019-10-04' }
+        beforeEach(function() {
+          req.getMove.returns(move)
+        })
+        context('When not today or tomorrow', function() {
+          it('should return just the move type', function() {
+            expect(controller.getUpdateValues(req, res)).to.deep.equal({
+              date_custom: '4 Oct 2019',
+              date_type: 'custom',
+            })
+          })
+        })
+        context('When a today', function() {
+          beforeEach(function() {
+            move.date = today
+          })
+          it('should return just the move type', function() {
+            expect(controller.getUpdateValues(req, res)).to.deep.equal({
+              date_type: 'today',
+            })
+          })
+        })
+        context('When a tomorrow', function() {
+          beforeEach(function() {
+            move.date = tomorrow
+          })
+          it('should return just the move type', function() {
+            expect(controller.getUpdateValues(req, res)).to.deep.equal({
+              date_type: 'tomorrow',
+            })
+          })
+        })
+      })
+    })
+
+    describe('#saveValues', function() {
+      let req = {}
+      const res = {}
+      let nextSpy
+      beforeEach(function() {
+        nextSpy = sinon.spy()
+        sinon.stub(moveService, 'update').resolves()
+        req = {
+          getMoveId: sinon.stub().returns('#moveId'),
+          getMove: sinon.stub().returns({ date: '2019-10-03' }),
+          form: {
+            values: {
+              date: '2019-10-02',
+              date_type: 'custom',
+              date_custom: '2019-10-02',
+              another_prop: true,
+            },
+          },
+        }
+      })
+
+      it('should call move API with correct values', async function() {
+        await controller.saveValues(req, res, nextSpy)
+        expect(moveService.update).to.be.calledOnceWithExactly({
+          id: '#moveId',
+          date: '2019-10-02',
+          date_type: 'custom',
+          date_custom: '2019-10-02',
+        })
+      })
+
+      context('should not call move API if date unchanged', function() {
+        beforeEach(function() {
+          req.getMove = sinon.stub().returns({ date: '2019-10-02' })
+        })
+        it('should call move API with correct values', async function() {
+          await controller.saveValues(req, res, nextSpy)
+          expect(moveService.update).to.not.be.called
+        })
+      })
+
+      it('should invoke the next method without error', async function() {
+        await controller.saveValues(req, res, nextSpy)
+        expect(nextSpy).to.be.calledOnceWithExactly()
+      })
+
+      context('When the API throws an error', function() {
+        const err = new Error()
+        beforeEach(function() {
+          moveService.update.throws(err)
+        })
+
+        it('should invoke the next method without error', async function() {
+          try {
+            await controller.saveValues(req, res, nextSpy)
+          } catch (e) {}
+          expect(nextSpy).to.be.calledOnceWithExactly(err)
+        })
+      })
+    })
+  })
+})

--- a/app/move/controllers/update/move-details.js
+++ b/app/move/controllers/update/move-details.js
@@ -1,0 +1,46 @@
+const { get, pick } = require('lodash')
+
+const moveService = require('../../../../common/services/move')
+const CreateMoveDetailsController = require('../create/move-details')
+
+const UpdateBase = require('./base')
+
+class UpdateMoveDetailsController extends UpdateBase {
+  getUpdateValues(req, res) {
+    const move = req.getMove()
+    if (!move) {
+      return {}
+    }
+
+    const values = pick(move, ['move_type'])
+    if (values.move_type) {
+      const toLocation = get(move, 'to_location.id')
+      if (toLocation) {
+        values[`to_location_${values.move_type}`] = toLocation
+      }
+    }
+
+    return values
+  }
+
+  async saveValues(req, res, next) {
+    try {
+      const id = req.getMoveId()
+      const data = {
+        id,
+        ...pick(get(req, 'form.values'), ['move_type', 'to_location']),
+      }
+      // TODO; short-circuit if no need to update
+      await moveService.update(data)
+
+      // no need to call super
+      next()
+    } catch (error) {
+      next(error)
+    }
+  }
+}
+
+UpdateBase.mixin(UpdateMoveDetailsController, CreateMoveDetailsController)
+
+module.exports = UpdateMoveDetailsController

--- a/app/move/controllers/update/move-details.test.js
+++ b/app/move/controllers/update/move-details.test.js
@@ -1,0 +1,167 @@
+const moveService = require('../../../../common/services/move')
+const CreateMoveDetails = require('../create/move-details')
+
+const UpdateBaseController = require('./base')
+const MoveDetailsController = require('./move-details')
+
+const MixinProto = CreateMoveDetails.prototype
+
+const controller = new MoveDetailsController({ route: '/' })
+const ownProto = Object.getPrototypeOf(controller)
+
+describe('Move controllers', function() {
+  describe('Update move details controller', function() {
+    it('should extend UpdateBaseController', function() {
+      expect(Object.getPrototypeOf(ownProto)).to.equal(
+        UpdateBaseController.prototype
+      )
+    })
+
+    describe('When mixing in create controller', function() {
+      it('should copy configure from CreateMoveDetails', function() {
+        expect(controller.configure).to.exist.and.equal(MixinProto.configure)
+      })
+
+      it('should copy middlewareSetup from CreateMoveDetails', function() {
+        expect(controller.middlewareSetup).to.exist.and.equal(
+          MixinProto.middlewareSetup
+        )
+      })
+
+      it('should copy setLocationItems from CreateMoveDetails', function() {
+        expect(controller.setLocationItems).to.exist.and.equal(
+          MixinProto.setLocationItems
+        )
+      })
+
+      it('should copy setLocationItems from CreateMoveDetails', function() {
+        expect(controller.setMoveTypes).to.exist.and.equal(
+          MixinProto.setMoveTypes
+        )
+      })
+
+      it('should copy process from CreateMoveDetails', function() {
+        expect(controller.process).to.exist.and.equal(MixinProto.process)
+      })
+
+      it('should copy successHandler from CreateMoveDetails', function() {
+        expect(controller.successHandler).to.exist.and.equal(
+          MixinProto.successHandler
+        )
+      })
+
+      it('should only have the expected methods of its own', function() {
+        const ownMethods = ['getUpdateValues', 'saveValues']
+        const mixedinMethods = Object.getOwnPropertyNames(MixinProto)
+        const ownProps = Object.getOwnPropertyNames(ownProto).filter(
+          prop => !mixedinMethods.includes(prop) || ownMethods.includes(prop)
+        )
+        expect(ownProps).to.deep.equal(ownMethods)
+      })
+    })
+
+    describe('#getUpdateValues', function() {
+      let req = {}
+      const res = {}
+      beforeEach(function() {
+        req = {
+          getMove: sinon.stub(),
+        }
+      })
+
+      context('When no move exists', function() {
+        it('should return an empty object', function() {
+          expect(controller.getUpdateValues(req, res)).to.deep.equal({})
+        })
+      })
+
+      context('When a move exists without a move type', function() {
+        const move = { id: '#moveWithoutType' }
+        beforeEach(function() {
+          req.getMove.returns(move)
+        })
+        it('should return an empty object', function() {
+          expect(controller.getUpdateValues(req, res)).to.deep.equal({})
+        })
+      })
+
+      context('When a move exists without a location id', function() {
+        const move = { move_type: '#move_type' }
+        beforeEach(function() {
+          req.getMove.returns(move)
+        })
+        it('should return just the move type', function() {
+          expect(controller.getUpdateValues(req, res)).to.deep.equal({
+            move_type: '#move_type',
+          })
+        })
+      })
+
+      context('When a move exists with a location id', function() {
+        const move = {
+          move_type: '#move_type',
+          to_location: {
+            id: '#to_location_id',
+          },
+        }
+        beforeEach(function() {
+          req.getMove.returns(move)
+        })
+        it('should return the move type and to_location', function() {
+          expect(controller.getUpdateValues(req, res)).to.deep.equal({
+            move_type: '#move_type',
+            'to_location_#move_type': '#to_location_id',
+          })
+        })
+      })
+    })
+
+    describe('#saveValues', function() {
+      let req = {}
+      const res = {}
+      let nextSpy
+      beforeEach(function() {
+        nextSpy = sinon.spy()
+        sinon.stub(moveService, 'update').resolves()
+        req = {
+          getMoveId: sinon.stub().returns('#moveId'),
+          form: {
+            values: {
+              move_type: '#move_type',
+              to_location: '#to_location',
+              another_prop: true,
+            },
+          },
+        }
+      })
+
+      it('should call move API with correct values', async function() {
+        await controller.saveValues(req, res, nextSpy)
+        expect(moveService.update).to.be.calledOnceWithExactly({
+          id: '#moveId',
+          move_type: '#move_type',
+          to_location: '#to_location',
+        })
+      })
+
+      it('should invoke the next method without error', async function() {
+        await controller.saveValues(req, res, nextSpy)
+        expect(nextSpy).to.be.calledOnceWithExactly()
+      })
+
+      context('When the API throws an error', function() {
+        const err = new Error()
+        beforeEach(function() {
+          moveService.update.throws(err)
+        })
+
+        it('should invoke the next method without error', async function() {
+          try {
+            await controller.saveValues(req, res, nextSpy)
+          } catch (e) {}
+          expect(nextSpy).to.be.calledOnceWithExactly(err)
+        })
+      })
+    })
+  })
+})

--- a/app/move/controllers/update/personal-details.js
+++ b/app/move/controllers/update/personal-details.js
@@ -1,0 +1,25 @@
+const personService = require('../../../../common/services/person')
+const PersonalDetails = require('../create/personal-details')
+
+const UpdateBase = require('./base')
+
+class UpdatePersonalDetailsController extends UpdateBase {
+  async saveValues(req, res, next) {
+    const person = req.getPerson()
+
+    const identifiers = person.identifiers.map(
+      identifier => identifier.identifier_type
+    )
+    const identifiersData = personService.unformat(person, identifiers)
+    req.form.values = {
+      ...identifiersData,
+      ...req.form.values,
+    }
+
+    PersonalDetails.prototype.saveValues.apply(this, [req, res, next])
+  }
+}
+
+UpdateBase.mixin(UpdatePersonalDetailsController, PersonalDetails)
+
+module.exports = UpdatePersonalDetailsController

--- a/app/move/controllers/update/personal-details.test.js
+++ b/app/move/controllers/update/personal-details.test.js
@@ -1,0 +1,92 @@
+const personService = require('../../../../common/services/person')
+const CreatePersonalDetails = require('../create/personal-details')
+
+const MixinProto = CreatePersonalDetails.prototype
+const UpdateBaseController = require('./base')
+const PersonalDetailsController = require('./personal-details')
+
+const controller = new PersonalDetailsController({ route: '/' })
+const ownProto = Object.getPrototypeOf(controller)
+
+describe('Move controllers', function() {
+  describe('Update personal details controller', function() {
+    it('should extend UpdateBaseController', function() {
+      expect(Object.getPrototypeOf(ownProto)).to.equal(
+        UpdateBaseController.prototype
+      )
+    })
+
+    context('mixing in create controller', function() {
+      it('should inherit configure from CreatePersonalDetails', function() {
+        expect(controller.configure).to.exist.and.equal(MixinProto.configure)
+      })
+
+      it('should inherit savePerson from CreatePersonalDetails', function() {
+        expect(controller.savePerson).to.exist.and.equal(MixinProto.savePerson)
+      })
+
+      it('should override saveValues', function() {
+        expect(controller.saveValues).to.exist.and.equal(ownProto.saveValues)
+      })
+
+      it('should have no further methods of its own', function() {
+        const mixedinMethods = Object.getOwnPropertyNames(MixinProto)
+        const ownProps = Object.getOwnPropertyNames(ownProto).filter(
+          prop => !mixedinMethods.includes(prop)
+        )
+        expect(ownProps).to.deep.equal([])
+      })
+    })
+
+    describe('#saveValues', function() {
+      let req
+      const res = {}
+      let nextSpy
+      beforeEach(async function() {
+        sinon.stub(CreatePersonalDetails.prototype, 'saveValues')
+        sinon.stub(personService, 'update').resolves()
+        sinon.stub(personService, 'unformat').returns({})
+        req = {
+          getPersonId: sinon.stub().returns('#personId'),
+          getPerson: sinon.stub().returns({
+            id: '#personId',
+            identifiers: [
+              {
+                identifier_type: 'foo',
+              },
+            ],
+          }),
+          form: {
+            values: {
+              bar: 'baz',
+            },
+          },
+        }
+        nextSpy = sinon.spy()
+
+        await controller.saveValues(req, res, nextSpy)
+      })
+
+      it('should call unformat with expected identifier fields', async function() {
+        expect(personService.unformat).to.be.calledOnceWithExactly(
+          {
+            id: '#personId',
+            identifiers: [
+              {
+                identifier_type: 'foo',
+              },
+            ],
+          },
+          ['foo']
+        )
+      })
+
+      it('should yield to CreatePersonalDetails’s saveValue', async function() {
+        expect(personService.update).to.not.be.called
+        expect(
+          CreatePersonalDetails.prototype.saveValues
+        ).to.be.calledOnceWithExactly(req, res, nextSpy)
+      })
+    })
+  })
+})

--- a/app/move/controllers/view.js
+++ b/app/move/controllers/view.js
@@ -1,6 +1,7 @@
 const { sortBy } = require('lodash')
 
 const presenters = require('../../../common/presenters')
+const updateSteps = require('../steps/update')
 
 module.exports = function view(req, res) {
   const { move } = res.locals
@@ -14,6 +15,21 @@ module.exports = function view(req, res) {
     cancellationReason === 'other'
       ? cancellationComments
       : req.t(`fields::cancellation_reason.items.${cancellationReason}.label`)
+
+  const urls = {
+    update: {},
+  }
+  updateSteps.forEach(step => {
+    const url = Object.keys(step)[0].replace(/^\//, '')
+    const key = url.replace(/-/g, '_')
+    urls.update[key] = `/move/${move.id}/edit/${url}`
+    // some assessment categories aren't suffixed with _information
+    if (key.endsWith('_information')) {
+      const keyWithoutInformation = key.replace(/_information$/, '')
+      urls.update[keyWithoutInformation] = urls.update[key]
+    }
+  })
+
   const locals = {
     moveSummary: presenters.moveToMetaListComponent(move),
     personalDetailsSummary: presenters.personToSummaryListComponent(person),
@@ -38,6 +54,7 @@ module.exports = function view(req, res) {
       context: status,
       reason,
     }),
+    urls,
   }
 
   res.render('move/views/view', locals)

--- a/app/move/controllers/view.test.js
+++ b/app/move/controllers/view.test.js
@@ -1,8 +1,19 @@
+const proxyquire = require('proxyquire')
+
 const presenters = require('../../../common/presenters')
 
-const controller = require('./view')
+const updateSteps = [
+  { '/foo': {} },
+  { '/bar-details': {} },
+  { '/baz-information': {} },
+]
+Object.defineProperty(updateSteps, '@noCallThru', { value: true })
+const controller = proxyquire('./view', {
+  '../steps/update': updateSteps,
+})
 
 const mockMove = {
+  id: 'moveId',
   status: 'requested',
   person: {
     assessment_answers: [],
@@ -191,6 +202,27 @@ describe('Move controllers', function() {
         const params = res.render.args[0][1]
         expect(params).to.have.property('messageContent')
         expect(params.messageContent).to.equal('statuses::description')
+      })
+
+      describe('update urls', function() {
+        let update
+        beforeEach(function() {
+          update = res.render.args[0][1].urls.update
+        })
+
+        it('should contain update urls', function() {
+          const urls = res.render.args[0][1].urls
+          expect(urls).to.have.property('update')
+        })
+
+        it('should contain expected url values', function() {
+          expect(update.foo).to.equal('/move/moveId/edit/foo')
+          expect(update.bar_details).to.equal('/move/moveId/edit/bar-details')
+          expect(update.baz_information).to.equal(
+            '/move/moveId/edit/baz-information'
+          )
+          expect(update.baz).to.equal('/move/moveId/edit/baz-information')
+        })
       })
     })
 

--- a/app/move/fields/index.js
+++ b/app/move/fields/index.js
@@ -1,7 +1,9 @@
 const cancel = require('./cancel')
 const create = require('./create')
+const update = require('./update')
 
 module.exports = {
   cancel,
   create,
+  update,
 }

--- a/app/move/fields/update.js
+++ b/app/move/fields/update.js
@@ -1,0 +1,23 @@
+const { cloneDeep } = require('lodash')
+
+const createFields = require('./create')
+
+const updateFields = cloneDeep(createFields)
+
+updateFields.police_national_computer = {
+  ...updateFields.police_national_computer,
+  readOnly: true,
+  updateComponent: {
+    component: 'appReadOnlyField',
+    classes: '',
+    items: [
+      {
+        component: 'govukDetails',
+        summaryHtml: 'fields::police_national_computer.details.summaryHtml',
+        html: 'fields::police_national_computer.details.html',
+      },
+    ],
+  },
+}
+
+module.exports = updateFields

--- a/app/move/index.js
+++ b/app/move/index.js
@@ -5,6 +5,7 @@ const wizard = require('hmpo-form-wizard')
 // Local dependencies
 const FormWizardController = require('../../common/controllers/form-wizard')
 const { protectRoute } = require('../../common/middleware/permissions')
+const { FEATURE_FLAGS } = require('../../config')
 
 const { confirmation, create, update, view } = require('./controllers')
 const {
@@ -63,19 +64,21 @@ router.use(
   wizard(cancelSteps, cancelFields, cancelConfig)
 )
 
-updateSteps.forEach(updateStep => {
-  const key = Object.keys(updateStep)[0]
-  const updateStepConfig = {
-    ...updateConfig,
-    name: 'update-a-move' + key,
-    journeyName: 'update-a-move' + key,
-  }
-  router.use(
-    '/:moveId/edit',
-    protectRoute('move:update'),
-    wizard(updateStep, updateFields, updateStepConfig)
-  )
-})
+if (FEATURE_FLAGS.EDITABILITY) {
+  updateSteps.forEach(updateStep => {
+    const key = Object.keys(updateStep)[0]
+    const updateStepConfig = {
+      ...updateConfig,
+      name: 'update-a-move' + key,
+      journeyName: 'update-a-move' + key,
+    }
+    router.use(
+      '/:moveId/edit',
+      protectRoute('move:update'),
+      wizard(updateStep, updateFields, updateStepConfig)
+    )
+  })
+}
 
 // Export
 module.exports = {

--- a/app/move/index.js
+++ b/app/move/index.js
@@ -6,10 +6,18 @@ const wizard = require('hmpo-form-wizard')
 const FormWizardController = require('../../common/controllers/form-wizard')
 const { protectRoute } = require('../../common/middleware/permissions')
 
-const { confirmation, create, view } = require('./controllers')
-const { cancel: cancelFields, create: createFields } = require('./fields')
+const { confirmation, create, update, view } = require('./controllers')
+const {
+  cancel: cancelFields,
+  create: createFields,
+  update: updateFields,
+} = require('./fields')
 const { setMove } = require('./middleware')
-const { cancel: cancelSteps, create: createSteps } = require('./steps')
+const {
+  cancel: cancelSteps,
+  create: createSteps,
+  update: updateSteps,
+} = require('./steps')
 
 const wizardConfig = {
   controller: FormWizardController,
@@ -23,6 +31,13 @@ const createConfig = {
   template: '../../../form-wizard',
   journeyName: 'create-a-move',
   journeyPageTitle: 'actions::create_move',
+}
+const updateConfig = {
+  ...wizardConfig,
+  controller: update.Base,
+  templatePath: 'move/views/create/',
+  template: '../../../form-wizard',
+  journeyPageTitle: 'actions::update_move',
 }
 const cancelConfig = {
   ...wizardConfig,
@@ -40,12 +55,27 @@ router.use(
   wizard(createSteps, createFields, createConfig)
 )
 router.get('/:moveId', protectRoute('move:view'), view)
+
 router.get('/:moveId/confirmation', protectRoute('move:create'), confirmation)
 router.use(
   '/:moveId/cancel',
   protectRoute('move:cancel'),
   wizard(cancelSteps, cancelFields, cancelConfig)
 )
+
+updateSteps.forEach(updateStep => {
+  const key = Object.keys(updateStep)[0]
+  const updateStepConfig = {
+    ...updateConfig,
+    name: 'update-a-move' + key,
+    journeyName: 'update-a-move' + key,
+  }
+  router.use(
+    '/:moveId/edit',
+    protectRoute('move:update'),
+    wizard(updateStep, updateFields, updateStepConfig)
+  )
+})
 
 // Export
 module.exports = {

--- a/app/move/steps/index.js
+++ b/app/move/steps/index.js
@@ -1,7 +1,9 @@
 const cancel = require('./cancel')
 const create = require('./create')
+const update = require('./update')
 
 module.exports = {
   cancel,
   create,
+  update,
 }

--- a/app/move/steps/update.js
+++ b/app/move/steps/update.js
@@ -1,0 +1,44 @@
+const { cloneDeep } = require('lodash')
+
+const {
+  Assessment,
+  MoveDate,
+  MoveDetails,
+  PersonalDetails,
+} = require('../controllers/update')
+
+const createSteps = require('./create')
+
+const updateControllers = {
+  '/personal-details': PersonalDetails,
+  '/move-details': MoveDetails,
+  '/move-date': MoveDate,
+  '/court-information': Assessment,
+  '/risk-information': Assessment,
+  '/health-information': Assessment,
+}
+
+const provideStepProps = (key, step) => {
+  const stepProps = {
+    entryPoint: true,
+    backLink: null,
+    next: undefined,
+    buttonText: 'actions::save_and_continue',
+  }
+
+  const updatedStep = {
+    ...cloneDeep(step),
+    ...stepProps,
+  }
+
+  if (updateControllers[key]) {
+    updatedStep.controller = updateControllers[key]
+  }
+  return updatedStep
+}
+
+const updateSteps = Object.keys(createSteps)
+  .filter(key => updateControllers[key])
+  .map(key => ({ [key]: provideStepProps(key, createSteps[key]) }))
+
+module.exports = updateSteps

--- a/app/move/views/_includes/assessment.njk
+++ b/app/move/views/_includes/assessment.njk
@@ -1,112 +1,118 @@
 {% for assessmentCategory in assessment %}
-  <h2 class="govuk-heading-m govuk-!-margin-bottom-2 govuk-!-margin-top-7">
-    {{ t("moves::assessment.categories." + assessmentCategory.key + ".heading") }}
-  </h2>
+  <section class="app-!-position-relative" data-app-section="{{ assessmentCategory.key }}">
+    <h2 class="govuk-heading-m govuk-!-margin-bottom-2 govuk-!-margin-top-7">
+      {{ t("moves::assessment.categories." + assessmentCategory.key + ".heading") }}
+    </h2>
 
-  {% for title, answers in assessmentCategory.answersByTitle %}
-    {% call appPanel({
-      attributes: {
-        id: title | kebabcase
-      },
-      tag: {
-        text: title,
-        classes: assessmentCategory.tagClass
-      }
-    }) %}
+    {% for title, answers in assessmentCategory.answersByTitle %}
+      {% call appPanel({
+        attributes: {
+          id: title | kebabcase
+        },
+        tag: {
+          text: title,
+          classes: assessmentCategory.tagClass
+        }
+      }) %}
 
-      {% set items = [] %}
-      {% for answer in answers %}
-        {% set answerHtml %}
-          {% if answer.nomis_alert_description %}
-            <h4 class="govuk-!-margin-top-0 govuk-!-margin-bottom-2">
-              {{ answer.nomis_alert_description }}
-            </h4>
-          {% endif %}
+        {% set items = [] %}
+        {% for answer in answers %}
+          {% set answerHtml %}
+            {% if answer.nomis_alert_description %}
+              <h4 class="govuk-!-margin-top-0 govuk-!-margin-bottom-2">
+                {{ answer.nomis_alert_description }}
+              </h4>
+            {% endif %}
 
-          {{ answer.comments if answer.comments }}
+            {{ answer.comments if answer.comments }}
 
-          {% if answer.created_at %}
-            <div class="govuk-!-margin-top-2 govuk-!-font-size-16">
-              {{ answer.created_at | formatDateWithDay }}
-            </div>
-          {% endif %}
-        {% endset %}
+            {% if answer.created_at %}
+              <div class="govuk-!-margin-top-2 govuk-!-font-size-16">
+                {{ answer.created_at | formatDateWithDay }}
+              </div>
+            {% endif %}
+          {% endset %}
 
-        {% set items = (items.push({ value: { html: answerHtml } }), items) %}
-      {% endfor %}
+          {% set items = (items.push({ value: { html: answerHtml } }), items) %}
+        {% endfor %}
 
-      {{ appMetaList({
-        classes: "app-meta-list--divider",
-        items: items
+        {{ appMetaList({
+          classes: "app-meta-list--divider",
+          items: items
+        }) }}
+      {% endcall %}
+    {% else %}
+      {{ appMessage({
+        classes: "app-message--muted",
+        allowDismiss: false,
+        content: {
+          html: t("moves::assessment.categories." + assessmentCategory.key + ".empty")
+        }
       }) }}
-    {% endcall %}
-  {% else %}
-    {{ appMessage({
-      classes: "app-message--muted",
-      allowDismiss: false,
-      content: {
-        html: t("moves::assessment.categories." + assessmentCategory.key + ".empty")
-      }
-    }) }}
-  {% endfor %}
+    {% endfor %}
+    {{ updateLink(assessmentCategory.key) }}
+  </section>
 {% endfor %}
 
-{% if move.to_location.location_type == 'court' %}
-  {% if move.from_location.location_type == 'prison' and not courtSummary.rows.length %}
-    <h2 class="govuk-heading-m govuk-!-margin-bottom-2 govuk-!-margin-top-7">
-      {{ t("moves::detail.court_hearings.heading", {
-        context: "with_count" if courtHearings.length > 1,
-        count: courtHearings.length
-      }) }}
-    </h2>
+<section class="app-!-position-relative" data-app-section="court">
+  {% if move.to_location.location_type == 'court' %}
+    {% if move.from_location.location_type == 'prison' and not courtSummary.rows.length %}
+      <h2 class="govuk-heading-m govuk-!-margin-bottom-2 govuk-!-margin-top-7">
+        {{ t("moves::detail.court_hearings.heading", {
+          context: "with_count" if courtHearings.length > 1,
+          count: courtHearings.length
+        }) }}
+      </h2>
 
-    {% if courtHearings.length %}
-      {% for courtHearing in courtHearings %}
-        {% if courtHearings.length > 1 %}
-          <h3 class="govuk-heading-s govuk-!-margin-bottom-2 govuk-!-margin-top-6">
-            {{ t("moves::detail.court_hearings.subheading", {
-              context: "with_index",
-              index: loop.index
+      {% if courtHearings.length %}
+        {% for courtHearing in courtHearings %}
+          {% if courtHearings.length > 1 %}
+            <h3 class="govuk-heading-s govuk-!-margin-bottom-2 govuk-!-margin-top-6">
+              {{ t("moves::detail.court_hearings.subheading", {
+                context: "with_index",
+                index: loop.index
+              }) }}
+            </h3>
+          {% endif %}
+
+          {{ govukSummaryList(courtHearing.summaryList) }}
+
+          {% if not courtHearing.saved_to_nomis %}
+            {{ govukWarningText({
+              text: t("moves::detail.court_hearings.nomis_failed", {
+                context: "with_index" if courtHearings.length > 1,
+                index: loop.index
+              }),
+              iconFallbackText: "Warning"
             }) }}
-          </h3>
-        {% endif %}
-
-        {{ govukSummaryList(courtHearing.summaryList) }}
-
-        {% if not courtHearing.saved_to_nomis %}
-          {{ govukWarningText({
-            text: t("moves::detail.court_hearings.nomis_failed", {
-              context: "with_index" if courtHearings.length > 1,
-              index: loop.index
-            }),
-            iconFallbackText: "Warning"
-          }) }}
-        {% endif %}
-      {% endfor %}
+          {% endif %}
+        {% endfor %}
+      {% else %}
+        {{ appMessage({
+          classes: "app-message--muted",
+          allowDismiss: false,
+          content: {
+            html: t("moves::detail.court_hearings.empty")
+          }
+        }) }}
+      {% endif %}
     {% else %}
-      {{ appMessage({
-        classes: "app-message--muted",
-        allowDismiss: false,
-        content: {
-          html: t("moves::detail.court_hearings.empty")
-        }
-      }) }}
-    {% endif %}
-  {% else %}
-    <h2 class="govuk-heading-m govuk-!-margin-bottom-2 govuk-!-margin-top-7">
-      {{ t("moves::assessment.categories.court.heading") }}
-    </h2>
+      <h2 class="govuk-heading-m govuk-!-margin-bottom-2 govuk-!-margin-top-7">
+        {{ t("moves::assessment.categories.court.heading") }}
+      </h2>
 
-    {% if courtSummary.rows | length %}
-      {{ govukSummaryList(courtSummary) }}
-    {% else %}
-      {{ appMessage({
-        classes: "app-message--muted",
-        allowDismiss: false,
-        content: {
-          html: t("moves::assessment.categories.court.empty")
-        }
-      }) }}
+      {% if courtSummary.rows | length %}
+        {{ govukSummaryList(courtSummary) }}
+      {% else %}
+        {{ appMessage({
+          classes: "app-message--muted",
+          allowDismiss: false,
+          content: {
+            html: t("moves::assessment.categories.court.empty")
+          }
+        }) }}
+      {% endif %}
     {% endif %}
   {% endif %}
-{% endif %}
+  {{ updateLink('court') }}
+</section>

--- a/app/move/views/view.njk
+++ b/app/move/views/view.njk
@@ -60,12 +60,28 @@
   </header>
 {% endblock %}
 
-{% block contentMain %}
-  <h2 class="govuk-heading-m">
-    {{ t("moves::steps.personal_details.heading") }}
-  </h2>
+{% macro updateLink(category, permission='move:update', classes='app-!-position-top-right') %}
+  {% if canAccess(permission) %}
+    <p class="{{ classes }}">
+      <a href="{{ urls.update[category] }}" data-update-link="{{ category }}">
+        {{ t('moves::update_link.link_text', {
+          context: 'with_category',
+          category: t('moves::update_link.categories.' + category)
+        }) | safe }}
+      </a>
+    </p>
+  {% endif %}
+{% endmacro %}
 
-  {{ govukSummaryList(personalDetailsSummary) }}
+{% block contentMain %}
+  <section class="app-!-position-relative" data-app-section="personal_details">
+    <h2 class="govuk-heading-m">
+      {{ t("moves::steps.personal_details.heading") }}
+    </h2>
+
+    {{ govukSummaryList(personalDetailsSummary) }}
+    {{ updateLink('personal_details') }}
+  </section>
 
   {% include "move/views/_includes/assessment.njk" %}
 
@@ -124,6 +140,8 @@
         </h3>
 
         {{ appMetaList(moveSummary) }}
+        {# TODO: enable updating of move details when to_location can be set via api #}
+        {# {{ updateLink('move_details', classes='govuk-!-padding-top-4') }} #}
       </div>
     </div>
   {% endif %}

--- a/common/assets/scss/overrides/_positioning.scss
+++ b/common/assets/scss/overrides/_positioning.scss
@@ -5,3 +5,15 @@
 .app-\!-float-left {
   float: left !important;
 }
+
+.app-\!-position-relative {
+  position: relative !important;
+}
+
+@include govuk-media-query($from: tablet) {
+  .app-\!-position-top-right {
+    position: absolute;
+    top: 0;
+    right: 0;
+  }
+}

--- a/common/assets/scss/overrides/_visibility.scss
+++ b/common/assets/scss/overrides/_visibility.scss
@@ -13,3 +13,19 @@
     display: block;
   }
 }
+
+@include govuk-media-query($from: tablet) {
+  .app-\!-visually-hidden-desktop {
+    position: absolute !important;
+    width: 1px !important;
+    height: 1px !important;
+    margin: 0 !important;
+    padding: 0 !important;
+    overflow: hidden !important;
+    clip: rect(0 0 0 0) !important;
+    -webkit-clip-path: inset(50%) !important;
+    clip-path: inset(50%) !important;
+    border: 0 !important;
+    white-space: nowrap !important;
+  }
+}

--- a/common/helpers/field.js
+++ b/common/helpers/field.js
@@ -161,6 +161,7 @@ function translateField(translate) {
       'fieldset.legend.html',
       'heading.text',
       'heading.html',
+      'summaryHtml',
     ]
 
     translationPaths.forEach(path => {

--- a/common/helpers/field.test.js
+++ b/common/helpers/field.test.js
@@ -638,6 +638,9 @@ describe('Form helpers', function() {
             html: 'heading.html',
           },
         },
+        summaryHtml: {
+          summaryHtml: 'summaryHtml',
+        },
       }
 
       Object.entries(scenarios).forEach(function([path, properties]) {

--- a/common/lib/permissions.js
+++ b/common/lib/permissions.js
@@ -1,3 +1,5 @@
+const { FEATURE_FLAGS } = require('../../config')
+
 const policePermissions = [
   'moves:view:outgoing',
   'moves:download',
@@ -6,8 +8,11 @@ const policePermissions = [
   'move:create:court_appearance',
   'move:create:prison_recall',
   'move:cancel',
-  'move:update',
 ]
+
+if (FEATURE_FLAGS.EDITABILITY) {
+  policePermissions.push('move:update')
+}
 
 const secureChildrensHomePermissions = [
   'moves:view:outgoing',

--- a/common/lib/permissions.js
+++ b/common/lib/permissions.js
@@ -6,7 +6,9 @@ const policePermissions = [
   'move:create:court_appearance',
   'move:create:prison_recall',
   'move:cancel',
+  'move:update',
 ]
+
 const secureChildrensHomePermissions = [
   'moves:view:outgoing',
   'moves:download',
@@ -23,6 +25,7 @@ const secureTrainingCentrePermissions = [
   'move:create:court_appearance',
   'move:cancel',
 ]
+
 const supplierPermissions = [
   'moves:view:all',
   'moves:view:outgoing',

--- a/common/lib/user.test.js
+++ b/common/lib/user.test.js
@@ -97,7 +97,7 @@ describe('User class', function() {
       })
 
       it('should contain correct permission', function() {
-        expect(permissions).to.deep.equal([
+        const policePermissions = [
           'moves:view:outgoing',
           'moves:download',
           'move:view',
@@ -105,7 +105,9 @@ describe('User class', function() {
           'move:create:court_appearance',
           'move:create:prison_recall',
           'move:cancel',
-        ])
+          'move:update',
+        ]
+        expect(permissions).to.deep.equal(policePermissions)
       })
     })
 
@@ -225,7 +227,7 @@ describe('User class', function() {
       })
 
       it('should contain correct permission', function() {
-        expect(permissions).to.deep.equal([
+        const allPermissions = [
           'moves:view:outgoing',
           'moves:download',
           'move:view',
@@ -233,13 +235,15 @@ describe('User class', function() {
           'move:create:court_appearance',
           'move:create:prison_recall',
           'move:cancel',
+          'move:update',
           'moves:view:all',
           'moves:view:dashboard',
           'moves:view:proposed',
           'move:create:prison_transfer',
           'allocations:view',
           'allocation:create',
-        ])
+        ]
+        expect(permissions.sort()).to.deep.equal(allPermissions.sort())
       })
     })
   })

--- a/common/lib/user.test.js
+++ b/common/lib/user.test.js
@@ -1,3 +1,5 @@
+const { FEATURE_FLAGS } = require('../../config')
+
 const User = require('./user')
 
 describe('User class', function() {
@@ -105,8 +107,10 @@ describe('User class', function() {
           'move:create:court_appearance',
           'move:create:prison_recall',
           'move:cancel',
-          'move:update',
         ]
+        if (FEATURE_FLAGS.EDITABILITY) {
+          policePermissions.push('move:update')
+        }
         expect(permissions).to.deep.equal(policePermissions)
       })
     })
@@ -235,7 +239,6 @@ describe('User class', function() {
           'move:create:court_appearance',
           'move:create:prison_recall',
           'move:cancel',
-          'move:update',
           'moves:view:all',
           'moves:view:dashboard',
           'moves:view:proposed',
@@ -243,6 +246,9 @@ describe('User class', function() {
           'allocations:view',
           'allocation:create',
         ]
+        if (FEATURE_FLAGS.EDITABILITY) {
+          allPermissions.push('move:update')
+        }
         expect(permissions.sort()).to.deep.equal(allPermissions.sort())
       })
     })

--- a/common/services/person-unformat.js
+++ b/common/services/person-unformat.js
@@ -1,0 +1,83 @@
+const { formatDate } = require('../../config/nunjucks/filters')
+
+const getAnswer = (person, field) => {
+  const assessments = person.assessment_answers || []
+  return assessments.filter(assessment => {
+    return assessment.key === field
+  })[0]
+}
+
+const mapMethods = {}
+
+mapMethods.identifier = (person, field) => {
+  const identifiers = person.identifiers || []
+  const identifier = identifiers.filter(
+    identifier => identifier.identifier_type === field
+  )[0]
+  if (identifier) {
+    return identifier.value
+  }
+}
+
+mapMethods.relationship = (person, field) => {
+  const relationship = person[field]
+  if (relationship) {
+    return relationship.id
+  }
+}
+
+mapMethods.date = (person, field) => {
+  const fieldValue = person[field]
+  if (fieldValue) {
+    return formatDate(fieldValue)
+  }
+}
+
+mapMethods.explicitAssessment = (person, field, assessmentCategories) => {
+  let value
+  const matchedAnswer = getAnswer(person, field)
+  const explicitKey = `${field}__explicit`
+
+  if (matchedAnswer) {
+    const questionId = matchedAnswer.assessment_question_id
+    value = matchedAnswer.comments
+    assessmentCategories[explicitKey] = questionId
+  } else {
+    assessmentCategories[explicitKey] = 'false'
+  }
+  return value
+}
+
+mapMethods.assessment = (person, field, assessmentCategories) => {
+  let value
+  const matchedAnswer = getAnswer(person, field)
+
+  if (matchedAnswer) {
+    const questionId = matchedAnswer.assessment_question_id
+    value = matchedAnswer.comments
+    const category = matchedAnswer.category
+    assessmentCategories[category] = assessmentCategories[category] || []
+    assessmentCategories[category].push(questionId)
+  }
+  return value
+}
+
+mapMethods.value = (person, field) => person[field]
+
+const mapKeys = Object.keys(mapMethods)
+
+const unformat = (person, fields = [], fieldKeys = {}) => {
+  const assessmentCategories = {}
+
+  const fieldData = fields.map(field => {
+    const method =
+      mapKeys.filter(
+        key => fieldKeys[key] && fieldKeys[key].includes(field)
+      )[0] || 'value'
+    const value = mapMethods[method](person, field, assessmentCategories)
+    return { [field]: value }
+  })
+  return Object.assign({}, ...fieldData, assessmentCategories)
+}
+
+module.exports = unformat

--- a/common/services/person.js
+++ b/common/services/person.js
@@ -2,6 +2,40 @@ const { mapKeys, mapValues, uniqBy, omitBy, isNil } = require('lodash')
 
 const apiClient = require('../lib/api-client')()
 
+const unformat = require('./person-unformat')
+
+const relationshipKeys = ['gender', 'ethnicity']
+const identifierKeys = [
+  'police_national_computer',
+  'criminal_records_office',
+  'prison_number',
+  'niche_reference',
+  'athena_reference',
+]
+const dateKeys = ['date_of_birth']
+const assessmentKeys = [
+  // court
+  'solicitor',
+  'interpreter',
+  'other_court',
+  // risk
+  'violent',
+  'escape',
+  'hold_separately',
+  'self_harm',
+  'concealed_items',
+  'other_risks',
+  // health
+  'special_diet_or_allergy',
+  'health_issue',
+  'medication',
+  'wheelchair',
+  'pregnant',
+  'other_health',
+  'special_vehicle',
+]
+const explicitAssessmentKeys = ['special_vehicle', 'not_to_be_released']
+
 const personService = {
   transform(person = {}) {
     return {
@@ -15,15 +49,6 @@ const personService = {
 
   format(data) {
     const existingIdentifiers = data.identifiers || []
-    const relationshipKeys = ['gender', 'ethnicity']
-    const identifierKeys = [
-      'police_national_computer',
-      'criminal_records_office',
-      'prison_number',
-      'niche_reference',
-      'athena_reference',
-    ]
-
     const formatted = mapValues(data, (value, key) => {
       if (typeof value === 'string') {
         if (relationshipKeys.includes(key)) {
@@ -54,6 +79,16 @@ const personService = {
       },
       isNil
     )
+  },
+
+  unformat(person, fields = []) {
+    return unformat(person, fields, {
+      identifier: identifierKeys,
+      relationship: relationshipKeys,
+      date: dateKeys,
+      assessment: assessmentKeys,
+      explicitAssessment: explicitAssessmentKeys,
+    })
   },
 
   create(data) {

--- a/common/services/person.test.js
+++ b/common/services/person.test.js
@@ -1,8 +1,18 @@
 const { forEach } = require('lodash')
+const proxyquire = require('proxyquire')
 
+const filters = require('../../config/nunjucks/filters')
 const apiClient = require('../lib/api-client')()
 
-const personService = require('./person')
+const formatDateStub = sinon.stub(filters, 'formatDate').returns('28 Oct 2010')
+
+const unformat = proxyquire('./person-unformat', {
+  '../../config/nunjucks/filters': filters,
+})
+
+const personService = proxyquire('./person', {
+  './person-unformat': unformat,
+})
 
 const genderMockId = 'd335715f-c9d1-415c-a7c8-06e830158214'
 const ethnicityMockId = 'b95bfb7c-18cd-419d-8119-2dee1506726f'
@@ -426,6 +436,266 @@ describe('Person Service', function() {
           first_names: 'Foo',
           last_name: '',
           ethnicity: false,
+        })
+      })
+    })
+  })
+
+  describe('#unformat()', function() {
+    context('when values are present', function() {
+      const mockPerson = {
+        id: 'd8ddd29b-2e16-4d5e-8b90-9306b77e942d',
+        type: 'people',
+        first_names: 'Albert',
+        last_name: 'Aardvark',
+        date_of_birth: '1990-10-28',
+        identifiers: [
+          {
+            identifier_type: 'police_national_computer',
+            value: 'AAA',
+          },
+          {
+            identifier_type: 'criminal_records_office',
+            value: 'CRO',
+          },
+          {
+            identifier_type: 'prison_number',
+            value: 'PNO',
+          },
+          {
+            identifier_type: 'niche_reference',
+            value: 'NICHE',
+          },
+          {
+            identifier_type: 'athena_reference',
+            value: 'ATHENA',
+          },
+        ],
+        gender_additional_information: '',
+        ethnicity: {
+          id: '8bf95acf-2fb3-4d7a-8b30-b06c6cb821e2',
+          type: 'ethnicities',
+          key: 'a4',
+          title: 'Asian/Asian British: Chinese',
+          description: null,
+          nomis_code: 'A4',
+          disabled_at: null,
+        },
+        gender: {
+          id: 'ffac6763-26d6-4425-8005-6e5d052aed88',
+          type: 'genders',
+          key: 'male',
+          title: 'Male',
+          description: null,
+          disabled_at: null,
+          nomis_code: 'M',
+        },
+        assessment_answers: [
+          {
+            key: 'solicitor',
+            category: 'court',
+            assessment_question_id: '9bf95acf-2fb3-4d7a-8b30-b06c6cb821e2',
+            comments: '#solicitor',
+          },
+          {
+            key: 'interpreter',
+            category: 'court',
+            assessment_question_id: '6bf95acf-2fb3-4d7a-8b30-b06c6cb821e2',
+            comments: '#interpreter',
+          },
+          {
+            key: 'special_vehicle',
+            category: 'health',
+            assessment_question_id: '1bf95acf-2fb3-4d7a-8b30-b06c6cb821e2',
+            comments: '#special_vehicle',
+          },
+        ],
+        image_url: '/person/d8ddd29b-2e16-4d5e-8b90-9306b77e942d/image',
+        fullname: 'Aardvark, Albert',
+      }
+
+      it('should return correct value for regular property', function() {
+        const unformatted = personService.unformat(mockPerson, ['first_names'])
+        expect(unformatted).to.deep.equal({
+          first_names: 'Albert',
+        })
+      })
+
+      it('should return correct values for regular properties', function() {
+        const unformatted = personService.unformat(mockPerson, [
+          'first_names',
+          'last_name',
+        ])
+        expect(unformatted).to.deep.equal({
+          first_names: 'Albert',
+          last_name: 'Aardvark',
+        })
+      })
+
+      it('should return correct value for ethnicity property', function() {
+        const unformatted = personService.unformat(mockPerson, ['ethnicity'])
+        expect(unformatted).to.deep.equal({
+          ethnicity: '8bf95acf-2fb3-4d7a-8b30-b06c6cb821e2',
+        })
+      })
+
+      it('should return correct value for gender property', function() {
+        const unformatted = personService.unformat(mockPerson, ['gender'])
+        expect(unformatted).to.deep.equal({
+          gender: 'ffac6763-26d6-4425-8005-6e5d052aed88',
+        })
+      })
+
+      it('should return correct value for police_national_computer property', function() {
+        const unformatted = personService.unformat(mockPerson, [
+          'police_national_computer',
+        ])
+        expect(unformatted).to.deep.equal({
+          police_national_computer: 'AAA',
+        })
+      })
+
+      it('should return correct value for criminal_records_office property', function() {
+        const unformatted = personService.unformat(mockPerson, [
+          'criminal_records_office',
+        ])
+        expect(unformatted).to.deep.equal({
+          criminal_records_office: 'CRO',
+        })
+      })
+
+      it('should return correct value for prison_number property', function() {
+        const unformatted = personService.unformat(mockPerson, [
+          'prison_number',
+        ])
+        expect(unformatted).to.deep.equal({
+          prison_number: 'PNO',
+        })
+      })
+
+      it('should return correct value for niche_reference property', function() {
+        const unformatted = personService.unformat(mockPerson, [
+          'niche_reference',
+        ])
+        expect(unformatted).to.deep.equal({
+          niche_reference: 'NICHE',
+        })
+      })
+
+      it('should return correct value for athena_reference property', function() {
+        const unformatted = personService.unformat(mockPerson, [
+          'athena_reference',
+        ])
+        expect(unformatted).to.deep.equal({
+          athena_reference: 'ATHENA',
+        })
+      })
+
+      it('should return correct values for assessment property', function() {
+        const unformatted = personService.unformat(mockPerson, ['solicitor'])
+        expect(unformatted).to.deep.equal({
+          solicitor: '#solicitor',
+          court: ['9bf95acf-2fb3-4d7a-8b30-b06c6cb821e2'],
+        })
+      })
+
+      it('should return correct values for multiple assessment property sharing the same category', function() {
+        const unformatted = personService.unformat(mockPerson, [
+          'interpreter',
+          'solicitor',
+        ])
+        expect(unformatted).to.deep.equal({
+          interpreter: '#interpreter',
+          solicitor: '#solicitor',
+          court: [
+            '6bf95acf-2fb3-4d7a-8b30-b06c6cb821e2',
+            '9bf95acf-2fb3-4d7a-8b30-b06c6cb821e2',
+          ],
+        })
+      })
+
+      it('should return correct value for explicit assessment property', function() {
+        const unformatted = personService.unformat(mockPerson, [
+          'special_vehicle',
+        ])
+        expect(unformatted).to.deep.equal({
+          special_vehicle: '#special_vehicle',
+          special_vehicle__explicit: '1bf95acf-2fb3-4d7a-8b30-b06c6cb821e2',
+        })
+      })
+
+      it('should return correct value for date_of_birth property', function() {
+        formatDateStub.resetHistory()
+        const unformatted = personService.unformat(mockPerson, [
+          'date_of_birth',
+        ])
+        expect(formatDateStub).to.be.calledOnceWithExactly('1990-10-28')
+        expect(unformatted).to.deep.equal({
+          date_of_birth: '28 Oct 2010',
+        })
+        formatDateStub.resetHistory()
+      })
+    })
+    context('when values are missing', function() {
+      const mockPerson = {}
+
+      it('should return undefined for missing regular property', function() {
+        const unformatted = personService.unformat(mockPerson, ['first_names'])
+        expect(unformatted).to.deep.equal({
+          first_names: undefined,
+        })
+      })
+
+      it('should return undefined for missing regular properties', function() {
+        const unformatted = personService.unformat(mockPerson, [
+          'first_names',
+          'last_name',
+        ])
+        expect(unformatted).to.deep.equal({
+          first_names: undefined,
+          last_name: undefined,
+        })
+      })
+
+      it('should return undefined for missing relationship property', function() {
+        const unformatted = personService.unformat(mockPerson, ['ethnicity'])
+        expect(unformatted).to.deep.equal({
+          ethnicity: undefined,
+        })
+      })
+
+      it('should return undefined for missing identifier property', function() {
+        const unformatted = personService.unformat(mockPerson, [
+          'police_national_computer',
+        ])
+        expect(unformatted).to.deep.equal({
+          police_national_computer: undefined,
+        })
+      })
+
+      it('should return undefined for missing assessment property', function() {
+        const unformatted = personService.unformat(mockPerson, ['solicitor'])
+        expect(unformatted).to.deep.equal({
+          solicitor: undefined,
+        })
+      })
+
+      it('should return correct values for missing explicit assessment property', function() {
+        const unformatted = personService.unformat(mockPerson, [
+          'special_vehicle',
+        ])
+        expect(unformatted).to.deep.equal({
+          special_vehicle: undefined,
+          special_vehicle__explicit: 'false',
+        })
+      })
+
+      it('should return undefined for missing date property', function() {
+        const unformatted = personService.unformat(mockPerson, [
+          'date_of_birth',
+        ])
+        expect(unformatted).to.deep.equal({
+          date_of_birth: undefined,
         })
       })
     })

--- a/config/index.js
+++ b/config/index.js
@@ -126,6 +126,7 @@ module.exports = {
   FEATURE_FLAGS: {
     // TODO: Remove once court hearings are fully released
     PRISON_COURT_HEARINGS: process.env.FEATURE_FLAG_PRISON_COURT_HEARINGS,
+    EDITABILITY: process.env.FEATURE_FLAG_EDITABILITY,
   },
   E2E: {
     BASE_URL: process.env.E2E_BASE_URL || BASE_URL,

--- a/locales/en/actions.json
+++ b/locales/en/actions.json
@@ -22,5 +22,6 @@
   "print_move_list": "Print moves",
   "print_move_detail": "Print move",
   "sign_out": "Sign out",
-  "switch_location": "Switch location"
+  "switch_location": "Switch location",
+  "save_and_continue": "Save and continue"
 }

--- a/locales/en/fields.json
+++ b/locales/en/fields.json
@@ -15,7 +15,11 @@
     "hint": "Select the person you are moving"
   },
   "police_national_computer": {
-    "label": "<abbr title=\"Police National Computer\">PNC</abbr> number"
+    "label": "<abbr title=\"Police National Computer\">PNC</abbr> number",
+    "details": {
+      "summaryHtml": "I need to change the PNC number",
+      "html": "If you have created the move for the wrong person cancel this request and create a new one"
+    }
   },
   "prison_number": {
     "label": "Prison number"

--- a/locales/en/moves.json
+++ b/locales/en/moves.json
@@ -57,7 +57,8 @@
       "heading": "When is this person moving?"
     },
     "move_details": {
-      "heading": "Where is this person moving?"
+      "heading": "Where is this person moving?",
+      "update_link": "where this person is moving to"
     },
     "hearing_details": {
       "heading": "Is this move associated with a court case?"
@@ -195,6 +196,17 @@
       "case_type": {
         "label": "Case type"
       }
+    }
+  },
+  "update_link": {
+    "link_text": "Change",
+    "link_text_with_category": "Change <span class=\"app-!-visually-hidden-desktop\">{{ category }}</span>",
+    "categories": {
+      "court": "information for the court",
+      "health": "health information",
+      "move_details": "move details",
+      "personal_details": "personal details",
+      "risk": "risk information"
     }
   }
 }

--- a/test/e2e/_helpers.js
+++ b/test/e2e/_helpers.js
@@ -5,21 +5,37 @@ import { join } from 'path'
 import { format } from 'date-fns'
 import faker from 'faker'
 import glob from 'glob'
-import { find, isArray, isNil } from 'lodash'
-import { ClientFunction, t } from 'testcafe'
+import { find, get, isArray, isNil } from 'lodash'
+import { ClientFunction, RequestLogger, t } from 'testcafe'
 
+import moveService from '../../common/services/move'
 import personService from '../../common/services/person'
+import referenceDataService from '../../common/services/reference-data'
+import { formatDate } from '../../config/nunjucks/filters'
 
 export const scrollToTop = ClientFunction(() => {
   window.scrollTo(0, 0)
 })
 
-export function generatePerson(overrides = {}) {
+export async function generatePerson(overrides = {}) {
   const firstNames = faker.name.firstName()
   const lastName = faker.name.lastName()
+
+  let genders = await referenceDataService.getGenders()
+  // TODO: implement proper test to render this filter unnecessary
+  genders = genders.filter(gender => gender.title.match(/^(Male|Female)$/i))
+  const ethnicities = await referenceDataService.getEthnicities()
+
+  const gender = faker.random.arrayElement(genders.map(({ title }) => title))
+  const ethnicity = faker.random.arrayElement(
+    ethnicities.map(({ title }) => title)
+  )
+
   return {
     lastName,
     firstNames,
+    gender,
+    ethnicity,
     fullname: `${lastName}, ${firstNames}`.toUpperCase(),
     policeNationalComputer: faker
       .fake('{{random.alphaNumeric(6)}}/{{random.alphaNumeric(2)}}')
@@ -38,8 +54,17 @@ export function generatePerson(overrides = {}) {
   }
 }
 
-export async function createPersonFixture() {
-  const fixture = generatePerson()
+export async function createPersonFixture(overrides = {}) {
+  const fixture = await generatePerson(overrides)
+
+  const genders = await referenceDataService.getGenders()
+  const ethnicities = await referenceDataService.getEthnicities()
+
+  const gender = genders.filter(gen => gen.title === fixture.gender)[0].id
+  const ethnicity = ethnicities.filter(
+    eth => eth.title === fixture.ethnicity
+  )[0].id
+
   const person = await personService.create({
     police_national_computer: fixture.policeNationalComputer,
     prison_number: fixture.prisonNumber,
@@ -49,6 +74,8 @@ export async function createPersonFixture() {
     last_name: fixture.lastName,
     first_names: fixture.firstNames,
     date_of_birth: fixture.dateOfBirth,
+    ethnicity,
+    gender,
   })
 
   return {
@@ -57,12 +84,17 @@ export async function createPersonFixture() {
     lastName: person.last_name,
     firstNames: person.first_names,
     dateOfBirth: person.date_of_birth,
+    gender: fixture.gender,
+    ethnicity: fixture.ethnicity,
     prisonNumber: find(person.identifiers, {
       identifier_type: 'prison_number',
     }).value,
-    policeNationalComputer: find(person.identifiers, {
-      identifier_type: 'police_national_computer',
-    }).value,
+    policeNationalComputer: get(
+      find(person.identifiers, {
+        identifier_type: 'police_national_computer',
+      }),
+      'value'
+    ),
     criminalRecordsOffice: find(person.identifiers, {
       identifier_type: 'criminal_records_office',
     }).value,
@@ -73,6 +105,71 @@ export async function createPersonFixture() {
       identifier_type: 'athena_reference',
     }).value,
   }
+}
+
+/**
+ * Get a random location
+ *
+ * @param {string} [locationType] - type of location
+ *
+ * @returns {string} - location id
+ */
+const getRandomLocation = async locationType => {
+  let locations
+  if (locationType) {
+    locations = await referenceDataService.getLocationsByType(locationType)
+  } else {
+    locations = await referenceDataService.getLocations()
+  }
+  return faker.random.arrayElement(locations.map(({ id }) => id))
+}
+
+/**
+ * Generate move data
+ *
+ * @param {object} [moveOverrides] - explicit values to use for move
+ *
+ * @param {object} [moveOptions] - config options for move creation
+ *
+ * @returns {object} - move data
+ */
+export async function generateMove(personId, options = {}, overrides = {}) {
+  const fromLocationType = options.from_location_type || 'police'
+  const toLocationType = options.to_location_type || 'court'
+
+  return {
+    person: {
+      id: personId,
+    },
+    from_location: await getRandomLocation(fromLocationType),
+    to_location: await getRandomLocation(toLocationType),
+    move_type: 'court_appearance',
+    date: formatDate(new Date(), 'yyyy-MM-dd'),
+    ...overrides,
+  }
+}
+
+/**
+ * Create a move object
+ *
+ * @param {object} [personOverrides] - explicit values to use for person
+ *
+ * @param {object} [moveOverrides] - explicit values to use for move
+ *
+ * @param {object} [moveOptions] - config options for move creation
+ *
+ * @returns {object} - created move object containing person data retunred from createPersonFixture
+ */
+export async function createMoveFixture({
+  personOverrides = {},
+  moveOverrides,
+  moveOptions = {},
+} = {}) {
+  const person = await createPersonFixture(personOverrides)
+  const moveFixture = await generateMove(person.id, moveOptions, moveOverrides)
+  const move = await moveService.create(moveFixture)
+  move.person = person
+  return move
 }
 
 /**
@@ -246,4 +343,85 @@ export function deleteCsvDownloads() {
       throw new Error(`Failed to delete CSV download file: ${err.message}`)
     }
   }
+}
+
+/**
+ * Create TestCafe RequestLogger
+ *
+ * @param {string} baseUrl - Base url to capture requests
+ *
+ * @returns {object} - logger
+ */
+export function createLogger(baseUrl) {
+  return RequestLogger(request => {
+    if (request.url.match(/\.(js|css|woff|woff2|gif|svg|jpg|png)$/)) {
+      return false
+    }
+    if (request.url.startsWith(`${baseUrl}/connect`)) {
+      return false
+    }
+    if (request.url.startsWith(`${baseUrl}/browser-sync`)) {
+      return false
+    }
+    return request.url.startsWith(baseUrl)
+  })
+}
+
+/**
+ * Get logged response values for a url
+ *
+ * @param {string} url - URL to match
+ *
+ * @returns {object} - logger response object
+ */
+export function getLoggerResponse(logger, url) {
+  const response =
+    logger.requests
+      .filter(req => req.request.url === url)
+      .map(req => req.response)[0] || {}
+  return response
+}
+
+/**
+ * Get status code for a url
+ *
+ * @param {string} url - URL to match
+ *
+ * @returns {number} - status code
+ */
+export function getResponseStatus(logger, url) {
+  return getLoggerResponse(logger, url).statusCode
+}
+
+/**
+ * Check status code for a url
+ *
+ * @param {string} url - URL to check
+ *
+ * @param {number} statusCode - Expected status code
+ *
+ * @param {boolean} [negated] - whether to negate the assertion
+ *
+ * @returns {Promise<boolean>}
+ */
+export async function expectStatusCode(url, statusCode, negated = true) {
+  const logger = createLogger(url)
+  await t.addRequestHooks(logger)
+  await t.navigateTo(url)
+  const expectMethod = negated === false ? 'notOk' : 'ok'
+  await t.expect(getResponseStatus(logger, url) === statusCode)[expectMethod]()
+  await t.removeRequestHooks(logger)
+}
+
+/**
+ * Check whether a url is protected
+ *
+ * @param {string} url - URL to check
+ *
+ * @param {boolean} [negated] - whether to negate the assertion
+ *
+ * @returns {Promise<boolean>}
+ */
+export async function expectForbidden(url, negated) {
+  await expectStatusCode(url, 403, negated)
 }

--- a/test/e2e/_move.js
+++ b/test/e2e/_move.js
@@ -1,0 +1,386 @@
+import { t } from 'testcafe'
+
+import { createMoveFixture, expectForbidden } from './_helpers'
+import { policeUser, stcUser } from './_roles'
+import { home, getMove, getUpdateMove } from './_routes'
+import { page, moveDetailPage } from './pages'
+import UpdateMovePage from './pages/update-move'
+
+/**
+ * Create a move
+ *
+ * @param {object} options
+ *
+ * @param {Role} options.user - user to be able to view move with
+ *
+ * @param {object} [options.personOverrides] - override values for person
+ *
+ * @param {object} [options.moveOverrides] - override values for move
+ *
+ * @param {object} [options.moveOptions] - config for move creation
+ * See createMoveFixture for more details
+ *
+ * @returns {undefined} Creates person and move, checking that move has all expected values
+ */
+export async function createMove(options) {
+  await t.useRole(options.user)
+
+  if (!options.moveOverrides || !options.moveOverrides.from_location) {
+    await t.navigateTo(home)
+
+    const currentUrl = await page.getCurrentUrl()
+    const matched = currentUrl.match(
+      /([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})/
+    )
+    if (!matched) {
+      throw new Error('Could not determine current location')
+    }
+    const currentLocation = matched[0]
+    t.ctx.from_location = currentLocation
+
+    options.moveOverrides = {
+      from_location: currentLocation,
+      ...options.moveOverrides,
+    }
+  }
+
+  if (options.defaultMoveOptions) {
+    options.moveOptions = {
+      ...options.defaultMoveOptions,
+      ...options.moveOptions,
+    }
+  }
+
+  const move = await createMoveFixture(options)
+  t.ctx.move = move
+  t.ctx.person = move.person
+  await t.navigateTo(getMove(move.id))
+
+  // double check that personal data is as expected
+  const { person } = t.ctx
+  await moveDetailPage.checkPersonalDetails(person)
+  await moveDetailPage.checkCourtInformation(person)
+  await moveDetailPage.checkRiskInformation(person)
+  await moveDetailPage.checkHealthInformation(person)
+}
+
+/**
+ * Create a move as a police user
+ *
+ * @param {object} options
+ *
+ * @param {object} [options.personOverrides] - override values for person
+ *
+ * @param {object} [options.moveOverrides] - override values for move
+ *
+ * @param {object} [options.moveOptions] - config for move creation
+ * See createMoveFixture for more details
+ *
+ * @returns {undefined} Creates person and move, checking that move has all expected values
+ */
+export async function createPoliceMove(options) {
+  return createMove({
+    user: policeUser,
+    defaultMoveOptions: {
+      to_location_type: 'court',
+      move_type: 'court_appearance',
+    },
+    ...options,
+  })
+}
+
+/**
+ * Create a move as a stc user
+ *
+ * @param {object} options
+ *
+ * @param {object} [options.personOverrides] - override values for person
+ *
+ * @param {object} [options.moveOverrides] - override values for move
+ *
+ * @param {object} [options.moveOptions] - config for move creation
+ * See createMoveFixture for more details
+ *
+ * @returns {undefined} Creates person and move, checking that move has all expected values
+ */
+export async function createStcMove(options) {
+  return createMove({
+    user: stcUser,
+    ...options,
+  })
+}
+
+/**
+ * Check whether an update link for page is present
+ *
+ * @param {string} page - page key
+ *
+ * @returns {undefined}
+ */
+export async function checkUpdateLink(page) {
+  return moveDetailPage.checkUpdateLink(page)
+}
+
+/**
+ * Check whether an update link for page is not present
+ *
+ * @param {string} page - page key
+ *
+ * @returns {undefined}
+ */
+export async function checkNoUpdateLink(page) {
+  return moveDetailPage.checkNoUpdateLink(page)
+}
+
+const updatePages = [
+  'personal_details',
+  'risk',
+  'health',
+  'court',
+  'move_details',
+]
+
+/**
+ * Filter update pages into
+ *
+ * @param {string} page - page key
+ *
+ * @returns {undefined}
+ */
+const filterUpdatePages = (pages = updatePages, exclude = false) => {
+  let show = updatePages.filter(cat => pages.includes(cat))
+  let hide = updatePages.filter(cat => !pages.includes(cat))
+
+  if (exclude) {
+    ;[show, hide] = [hide, show]
+  }
+  return {
+    show,
+    hide,
+  }
+}
+
+/**
+ * Check for presence of update links on page - any not listed are explicitly expected to not be present
+ *
+ * @param {string[]} pages - explicit pages to check
+ *
+ * @param {boolean} [exclude] - whether to use list of pages as a blacklist rather than whitelist
+ *
+ * @returns {undefined}
+ */
+export async function checkUpdateLinks(pages, exclude) {
+  const filteredPages = filterUpdatePages(pages, exclude)
+
+  for await (const cat of filteredPages.show) {
+    await checkUpdateLink(cat)
+  }
+  for await (const cat of filteredPages.hide) {
+    await checkNoUpdateLink(cat)
+  }
+}
+
+/**
+ * Check for presence of all update links on page except for those explicitly listed
+ *
+ * @param {string[]} pages - explicit pages to check for absence
+ *
+ * @returns {undefined}
+ */
+export async function checkUpdateLinksExcluding(pages) {
+  await checkUpdateLinks(pages, true)
+}
+
+/**
+ * Check for absence of all update links on page
+ *
+ * @returns {undefined}
+ */
+export async function checkNoUpdateLinks() {
+  await checkUpdateLinks([])
+}
+
+/**
+ * Check whether current user is forbidden from accessing update page
+ *
+ * @param {string} page - page key
+ *
+ * @param {boolean} [negated] - whether to negate the assertion
+ *
+ * @returns {undefined}
+ */
+export async function checkUpdatePageForbidden(page, negated) {
+  const url = getUpdateMove(t.ctx.move.id, page)
+  await expectForbidden(url, negated)
+}
+
+/**
+ * Check update pages are accessible to user - any not explicity mentioned
+ *
+ * @param {string[]} pages - list of page keys to check
+ *
+ * @param {boolean} [negated] - whether to negate the assertion
+ *
+ * @returns {undefined}
+ */
+export async function checkUpdatePagesAccessible(pages, negated) {
+  const filteredPages = filterUpdatePages(pages, negated)
+
+  for await (const page of filteredPages.show) {
+    await checkUpdatePageForbidden(page, false)
+  }
+  for await (const page of filteredPages.hide) {
+    await checkUpdatePageForbidden(page)
+  }
+}
+
+/**
+ * Check all update pages inaccessible to user
+ *
+ * @returns {undefined}
+ */
+export async function checkUpdatePagesForbidden() {
+  await checkUpdatePagesAccessible([])
+}
+
+/**
+ * Click link to update page
+ *
+ * @param {string} page - page key
+ *
+ * @returns {updateMovePage} - UpdateMovePage instance
+ */
+export async function clickUpdateLink(page) {
+  const { move } = t.ctx
+
+  await moveDetailPage.clickUpdateLink(page)
+  return new UpdateMovePage(move.id)
+}
+
+/**
+ * Change personal details and confirm changes on move view page
+ *
+ * @param {object} options - same options as can be passed to updateMovePage.fillInPersonalDetails
+ *
+ * @returns {undefined}
+ */
+export async function checkUpdatePersonalDetails(options) {
+  const { person } = t.ctx
+  const updateMovePage = await clickUpdateLink('personal_details')
+  const updatedFields = await updateMovePage.fillInPersonalDetails({}, options)
+  const updatedDetails = { ...person, ...updatedFields }
+
+  await updateMovePage.submitForm()
+
+  await moveDetailPage.checkPersonalDetails(updatedDetails)
+}
+
+/**
+ * Helper function change info on assessment answers page and confirm changes on move view page
+ *
+ * @param {string} page - page key
+ *
+ * @param {string} fillInMethod - updateMovePage method to use to fill in fields
+ *
+ * @param {string} checkMethod - updateMovePage method to use to check values
+ *
+ * @param {object} [options] - same options as can be passed to updateMovePage.fillInRiskInformation
+ *
+ * @param {boolean} [options.selectAll=true]
+ *
+ * @param {boolean} [options.fillInOptional=true]
+ *
+ * @returns {undefined}
+ */
+export async function checkUpdatePage(
+  page,
+  fillInMethod,
+  checkMethod,
+  { selectAll = true, fillInOptional = true } = {}
+) {
+  const { person } = t.ctx
+  const updateMovePage = await clickUpdateLink(page)
+  const updatedFields = await updateMovePage[fillInMethod]({
+    selectAll,
+    fillInOptional,
+  })
+  const updatedDetails = { ...person, ...updatedFields }
+
+  await updateMovePage.submitForm()
+
+  await moveDetailPage[checkMethod](updatedDetails)
+}
+
+/**
+ * Change risk information and confirm changes on move view page
+ *
+ * @param {object} [options] - same options as can be passed to updateMovePage.fillInRiskInformation
+ *
+ * @returns {undefined}
+ */
+export async function checkUpdateRiskInformation(options) {
+  await checkUpdatePage(
+    'risk',
+    'fillInRiskInformation',
+    'checkRiskInformation',
+    options
+  )
+}
+
+/**
+ * Change health information and confirm changes on move view page
+ *
+ * @param {object} [options] - same options as can be passed to updateMovePage.fillInHealthInformation
+ *
+ * @returns {undefined}
+ */
+export async function checkUpdateHealthInformation(options) {
+  await checkUpdatePage(
+    'health',
+    'fillInHealthInformation',
+    'checkHealthInformation',
+    options
+  )
+}
+
+/**
+ * Change court information and confirm changes on move view page
+ *
+ * @param {object} [options] - same options as can be passed to updateMovePage.fillInCourtInformation
+ *
+ * @returns {undefined}
+ */
+export async function checkUpdateCourtInformation(options) {
+  await checkUpdatePage(
+    'court',
+    'fillInCourtInformation',
+    'checkCourtInformation',
+    options
+  )
+}
+
+/**
+ * Check that PNC details are uneditable and displayed corectly on the personal details page
+ *
+ * @returns {undefined}
+ */
+export async function checkPoliceNationalComputerReadOnly() {
+  const { person } = t.ctx
+  const personalDetailsPage = await clickUpdateLink('personal_details')
+
+  const {
+    policeNationalComputer,
+    policeNationalComputerReadOnly,
+  } = personalDetailsPage.fields
+
+  const {
+    policeNationalComputerHeading,
+    policeNationalComputerValue,
+  } = personalDetailsPage.nodes
+  await t.expect(policeNationalComputer.exists).notOk()
+  await t.expect(policeNationalComputerReadOnly.exists).ok()
+  await t.expect(policeNationalComputerHeading.exists).ok()
+  await t
+    .expect(policeNationalComputerValue.innerText)
+    .eql(person.policeNationalComputer)
+}

--- a/test/e2e/_routes.js
+++ b/test/e2e/_routes.js
@@ -1,5 +1,19 @@
 import { E2E } from '../../config'
 
+const getUpdatePageStub = page => {
+  const updateMap = {
+    court: 'court-information',
+    health: 'health-information',
+    move_details: 'move-details',
+    personal_details: 'personal-details',
+    risk: 'risk-information',
+  }
+  return updateMap[page]
+}
+
 export const home = E2E.BASE_URL
 export const movesByDay = `${E2E.BASE_URL}/moves`
 export const newMove = `${E2E.BASE_URL}/move/new`
+export const getMove = id => `${E2E.BASE_URL}/move/${id}`
+export const getUpdateMove = (id, page) =>
+  `${E2E.BASE_URL}/move/${id}/edit/${getUpdatePageStub(page)}`

--- a/test/e2e/move.new.police.test.js
+++ b/test/e2e/move.new.police.test.js
@@ -16,7 +16,7 @@ fixture('New move from Police Custody to Court').beforeEach(async t => {
 })
 
 test('With unfound person', async t => {
-  const person = generatePerson()
+  const person = await generatePerson()
 
   // PNC lookup
   await createMovePage.fillInPncSearch(person.policeNationalComputer)

--- a/test/e2e/move.update.police.test.js
+++ b/test/e2e/move.update.police.test.js
@@ -1,0 +1,65 @@
+import {
+  createPoliceMove,
+  checkUpdateLinks,
+  checkUpdatePagesAccessible,
+  checkPoliceNationalComputerReadOnly,
+  checkUpdatePersonalDetails,
+  checkUpdateRiskInformation,
+  checkUpdateHealthInformation,
+  checkUpdateCourtInformation,
+} from './_move'
+
+fixture('Existing move from Police Custody to Court').beforeEach(async () => {
+  await createPoliceMove()
+})
+
+test('User should see expected update links on move page', async () => {
+  await checkUpdateLinks(['personal_details', 'risk', 'health', 'court'])
+})
+
+test('User should see be able to access update pages', async () => {
+  await checkUpdatePagesAccessible([
+    'personal_details',
+    'risk',
+    'health',
+    'court',
+    'move_details',
+  ])
+})
+
+test('User should not be able to edit PNC if it already exists', async t => {
+  await checkPoliceNationalComputerReadOnly()
+})
+
+test('User should be able to update other personal details', async () => {
+  await checkUpdatePersonalDetails({
+    exclude: ['policeNationalComputer'],
+  })
+})
+
+test.before(async () => {
+  await createPoliceMove({
+    personOverrides: {
+      policeNationalComputer: undefined,
+    },
+  })
+})(
+  'User should be able to update PNC if it does not already exist',
+  async t => {
+    await checkUpdatePersonalDetails({
+      include: ['policeNationalComputer'],
+    })
+  }
+)
+
+test('User should be able to update risk information', async () => {
+  await checkUpdateRiskInformation()
+})
+
+test('User should be able to update health information', async () => {
+  await checkUpdateHealthInformation()
+})
+
+test('User should be able to update court information', async () => {
+  await checkUpdateCourtInformation()
+})

--- a/test/e2e/move.update.police.test.js
+++ b/test/e2e/move.update.police.test.js
@@ -1,3 +1,5 @@
+import { FEATURE_FLAGS } from '../../config'
+
 import {
   createPoliceMove,
   checkUpdateLinks,
@@ -9,57 +11,59 @@ import {
   checkUpdateCourtInformation,
 } from './_move'
 
-fixture('Existing move from Police Custody to Court').beforeEach(async () => {
-  await createPoliceMove()
-})
-
-test('User should see expected update links on move page', async () => {
-  await checkUpdateLinks(['personal_details', 'risk', 'health', 'court'])
-})
-
-test('User should see be able to access update pages', async () => {
-  await checkUpdatePagesAccessible([
-    'personal_details',
-    'risk',
-    'health',
-    'court',
-    'move_details',
-  ])
-})
-
-test('User should not be able to edit PNC if it already exists', async t => {
-  await checkPoliceNationalComputerReadOnly()
-})
-
-test('User should be able to update other personal details', async () => {
-  await checkUpdatePersonalDetails({
-    exclude: ['policeNationalComputer'],
+if (FEATURE_FLAGS.EDITABILITY) {
+  fixture('Existing move from Police Custody to Court').beforeEach(async () => {
+    await createPoliceMove()
   })
-})
 
-test.before(async () => {
-  await createPoliceMove({
-    personOverrides: {
-      policeNationalComputer: undefined,
-    },
+  test('User should see expected update links on move page', async () => {
+    await checkUpdateLinks(['personal_details', 'risk', 'health', 'court'])
   })
-})(
-  'User should be able to update PNC if it does not already exist',
-  async t => {
+
+  test('User should see be able to access update pages', async () => {
+    await checkUpdatePagesAccessible([
+      'personal_details',
+      'risk',
+      'health',
+      'court',
+      'move_details',
+    ])
+  })
+
+  test('User should not be able to edit PNC if it already exists', async t => {
+    await checkPoliceNationalComputerReadOnly()
+  })
+
+  test('User should be able to update other personal details', async () => {
     await checkUpdatePersonalDetails({
-      include: ['policeNationalComputer'],
+      exclude: ['policeNationalComputer'],
     })
-  }
-)
+  })
 
-test('User should be able to update risk information', async () => {
-  await checkUpdateRiskInformation()
-})
+  test.before(async () => {
+    await createPoliceMove({
+      personOverrides: {
+        policeNationalComputer: undefined,
+      },
+    })
+  })(
+    'User should be able to update PNC if it does not already exist',
+    async t => {
+      await checkUpdatePersonalDetails({
+        include: ['policeNationalComputer'],
+      })
+    }
+  )
 
-test('User should be able to update health information', async () => {
-  await checkUpdateHealthInformation()
-})
+  test('User should be able to update risk information', async () => {
+    await checkUpdateRiskInformation()
+  })
 
-test('User should be able to update court information', async () => {
-  await checkUpdateCourtInformation()
-})
+  test('User should be able to update health information', async () => {
+    await checkUpdateHealthInformation()
+  })
+
+  test('User should be able to update court information', async () => {
+    await checkUpdateCourtInformation()
+  })
+}

--- a/test/e2e/move.update.stc.test.js
+++ b/test/e2e/move.update.stc.test.js
@@ -1,0 +1,19 @@
+import {
+  createStcMove,
+  checkNoUpdateLinks,
+  checkUpdatePagesForbidden,
+} from './_move'
+
+fixture('Existing move from Secure Training Centre (STC) to Court').beforeEach(
+  async () => {
+    await createStcMove()
+  }
+)
+
+test('User should not see any update links on move page', async () => {
+  await checkNoUpdateLinks()
+})
+
+test('User should not be able to access move update pages', async () => {
+  await checkUpdatePagesForbidden()
+})

--- a/test/e2e/move.update.stc.test.js
+++ b/test/e2e/move.update.stc.test.js
@@ -1,19 +1,23 @@
+import { FEATURE_FLAGS } from '../../config'
+
 import {
   createStcMove,
   checkNoUpdateLinks,
   checkUpdatePagesForbidden,
 } from './_move'
 
-fixture('Existing move from Secure Training Centre (STC) to Court').beforeEach(
-  async () => {
+if (FEATURE_FLAGS.EDITABILITY) {
+  fixture(
+    'Existing move from Secure Training Centre (STC) to Court'
+  ).beforeEach(async () => {
     await createStcMove()
-  }
-)
+  })
 
-test('User should not see any update links on move page', async () => {
-  await checkNoUpdateLinks()
-})
+  test('User should not see any update links on move page', async () => {
+    await checkNoUpdateLinks()
+  })
 
-test('User should not be able to access move update pages', async () => {
-  await checkUpdatePagesForbidden()
-})
+  test('User should not be able to access move update pages', async () => {
+    await checkUpdatePagesForbidden()
+  })
+}

--- a/test/e2e/pages/create-move.js
+++ b/test/e2e/pages/create-move.js
@@ -1,4 +1,5 @@
 import faker from 'faker'
+import { omit, pick } from 'lodash'
 import pluralize from 'pluralize'
 import { Selector, t } from 'testcafe'
 
@@ -101,7 +102,9 @@ class CreateMovePage extends Page {
    * @returns {Promise<FormDetails>}
    */
   async fillInPncSearch(searchTerm) {
-    await t.expect(this.getCurrentUrl()).contains('/move/new/person-lookup-pnc')
+    await t
+      .expect(this.getCurrentUrl())
+      .contains(`${this.url}/person-lookup-pnc`)
 
     return fillInForm({
       pncNumberSearch: {
@@ -120,7 +123,7 @@ class CreateMovePage extends Page {
   async fillInPrisonNumberSearch(searchTerm) {
     await t
       .expect(this.getCurrentUrl())
-      .contains('/move/new/person-lookup-prison-number')
+      .contains(`${this.url}/person-lookup-prison-number`)
 
     return fillInForm({
       prisonNumberSearch: {
@@ -150,13 +153,18 @@ class CreateMovePage extends Page {
    * Fill in personal details
    *
    * @param {Object} personalDetails - personal details to fill form in with
+   * @param {Object} [options]
+   * @param {String[]} [options.exclude] - fields to exclude
+   * @param {String[]} [options.include] - fields to include
    * @returns {Promise<FormDetails>} - filled in personal details
    */
-  async fillInPersonalDetails(personalDetails) {
-    await t.expect(this.getCurrentUrl()).contains('/move/new/personal-details')
+  async fillInPersonalDetails(personalDetails, { include, exclude } = {}) {
+    await t
+      .expect(this.getCurrentUrl())
+      .contains(`${this.url}/personal-details`)
 
-    const person = generatePerson(personalDetails)
-    const fields = await fillInForm({
+    const person = await generatePerson(personalDetails)
+    let data = {
       policeNationalComputer: {
         selector: this.fields.policeNationalComputer,
         value: person.policeNationalComputer,
@@ -182,7 +190,14 @@ class CreateMovePage extends Page {
         value: faker.random.arrayElement(['Male', 'Female']),
         type: 'radio',
       },
-    })
+    }
+    if (exclude) {
+      data = omit(data, exclude)
+    } else if (include) {
+      data = pick(data, include)
+    }
+
+    const fields = await fillInForm(data)
 
     return {
       ...fields,
@@ -197,7 +212,7 @@ class CreateMovePage extends Page {
    * @returns {Promise<FormDetails>} - filled in move details
    */
   async fillInMoveDetails(moveType) {
-    await t.expect(this.getCurrentUrl()).contains('/move/new/move-details')
+    await t.expect(this.getCurrentUrl()).contains(`${this.url}/move-details`)
 
     const fields = {
       moveType: {
@@ -235,7 +250,7 @@ class CreateMovePage extends Page {
    * Fill in date
    */
   async fillInDate() {
-    await t.expect(this.getCurrentUrl()).contains('/move/new/move-date')
+    await t.expect(this.getCurrentUrl()).contains(`${this.url}/move-date`)
 
     return fillInForm({
       dateType: {
@@ -250,7 +265,7 @@ class CreateMovePage extends Page {
    * Fill in date range
    */
   async fillInDateRange() {
-    await t.expect(this.getCurrentUrl()).contains('/move/new/move-date-range')
+    await t.expect(this.getCurrentUrl()).contains(`${this.url}/move-date-range`)
 
     return fillInForm({
       dateFrom: {
@@ -274,7 +289,9 @@ class CreateMovePage extends Page {
     selectAll = true,
     fillInOptional = false,
   } = {}) {
-    await t.expect(this.getCurrentUrl()).contains('/move/new/court-information')
+    await t
+      .expect(this.getCurrentUrl())
+      .contains(`${this.url}/court-information`)
 
     const fields = {
       selectedItems: {
@@ -331,7 +348,9 @@ class CreateMovePage extends Page {
     selectAll = true,
     fillInOptional = false,
   } = {}) {
-    await t.expect(this.getCurrentUrl()).contains('/move/new/risk-information')
+    await t
+      .expect(this.getCurrentUrl())
+      .contains(`${this.url}/risk-information`)
 
     const fields = {
       selectedItems: {
@@ -380,7 +399,7 @@ class CreateMovePage extends Page {
    * @returns {Promise}
    */
   async fillInReleaseStatus() {
-    await t.expect(this.getCurrentUrl()).contains('/move/new/release-status')
+    await t.expect(this.getCurrentUrl()).contains(`${this.url}/release-status`)
 
     return fillInForm({
       notToBeReleasedRadio: {
@@ -397,7 +416,9 @@ class CreateMovePage extends Page {
    * @returns {Promise}
    */
   async fillInAgreementStatus() {
-    await t.expect(this.getCurrentUrl()).contains('/move/new/agreement-status')
+    await t
+      .expect(this.getCurrentUrl())
+      .contains(`${this.url}/agreement-status`)
 
     return fillInForm({
       moveAgreed: {
@@ -420,7 +441,7 @@ class CreateMovePage extends Page {
   async fillInPrisonTransferReasons() {
     await t
       .expect(this.getCurrentUrl())
-      .contains('/move/new/prison-transfer-reason')
+      .contains(`${this.url}/prison-transfer-reason`)
 
     return fillInForm({
       prisonTransferReason: {
@@ -441,7 +462,7 @@ class CreateMovePage extends Page {
   } = {}) {
     await t
       .expect(this.getCurrentUrl())
-      .contains('/move/new/health-information')
+      .contains(`${this.url}/health-information`)
 
     if (!selectAll) {
       return fillInForm({
@@ -506,7 +527,7 @@ class CreateMovePage extends Page {
    * @returns {Promise}
    */
   async fillInSpecialVehicle() {
-    await t.expect(this.getCurrentUrl()).contains('/move/new/special-vehicle')
+    await t.expect(this.getCurrentUrl()).contains(`${this.url}/special-vehicle`)
 
     return fillInForm({
       specialVehicleRadio: {
@@ -524,7 +545,7 @@ class CreateMovePage extends Page {
    * @returns {Promise}
    */
   async fillInDocumentUploads(files) {
-    await t.expect(this.getCurrentUrl()).contains('/move/new/document')
+    await t.expect(this.getCurrentUrl()).contains(`${this.url}/document`)
     await t.setFilesToUpload(
       '#documents',
       files.map(fileName => `../fixtures/files/${fileName}`)
@@ -557,7 +578,7 @@ class CreateMovePage extends Page {
   checkPersonLookupResults(count, searchTerm) {
     return t
       .expect(this.getCurrentUrl())
-      .contains('/move/new/person-lookup-results')
+      .contains(`${this.url}/person-lookup-results`)
       .expect(this.steps.personLookupResults.nodes.searchSummary.innerText)
       .contains(
         `${count} ${pluralize('person', count)} found for “${searchTerm}”`

--- a/test/e2e/pages/index.js
+++ b/test/e2e/pages/index.js
@@ -3,6 +3,7 @@ import CreateMovePage from './create-move'
 import MoveDetailPage from './move-detail'
 import MovesDashboardPage from './moves-dashboard'
 import Page from './page'
+import UpdateMovePage from './update-move'
 
 const page = new Page()
 const moveDetailPage = new MoveDetailPage()
@@ -16,4 +17,5 @@ export {
   movesDashboardPage,
   createMovePage,
   cancelMovePage,
+  UpdateMovePage,
 }

--- a/test/e2e/pages/move-detail.js
+++ b/test/e2e/pages/move-detail.js
@@ -45,6 +45,9 @@ class MoveDetailPage extends Page {
       noHealthInformationMessage: Selector('.app-message').withText(
         'No health affecting transport'
       ),
+      getUpdateLink: category => {
+        return Selector(`[data-update-link="${category}"]`)
+      },
     }
   }
 
@@ -188,6 +191,20 @@ class MoveDetailPage extends Page {
         await t.expect(panel.innerText).contains(comment)
       }
     }
+  }
+
+  async checkUpdateLink(category, exists = true) {
+    const selector = this.nodes.getUpdateLink(category)
+    await t.expect(selector.exists).eql(exists)
+  }
+
+  async checkNoUpdateLink(category) {
+    await this.checkUpdateLink(category, false)
+  }
+
+  async clickUpdateLink(category, exists = true) {
+    const selector = this.nodes.getUpdateLink(category)
+    await t.click(selector)
   }
 }
 

--- a/test/e2e/pages/update-move.js
+++ b/test/e2e/pages/update-move.js
@@ -1,0 +1,44 @@
+import { Selector, t } from 'testcafe'
+
+import CreateMovePage from './create-move'
+import MoveDetailPage from './move-detail'
+
+const moveDetailPage = new MoveDetailPage()
+
+class UpdateMovePage extends CreateMovePage {
+  constructor(id) {
+    super()
+    this.url = `/move/${id}/edit`
+    this.fields = {
+      ...this.fields,
+      policeNationalComputerReadOnly: Selector(
+        '[type=hidden][name=police_national_computer]'
+      ),
+    }
+    this.nodes = {
+      ...this.nodes,
+      policeNationalComputerHeading: Selector('.app-read-only-field__heading'),
+      policeNationalComputerValue: Selector('.app-read-only-field__value'),
+    }
+  }
+}
+
+UpdateMovePage.gotoPersonalDetails = async () => {
+  const { move } = t.ctx
+
+  await moveDetailPage.clickUpdateLink('personal_details')
+  return new UpdateMovePage(move.id)
+}
+
+UpdateMovePage.updatePersonalDetails = async options => {
+  const { person } = t.ctx
+  const updateMovePage = await UpdateMovePage.gotoPersonalDetails()
+  const updatedFields = await updateMovePage.fillInPersonalDetails({}, options)
+  const updatedDetails = { ...person, ...updatedFields }
+
+  await updateMovePage.submitForm()
+
+  await moveDetailPage.checkPersonalDetails(updatedDetails)
+}
+
+export default UpdateMovePage


### PR DESCRIPTION
Implements P4 1195 - Ability to edit Police PTR

NB. this feature is currently hidden behind the feature flag `FEATURE_FLAG_EDITABILITY`.

Adds the following pages and links to them from the move view

- personal details
- risk information
- health information
- court information

These pages reuse the create move templates, with the only notable differences being

- PNC number is read-only if it has already been set
- uses save and continue rather than continue button

Cancelling or saving returns the user to the move view page.




![Move_details_for_GORCZANY__MAZIE](https://user-images.githubusercontent.com/4856/79985247-38c19300-84a2-11ea-84b3-55f1a03309bf.png)

![Personal_details_-_update_move](https://user-images.githubusercontent.com/4856/79985098-044dd700-84a2-11ea-9568-5fbabaf07f2a.png)



The pages for changing the move details and move date also exist but the links to them have been suppressed until it's confirmed that `from_location` can be changed.

### Checklist

- [x] If adding new environment variables, they have been documented in the [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md)
- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
