### PR TITLE
build: Output cache key when debugging API client

### DIFF
--- a/common/lib/api-client/middleware/request.js
+++ b/common/lib/api-client/middleware/request.js
@@ -28,7 +28,7 @@ function requestMiddleware({ cacheExpiry = 60, disableCache = false } = {}) {
       const cacheModel = get(models, `${req.model}.options.cache`)
 
       if (!cacheModel || req.params.cache === false || disableCache) {
-        debug('Uncached')
+        debug('NO CACHE', key)
         return jsonApi.axios(req)
       }
 
@@ -36,11 +36,11 @@ function requestMiddleware({ cacheExpiry = 60, disableCache = false } = {}) {
         .client.getAsync(key)
         .then(response => {
           if (!response) {
-            debug('From cache (uncached)')
+            debug('CACHED (first hit)', key)
             return jsonApi.axios(req).then(cacheResponse(key, cacheExpiry))
           }
 
-          debug('From cache (cached)')
+          debug('CACHED', key)
           return {
             data: JSON.parse(response),
           }


### PR DESCRIPTION
This adds the key that is used to cache requests from the API in
the devour middleware debugging lines. This then allows you to see
what URLs are being called on the API.