### PR TITLE
[P4-1155] Link timetable journey together

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,7 @@ It will also start a new deployment specific [job on CircleCI](https://app.circl
 | E2E_SUPPLIER_PASSWORD | Supplier user password used for acceptance testing | |
 | LOCATIONS_BATCH_SIZE | Maximum number of location IDs to send in one request when requesting moves for all locations | 40 |
 | FEATURE_FLAG_PRISON_COURT_HEARINGS | Whether to display the court hearings step from Prison locations | false |
+| FEATURE_FLAG_PRISON_COURT_TIMETABLE | Whether to display the NOMIS timetable during the prison to court journey | false |
 | FEATURE_FLAG_EDITABILITY | Whether to enable page views where moves can be updated | |
 
 ### Development specific

--- a/app/move/controllers/create/save.js
+++ b/app/move/controllers/create/save.js
@@ -37,10 +37,13 @@ class SaveController extends CreateBaseController {
         }),
         // create hearings
         ...(data.court_hearings || []).map(hearing =>
-          courtHearingService.create({
-            ...hearing,
-            move: move.id,
-          })
+          courtHearingService.create(
+            {
+              ...hearing,
+              move: move.id,
+            },
+            data.should_save_court_hearings === 'false'
+          )
         ),
       ])
 

--- a/app/move/fields/court-hearing-start-time.js
+++ b/app/move/fields/court-hearing-start-time.js
@@ -1,10 +1,10 @@
 const { time: timeFormatter } = require('../formatters')
-const { time: timeValidator } = require('../validators')
+const { datetime: datetimeValidator, after } = require('../validators')
 
 const courtHearingStartTime = {
   id: 'court_hearing__start_time',
   name: 'court_hearing__start_time',
-  validate: ['required', timeValidator],
+  validate: ['required', datetimeValidator, after],
   formatter: [timeFormatter],
   component: 'govukInput',
   classes: 'govuk-input--width-10',

--- a/app/move/fields/has-court-case.js
+++ b/app/move/fields/has-court-case.js
@@ -22,6 +22,9 @@ const hasCourtCase = {
     {
       value: 'false',
       text: 'fields::has_court_case.items.no.label',
+      hint: {
+        text: 'fields::has_court_case.items.no.hint',
+      },
     },
   ],
 }

--- a/app/move/steps/create.js
+++ b/app/move/steps/create.js
@@ -131,7 +131,7 @@ module.exports = {
             ),
             // field: 'from_location_type',
             // value: 'prison',
-            next: 'hearing-details',
+            next: 'court-hearings',
           },
           'court-information',
         ],
@@ -207,10 +207,10 @@ module.exports = {
     ],
     fields: ['solicitor', 'interpreter', 'other_court'],
   },
