### PR TITLE
fix: Update court cases endpoint to only return active cases

### DIFF
--- a/app/move/controllers/create/court-hearings.js
+++ b/app/move/controllers/create/court-hearings.js
@@ -21,7 +21,7 @@ class CourtHearingsController extends CreateBaseController {
     }
 
     try {
-      const courtCases = await personService.getCourtCases(person.id)
+      const courtCases = await personService.getActiveCourtCases(person.id)
       const {
         court_hearing__court_case: courtCaseField,
       } = req.form.options.fields

--- a/app/move/controllers/create/court-hearings.test.js
+++ b/app/move/controllers/create/court-hearings.test.js
@@ -70,7 +70,7 @@ describe('Move controllers', function() {
       let req, nextSpy
 
       beforeEach(function() {
-        sinon.stub(personService, 'getCourtCases')
+        sinon.stub(personService, 'getActiveCourtCases')
         sinon.stub(componentService, 'getComponent').returnsArg(0)
         sinon.stub(presenters, 'courtCaseToCardComponent').returnsArg(0)
         req = {
@@ -96,7 +96,7 @@ describe('Move controllers', function() {
         })
 
         it('should not person service', function() {
-          expect(personService.getCourtCases).not.to.be.called
+          expect(personService.getActiveCourtCases).not.to.be.called
         })
 
         it('should not set court case items', function() {
@@ -115,11 +115,11 @@ describe('Move controllers', function() {
           req.sessionModel.get.withArgs('person').returns(mockPerson)
         })
 
-        context('when getCourtCases rejects', function() {
+        context('when getActiveCourtCases rejects', function() {
           const mockError = new Error('Mock error')
 
           beforeEach(async function() {
-            personService.getCourtCases.rejects(mockError)
+            personService.getActiveCourtCases.rejects(mockError)
             await controller.setCourtCaseItems(req, {}, nextSpy)
           })
 
@@ -134,9 +134,9 @@ describe('Move controllers', function() {
           })
         })
 
-        context('when getCourtCases resolves', function() {
+        context('when getActiveCourtCases resolves', function() {
           beforeEach(async function() {
-            personService.getCourtCases.resolves(mockCourtCases)
+            personService.getActiveCourtCases.resolves(mockCourtCases)
             await controller.setCourtCaseItems(req, {}, nextSpy)
           })
 

--- a/common/services/person.js
+++ b/common/services/person.js
@@ -121,7 +121,7 @@ const personService = {
       .then(response => response.data.url)
   },
 
-  getCourtCases(personId) {
+  getActiveCourtCases(personId) {
     if (!personId) {
       return Promise.reject(new Error('No ID supplied'))
     }
@@ -129,7 +129,9 @@ const personService = {
     return apiClient
       .one('person', personId)
       .all('court_case')
-      .get()
+      .get({
+        'filter[active]': true,
+      })
       .then(response => response.data)
   },
 

--- a/common/services/person.test.js
+++ b/common/services/person.test.js
@@ -832,7 +832,7 @@ describe('Person Service', function() {
     })
   })
 
-  describe('#getCourtCases()', function() {
+  describe('#getActiveCourtCases()', function() {
     const mockId = 'b695d0f0-af8e-4b97-891e-92020d6820b9'
     const mockResponse = {
       data: [
@@ -854,7 +854,7 @@ describe('Person Service', function() {
 
     context('without ID', function() {
       it('should reject with error', function() {
-        return expect(personService.getCourtCases()).to.be.rejectedWith(
+        return expect(personService.getActiveCourtCases()).to.be.rejectedWith(
           'No ID supplied'
         )
       })
@@ -862,13 +862,15 @@ describe('Person Service', function() {
 
     context('with ID', function() {
       beforeEach(async function() {
-        imageUrl = await personService.getCourtCases(mockId)
+        imageUrl = await personService.getActiveCourtCases(mockId)
       })
 
       it('should call correct api client methods', function() {
         expect(apiClient.one).to.be.calledOnceWithExactly('person', mockId)
         expect(apiClient.all).to.be.calledOnceWithExactly('court_case')
-        expect(apiClient.get).to.be.calledOnceWithExactly()
+        expect(apiClient.get).to.be.calledOnceWithExactly({
+          'filter[active]': true,
+        })
       })
 
       it('should return image url property', function() {


### PR DESCRIPTION
The API endpoint has been updated to include a filter to show active
court cases rather. This is the corresponding change on the frontend
to support that update.

cc/ @alexdesi 