### PR TITLE
refactor: Allow permission check to use string or array

### DIFF
--- a/common/middleware/permissions.js
+++ b/common/middleware/permissions.js
@@ -1,7 +1,10 @@
 const { get } = require('lodash')
 
-function check(permission, userPermissions = []) {
-  return userPermissions.includes(permission)
+function check(permissions, userPermissions = []) {
+  if (!Array.isArray(permissions)) {
+    permissions = [permissions]
+  }
+  return permissions.every(permission => userPermissions.includes(permission))
 }
 
 function protectRoute(permission) {


### PR DESCRIPTION
Update middleware check method (and all methods that piggyback on it) to accept a string or an array.

```
app.use(protectRoute(['foo', 'bar']))
equivalent to: app.use(protectRoute('foo'), protectRoute('bar'))
```

```
canAccess(['foo', 'bar'])
equivalent to: canAccess('foo') && canAccess('bar')
```


### Checklist

- [x] If adding new environment variables, they have been documented in the [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md)
- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
