### PR TITLE
Improve loading of update steps

### DIFF
--- a/app/move/controllers/update/base.js
+++ b/app/move/controllers/update/base.js
@@ -76,7 +76,7 @@ class UpdateBaseController extends CreateBaseController {
 
       try {
         if (req.initialStep) {
-          values = this.getUpdateValues(req)
+          values = this.getUpdateValues(req, res)
         }
         this.protectReadOnlyFields(req, values)
       } catch (error) {

--- a/app/move/controllers/update/base.test.js
+++ b/app/move/controllers/update/base.test.js
@@ -444,7 +444,7 @@ describe('Move controllers', function() {
       })
       it('should call the getUpdateValues method with the correct args', function() {
         controller.getValues(req, res, callback)
-        expect(controller.getUpdateValues).to.be.calledOnceWithExactly(req)
+        expect(controller.getUpdateValues).to.be.calledOnceWithExactly(req, res)
       })
       it('should call the protectReadOnlyFields method with the correct args', function() {
         controller.getValues(req, res, callback)

--- a/app/move/controllers/view/view.update.links.js
+++ b/app/move/controllers/view/view.update.links.js
@@ -1,0 +1,28 @@
+const i18n = require('../../../../config/i18n')
+
+const getUpdateLinks = (updateSteps, urls) => {
+  const updateLinks = {}
+  updateSteps.forEach(updateJourney => {
+    const category = updateJourney.key
+    if (!urls[category]) {
+      return
+    }
+    const categoryText = i18n.t(`moves::update_link.categories.${category}`)
+    if (categoryText) {
+      updateLinks[category] = {
+        category,
+        attributes: {
+          'data-update-link': category,
+        },
+        href: urls[category],
+        html: i18n.t('moves::update_link.link_text', {
+          context: 'with_category',
+          category: categoryText,
+        }),
+      }
+    }
+  })
+  return updateLinks
+}
+
+module.exports = getUpdateLinks

--- a/app/move/controllers/view/view.update.links.test.js
+++ b/app/move/controllers/view/view.update.links.test.js
@@ -1,0 +1,78 @@
+const proxyquire = require('proxyquire')
+const i18n = {
+  t: sinon.stub(),
+}
+const getUpdateLinks = proxyquire('./view.update.links', {
+  '../../../../config/i18n': i18n,
+})
+
+const updateSteps = [
+  {
+    key: 'foo',
+  },
+  {
+    key: 'bar',
+  },
+]
+
+const urls = {
+  foo: '/move/moveId/edit/foo',
+}
+
+const expectedUpdateLinks = {
+  foo: {
+    attributes: {
+      'data-update-link': 'foo',
+    },
+    category: 'foo',
+    href: '/move/moveId/edit/foo',
+    html: 'Update foo',
+  },
+}
+
+describe('Move controllers', function() {
+  describe('#view()', function() {
+    describe('#getUpdateLinks', function() {
+      let updateLinks
+      const t = i18n.t
+      beforeEach(function() {
+        t.resetHistory()
+        t.callsFake((key, args) => {
+          if (args) {
+            return `Update ${args.category}`
+          }
+          return key.replace(/moves::update_link.categories./, '')
+        })
+        updateLinks = getUpdateLinks(updateSteps, urls)
+      })
+
+      it('should invoke t twice', function() {
+        expect(t.callCount).to.equal(2)
+      })
+
+      it('should invoke t first time with expected args', function() {
+        expect(t.getCall(0).args).to.deep.equal([
+          'moves::update_link.categories.foo',
+        ])
+      })
+
+      it('should invoke t second time with expected args', function() {
+        expect(t.getCall(1).args).to.deep.equal([
+          'moves::update_link.link_text',
+          {
+            context: 'with_category',
+            category: 'foo',
+          },
+        ])
+      })
+
+      it('should get expected value for key', function() {
+        expect(updateLinks.foo).to.deep.equal(expectedUpdateLinks.foo)
+      })
+
+      it('should return undefined if the route has no url', function() {
+        expect(updateLinks.bar).to.be.undefined
+      })
+    })
+  })
+})

--- a/app/move/controllers/view/view.update.urls.js
+++ b/app/move/controllers/view/view.update.urls.js
@@ -1,0 +1,19 @@
+const { check } = require('../../../../common/middleware/permissions')
+
+const getUpdateUrls = (updateSteps, moveId, userPermissions) => {
+  const updateUrls = {}
+  updateSteps.forEach(updateJourney => {
+    if (!check(updateJourney.permission, userPermissions)) {
+      return
+    }
+    const steps = updateJourney.steps
+    const entryPointUrl = Object.keys(steps).filter(
+      step => steps[step].entryPoint
+    )[0]
+    const key = updateJourney.key
+    updateUrls[key] = `/move/${moveId}/edit${entryPointUrl}`
+  })
+  return updateUrls
+}
+
+module.exports = getUpdateUrls

--- a/app/move/controllers/view/view.update.urls.test.js
+++ b/app/move/controllers/view/view.update.urls.test.js
@@ -1,0 +1,43 @@
+const getUpdateUrls = require('./view.update.urls')
+
+const updateSteps = [
+  {
+    key: 'foo',
+    permission: 'move:allowed',
+    steps: { '/foo': { entryPoint: true } },
+  },
+  {
+    key: 'bar',
+    permission: 'move:allowed',
+    steps: { '/another-step': {}, '/bar-details': { entryPoint: true } },
+  },
+  {
+    key: 'baz',
+    permission: 'move:forbidden',
+    steps: { '/baz': { entryPoint: true } },
+  },
+]
+
+describe('Move controllers', function() {
+  describe('#view()', function() {
+    describe('#getUpdateUrls', function() {
+      let updateUrls
+      const userPermissions = ['move:allowed']
+      beforeEach(function() {
+        updateUrls = getUpdateUrls(updateSteps, 'moveId', userPermissions)
+      })
+
+      it('should get expected value for key', function() {
+        expect(updateUrls.foo).to.equal('/move/moveId/edit/foo')
+      })
+
+      it('should get expected value for key when multiple steps exist', function() {
+        expect(updateUrls.bar).to.equal('/move/moveId/edit/bar-details')
+      })
+
+      it('should return undefined if the route is inaccessible', function() {
+        expect(updateUrls.baz).to.be.undefined
+      })
+    })
+  })
+})

--- a/app/move/index.js
+++ b/app/move/index.js
@@ -65,8 +65,9 @@ router.use(
 )
 
 if (FEATURE_FLAGS.EDITABILITY) {
-  updateSteps.forEach(updateStep => {
-    const key = Object.keys(updateStep)[0]
+  updateSteps.forEach(updateJourney => {
+    const steps = updateJourney.steps
+    const key = Object.keys(steps)[0]
     const updateStepConfig = {
       ...updateConfig,
       name: 'update-a-move' + key,
@@ -74,8 +75,8 @@ if (FEATURE_FLAGS.EDITABILITY) {
     }
     router.use(
       '/:moveId/edit',
-      protectRoute('move:update'),
-      wizard(updateStep, updateFields, updateStepConfig)
+      protectRoute(updateJourney.permission),
+      wizard(steps, updateFields, updateStepConfig)
     )
   })
 }

--- a/app/move/steps/update.js
+++ b/app/move/steps/update.js
@@ -1,44 +1,88 @@
-const { cloneDeep } = require('lodash')
-
 const {
   Assessment,
   MoveDate,
-  MoveDetails,
+  // TODO: reenable when redirect api available
+  // MoveDetails,
   PersonalDetails,
 } = require('../controllers/update')
 
 const createSteps = require('./create')
 
-const updateControllers = {
-  '/personal-details': PersonalDetails,
-  '/move-details': MoveDetails,
-  '/move-date': MoveDate,
-  '/court-information': Assessment,
-  '/risk-information': Assessment,
-  '/health-information': Assessment,
+const updateStepPropOverrides = {
+  entryPoint: true,
+  backLink: null,
+  next: undefined,
+  buttonText: 'actions::save_and_continue',
 }
 
-const provideStepProps = (key, step) => {
-  const stepProps = {
-    entryPoint: true,
-    backLink: null,
-    next: undefined,
-    buttonText: 'actions::save_and_continue',
-  }
-
-  const updatedStep = {
-    ...cloneDeep(step),
-    ...stepProps,
-  }
-
-  if (updateControllers[key]) {
-    updatedStep.controller = updateControllers[key]
-  }
-  return updatedStep
-}
-
-const updateSteps = Object.keys(createSteps)
-  .filter(key => updateControllers[key])
-  .map(key => ({ [key]: provideStepProps(key, createSteps[key]) }))
+const updateSteps = [
+  {
+    key: 'personal_details',
+    permission: 'move:update',
+    steps: {
+      '/personal-details': {
+        ...createSteps['/personal-details'],
+        ...updateStepPropOverrides,
+        controller: PersonalDetails,
+      },
+    },
+  },
+  // TODO: reenable when redirect api available
+  // {
+  //   key: 'move',
+  //   role: 'move:update',
+  //   steps: {
+  //     '/move-details': {
+  //       ...createSteps['/move-details'],
+  //       ...updateStepPropOverrides,
+  //       controller: MoveDetails,
+  //     },
+  //   },
+  // },
+  {
+    key: 'date',
+    permission: 'move:update',
+    steps: {
+      '/move-date': {
+        ...createSteps['/move-date'],
+        ...updateStepPropOverrides,
+        controller: MoveDate,
+      },
+    },
+  },
+  {
+    key: 'court',
+    permission: 'move:update',
+    steps: {
+      '/court-information': {
+        ...createSteps['/court-information'],
+        ...updateStepPropOverrides,
+        controller: Assessment,
+      },
+    },
+  },
+  {
+    key: 'risk',
+    permission: 'move:update',
+    steps: {
+      '/risk-information': {
+        ...createSteps['/risk-information'],
+        ...updateStepPropOverrides,
+        controller: Assessment,
+      },
+    },
+  },
+  {
+    key: 'health',
+    permission: 'move:update',
+    steps: {
+      '/health-information': {
+        ...createSteps['/health-information'],
+        ...updateStepPropOverrides,
+        controller: Assessment,
+      },
+    },
+  },
+]
 
 module.exports = updateSteps

--- a/app/move/views/_includes/assessment.njk
+++ b/app/move/views/_includes/assessment.njk
@@ -1,5 +1,5 @@
 {% for assessmentCategory in assessment %}
-  <section class="app-!-position-relative govuk-!-margin-top-7" data-app-section="{{ assessmentCategory.key }}">
+  <section class="app-!-position-relative govuk-!-margin-top-7">
     <h2 class="govuk-heading-m govuk-!-margin-bottom-2">
       {{ t('assessment::heading.text', {
         context: assessmentCategory.key
@@ -25,11 +25,11 @@
       }) }}
     {% endfor %}
 
-    {{ updateLink(assessmentCategory.key) }}
+    {{ updateLink(updateLinks[assessmentCategory.key]) }}
   </section>
 {% endfor %}
 
-<section class="app-!-position-relative" data-app-section="court">
+<section class="app-!-position-relative">
   {% if move.to_location.location_type == 'court' %}
     {% if move.from_location.location_type == 'prison' and not courtSummary.rows.length %}
       <h2 class="govuk-heading-m govuk-!-margin-bottom-2 govuk-!-margin-top-7">
@@ -93,5 +93,6 @@
       {% endif %}
     {% endif %}
   {% endif %}
-  {{ updateLink('court') }}
+
+  {{ updateLink(updateLinks.court) }}
 </section>

--- a/app/move/views/view.njk
+++ b/app/move/views/view.njk
@@ -68,27 +68,25 @@
   </header>
 {% endblock %}
 
-{% macro updateLink(category, permission='move:update', classes='app-!-position-top-right') %}
-  {% if canAccess(permission) %}
-    <p class="{{ classes }}">
-      <a href="{{ urls.update[category] }}" data-update-link="{{ category }}">
-        {{ t('moves::update_link.link_text', {
-          context: 'with_category',
-          category: t('moves::update_link.categories.' + category)
-        }) | safe }}
+{% macro updateLink(link) %}
+    {% if link.href %}
+    <p class="app-!-position-top-right">
+      <a href="{{ link.href }}" class="govuk-link" {%- for attribute, value in link.attributes %} {{attribute}}="{{value}}"{% endfor %}>
+        {{ link.html | safe }}
       </a>
     </p>
-  {% endif %}
+    {% endif %}
 {% endmacro %}
 
 {% block contentMain %}
-  <section class="app-!-position-relative" data-app-section="personal_details">
+  <section class="app-!-position-relative">
     <h2 class="govuk-heading-m">
       {{ t("moves::steps.personal_details.heading") }}
     </h2>
 
     {{ govukSummaryList(personalDetailsSummary) }}
-    {{ updateLink('personal_details') }}
+
+    {{ updateLink(updateLinks.personal_details) }}
   </section>
 
   {% include "move/views/_includes/assessment.njk" %}
@@ -154,8 +152,6 @@
         {% endif %}
 
         {{ appMetaList(moveSummary) }}
-        {# TODO: enable updating of move details when to_location can be set via api #}
-        {# {{ updateLink('move_details', classes='govuk-!-padding-top-4') }} #}
       </div>
     </div>
   {% endif %}

--- a/common/components/meta-list/_meta-list.scss
+++ b/common/components/meta-list/_meta-list.scss
@@ -32,3 +32,20 @@
 .app-meta-list__value {
   margin: 0;
 }
+
+.app-meta-list__action {
+  margin: 0;
+}
+
+@include govuk-media-query($from: tablet) {
+  .app-meta-list__item {
+    position: relative;
+  }
+
+  .app-meta-list__action--sidebar {
+    @include govuk-font($size: 16);
+    position: absolute;
+    top: 0;
+    right: 0;
+  }
+}

--- a/common/components/meta-list/meta-list.yaml
+++ b/common/components/meta-list/meta-list.yaml
@@ -34,6 +34,27 @@ params:
       type: string
       required: true
       description: If `text` is set, this is not required. HTML to use within each item value. If `html` is provided, the `text` argument will be ignored.
+  - name: action
+    type: object
+    required: false
+    description: Action object for an item
+    params:
+    - name: text
+      type: string
+      required: true
+      description: If `html` is set, this is not required. Text to use within each action value. If `html` is provided, the `text` argument will be ignored.
+    - name: html
+      type: string
+      required: true
+      description: If `text` is set, this is not required. HTML to use within each action value. If `html` is provided, the `text` argument will be ignored.
+    - name: classes
+      type: string
+      required: flase
+      description: Classes to add to the action element. eg. app-meta-list__action--sidebar
+    - name: attributes
+      type: object
+      required: false
+      description: Attributes to use on the action link
 
 examples:
   - name: default
@@ -47,3 +68,20 @@ examples:
           text: To
         value:
           text: Work
+  - name: with action
+    data:
+      items:
+      - key:
+          text: From
+        value:
+          text: Home
+      - key:
+          text: To
+        value:
+          text: Work
+        action:
+          html: Action text
+          href: /action
+          classes: action-class
+          attributes:
+            foo: bar

--- a/common/components/meta-list/template.njk
+++ b/common/components/meta-list/template.njk
@@ -1,7 +1,7 @@
 <dl class="app-meta-list {% if params.classes -%} {{ params.classes }}{%- endif %}">
   {% for item in params.items %}
     {% if item.value.text or item.value.html %}
-      <div class="app-meta-list__item">
+      <div class="app-meta-list__item {% if item.classes -%} {{ item.classes }}{%- endif %}">
         {% if item.key.html or item.key.text %}
           <dt class="app-meta-list__key">
             {{ item.key.html | safe if item.key.html else item.key.text }}
@@ -11,6 +11,14 @@
         <dd class="app-meta-list__value">
           {{ item.value.html | safe if item.value.html else item.value.text }}
         </dd>
+
+        {% if item.action.html or item.action.text %}
+          <dd class="app-meta-list__action {% if item.action.classes -%} {{ item.action.classes }}{%- endif %}">
+            <a href="{{ item.action.href }}" class="govuk-link" {%- for attribute, value in item.action.attributes %} {{attribute}}="{{value}}"{% endfor %}>
+              {{ item.action.html | safe if item.action.html else item.action.text }}
+            </a>
+          </dd>
+        {% endif %}
       </div>
     {% endif %}
   {% endfor %}

--- a/common/components/meta-list/template.test.js
+++ b/common/components/meta-list/template.test.js
@@ -7,12 +7,13 @@ const examples = getExamples('meta-list')
 
 describe('Meta list component', function() {
   context('default', function() {
-    let $, $component, $items
+    let $, $component, $items, $action
 
     beforeEach(function() {
       $ = renderComponentHtmlToCheerio('meta-list', examples.default)
       $component = $('.app-meta-list')
       $items = $component.find('.app-meta-list__item')
+      $action = $component.find('.app-meta-list__action')
     })
 
     it('should render', function() {
@@ -21,6 +22,10 @@ describe('Meta list component', function() {
 
     it('should render correct number of items', function() {
       expect($items.length).to.equal(2)
+    })
+
+    it('should render no actions', function() {
+      expect($action.length).to.equal(0)
     })
   })
 
@@ -159,6 +164,41 @@ describe('Meta list component', function() {
 
     it('should not render item', function() {
       expect($items.length).to.equal(0)
+    })
+  })
+
+  context('with action', function() {
+    let $, $component, $action, $link
+
+    beforeEach(function() {
+      $ = renderComponentHtmlToCheerio('meta-list', examples['with action'])
+      $component = $('.app-meta-list')
+      $action = $component.find('.app-meta-list__action')
+      $link = $action.find('.govuk-link')
+    })
+
+    it('should render action', function() {
+      expect($action.length).to.equal(1)
+    })
+
+    it('should set correct class on action', function() {
+      expect($action.hasClass('action-class')).to.be.true
+    })
+
+    it('should render action link', function() {
+      expect($link.length).to.equal(1)
+    })
+
+    it('should set correct text for link', function() {
+      expect($link.text().trim()).to.equal('Action text')
+    })
+
+    it('should set correct href on link', function() {
+      expect($link.attr('href')).to.equal('/action')
+    })
+
+    it('should set correct attributes on link', function() {
+      expect($link.attr('foo')).to.equal('bar')
     })
   })
 })

--- a/common/presenters/move-to-meta-list-component.js
+++ b/common/presenters/move-to-meta-list-component.js
@@ -32,22 +32,32 @@ function setDateToDisplay({ date, dateFrom, dateTo }) {
   return null
 }
 
-function moveToMetaListComponent({
-  date,
-  date_from: dateFrom,
-  date_to: dateTo,
-  time_due: timeDue,
-  move_type: moveType,
-  from_location: fromLocation,
-  to_location: toLocation,
-  additional_information: additionalInfo,
-} = {}) {
+function moveToMetaListComponent(
+  {
+    date,
+    date_from: dateFrom,
+    date_to: dateTo,
+    time_due: timeDue,
+    move_type: moveType,
+    from_location: fromLocation,
+    to_location: toLocation,
+    additional_information: additionalInfo,
+  } = {},
+  actions = {}
+) {
   const destination = get(toLocation, 'title', 'Unknown')
   const destinationLabel =
     moveType === 'prison_recall'
       ? i18n.t('fields::move_type.items.prison_recall.label')
       : destination
   const additionalInformation = additionalInfo ? ` — ${additionalInfo}` : ''
+
+  Object.keys(actions).forEach(key => {
+    actions[key] = {
+      classes: 'app-meta-list__action--sidebar',
+      ...actions[key],
+    }
+  })
   const items = [
     {
       key: {
@@ -64,6 +74,7 @@ function moveToMetaListComponent({
       value: {
         text: destinationLabel + additionalInformation,
       },
+      action: actions.move,
     },
     {
       key: {
@@ -72,6 +83,7 @@ function moveToMetaListComponent({
       value: {
         text: setDateToDisplay({ date, dateFrom, dateTo }),
       },
+      action: actions.date,
     },
     {
       key: {

--- a/common/presenters/move-to-meta-list-component.test.js
+++ b/common/presenters/move-to-meta-list-component.test.js
@@ -59,6 +59,7 @@ describe('Presenters', function() {
             value: {
               text: `${mockMove.to_location.title} — ${mockMove.additional_information}`,
             },
+            action: undefined,
           })
         })
 
@@ -68,6 +69,7 @@ describe('Presenters', function() {
           expect(item).to.deep.equal({
             key: { text: '__translated__' },
             value: { text: 'Sunday 9 Jun 2019' },
+            action: undefined,
           })
         })
 
@@ -132,6 +134,7 @@ describe('Presenters', function() {
           expect(item).to.deep.equal({
             key: { text: '__translated__' },
             value: { text: 'Sunday 9 Jun 2019 (Today)' },
+            action: undefined,
           })
         })
       })
@@ -159,6 +162,7 @@ describe('Presenters', function() {
           expect(item).to.deep.equal({
             key: { text: '__translated__' },
             value: { text: 'Sunday 9 Jun 2019 (Tomorrow)' },
+            action: undefined,
           })
         })
       })
@@ -186,6 +190,7 @@ describe('Presenters', function() {
           expect(item).to.deep.equal({
             key: { text: '__translated__' },
             value: { text: 'Sunday 9 Jun 2019 (Yesterday)' },
+            action: undefined,
           })
         })
       })
@@ -211,6 +216,7 @@ describe('Presenters', function() {
           expect(item).to.deep.equal({
             key: { text: '__translated__' },
             value: { text: null },
+            action: undefined,
           })
         })
         it('returns the from date if there is no "to" date', function() {
@@ -221,6 +227,7 @@ describe('Presenters', function() {
           expect(item).to.deep.equal({
             key: { text: '__translated__' },
             value: { text: '__translated__ Friday 1 May 2020' },
+            action: undefined,
           })
         })
         it('returns the range if both dates are present', function() {
@@ -230,6 +237,7 @@ describe('Presenters', function() {
           expect(item).to.deep.equal({
             key: { text: '__translated__' },
             value: { text: '1 to 5 May 2020' },
+            action: undefined,
           })
         })
         it('returns the date if date and range are both present', function() {
@@ -240,8 +248,50 @@ describe('Presenters', function() {
           expect(item).to.deep.equal({
             key: { text: '__translated__' },
             value: { text: 'Friday 1 Jan 2021' },
+            action: undefined,
           })
         })
+      })
+    })
+
+    context('when provided with an action', function() {
+      let transformedResponse
+      const moveAction = {
+        href: '/move',
+        html: 'Update move',
+      }
+      const dateAction = {
+        href: '/date',
+        html: 'Update date',
+      }
+
+      const expectedMoveAction = {
+        ...moveAction,
+        classes: 'app-meta-list__action--sidebar',
+      }
+      const expectedDateAction = {
+        ...dateAction,
+        classes: 'app-meta-list__action--sidebar',
+      }
+
+      it('should add actions to move and date items', function() {
+        transformedResponse = moveToMetaListComponent(mockMove, {
+          move: moveAction,
+          date: dateAction,
+        })
+        const { items } = transformedResponse
+        expect(items[0].action).to.be.undefined
+        expect(items[1].action).to.deep.equal(expectedMoveAction)
+        expect(items[2].action).to.deep.equal(expectedDateAction)
+      })
+
+      it('should add actions to move and date items', function() {
+        transformedResponse = moveToMetaListComponent(mockMove, {
+          date: dateAction,
+        })
+        const { items } = transformedResponse
+        expect(items[1].action).to.be.undefined
+        expect(items[2].action).to.deep.equal(expectedDateAction)
       })
     })
   })

--- a/locales/en/moves.json
+++ b/locales/en/moves.json
@@ -179,7 +179,8 @@
     "categories": {
       "court": "information for the court",
       "health": "health information",
-      "move_details": "move details",
+      "date": "when this person is moving",
+      "move": "where this person is moving",
       "personal_details": "personal details",
       "risk": "risk information"
     }

--- a/test/e2e/_move.js
+++ b/test/e2e/_move.js
@@ -132,13 +132,7 @@ export async function checkNoUpdateLink(page) {
   return moveDetailPage.checkNoUpdateLink(page)
 }
 
-const updatePages = [
-  'personal_details',
-  'risk',
-  'health',
-  'court',
-  'move_details',
-]
+const updatePages = ['personal_details', 'risk', 'health', 'court', 'date']
 
 /**
  * Filter update pages into
@@ -267,7 +261,11 @@ export async function clickUpdateLink(page) {
 export async function checkUpdatePersonalDetails(options) {
   const { person } = t.ctx
   const updateMovePage = await clickUpdateLink('personal_details')
-  const updatedFields = await updateMovePage.fillInPersonalDetails({}, options)
+  const gender = person.gender === 'Female' ? 'Male' : 'Female'
+  const updatedFields = await updateMovePage.fillInPersonalDetails(
+    { gender },
+    options
+  )
   const updatedDetails = { ...person, ...updatedFields }
 
   await updateMovePage.submitForm()

--- a/test/e2e/_routes.js
+++ b/test/e2e/_routes.js
@@ -3,8 +3,9 @@ import { E2E } from '../../config'
 const getUpdatePageStub = page => {
   const updateMap = {
     court: 'court-information',
+    date: 'move-date',
     health: 'health-information',
-    move_details: 'move-details',
+    move: 'move-details',
     personal_details: 'personal-details',
     risk: 'risk-information',
   }

--- a/test/e2e/move.update.police.test.js
+++ b/test/e2e/move.update.police.test.js
@@ -17,7 +17,13 @@ if (FEATURE_FLAGS.EDITABILITY) {
   })
 
   test('User should see expected update links on move page', async () => {
-    await checkUpdateLinks(['personal_details', 'risk', 'health', 'court'])
+    await checkUpdateLinks([
+      'personal_details',
+      'risk',
+      'health',
+      'court',
+      'date',
+    ])
   })
 
   test('User should see be able to access update pages', async () => {
@@ -26,7 +32,7 @@ if (FEATURE_FLAGS.EDITABILITY) {
       'risk',
       'health',
       'court',
-      'move_details',
+      'date',
     ])
   })
 

--- a/test/e2e/pages/create-move.js
+++ b/test/e2e/pages/create-move.js
@@ -187,7 +187,7 @@ class CreateMovePage extends Page {
       },
       gender: {
         selector: this.fields.gender,
-        value: faker.random.arrayElement(['Male', 'Female']),
+        value: person.gender,
         type: 'radio',
       },
     }


### PR DESCRIPTION
- Enable multiple steps to be loaded per journey
- Enable different role per journey
- Use key for urls and locales lookup rather than brittle url munging
- Process all update link data up front in move view
- Add ability to moveSummaryList component to output action links
- Enable link to update move date
- Suppress updating of to location route until redirect endpoint in place
- Ensure e2e tests actually change gender

![Move_details_for_MCDERMOTT__JAMES](https://user-images.githubusercontent.com/4856/80515003-34511a80-8979-11ea-9828-73b7d72c87b3.png)


### Checklist

- [x] If adding new environment variables, they have been documented in the [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md)
- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
