### PR TITLE
Update move detail banners

### DIFF
--- a/app/move/controllers/view.js
+++ b/app/move/controllers/view.js
@@ -15,7 +15,7 @@ module.exports = function view(req, res) {
     cancellationReason === 'other'
       ? cancellationComments
       : req.t(`fields::cancellation_reason.items.${cancellationReason}.label`)
-
+  const bannerStatuses = ['cancelled']
   const urls = {
     update: {},
   }
@@ -51,7 +51,9 @@ module.exports = function view(req, res) {
       person.assessment_answers,
       'court'
     ),
-    messageTitle: req.t('statuses::' + status),
+    messageTitle: bannerStatuses.includes(status)
+      ? req.t('statuses::' + status)
+      : undefined,
     messageContent: req.t('statuses::description', {
       context: status,
       reason,

--- a/app/move/controllers/view.test.js
+++ b/app/move/controllers/view.test.js
@@ -198,7 +198,7 @@ describe('Move controllers', function() {
       it('should contain message title param', function() {
         const params = res.render.args[0][1]
         expect(params).to.have.property('messageTitle')
-        expect(params.messageTitle).to.equal('statuses::requested')
+        expect(params.messageTitle).to.equal(undefined)
       })
 
       it('should contain message content param', function() {

--- a/app/move/views/cancel.njk
+++ b/app/move/views/cancel.njk
@@ -9,12 +9,12 @@
 {% endblock %}
 
 {% block beforeContent %}
-  {{ super() }}
-
   {{ govukBackLink({
     text: t("actions::back_to_move"),
     href: "/move/" + move.id
   }) }}
+
+  {{ super() }}
 {% endblock %}
 
 {% block formActions %}

--- a/app/move/views/confirmation.njk
+++ b/app/move/views/confirmation.njk
@@ -10,10 +10,6 @@
     name: move.person.fullname | upper }) }}
 {% endblock %}
 
-{% block beforeContent %}
-  {{ super() }}
-{% endblock %}
-
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">

--- a/app/move/views/create/save-conflict.njk
+++ b/app/move/views/create/save-conflict.njk
@@ -5,14 +5,14 @@
 {% endblock %}
 
 {% block beforeContent %}
-  {{ super() }}
-
   {% if backLink and not options.hideBackLink %}
     {{ govukBackLink({
       text: t("actions::back"),
       href: backLink
     }) }}
   {% endif %}
+
+  {{ super() }}
 {% endblock %}
 
 {% block contentHeader %}

--- a/app/move/views/view.njk
+++ b/app/move/views/view.njk
@@ -13,8 +13,6 @@
 {% endblock %}
 
 {% block beforeContent %}
-  {{ super() }}
-
   {{ govukBackLink({
     text: t("actions::back_to_dashboard"),
     classes: "app-print--hide",
@@ -24,6 +22,8 @@
   <a href="javascript:window.print()" class="app-!-float-right app-print--hide govuk-!-margin-top-3 app-icon app-icon--print">
     {{ t("actions::print_move_detail") }}
   </a>
+
+  {{ super() }}
 
   {% if messageTitle %}
     {{ appMessage({

--- a/app/move/views/view.njk
+++ b/app/move/views/view.njk
@@ -25,10 +25,10 @@
     {{ t("actions::print_move_detail") }}
   </a>
 
-  {% if move.status %}
+  {% if messageTitle %}
     {{ appMessage({
       allowDismiss: false,
-      classes: "app-message--info",
+      classes: "app-message--temporary",
       title: {
         text: messageTitle
       },
@@ -41,6 +41,14 @@
 
 {% block contentHeader %}
   <header class="govuk-!-margin-bottom-8">
+    {% if not messageTitle %}
+      <div class="govuk-!-margin-bottom-2">
+        {{ mojBadge({
+          text: t("statuses::" + move.status)
+        }) }}
+      </div>
+    {% endif %}
+
     <h1 class="govuk-heading-xl govuk-!-margin-bottom-1">
       {{ move.person.fullname | upper }}
     </h1>

--- a/common/templates/form-wizard.njk
+++ b/common/templates/form-wizard.njk
@@ -12,14 +12,14 @@
 {% endblock %}
 
 {% block beforeContent %}
-  {{ super() }}
-
   {% if backLink and not options.hideBackLink %}
     {{ govukBackLink({
       text: t("actions::back"),
       href: backLink
     }) }}
   {% endif %}
+
+  {{ super() }}
 {% endblock %}
 
 {% block contentHeader %}

--- a/common/templates/includes/messages.njk
+++ b/common/templates/includes/messages.njk
@@ -8,6 +8,7 @@
         title: {
           text: item.title or item
         },
+        focusOnload: true,
         content: {
           html: item.content
         }

--- a/common/templates/includes/messages.njk
+++ b/common/templates/includes/messages.njk
@@ -1,18 +1,20 @@
 {% set messages = getMessages() if getMessages %}
 
 {% if messages | length %}
-  {% for type, items in messages %}
-    {% for item in items %}
-      {{ appMessage({
-        classes: "app-message--" + type,
-        title: {
-          text: item.title or item
-        },
-        focusOnload: true,
-        content: {
-          html: item.content
-        }
-      }) }}
+  <div class="govuk-!-margin-top-3">
+    {% for type, items in messages %}
+      {% for item in items %}
+        {{ appMessage({
+          classes: "app-message--" + type,
+          title: {
+            text: item.title or item
+          },
+          focusOnload: true,
+          content: {
+            html: item.content
+          }
+        }) }}
+      {% endfor %}
     {% endfor %}
-  {% endfor %}
+  </div>
 {% endif %}

--- a/common/templates/layouts/base.njk
+++ b/common/templates/layouts/base.njk
@@ -17,8 +17,9 @@
 {% from "govuk/components/warning-text/macro.njk"      import govukWarningText %}
 {% from "govuk/components/table/macro.njk"             import govukTable %}
 
-{% from "moj/components/organisation-switcher/macro.njk" import mojOrganisationSwitcher %}
-{% from "moj/components/primary-navigation/macro.njk" import mojPrimaryNavigation %}
+{% from "moj/components/badge/macro.njk"                  import mojBadge %}
+{% from "moj/components/organisation-switcher/macro.njk"  import mojOrganisationSwitcher %}
+{% from "moj/components/primary-navigation/macro.njk"     import mojPrimaryNavigation %}
 
 {# App level components #}
 {% from "card/macro.njk"              import appCard %}

--- a/common/templates/layouts/base.njk
+++ b/common/templates/layouts/base.njk
@@ -100,23 +100,23 @@
       items: primaryNavigation
     }) }}
   {% endblock %}
-{% endblock %}
-
-{% block beforeContent %}
-
 
   {% block organisationSwitcher %}
     {% if CURRENT_LOCATION or canAccess("moves:view:all") %}
-      {{ mojOrganisationSwitcher({
-        text: CURRENT_LOCATION.title or t("locations::all_locations"),
-        link: {
-          text: t("actions::switch_location"),
-          href: '/locations'
-        } if USER.locations.length > 1
-      }) }}
+      <div class="govuk-width-container">
+        {{ mojOrganisationSwitcher({
+          text: CURRENT_LOCATION.title or t("locations::all_locations"),
+          link: {
+            text: t("actions::switch_location"),
+            href: '/locations'
+          } if USER.locations.length > 1
+        }) }}
+      </div>
     {% endif %}
   {% endblock %}
+{% endblock %}
 
+{% block beforeContent %}
   {% include "includes/messages.njk" %}
 {% endblock %}
 

--- a/locales/en/statuses.json
+++ b/locales/en/statuses.json
@@ -1,11 +1,9 @@
 {
+  "proposed": "Move pending",
   "requested": "Move requested",
   "accepted": "Move accepted",
   "completed": "Move completed",
   "cancelled": "Move cancelled",
   "description": "",
-  "description_requested": "This move has been requested with the supplier",
-  "description_accepted": "This move has been accepted by the supplier",
-  "description_completed": "This move has been completed",
   "description_cancelled": "Reason — {{reason}}"
 }


### PR DESCRIPTION
## Proposed changes

This updates the header section of the move detail page to use banners
less frequently and only for particular states. It reverts some changes
to introduce the banner for all statuses.

Now it uses the same style as on the dashboard to provide more continuity
across pages.

Particular states which need to draw more attention, like a cancelled
state, now use the temporary notice banner so that they are more obvious
that the move is in a unique state.

This change will also now better support the addition of "flash" banners that will appear after successfully saving updates.

## Screenshots

### Requested state

| Before | After |
| ------ | ----- |
| <kbd><img src="https://user-images.githubusercontent.com/3327997/80415379-5fc8fc00-88ca-11ea-9634-7a2ade3e78e7.png"></kbd> | <kbd><img src="https://user-images.githubusercontent.com/3327997/80414907-a9651700-88c9-11ea-8eb8-cad7cebe935e.png"></kbd> |

### Requested state (with other "badges")

| Before | After |
| ------ | ----- |
| <kbd><img src="https://user-images.githubusercontent.com/3327997/80415390-63f51980-88ca-11ea-9c5d-934f5e03bfa0.png"></kbd> | <kbd><img src="https://user-images.githubusercontent.com/3327997/80414897-a66a2680-88c9-11ea-812f-07c5e70493db.png"></kbd> |

### Proposed state (pending review)

| Before | After |
| ------ | ----- |
| <kbd><img src="https://user-images.githubusercontent.com/3327997/80475441-cab51a00-8940-11ea-90b3-adb65f27bf21.png"></kbd> | <kbd><img src="https://user-images.githubusercontent.com/3327997/80475525-e7e9e880-8940-11ea-98e9-e067b2883f33.png"></kbd> |

### Cancelled state

| Before | After |
| ------ | ----- |
| <kbd><img src="https://user-images.githubusercontent.com/3327997/80415407-6a839100-88ca-11ea-99c9-84a34dcd61e1.png"></kbd> | <kbd><img src="https://user-images.githubusercontent.com/3327997/80414918-acf89e00-88c9-11ea-9b20-9ab8bc63a56f.png"></kbd> |

### With other "flash" banners

| Before | After |
| ------ | ----- |
| <kbd><img src="https://user-images.githubusercontent.com/3327997/80416240-b5ea6f00-88cb-11ea-9f74-ee7831fd2fa4.png"></kbd> | <kbd><img src="https://user-images.githubusercontent.com/3327997/80472004-15806300-893c-11ea-84b1-ec8d57e7f59c.png"></kbd> |
