### PR TITLE
fix: Use correct variable for person image during creation journey

### DIFF
--- a/common/templates/form-wizard.njk
+++ b/common/templates/form-wizard.njk
@@ -94,7 +94,7 @@
 
         {% if person.image_url %}
           <div class="govuk-!-width-one-half govuk-!-margin-bottom-3">
-            <img src="{{ move.person.image_url }}" alt="{{ move.person.fullname | upper }}">
+            <img src="{{ person.image_url }}" alt="{{ person.fullname | upper }}">
           </div>
         {% endif %}
 


### PR DESCRIPTION
The person image in the form wizard journey is using the wrong
variable.

Copy + paste error when making a tweak to the two different
places it was being used...