### PR TITLE
[Fix] End-to-end tests for cancelled banner

### DIFF
--- a/common/presenters/move-to-card-component.js
+++ b/common/presenters/move-to-card-component.js
@@ -5,6 +5,10 @@ const personToCardComponent = require('./person-to-card-component')
 function moveToCardComponent({ showMeta = true, showTags = true } = {}) {
   return function item({ id, reference, person = {}, status }) {
     const href = `/move/${id}`
+    const excludedBadgeStatuses = ['cancelled']
+    const statusBadge = excludedBadgeStatuses.includes(status)
+      ? undefined
+      : { text: i18n.t(`statuses::${status}`) }
     const personCardComponent = personToCardComponent({ showMeta, showTags })({
       ...person,
       href,
@@ -12,9 +16,7 @@ function moveToCardComponent({ showMeta = true, showTags = true } = {}) {
 
     return {
       ...personCardComponent,
-      status: {
-        text: i18n.t(`statuses::${status}`),
-      },
+      status: statusBadge,
       caption: {
         text: i18n.t('moves::move_reference', {
           reference,

--- a/common/presenters/move-to-card-component.test.js
+++ b/common/presenters/move-to-card-component.test.js
@@ -67,18 +67,15 @@ describe('Presenters', function() {
 
         describe('translations', function() {
           it('should translate status', function() {
-            expect(i18n.t.firstCall).to.be.calledWithExactly(
+            expect(i18n.t).to.be.calledWithExactly(
               `statuses::${mockMove.status}`
             )
           })
 
           it('should translate move reference', function() {
-            expect(i18n.t.secondCall).to.be.calledWithExactly(
-              'moves::move_reference',
-              {
-                reference: 'AB12FS45',
-              }
-            )
+            expect(i18n.t).to.be.calledWithExactly('moves::move_reference', {
+              reference: 'AB12FS45',
+            })
           })
 
           it('should translate correct number of times', function() {
@@ -124,6 +121,35 @@ describe('Presenters', function() {
           showTags: false,
         })
       })
+    })
+
+    context('with statuses that should not show badge', function() {
+      const excludedStatuses = ['cancelled']
+
+      for (const excludedStatus of excludedStatuses) {
+        beforeEach(function() {
+          transformedResponse = moveToCardComponent()({
+            ...mockMove,
+            status: excludedStatus,
+          })
+        })
+
+        it('should not translate status', function() {
+          expect(i18n.t).not.to.be.calledWithExactly(
+            `statuses::${excludedStatus}`
+          )
+        })
+
+        it('should contain correct output', function() {
+          expect(transformedResponse).to.deep.equal({
+            ...mockPersonCardComponent,
+            status: undefined,
+            caption: {
+              text: '__translated__',
+            },
+          })
+        })
+      }
     })
   })
 })

--- a/test/e2e/pages/move-detail.js
+++ b/test/e2e/pages/move-detail.js
@@ -12,8 +12,8 @@ class MoveDetailPage extends Page {
       title: Selector('#main-content > header > h1'),
       subTitle: Selector('#main-content > header > span'),
       banner: Selector('.app-message--info'),
-      bannerHeading: Selector('.app-message--info .app-message__heading'),
-      bannerContent: Selector('.app-message--info .app-message__content'),
+      bannerHeading: Selector('.app-message--temporary .app-message__heading'),
+      bannerContent: Selector('.app-message--temporary .app-message__content'),
       cancelLink: Selector('.app-link--destructive').withText(
         'Cancel this move'
       ),


### PR DESCRIPTION
## Proposed changes

The banners were recently updated and the identifier used has also
changed.

This caused some of the end-to-end tests to fail.

This fix updates the identifier for that element to the new one.

This PR also contains an update to ensure the status badge is only shown for
cards that require them to be distinguished - cancelled moves are already separated
on the page.