### PR TITLE
[P4 1280] List view for allocations

### DIFF
--- a/app/allocations/controllers/index.js
+++ b/app/allocations/controllers/index.js
@@ -1,5 +1,7 @@
 const dashboard = require('./dashboard')
+const list = require('./list')
 
 module.exports = {
   dashboard,
+  list,
 }

--- a/app/allocations/controllers/list.js
+++ b/app/allocations/controllers/list.js
@@ -1,0 +1,12 @@
+const presenters = require('../../../common/presenters')
+
+module.exports = function list(req, res) {
+  const { allocations = [] } = res.locals
+  const template = 'allocations/views/list'
+  const locals = {
+    pageTitle: req.t('allocations::dashboard.heading'),
+    ...presenters.allocationsToTable(allocations),
+  }
+
+  res.render(template, locals)
+}

--- a/app/allocations/controllers/list.test.js
+++ b/app/allocations/controllers/list.test.js
@@ -1,0 +1,56 @@
+const presenters = require('../../../common/presenters')
+
+const controller = require('./list')
+
+describe('the controller of the allocations outgoing list view', function() {
+  let locals
+  let render
+  let t
+  beforeEach(function() {
+    t = sinon.stub().returnsArg(0)
+    render = sinon.stub()
+    sinon.stub(presenters, 'allocationsToTable').returns({
+      head: [],
+      rows: [],
+    })
+    locals = {
+      allocations: [
+        {
+          id: '123',
+        },
+        {
+          id: '124',
+        },
+      ],
+    }
+    controller(
+      {
+        t,
+      },
+      {
+        locals,
+        render,
+      }
+    )
+  })
+  it('invokes the presenter with res.locals.allocations', function() {
+    expect(presenters.allocationsToTable).to.have.been.calledOnceWithExactly([
+      {
+        id: '123',
+      },
+      {
+        id: '124',
+      },
+    ])
+  })
+  it('renders the template', function() {
+    expect(render).to.have.been.calledOnceWithExactly(
+      'allocations/views/list',
+      {
+        pageTitle: 'allocations::dashboard.heading',
+        head: [],
+        rows: [],
+      }
+    )
+  })
+})

--- a/app/allocations/index.js
+++ b/app/allocations/index.js
@@ -5,8 +5,13 @@ const { dateFormat } = require('../../common/helpers/date-utils')
 const { setDateRange, setDatePeriod } = require('../../common/middleware')
 const { protectRoute } = require('../../common/middleware/permissions')
 
-const { dashboard } = require('./controllers')
-const { setAllocationsSummary, setPagination } = require('./middleware')
+const { dashboard, list } = require('./controllers')
+const {
+  setAllocationsByDateAndFilter,
+  setAllocationsSummary,
+  setAllocationTypeNavigation,
+  setPagination,
+} = require('./middleware')
 
 router.param('period', setDatePeriod)
 router.param('date', setDateRange)