-  '/hearing-details': {
+  '/court-hearings': {
     controller: CourtHearings,
     pageTitle: 'moves::steps.hearing_details.heading',
-    next: ['release-status'],
+    next: 'timetable',
     fields: [
       'has_court_case',
       'court_hearing__start_time',

--- a/app/move/steps/create.js
+++ b/app/move/steps/create.js
@@ -210,7 +210,19 @@ module.exports = {
   '/court-hearings': {
     controller: CourtHearings,
     pageTitle: 'moves::steps.hearing_details.heading',
-    next: 'timetable',
+    next: [
+      // TODO: Remove feature flag when this feature has been released
+      {
+        fn: () => !FEATURE_FLAGS.PRISON_COURT_TIMETABLE,
+        next: 'release-status',
+      },
+      {
+        field: 'has_court_case',
+        value: 'true',
+        next: 'timetable',
+      },
+      'release-status',
+    ],
     fields: [
       'has_court_case',
       'court_hearing__start_time',

--- a/app/move/validators.js
+++ b/app/move/validators.js
@@ -1,3 +1,4 @@
+const { parseISO, isValid, isAfter } = require('date-fns')
 const { Controller } = require('hmpo-form-wizard')
 
 module.exports = {
@@ -8,6 +9,22 @@ module.exports = {
         value,
         /^([0-9]|0[0-9]|1[0-9]|2[0-3]):([0-5][0-9]) ?([AaPp][Mm])?$/
       )
+    )
+  },
+  datetime(value) {
+    return value === '' || isValid(parseISO(value))
+  },
+  after(value, date) {
+    const test = parseISO(value)
+    let comparator = new Date()
+
+    if (arguments.length === 2 && Controller.validators.date(date)) {
+      comparator = parseISO(date)
+    }
+
+    return (
+      value === '' ||
+      (Controller.validators.date(value) && isAfter(test, comparator))
     )
   },
 }

--- a/app/move/validators.test.js
+++ b/app/move/validators.test.js
@@ -1,6 +1,17 @@
 const validators = require('./validators')
 
 describe('Validators', function() {
+  let clock
+
+  beforeEach(function() {
+    const now = new Date('2014-11-05T15:09:00Z')
+    clock = sinon.useFakeTimers(now.getTime())
+  })
+
+  afterEach(function() {
+    clock.restore()
+  })
+
   describe('#time()', function() {
     describe('invalid values', function() {
       const inputs = [
@@ -41,6 +52,83 @@ describe('Validators', function() {
       inputs.forEach(i => {
         it(`test for: "${i}"`, function() {
           expect(validators.time(i)).to.be.ok
+        })
+      })
+    })
+  })
+
+  describe('#datetime()', function() {
+    describe('invalid values', function() {
+      const inputs = [
+        10,
+        null,
+        '25:00',
+        '2010-10-10T10:65',
+        'asdf',
+        '10:00a',
+        '2010-10-10:9:00p',
+        '20-10-10T10:00Z',
+        '2020-20-10T10:00Z',
+        '2020-10-40T10:00Z',
+        'midnight',
+        'midday',
+      ]
+
+      inputs.forEach(i => {
+        it(`test for: "${i}"`, function() {
+          expect(validators.datetime(i)).not.to.be.ok
+        })
+      })
+    })
+
+    describe('valid values', function() {
+      const inputs = [
+        '',
+        '2010-10-10T10:00Z',
+        '2010-10-10T10:00+01:00',
+        '2010-10-10T10:00-10:00',
+      ]
+
+      inputs.forEach(i => {
+        it(`test for: "${i}"`, function() {
+          expect(validators.datetime(i)).to.be.ok
+        })
+      })
+    })
+  })
+
+  describe('after', function() {
+    // note date is set to 2014-11-05T15:09:00Z in all tests
+
+    describe('invalid values', function() {
+      const inputs = [
+        '2014-11-05',
+        ['2014-12-16', '2014-12-16'],
+        ['2013-12-15', '2013-12-16'],
+      ]
+
+      inputs.forEach(i => {
+        it(`test for: "${i}"`, function() {
+          if (typeof i === 'string') {
+            expect(validators.after(i)).not.to.be.ok
+          } else {
+            expect(validators.after.apply(null, i)).not.to.be.ok
+          }
+        })
+      })
+    })
+
+    describe('valid inputs', function() {
+      const inputs = [
+        ['', '2014-12-15'],
+        ['2014-12-16', '2014-12-15'],
+        ['2014-12-16T00:00Z', '2014-12-15T00:00Z'],
+        ['2014-12-16T12:00+01:00', '2014-12-16T11:59+02:00'],
+      ]
+
+      inputs.forEach(i => {
+        it(`test for: "${i}"`, function() {
+          expect(validators.after.apply(null, i)).to.be.ok
         })
       })
     })

--- a/common/lib/api-client/models.js
+++ b/common/lib/api-client/models.js
@@ -93,15 +93,18 @@ module.exports = {
       },
     },
   },
-  timetable: {
+  timetable_entry: {
     attributes: {
       start_time: '',
-      activity_type: '',
+      nomis_type: '',
       reason: '',
       location: {
         jsonApi: 'hasOne',
         type: 'locations',
       },
+    },
+    options: {
+      collectionPath: 'timetable',
     },
   },
   gender: {

--- a/common/lib/api-client/models.test.js
+++ b/common/lib/api-client/models.test.js
@@ -65,7 +65,7 @@ const testCases = {
       args: {},
     },
   ],
-  timetable: [
+  timetable_entry: [
     {
       method: 'findAll',
       httpMock: 'get',

--- a/common/presenters/timetable-to-table-component.js
+++ b/common/presenters/timetable-to-table-component.js
@@ -11,7 +11,7 @@ module.exports = function timetableToTableComponent(timetable) {
     { text: i18n.t('location') },
   ]
   const rows = sortBy(timetable, 'start_time').map(
-    ({ start_time: time, activity_type: type, reason, location }) => {
+    ({ start_time: time, nomis_type: type, reason, location }) => {
       return [
         { text: time ? filters.formatTime(time) : '' },
         { text: type || '' },

--- a/common/presenters/timetable-to-table-component.test.js
+++ b/common/presenters/timetable-to-table-component.test.js
@@ -51,7 +51,7 @@ describe('Presenters', function() {
         {
           id: '12345',
           start_time: '2020-10-10T11:00Z',
-          activity_type: 'Prison act.',
+          nomis_type: 'Prison act.',
           reason: 'Because',
           location: {
             title: 'HMP Bedford',
@@ -60,7 +60,7 @@ describe('Presenters', function() {
         {
           id: '67890',
           start_time: '2020-10-10T15:00Z',
-          activity_type: 'Prison act.',
+          nomis_type: 'Prison act.',
           reason: 'Bricklaying course',
           location: {
             title: 'HMP Bedford',
@@ -69,7 +69,7 @@ describe('Presenters', function() {
         {
           id: '09876',
           start_time: '2020-10-10T08:00Z',
-          activity_type: 'Court date',
+          nomis_type: 'Court date',
           reason: 'Sentence',
           location: {
             title: 'Luton Crown Court',
@@ -117,19 +117,19 @@ describe('Presenters', function() {
             rows: [
               [
                 { text: mockTimetable[2].start_time },
-                { text: mockTimetable[2].activity_type },
+                { text: mockTimetable[2].nomis_type },
                 { text: mockTimetable[2].reason },
                 { text: mockTimetable[2].location.title },
               ],
               [
                 { text: mockTimetable[0].start_time },
-                { text: mockTimetable[0].activity_type },
+                { text: mockTimetable[0].nomis_type },
                 { text: mockTimetable[0].reason },
                 { text: mockTimetable[0].location.title },
               ],
               [
                 { text: mockTimetable[1].start_time },
-                { text: mockTimetable[1].activity_type },
+                { text: mockTimetable[1].nomis_type },
                 { text: mockTimetable[1].reason },
                 { text: mockTimetable[1].location.title },
               ],
@@ -145,7 +145,7 @@ describe('Presenters', function() {
             {
               id: '12345',
               start_time: null,
-              activity_type: null,
+              nomis_type: null,
               reason: null,
             },
           ])

--- a/common/services/court-hearing.js
+++ b/common/services/court-hearing.js
@@ -14,9 +14,15 @@ const courtHearingService = {
     })
   },
 
-  create(data) {
+  create(data, disableSaveToNomis = false) {
+    const params = {}
+
+    if (disableSaveToNomis) {
+      params.do_not_save_to_nomis = true
+    }
+
     return apiClient
-      .create('court_hearing', courtHearingService.format(data))
+      .create('court_hearing', courtHearingService.format(data), params)
       .then(response => response.data)
   },
 }

--- a/common/services/court-hearing.test.js
+++ b/common/services/court-hearing.test.js
@@ -97,18 +97,62 @@ describe('Court Hearing Service', function() {
 
     beforeEach(async function() {
       sinon.stub(apiClient, 'create').resolves(mockResponse)
-      courtHearing = await courtHearingService.create(mockData)
     })
 
-    it('should call create method with data', function() {
-      expect(apiClient.create).to.be.calledOnceWithExactly(
-        'court_hearing',
-        mockData
-      )
+    context('by default', function() {
+      beforeEach(async function() {
+        courtHearing = await courtHearingService.create(mockData)
+      })
+
+      it('should create with empty params', function() {
+        expect(apiClient.create).to.be.calledOnceWithExactly(
+          'court_hearing',
+          mockData,
+          {}
+        )
+      })
+
+      it('should return court hearing', function() {
+        expect(courtHearing).to.deep.equal(mockResponse.data)
+      })
     })
 
-    it('should return court hearing', function() {
-      expect(courtHearing).to.deep.equal(mockResponse.data)
+    context('with disabled save set to true', function() {
+      beforeEach(async function() {
+        courtHearing = await courtHearingService.create(mockData, true)
+      })
+
+      it('should create with query string', function() {
+        expect(apiClient.create).to.be.calledOnceWithExactly(
+          'court_hearing',
+          mockData,
+          {
+            do_not_save_to_nomis: true,
+          }
+        )
+      })
+
+      it('should return court hearing', function() {
+        expect(courtHearing).to.deep.equal(mockResponse.data)
+      })
+    })
+
+    context('with disabled save set to true', function() {
+      beforeEach(async function() {
+        courtHearing = await courtHearingService.create(mockData, false)
+      })
+
+      it('should create with empty params', function() {
+        expect(apiClient.create).to.be.calledOnceWithExactly(
+          'court_hearing',
+          mockData,
+          {}
+        )
+      })
+
+      it('should return court hearing', function() {
+        expect(courtHearing).to.deep.equal(mockResponse.data)
+      })
     })
   })
 })

--- a/common/services/person.js
+++ b/common/services/person.js
@@ -152,11 +152,11 @@ const personService = {
 
     return apiClient
       .one('person', personId)
-      .all('timetable')
+      .all('timetable_entry')
       .get({
         filter: {
-          'filter[date_from]': date,
-          'filter[date_to]': date,
+          date_from: date,
+          date_to: date,
         },
       })
       .then(response => response.data)

--- a/common/services/person.test.js
+++ b/common/services/person.test.js
@@ -752,11 +752,11 @@ describe('Person Service', function() {
 
         it('should call correct api client methods', function() {
           expect(apiClient.one).to.be.calledOnceWithExactly('person', mockId)
-          expect(apiClient.all).to.be.calledOnceWithExactly('timetable')
+          expect(apiClient.all).to.be.calledOnceWithExactly('timetable_entry')
           expect(apiClient.get).to.be.calledOnceWithExactly({
             filter: {
-              'filter[date_from]': mockDate,
-              'filter[date_to]': mockDate,
+              date_from: mockDate,
+              date_to: mockDate,
             },
           })
         })
@@ -773,11 +773,11 @@ describe('Person Service', function() {
 
         it('should call correct api client methods', function() {
           expect(apiClient.one).to.be.calledOnceWithExactly('person', mockId)
-          expect(apiClient.all).to.be.calledOnceWithExactly('timetable')
+          expect(apiClient.all).to.be.calledOnceWithExactly('timetable_entry')
           expect(apiClient.get).to.be.calledOnceWithExactly({
             filter: {
-              'filter[date_from]': undefined,
-              'filter[date_to]': undefined,
+              date_from: undefined,
+              date_to: undefined,
             },
           })
         })

--- a/config/index.js
+++ b/config/index.js
@@ -126,6 +126,7 @@ module.exports = {
   FEATURE_FLAGS: {
     // TODO: Remove once court hearings are fully released
     PRISON_COURT_HEARINGS: process.env.FEATURE_FLAG_PRISON_COURT_HEARINGS,
+    PRISON_COURT_TIMETABLE: process.env.FEATURE_FLAG_PRISON_COURT_TIMETABLE,
     EDITABILITY: process.env.FEATURE_FLAG_EDITABILITY,
   },
   E2E: {

--- a/config/nunjucks/filters.js
+++ b/config/nunjucks/filters.js
@@ -211,10 +211,6 @@ function formatTime(value) {
     return 'Midnight'
   }
 
-  if (timeStr === '12pm') {
-    return 'Midday'
-  }
-
   return `${hours}${minutes}${suffix}`
 }
 

--- a/config/nunjucks/filters.test.js
+++ b/config/nunjucks/filters.test.js
@@ -478,13 +478,6 @@ describe('Nunjucks filters', function() {
           })
         })
 
-        context('when the time is 12pm', function() {
-          it('should midday as a string', function() {
-            const time = filters.formatTime('2000-01-01T12:00:00Z')
-            expect(time).to.equal('Midday')
-          })
-        })
-
         context('when time is in the morning', function() {
           it('should return correct format', function() {
             const time = filters.formatTime('2000-01-01T08:00:00Z')

--- a/locales/en/fields.json
+++ b/locales/en/fields.json
@@ -114,7 +114,8 @@
         "label": "Yes"
       },
       "no": {
-        "label": "No"
+        "label": "No",
+        "hint": "A court date will not be added to NOMIS"
       }
     }
   },

--- a/locales/en/moves.json
+++ b/locales/en/moves.json
@@ -161,7 +161,7 @@
     "page_title_proposed": "Move sent for {{name}}",
     "detail": "The move for <strong><a href=\"{{href}}\">{{name}}</a></strong> to <strong>{{location}}</strong> on <strong>{{date}}</strong> has been requested with {{supplier}}.",
     "detail_proposed": "The move for <strong><a href=\"{{href}}\">{{name}}</a></strong> to <strong>{{location}}</strong> has been sent to the Population Management Unit (PMU) for review.",
-    "saved_to_nomis": "<p>A court date for case number <strong>{{cases}}</strong> on <strong>{{date}}</strong> has been added to NOMIS.</p><p>If this person has more than one hearing you will need to add any extra court dates.</p>",
+    "saved_to_nomis": "<p>One court date for case number <strong>{{cases}}</strong> on <strong>{{date}}</strong> has been added to NOMIS.</p><p>Add additional court dates for {{date}} in NOMIS.</p>",
     "saved_to_nomis_plural": "<p>Court dates for case numbers <strong>{{cases}}</strong> on <strong>{{date}}</strong> have been added to NOMIS.</p>",
     "saved_to_nomis_failed": "You need to add this court date to NOMIS as it could not be added.",
     "saved_to_nomis_failed_plural": "You need to add court dates to NOMIS for {{cases}} as they could not be added."

--- a/locales/en/validation.json
+++ b/locales/en/validation.json
@@ -11,6 +11,8 @@
   "date_with_label": "{{label}} must be a valid date",
   "time": "must be a valid time, for example 12:00 or 12pm",
   "time_with_label": "{{label}} must be a valid time, for example 12:00 or 12pm",
+  "datetime": "$t(validation::time)",
+  "datetime_with_label": "{{label}} $t(validation::time)",
   "after": "must be in the future",
   "after_with_label": "{{label}} must be in the future",
   "before": "must be in the past",

--- a/test/e2e/pages/create-move.js
+++ b/test/e2e/pages/create-move.js
@@ -328,7 +328,7 @@ class CreateMovePage extends Page {
    * @returns {Promise}
    */
   async fillInCourtHearings() {
-    await t.expect(this.getCurrentUrl()).contains('/move/new/hearing-details')
+    await t.expect(this.getCurrentUrl()).contains('/move/new/court-hearings')
 
     return fillInForm({
       hasCourtCase: {

--- a/test/e2e/smoke.test.js
+++ b/test/e2e/smoke.test.js
@@ -46,7 +46,7 @@ const usersWhoHaveADashboard = [
   },
 ]
 
-fixture.only('Smoke tests')
+fixture('Smoke tests')
 
 users.forEach(user => {
   test.before(async t => {

--- a/test/fixtures/api-client/timetable_entry.findAll.json
+++ b/test/fixtures/api-client/timetable_entry.findAll.json
@@ -2,10 +2,10 @@
   "data": [
     {
       "id": "007f6aa0-7d82-4bf1-9191-2e27235d0f76",
-      "type": "timetable",
+      "type": "timetable_entries",
       "attributes": {
         "start_time": "2016-11-14",
-        "activity_type": "Prison activities",
+        "nomis_type": "Prison activities",
         "reason": "Bricklaying course"
       },
       "relationships": {
@@ -19,10 +19,10 @@
     },
     {
       "id": "0194fe97-fa7e-49f5-b109-e1db6fee2190",
-      "type": "timetable",
+      "type": "timetable_entries",
       "attributes": {
         "start_time": "2018-10-10",
-        "activity_type": "Court date",
+        "nomis_type": "Court date",
         "reason": "Sentencing"
       },
       "relationships": {
@@ -36,10 +36,10 @@
     },
     {
       "id": "04a177a2-b899-425d-90ec-47f61cc5cc2d",
-      "type": "timetable",
+      "type": "timetable_entries",
       "attributes": {
         "start_time": "2017-04-19",
-        "activity_type": "Prison activities",
+        "nomis_type": "Prison activities",
         "reason": "PE"
       },
       "relationships": {


### PR DESCRIPTION
## Proposed

This adds the timetable step to the existing journey that was built in #459.

It now also includes some updates to the way the frontend talks to the API and some extra validation to ensure the start time of the court hearing is in the future.

This work also adds a feature flag so this can be merged and deployed without being immediately released.