### PR TITLE
[P4-1307] Add image to move detail and create summary

### DIFF
--- a/app/move/views/view.njk
+++ b/app/move/views/view.njk
@@ -135,9 +135,15 @@
   {% if moveSummary %}
     <div class="sticky-sidebar">
       <div class="sticky-sidebar__inner">
-        <h3 class="govuk-heading-m app-border-top-2 app-border--blue govuk-!-padding-top-4">
+        <h3 class="govuk-heading-m app-border-top-2 app-border--blue govuk-!-padding-top-4 govuk-!-margin-bottom-3">
           {{ move.person.fullname | upper }}
         </h3>
+
+        {% if move.person.image_url %}
+          <div class="govuk-!-width-one-half govuk-!-margin-bottom-3">
+            <img src="{{ move.person.image_url }}" alt="{{ move.person.fullname | upper }}">
+          </div>
+        {% endif %}
 
         {{ appMetaList(moveSummary) }}
         {# TODO: enable updating of move details when to_location can be set via api #}

--- a/common/assets/scss/core/_elements.scss
+++ b/common/assets/scss/core/_elements.scss
@@ -5,3 +5,8 @@ abbr {
 abbr[title] {
   cursor: help;
 }
+
+img {
+  display: inline-block;
+  max-width: 100%;
+}

--- a/common/templates/form-wizard.njk
+++ b/common/templates/form-wizard.njk
@@ -88,9 +88,15 @@
   {% if person %}
     <div class="sticky-sidebar">
       <div class="sticky-sidebar__inner">
-        <h3 class="govuk-heading-m app-border-top-2 app-border--blue govuk-!-padding-top-4">
+        <h3 class="govuk-heading-m app-border-top-2 app-border--blue govuk-!-padding-top-4 govuk-!-margin-bottom-3">
           {{ person.fullname | upper }}
         </h3>
+
+        {% if person.image_url %}
+          <div class="govuk-!-width-one-half govuk-!-margin-bottom-3">
+            <img src="{{ move.person.image_url }}" alt="{{ move.person.fullname | upper }}">
+          </div>
+        {% endif %}
 
         {{ appMetaList(moveSummary) }}
       </div>

--- a/common/templates/layouts/two-column.njk
+++ b/common/templates/layouts/two-column.njk
@@ -8,7 +8,7 @@
 
   <div class="{{ containerClass }}">
 
-    <div class="govuk-grid-column-two-thirds">
+    <div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-6">
 
       {% block contentMain %}{% endblock %}
 


### PR DESCRIPTION
## Proposed changes

This change adds the person's image to the right hand summary panel
displayed on both the move creation journey and the move detail
page.

## Screenshots

<kbd><img src="https://user-images.githubusercontent.com/3327997/80319423-05fffd80-8808-11ea-89ba-4cddc9ef0bf5.png"></kbd>

<kbd><img src="https://user-images.githubusercontent.com/3327997/80319437-1adc9100-8808-11ea-93ba-782bd0363ce7.png"></kbd>
