### PR TITLE
fix: Ensure that radios and checkboxes are selected when clicked

### DIFF
--- a/test/e2e/_helpers.js
+++ b/test/e2e/_helpers.js
@@ -6,7 +6,7 @@ import { format } from 'date-fns'
 import faker from 'faker'
 import glob from 'glob'
 import { find, get, isArray, isNil } from 'lodash'
-import { ClientFunction, RequestLogger, t } from 'testcafe'
+import { ClientFunction, RequestLogger, Selector, t } from 'testcafe'
 
 import moveService from '../../common/services/move'
 import personService from '../../common/services/person'
@@ -208,7 +208,14 @@ async function selectOption({ options, value }) {
     )
   }
 
-  await t.click(option)
+  const optionFor = await option.getAttribute('for')
+  if (optionFor) {
+    const idOption = Selector('#' + optionFor)
+    await t.click(idOption)
+  } else {
+    await t.click(option)
+  }
+
   return option.innerText
 }
 


### PR DESCRIPTION
When selector is a label with a `for` attribute targeting a radio or checkbox input, `t.click(selector)` focuses the input but does not always select it.

This ensures that the actual input (if one is present) is clicked instead which appears to be rock solid.

### Checklist

- [x] If adding new environment variables, they have been documented in the [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md)
- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