@@ -21,6 +26,14 @@ router.get(
   setAllocationsSummary,
   setPagination,
   dashboard
+)
+router.get(
+  '/:period(week|day)/:date/:view(outgoing)',
+  protectRoute('allocations:view'),
+  setAllocationsByDateAndFilter,
+  setAllocationTypeNavigation,
+  setPagination,
+  list
 )
 module.exports = {
   router,

--- a/app/allocations/middleware.js
+++ b/app/allocations/middleware.js
@@ -1,44 +1,149 @@
 const { format } = require('date-fns')
+const { cloneDeep, isEqual, mapValues } = require('lodash')
+const queryString = require('query-string')
 
 const {
   dateFormat,
   getDateFromParams,
   getPeriod,
 } = require('../../common/helpers/date-utils')
+const presenters = require('../../common/presenters')
 const allocationService = require('../../common/services/allocation')
 
-const allocationsMiddleware = {
-  // TODO: refactor this to be common with the /moves pagination.
-  //  It differs only in the output of the url
-  setPagination: (req, res, next) => {
-    const { period } = req.params
-    const today = format(new Date(), dateFormat)
-    const baseDate = getDateFromParams(req)
-    const interval = period === 'week' ? 7 : 1
-
-    const previousPeriod = getPeriod(baseDate, -interval)
-    const nextPeriod = getPeriod(baseDate, interval)
-
-    res.locals.pagination = {
-      todayUrl: `${req.baseUrl}/${period}/${today}/`,
-      nextUrl: `${req.baseUrl}/${period}/${nextPeriod}/`,
-      prevUrl: `${req.baseUrl}/${period}/${previousPeriod}/`,
-    }
-    next()
+const allocationTypeNavigationConfig = [
+  {
+    label: 'allocations::complete',
+    filter: { complete_in_full: true },
   },
-  setAllocationsSummary: async (req, res, next) => {
-    const { dateRange } = res.locals
-    const value = await allocationService.getCount({ dateRange })
-    res.locals.allocationsSummary = [
-      {
-        active: false,
-        label: req.t('allocations::dashboard.labels.single_requests'),
-        href: `/allocations/week/${getDateFromParams(req)}/`,
-        value,
-      },
-    ]
-    next()
+  {
+    label: 'allocations::incomplete',
+    filter: { complete_in_full: false },
   },
+]
+
+// TODO: refactor this to be common with the /moves pagination.
+//  It differs only in the output of the url
+function setPagination(req, res, next) {
+  const { period, view } = req.params
+  const query = req.query
+  const today = format(new Date(), dateFormat)
+  const baseDate = getDateFromParams(req)
+  const interval = period === 'week' ? 7 : 1
+
+  const previousPeriod = getPeriod(baseDate, -interval)
+  const nextPeriod = getPeriod(baseDate, interval)
+  const viewInUrl = view ? `${view}` : ''
+
+  const urlPeriods = {
+    todayUrl: today,
+    nextUrl: nextPeriod,
+    prevUrl: previousPeriod,
+  }
+
+  res.locals.pagination = mapValues(urlPeriods, urlPeriod => {
+    return queryString.stringifyUrl({
+      url: `${req.baseUrl}/${period}/${urlPeriod}/${viewInUrl}`,
+      query,
+    })
+  })
+  next()
+}
+async function setAllocationsSummary(req, res, next) {
+  const { dateRange } = res.locals
+  const value = await allocationService.getCount({ dateRange })
+  res.locals.allocationsSummary = [
+    {
+      active: false,
+      label: req.t('allocations::dashboard.labels.single_requests'),
+      href: `/allocations/week/${getDateFromParams(req)}/outgoing`,
+      value,
+    },
+  ]
+  next()
+}
+async function setAllocationsByDateAndFilter(req, res, next) {
+  const additionalFilters = queryString.parse(req._parsedOriginalUrl.query, {
+    parseBooleans: true,
+  })
+  const { dateRange } = res.locals
+  res.locals.allocations = await allocationService.getByStatus({
+    dateRange,
+    additionalFilters,
+  })
+  next()
+}
+function getAllocationTypeMetadata(params, allocationType) {
+  const { baseUrl, dateRange, period, date, currentFilter } = params
+  return allocationService
+    .getCount({ dateRange, additionalFilters: allocationType.filter })
+    .then(count => {
+      return {
+        ...allocationType,
+        value: count,
+        active: isEqual(allocationType.filter, currentFilter),
+        href: `${baseUrl}/${period}/${date}/outgoing?${queryString.stringify(
+          allocationType.filter
+        )}`,
+      }
+    })
+}
+function addTotalAllocationsToFilter(
+  allocationTypes,
+  { baseUrl, period, date, currentFilter }
+) {
+  const totalAllocationItem = {
+    label: 'allocations::total',
+    filter: null,
+    value: allocationTypes.reduce((accumulator, item) => {
+      return (accumulator += item.value)
+    }, 0),
+    active: isEqual({}, currentFilter),
+    href: `${baseUrl}/${period}/${date}/outgoing`,
+  }
+  return [totalAllocationItem, ...allocationTypes]
+}
+async function setAllocationTypeNavigation(req, res, next) {
+  const { baseUrl } = req
+  const { dateRange } = res.locals
+  const { locationId, period, date } = req.params
+  const currentFilter = queryString.parse(req._parsedOriginalUrl.query, {
+    parseBooleans: true,
+  })
+  try {
+    res.locals.allocationTypeNavigation = await Promise.all(
+      cloneDeep(allocationTypeNavigationConfig).map(
+        getAllocationTypeMetadata.bind(null, {
+          baseUrl,
+          dateRange,
+          locationId,
+          period,
+          date,
+          currentFilter,
+        })
+      )
+    ).then(allocationTypes => {
+      const allocationTypesWithTotal = addTotalAllocationsToFilter(
+        allocationTypes,
+        {
+          baseUrl,
+          period,
+          date,
+          currentFilter,
+        }
+      )
+      return allocationTypesWithTotal.map(presenters.moveTypesToFilterComponent)
+    })
+    next()
+  } catch (error) {
+    next(error)
+  }
 }
 
-module.exports = allocationsMiddleware
+module.exports = {
+  setPagination,
+  setAllocationsSummary,
+  setAllocationsByDateAndFilter,
+  getAllocationTypeMetadata,
+  addTotalAllocationsToFilter,
+  setAllocationTypeNavigation,
+}

--- a/app/allocations/middleware.test.js
+++ b/app/allocations/middleware.test.js
@@ -36,7 +36,7 @@ describe('#setAllocationsSummary', function() {
       {
         active: false,
         label: 'allocations::dashboard.labels.single_requests',
-        href: '/allocations/week/2020-01-01/',
+        href: '/allocations/week/2020-01-01/outgoing',
         value: 18,
       },
     ])
@@ -69,6 +69,7 @@ describe('#setPagination', function() {
         params: {
           date: '2020-04-16',
           period: 'week',
+          view: 'outgoing',
         },
       }
       nextSpy = sinon.spy()
@@ -82,21 +83,21 @@ describe('#setPagination', function() {
     it('creats correctly todayUrl', function() {
       expect(res.locals.pagination.todayUrl).to.exist
       expect(res.locals.pagination.todayUrl).to.equal(
-        '/allocations/week/2020-04-13/'
+        '/allocations/week/2020-04-13/outgoing'
       )
     })
 
     it('creats correctly prevUrl', function() {
       expect(res.locals.pagination.todayUrl).to.exist
       expect(res.locals.pagination.prevUrl).to.equal(
-        '/allocations/week/2020-04-09/'
+        '/allocations/week/2020-04-09/outgoing'
       )
     })
 
     it('creats correctly nextUrl', function() {
       expect(res.locals.pagination.nextUrl).to.exist
       expect(res.locals.pagination.nextUrl).to.equal(
-        '/allocations/week/2020-04-23/'
+        '/allocations/week/2020-04-23/outgoing'
       )
     })
   })
@@ -128,7 +129,7 @@ describe('#setPagination', function() {
     })
 
     it('creats correctly prevUrl', function() {
-      expect(res.locals.pagination.todayUrl).to.exist
+      expect(res.locals.pagination.prevUrl).to.exist
       expect(res.locals.pagination.prevUrl).to.equal(
         '/allocations/day/2020-04-15/'
       )
@@ -138,6 +139,190 @@ describe('#setPagination', function() {
       expect(res.locals.pagination.nextUrl).to.exist
       expect(res.locals.pagination.nextUrl).to.equal(
         '/allocations/day/2020-04-17/'
+      )
+    })
+  })
+  context('with filters', function() {
+    beforeEach(function() {
+      res = {
+        locals: {},
+      }
+      req = {
+        baseUrl: '/allocations',
+        query: {
+          filter1: true,
+          filter2: false,
+        },
+        params: {
+          date: '2020-04-16',
+          period: 'week',
+          view: 'outgoing',
+        },
+      }
+      nextSpy = sinon.spy()
+      middleware.setPagination(req, res, nextSpy)
+    })
+
+    it('creats correctly todayUrl', function() {
+      expect(res.locals.pagination.todayUrl).to.exist
+      expect(res.locals.pagination.todayUrl).to.equal(
+        '/allocations/week/2020-04-13/outgoing?filter1=true&filter2=false'
+      )
+    })
+
+    it('creats correctly prevUrl', function() {
+      expect(res.locals.pagination.todayUrl).to.exist
+      expect(res.locals.pagination.prevUrl).to.equal(
+        '/allocations/week/2020-04-09/outgoing?filter1=true&filter2=false'
+      )
+    })
+
+    it('creats correctly nextUrl', function() {
+      expect(res.locals.pagination.nextUrl).to.exist
+      expect(res.locals.pagination.nextUrl).to.equal(
+        '/allocations/week/2020-04-23/outgoing?filter1=true&filter2=false'
+      )
+    })
+  })
+})
+describe('#setAllocationsByDateAndFilter', function() {
+  let next
+  beforeEach(async function() {
+    sinon.stub(allocationService, 'getByStatus')
+    next = sinon.stub()
+    await middleware.setAllocationsByDateAndFilter(
+      {
+        _parsedOriginalUrl: {
+          query: 'complete_in_full=true',
+        },
+      },
+      {
+        locals: {
+          dateRange: ['2020-01-01', null],
+        },
+      },
+      next
+    )
+  })
+  it('invokes the allocation service with the filters and the date range', function() {
+    expect(allocationService.getByStatus).to.have.been.calledWithExactly({
+      dateRange: ['2020-01-01', null],
+      additionalFilters: { complete_in_full: true },
+    })
+  })
+  it('calls next', function() {
+    expect(next).to.have.been.called
+  })
+})
+describe('#setAllocationTypeNavigation', function() {
+  context('when everything is fine', function() {
+    let next
+    let locals
+    beforeEach(async function() {
+      sinon.stub(allocationService, 'getCount').resolves(1)
+      locals = {
+        dateRange: ['2019-12-30', '2020-01-05'],
+      }
+      next = sinon.stub()
+      await middleware.setAllocationTypeNavigation(
+        {
+          baseUrl: '/allocations',
+          params: {
+            locationId: 123,
+            period: 'week',
+            date: '2020-01-01',
+          },
+          _parsedOriginalUrl: {
+            query: '?filter[complete_in_full]=true&createdBy=456',
+          },
+        },
+        {
+          locals,
+        },
+        next
+      )
+    })
+    it('calls getAllocationTypeMetadata once per item in the config', function() {
+      expect(allocationService.getCount).to.have.been.calledTwice
+      expect(allocationService.getCount).to.have.been.calledWith({
+        dateRange: ['2019-12-30', '2020-01-05'],
+        additionalFilters: { complete_in_full: true },
+      })
+      expect(allocationService.getCount).to.have.been.calledWith({
+        dateRange: ['2019-12-30', '2020-01-05'],
+        additionalFilters: { complete_in_full: false },
+      })
+    })
+    it('takes the resulting counts and calculates the total', function() {
+      expect(locals).to.deep.equal({
+        dateRange: ['2019-12-30', '2020-01-05'],
+        allocationTypeNavigation: [
+          {
+            label: 'total',
+            filter: null,
+            value: 2,
+            active: false,
+            href: '/allocations/week/2020-01-01/outgoing',
+          },
+          {
+            label: 'complete',
+            filter: {
+              complete_in_full: true,
+            },
+            value: 1,
+            active: false,
+            href: '/allocations/week/2020-01-01/outgoing?complete_in_full=true',
+          },
+          {
+            label: 'incomplete',
+            filter: {
+              complete_in_full: false,
+            },
+            value: 1,
+            active: false,
+            href:
+              '/allocations/week/2020-01-01/outgoing?complete_in_full=false',
+          },
+        ],
+      })
+    })
+    it('invokes next', function() {
+      expect(next).to.have.been.calledOnce
+    })
+  })
+  context('when the service errors', function() {
+    let next
+    let locals
+    beforeEach(async function() {
+      sinon.stub(allocationService, 'getCount').throws(new Error('500!'))
+      locals = {
+        dateRange: ['2019-12-30', '2020-01-05'],
+      }
+      next = sinon.stub()
+      await middleware.setAllocationTypeNavigation(
+        {
+          baseUrl: '/allocations',
+          params: {
+            locationId: 123,
+            period: 'week',
+            date: '2020-01-01',
+          },
+          _parsedOriginalUrl: {
+            query: '?filter[complete_in_full]=true&createdBy=456',
+          },
+        },
+        {
+          locals,
+        },
+        next
+      )
+    })
+
+    it('if there is an error, it invokes next with the error', function() {
+      expect(next).to.have.been.calledWithExactly(
+        sinon.match({
+          message: '500!',
+        })
       )
     })
   })

--- a/app/allocations/views/list.njk
+++ b/app/allocations/views/list.njk
@@ -1,0 +1,34 @@
+{% extends "layouts/list-view.njk" %}
+
+{% block headerGridColumnClass %}govuk-grid-column-full{% endblock %}
+
+{% block headerActions %}
+  {% if canAccess('move:create') %}
+    {{ govukButton({
+      isStartButton: true,
+      text: t("actions::create_move"),
+      href: "/allocations/new",
+      classes: "govuk-!-margin-top-2 app-print--hide"
+    }) }}
+  {% endif %}
+  {{ appFilter({
+    items: allocationTypeNavigation
+  }) }}
+{% endblock %}
+
+{% block pageContent %}
+  {% if allocations.length %}
+    {{ govukTable({
+      rows: rowsForAllocationTable,
+      head: headerForAllocationTable
+    }) }}
+  {% else %}
+    {{ appMessage({
+      classes: "app-message--muted govuk-!-margin-top-7",
+      allowDismiss: false,
+      content: {
+        html: t("allocations::dashboard.no_results")
+      }
+    }) }}
+  {% endif %}
+{% endblock %}

--- a/common/presenters/allocations-to-table.js
+++ b/common/presenters/allocations-to-table.js
@@ -1,0 +1,47 @@
+const i18n = require('../../config/i18n')
+const filters = require('../../config/nunjucks/filters')
+
+const objectToTableHead = require('./object-to-table-head')
+const objectToTableRow = require('./object-to-table-row')
+
+const tableConfig = [
+  {
+    head: i18n.t('allocations::move_size'),
+    attributes: {
+      attributes: {
+        scope: 'row',
+      },
+    },
+    row: 'moves_count',
+  },
+  {
+    head: i18n.t('allocations::requested'),
+    row: data => filters.formatDate(data.created_at),
+  },
+  {
+    head: i18n.t('allocations::move_from'),
+    row: 'from_location.title',
+  },
+  {
+    head: i18n.t('allocations::move_to'),
+    row: 'to_location.title',
+  },
+  {
+    head: i18n.t('date'),
+    row: data => filters.formatDate(data.date),
+  },
+  {
+    head: i18n.t('allocations::progress'),
+    // todo: this field does not exist yet and it might end up having a different name or format
+    row: 'progress',
+  },
+]
+
+function allocationsToTable(allocations) {
+  return {
+    headerForAllocationTable: tableConfig.map(objectToTableHead),
+    rowsForAllocationTable: allocations.map(objectToTableRow(tableConfig)),
+  }
+}
+
+module.exports = allocationsToTable

--- a/common/presenters/allocations-to-table.test.js
+++ b/common/presenters/allocations-to-table.test.js
@@ -1,0 +1,143 @@
+const mockAllocations = [
+  {
+    id: '8567f1a5-2201-4bc2-b655-f6526401303a',
+    type: 'allocations',
+    moves_count: 3,
+    date: '2020-05-03',
+    complete_in_full: true,
+    other_criteria: null,
+    created_at: '2020-04-20T10:44:36+01:00',
+    updated_at: '2020-04-20T10:44:36+01:00',
+    from_location: {
+      id: '9380cb63-f588-4fef-99d0-322c7838f265',
+      type: 'locations',
+      key: 'hhi',
+      title: 'HOLME HOUSE (HMP)',
+    },
+    to_location: {
+      id: '5640c8b0-508a-4dfc-bde6-ade4a648d340',
+      type: 'locations',
+      key: 'hmp_ashfield',
+      title: 'HMP Ashfield',
+    },
+  },
+  {
+    id: '05140394-c517-45d9-8c24-9b4913972d87',
+    type: 'allocations',
+    moves_count: 6,
+    date: '2020-04-27',
+    complete_in_full: false,
+    other_criteria: null,
+    created_at: '2020-04-20T10:44:36+01:00',
+    updated_at: '2020-04-20T10:44:36+01:00',
+    from_location: {
+      id: '21512459-1505-4950-aec3-7bdbad291e33',
+      type: 'locations',
+      key: 'hmp_yoi_downview',
+      title: 'HMP/YOI Downview',
+    },
+    to_location: {
+      id: '3613fe8f-2e3b-490a-9cc9-a066981d05f0',
+      type: 'locations',
+      key: 'hmirc_the_verne',
+      title: 'HMIRC The Verne',
+    },
+  },
+  {
+    id: 'c213ebd7-fd77-4b27-aa0c-5545204f3521',
+    type: 'allocations',
+    moves_count: 6,
+    date: '2020-05-03',
+    complete_in_full: true,
+    other_criteria: null,
+    created_at: '2020-04-20T10:44:37+01:00',
+    updated_at: '2020-04-20T10:44:37+01:00',
+    from_location: {
+      id: 'b9e8bc2b-9224-4a8f-b1e7-19b2973c30fa',
+      type: 'locations',
+      key: 'hmp_yoi_thorn_cross',
+      title: 'HMP/YOI Thorn Cross',
+    },
+    to_location: {
+      id: '8f5347f8-6463-4eea-8ec5-9d00c02e0acd',
+      type: 'locations',
+      key: 'hmp_yoi_parc',
+      title: 'HMP/YOI Parc',
+    },
+  },
+]
+const presenter = require('./allocations-to-table')
+describe('#allocationsToTable', function() {
+  let output
+  beforeEach(function() {
+    output = presenter([])
+  })
+  it('returns an object with allocationsHeads', function() {
+    expect(output.headerForAllocationTable).to.exist
+    expect(output.headerForAllocationTable).to.be.an('array')
+  })
+  it('returns an object with allocations', function() {
+    expect(output.rowsForAllocationTable).to.exist
+    expect(output.rowsForAllocationTable).to.be.an('array')
+  })
+  describe('its behaviour', function() {
+    let output
+    beforeEach(function() {
+      output = presenter(mockAllocations)
+    })
+    it('returns the total moves count on the first cell', function() {
+      expect(output.rowsForAllocationTable[0][0]).to.deep.equal({
+        html: 3,
+        attributes: {
+          scope: 'row',
+        },
+      })
+    })
+    it('returns the created date on the second cell', function() {
+      expect(output.rowsForAllocationTable[0][1]).to.deep.equal({
+        html: '20 Apr 2020',
+      })
+    })
+    it('returns location_from on the third cell', function() {
+      expect(output.rowsForAllocationTable[0][2]).to.deep.equal({
+        html: 'HOLME HOUSE (HMP)',
+      })
+    })
+    it('returns location_to on the fourth cell', function() {
+      expect(output.rowsForAllocationTable[0][3]).to.deep.equal({
+        html: 'HMP Ashfield',
+      })
+    })
+    it('returns move date on the fifth cell', function() {
+      expect(output.rowsForAllocationTable[0][4]).to.deep.equal({
+        html: '3 May 2020',
+      })
+    })
+    xit('returns progress on the sixth cell', function() {
+      // define this when we have agreed on this field's format
+      expect(output.rowsForAllocationTable[0][5]).to.deep.equal()
+    })
+    it('returns one head row with all the cells', function() {
+      expect(output.headerForAllocationTable).to.deep.equal([
+        {
+          html: 'Move size',
+        },
+        {
+          html: 'Requested',
+        },
+        {
+          html: 'Move from',
+        },
+        {
+          html: 'Move to',
+        },
+        {
+          html: 'Date',
+        },
+        {
+          html: 'Progress',
+        },
+      ])
+    })
+  })
+})

--- a/common/presenters/index.js
+++ b/common/presenters/index.js
@@ -1,3 +1,4 @@
+const allocationsToTable = require('./allocations-to-table')
 const assessmentAnswerToTag = require('./assessment-answer-to-tag')
 const assessmentAnswersByCategory = require('./assessment-answers-by-category')
 const assessmentCategoryToPanelComponent = require('./assessment-category-to-panel-component')
@@ -17,6 +18,7 @@ const personToCardComponent = require('./person-to-card-component')
 const personToSummaryListComponent = require('./person-to-summary-list-component')
 
 module.exports = {
+  allocationsToTable,
   assessmentAnswerToTag,
   assessmentAnswersByCategory,
   assessmentCategoryToPanelComponent,

--- a/common/services/allocation.js
+++ b/common/services/allocation.js
@@ -1,11 +1,19 @@
+const { mapKeys } = require('lodash')
+
 const apiClient = require('../lib/api-client')()
 
+function urlKeyToFilter(additionalFilters) {
+  return mapKeys(additionalFilters, (value, key) => {
+    return `filter[${key}]`
+  })
+}
 const allocationService = {
-  getCount({ dateRange = [] }) {
+  getCount({ dateRange = [], additionalFilters }) {
     const [dateFrom, dateTo] = dateRange
     const filter = {
       'filter[date_from]': dateFrom,
       'filter[date_to]': dateTo,
+      ...urlKeyToFilter(additionalFilters),
     }
     return apiClient
       .findAll('allocation', {
@@ -14,6 +22,21 @@ const allocationService = {
         per_page: 1,
       })
       .then(response => response.meta.pagination.total_objects)
+  },
+  getByStatus({ dateRange = [], additionalFilters }) {
+    const [dateFrom, dateTo] = dateRange
+    const filter = {
+      'filter[date_from]': dateFrom,
+      'filter[date_to]': dateTo,
+      ...urlKeyToFilter(additionalFilters),
+    }
+    return apiClient
+      .findAll('allocation', {
+        ...filter,
+        page: 1,
+        per_page: 100,
+      })
+      .then(response => response.data)
   },
 }
 

--- a/common/services/allocation.test.js
+++ b/common/services/allocation.test.js
@@ -46,3 +46,57 @@ describe('#getMovesCount', function() {
     })
   })
 })
+describe('#getByStatus', function() {
+  const mockResponse = [
+    {
+      id: '8567f1a5-2201-4bc2-b655-f6526401303a',
+      type: 'allocations',
+    },
+    {
+      id: '05140394-c517-45d9-8c24-9b4913972d87',
+      type: 'allocations',
+    },
+  ]
+  let allocations
+  const mockDateRange = ['2019-04-13', '2019-04-19']
+  beforeEach(async function() {
+    sinon.stub(apiClient, 'findAll').resolves({
+      data: mockResponse,
+    })
+  })
+  context('by default', async function() {
+    beforeEach(async function() {
+      allocations = await allocationService.getByStatus({})
+    })
+    it('calls the api service', function() {
+      expect(apiClient.findAll).to.be.calledOnceWithExactly('allocation', {
+        page: 1,
+        per_page: 100,
+        'filter[date_from]': undefined,
+        'filter[date_to]': undefined,
+      })
+    })
+    it('returns the allocations', function() {
+      expect(allocations).to.deep.equal(mockResponse)
+    })
+  })
+  context('with dates and filter', async function() {
+    beforeEach(async function() {
+      await allocationService.getByStatus({
+        dateRange: mockDateRange,
+        additionalFilters: {
+          complete_in_full: true,
+        },
+      })
+    })
+    it('calls the api service with the correct params', function() {
+      expect(apiClient.findAll).to.be.calledOnceWithExactly('allocation', {
+        page: 1,
+        per_page: 100,
+        'filter[date_from]': mockDateRange[0],
+        'filter[date_to]': mockDateRange[1],
+        'filter[complete_in_full]': true,
+      })
+    })
+  })
+})

--- a/locales/en/allocations.json
+++ b/locales/en/allocations.json
@@ -1,6 +1,15 @@
 {
   "dashboard": {
     "heading": "Allocations",
-    "labels": { "single_requests": "single requests" }
-  }
+    "labels": { "single_requests": "single requests" },
+    "no_results": "No allocations found"
+  },
+  "complete": "complete",
+  "incomplete": "incomplete",
+  "total": "total",
+  "move_size": "Move size",
+  "move_from": "Move from",
+  "move_to": "Move to",
+  "requested": "Requested",
+  "progress": "Progress"
 }


### PR DESCRIPTION
This is a partial version of the dashboard for allocations. It doesn't contain yet the progress status, nor the sorting. There's no BE support for either yet, nor there is proper filtering: every allocation is always returned.

One notable awkwardness is that some of our filters are boolean, and when they are in the url, `req.query` returns them as strings. This is due by express depending on qs, where `parseBool` is apparently an hotly debated issue and has never been included.

This has led to reverting the elimination of query-string, and using said module to parse the original query string instead of using `req.query`. It's not that great and we might just decide we don't want boolean filters, although this can be seen as a serious limitation.



<img width="1009" alt="Screenshot 2020-04-27 at 11 16 26" src="https://user-images.githubusercontent.com/853989/80361295-97a75380-8878-11ea-9485-6d01efaff67d.png">


### Checklist

- [x] If adding new environment variables, they have been documented in the [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md)
- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
