### PR TITLE
[Fix] Date range filters

### DIFF
--- a/common/templates/layouts/list-view.njk
+++ b/common/templates/layouts/list-view.njk
@@ -9,7 +9,7 @@
   {% set displayDate = datetime | formatDateAsRelativeDay %}
 {% else %}
   {% set datetime = dateRange | formatISOWeek %}
-  {% set displayDate = dateRange | formatDateRange %}
+  {% set displayDate = dateRange | formatDateRangeAsRelativeWeek %}
 {% endif %}
 
 {% block pageTitle %}

--- a/config/nunjucks/filters.js
+++ b/config/nunjucks/filters.js
@@ -1,6 +1,5 @@
 const chrono = require('chrono-node')
 const {
-  differenceInDays,
   format,
   isThisWeek,
   isToday,
@@ -19,9 +18,6 @@ const pluralize = require('pluralize')
 
 const i18n = require('../i18n')
 const { DATE_FORMATS } = require('../index')
-const weekOptions = {
-  weekStartsOn: 1,
-}
 
 /**
  * Formats a date into the desired string format
@@ -73,13 +69,6 @@ function formatDateRange(value) {
   const [startDate, endDate] = dates.map(date =>
     isDate(date) ? date : parseISO(date)
   )
-  const isCurrentWeek =
-    isThisWeek(startDate, weekOptions) &&
-    differenceInDays(endDate, startDate) === 6
-
-  if (isCurrentWeek) {
-    return i18n.t('actions::current_week')
-  }
 
   const yearFormat = isSameYear(startDate, endDate) ? '' : ' yyyy'
   const monthFormat = isSameMonth(startDate, endDate) ? '' : ' MMM'
@@ -90,6 +79,45 @@ function formatDateRange(value) {
   const formattedEndDate = formatDate(endDate)
 
   return `${formattedStartDate} to ${formattedEndDate}`
+}
+
+/**
+ * Formats an array of dates into the desired string format
+ *
+ * With multiple dates it will join them using `to`
+ *
+ * @param  {Any} a any type
+ * @param  {String} a string date format to return
+ * @return {String} a formatted date
+ *
+ * @example {{ "2019-02-21" | formatDateRange }}
+ * @example {{ ["2019-02-21"] | formatDateRange }}
+ * @example {{ ["2019-02-21", "2019-02-28"] | formatDateRange }}
+ * @example {{ "2019-02-21" | formatDateRange("DD/MM/YY") }}
+ */
+function formatDateRangeAsRelativeWeek(value) {
+  const dates = filter(value)
+
+  if (!value || !Array.isArray(value) || dates.length === 0) {
+    return value
+  }
+
+  if (dates.length === 1) {
+    return formatDate(dates[0])
+  }
+
+  const options = { weekStartsOn: 1 }
+  const [startDate, endDate] = dates.map(date =>
+    isDate(date) ? date : parseISO(date)
+  )
+  const isCurrentWeek =
+    isThisWeek(startDate, options) && isThisWeek(endDate, options)
+
+  if (isCurrentWeek) {
+    return i18n.t('actions::current_week')
+  }
+
+  return formatDateRange(value)
 }
 
 function formatISOWeek(dateRange) {
@@ -226,6 +254,7 @@ function filesize(str) {
 module.exports = {
   formatDate,
   formatDateRange,
+  formatDateRangeAsRelativeWeek,
   formatDateWithDay,
   formatDateAsRelativeDay,
   formatISOWeek,

--- a/config/nunjucks/filters.test.js
+++ b/config/nunjucks/filters.test.js
@@ -1,4 +1,3 @@
-const { startOfWeek, endOfWeek } = require('date-fns')
 const proxyquire = require('proxyquire')
 const timezoneMock = require('timezone-mock')
 
@@ -218,25 +217,6 @@ describe('Nunjucks filters', function() {
             })
           }
         )
-
-        context('when dates and are in the current week', function() {
-          const weekOpts = {
-            weekStartsOn: 1,
-          }
-
-          beforeEach(function() {
-            sinon.stub(i18n, 't').returnsArg(0)
-          })
-
-          it('returns "this week"', function() {
-            expect(
-              formatDateRange([
-                startOfWeek(new Date(), weekOpts),
-                endOfWeek(new Date(), weekOpts),
-              ])
-            ).to.equal('actions::current_week')
-          })
-        })
       })
     })
 
@@ -289,25 +269,96 @@ describe('Nunjucks filters', function() {
             })
           }
         )
+      })
+    })
+  })
 
-        context('when dates and are in the current week', function() {
-          const weekOpts = {
-            weekStartsOn: 1,
-          }
+  describe('#formatDateRangeAsRelativeWeek()', function() {
+    beforeEach(function() {
+      const mockDate = new Date('2020-04-06')
+      this.clock = sinon.useFakeTimers(mockDate.getTime())
+      sinon.stub(i18n, 't').returnsArg(0)
+    })
 
-          beforeEach(function() {
-            sinon.stub(i18n, 't').returnsArg(0)
-          })
+    afterEach(function() {
+      this.clock.restore()
+    })
 
-          it('returns "this week"', function() {
-            expect(
-              formatDateRange([
-                startOfWeek(new Date(), weekOpts),
-                endOfWeek(new Date(), weekOpts),
-              ])
-            ).to.equal('actions::current_week')
-          })
+    context('when current dates are this week', function() {
+      context('with exact dates', function() {
+        it('should return `This week`', function() {
+          const formattedRange = filters.formatDateRangeAsRelativeWeek([
+            '2020-04-06',
+            '2020-04-12',
+          ])
+          expect(formattedRange).to.equal('actions::current_week')
         })
+      })
+
+      context('with dates within this week', function() {
+        it('should return `This week`', function() {
+          const formattedRange = filters.formatDateRangeAsRelativeWeek([
+            '2020-04-08',
+            '2020-04-12',
+          ])
+          expect(formattedRange).to.equal('actions::current_week')
+        })
+
+        it('should return `This week`', function() {
+          const formattedRange = filters.formatDateRangeAsRelativeWeek([
+            '2020-04-06',
+            '2020-04-10',
+          ])
+          expect(formattedRange).to.equal('actions::current_week')
+        })
+      })
+    })
+
+    context('when current dates are next week', function() {
+      it('should return `Next week`', function() {
+        const formattedRange = filters.formatDateRangeAsRelativeWeek([
+          '2020-04-13',
+          '2020-04-19',
+        ])
+        expect(formattedRange).to.equal('13 to 19 Apr 2020')
+        // expect(formattedRange).to.equal('Next week')
+      })
+    })
+
+    context('when current dates are last week', function() {
+      it('should return `Last week`', function() {
+        const formattedRange = filters.formatDateRangeAsRelativeWeek([
+          '2020-03-30',
+          '2020-04-05',
+        ])
+        expect(formattedRange).to.equal('30 Mar to 5 Apr 2020')
+        // expect(formattedRange).to.equal('Last week')
+      })
+    })
+
+    context('when dates are other weeks', function() {
+      it('should return date in default format', function() {
+        const formattedRange = filters.formatDateRangeAsRelativeWeek([
+          '2020-04-05',
+          '2020-04-12',
+        ])
+        expect(formattedRange).to.equal('5 to 12 Apr 2020')
+      })
+
+      it('should return date in default format', function() {
+        const formattedRange = filters.formatDateRangeAsRelativeWeek([
+          '2020-04-06',
+          '2020-04-13',
+        ])
+        expect(formattedRange).to.equal('6 to 13 Apr 2020')
+      })
+
+      it('should return date in default format', function() {
+        const formattedRange = filters.formatDateRangeAsRelativeWeek([
+          '2017-08-01',
+          '2017-08-08',
+        ])
+        expect(formattedRange).to.equal('1 to 8 Aug 2017')
       })
     })
   })

--- a/config/nunjucks/filters.test.js
+++ b/config/nunjucks/filters.test.js
@@ -145,79 +145,171 @@ describe('Nunjucks filters', function() {
 
   describe('#formatDateRange', function() {
     const formatDateRange = filters.formatDateRange
-    context('when unforeseen parameters are passed to it', function() {
-      it('returns empty string if passed empty string', function() {
-        expect(formatDateRange('')).to.equal('')
-      })
-      it('returns a string if passed a string', function() {
-        expect(formatDateRange('10/10/2019')).to.equal('10/10/2019')
-      })
-      it('accepts a null second date', function() {
-        expect(formatDateRange(['10/10/2019', null])).to.equal('10/10/2019')
-      })
-      it('returns other unexpected things if passed to it', function() {
-        expect(formatDateRange({ time: '1' })).to.deep.equal({ time: '1' })
-        expect(formatDateRange(['2010-10-10'])).to.deep.equal(['2010-10-10'])
-      })
-      it('throws on invalid dates', function() {
-        expect(
-          formatDateRange.bind(null, ['2010-30-30', '2010-30-31'])
-        ).to.throw()
-      })
-    })
-    context('when dates as strings are passed to it ', function() {
-      it('returns the range correctly when spanning different years', function() {
-        expect(formatDateRange(['2019-11-01', '2020-01-18'])).to.equal(
-          '1 Nov 2019 to 18 Jan 2020'
-        )
-      })
-      it('returns the range correctly when spanning different months', function() {
-        expect(formatDateRange(['2019-11-01', '2019-12-10'])).to.equal(
-          '1 Nov to 10 Dec 2019'
-        )
-      })
-      it('returns the range correctly when in the same month', function() {
-        expect(formatDateRange(['2019-11-01', '2019-11-10'])).to.equal(
-          '1 to 10 Nov 2019'
-        )
-      })
-    })
-    context('when dates as date objects are passed to it ', function() {
-      it('returns the range correctly when spanning different years', function() {
-        expect(
-          formatDateRange([new Date('2019-11-01'), new Date('2020-01-18')])
-        ).to.equal('1 Nov 2019 to 18 Jan 2020')
-      })
-      it('returns the range correctly when spanning different months', function() {
-        expect(
-          formatDateRange([new Date('2019-11-01'), new Date('2019-12-10')])
-        ).to.equal('1 Nov to 10 Dec 2019')
-      })
-      it('returns the range correctly when in the same month', function() {
-        expect(
-          formatDateRange([new Date('2019-11-01'), new Date('2019-11-10')])
-        ).to.equal('1 to 10 Nov 2019')
-      })
-    })
-    context(
-      'when both start date and end date are on the current week ',
-      function() {
-        const weekOpts = {
-          weekStartsOn: 1,
-        }
-        before(function() {
-          sinon.stub(i18n, 't').returnsArg(0)
+
+    describe('invalid inputs', function() {
+      context('with no date range', function() {
+        it('returns input value', function() {
+          expect(formatDateRange()).to.be.undefined
+          expect(formatDateRange('')).to.equal('')
         })
-        it('returns "this week"', function() {
-          expect(
-            formatDateRange([
-              startOfWeek(new Date(), weekOpts),
-              endOfWeek(new Date(), weekOpts),
-            ])
-          ).to.equal('actions::current_week')
+      })
+
+      context('with empty array', function() {
+        it('returns input value', function() {
+          expect(formatDateRange([])).to.deep.equal([])
+          expect(formatDateRange(['', ''])).to.deep.equal(['', ''])
+          expect(formatDateRange(['', '', ''])).to.deep.equal(['', '', ''])
         })
-      }
-    )
+      })
+
+      context('with object', function() {
+        it('returns input value', function() {
+          expect(formatDateRange({ time: '1' })).to.deep.equal({ time: '1' })
+        })
+      })
+    })
+
+    context('with dates strings', function() {
+      const mockStartDate = '2019-11-01'
+
+      context('with one date', function() {
+        it('return formatted date', function() {
+          expect(formatDateRange(['', mockStartDate])).to.equal('1 Nov 2019')
+          expect(formatDateRange([mockStartDate, ''])).to.equal('1 Nov 2019')
+          expect(formatDateRange([mockStartDate])).to.equal('1 Nov 2019')
+          expect(formatDateRange(['', mockStartDate, ''])).to.equal(
+            '1 Nov 2019'
+          )
+        })
+      })
+
+      context('with two dates', function() {
+        context('when dates span different years', function() {
+          it('should contain both years', function() {
+            expect(formatDateRange([mockStartDate, '2020-01-18'])).to.equal(
+              '1 Nov 2019 to 18 Jan 2020'
+            )
+          })
+        })
+
+        context('when dates span different months', function() {
+          it('should contain both months', function() {
+            expect(formatDateRange([mockStartDate, '2019-12-10'])).to.equal(
+              '1 Nov to 10 Dec 2019'
+            )
+          })
+        })
+
+        context('when dates are in the same month', function() {
+          it('should contain both years', function() {
+            expect(formatDateRange([mockStartDate, '2019-11-10'])).to.equal(
+              '1 to 10 Nov 2019'
+            )
+          })
+        })
+
+        context(
+          'when dates are in the same month of different years',
+          function() {
+            it('should contain both years', function() {
+              expect(formatDateRange([mockStartDate, '2020-11-10'])).to.equal(
+                '1 Nov 2019 to 10 Nov 2020'
+              )
+            })
+          }
+        )
+
+        context('when dates and are in the current week', function() {
+          const weekOpts = {
+            weekStartsOn: 1,
+          }
+
+          beforeEach(function() {
+            sinon.stub(i18n, 't').returnsArg(0)
+          })
+
+          it('returns "this week"', function() {
+            expect(
+              formatDateRange([
+                startOfWeek(new Date(), weekOpts),
+                endOfWeek(new Date(), weekOpts),
+              ])
+            ).to.equal('actions::current_week')
+          })
+        })
+      })
+    })
+
+    context('with date objects', function() {
+      const mockStartDate = new Date('2019-11-01')
+
+      context('with one date', function() {
+        it('return formatted date', function() {
+          expect(formatDateRange(['', mockStartDate])).to.equal('1 Nov 2019')
+          expect(formatDateRange([mockStartDate, ''])).to.equal('1 Nov 2019')
+          expect(formatDateRange([mockStartDate])).to.equal('1 Nov 2019')
+          expect(formatDateRange(['', mockStartDate, ''])).to.equal(
+            '1 Nov 2019'
+          )
+        })
+      })
+
+      context('with two dates', function() {
+        context('when dates span different years', function() {
+          it('should contain both years', function() {
+            expect(
+              formatDateRange([mockStartDate, new Date('2020-01-18')])
+            ).to.equal('1 Nov 2019 to 18 Jan 2020')
+          })
+        })
+
+        context('when dates span different months', function() {
+          it('should contain both months', function() {
+            expect(
+              formatDateRange([mockStartDate, new Date('2019-12-10')])
+            ).to.equal('1 Nov to 10 Dec 2019')
+          })
+        })
+
+        context('when dates are in the same month', function() {
+          it('should contain both years', function() {
+            expect(
+              formatDateRange([mockStartDate, new Date('2019-11-10')])
+            ).to.equal('1 to 10 Nov 2019')
+          })
+        })
+
+        context(
+          'when dates are in the same month of different years',
+          function() {
+            it('should contain both years', function() {
+              expect(
+                formatDateRange([mockStartDate, new Date('2020-11-10')])
+              ).to.equal('1 Nov 2019 to 10 Nov 2020')
+            })
+          }
+        )
+
+        context('when dates and are in the current week', function() {
+          const weekOpts = {
+            weekStartsOn: 1,
+          }
+
+          beforeEach(function() {
+            sinon.stub(i18n, 't').returnsArg(0)
+          })
+
+          it('returns "this week"', function() {
+            expect(
+              formatDateRange([
+                startOfWeek(new Date(), weekOpts),
+                endOfWeek(new Date(), weekOpts),
+              ])
+            ).to.equal('actions::current_week')
+          })
+        })
+      })
+    })
   })
 
   describe('#calculateAge()', function() {


### PR DESCRIPTION
## Proposed changes

This set of changes improves the way date ranges are handled around the single request journeys.

It caters for when there is only date, ensuring it uses the same default format as elsewhere in the application as well as allowing relative dates to be explicitly used to avoid date ranges in a table being shown as "This week".

## Screenshots

| Before | After |
| ------ | ----- |
| <kbd><img src="https://user-images.githubusercontent.com/3327997/80604572-ca447e00-8a29-11ea-9f13-7c13d8e63d02.png"></kbd> | <kbd><img src="https://user-images.githubusercontent.com/3327997/80604682-f06a1e00-8a29-11ea-910d-e586aa30d4aa.png"></kbd> |
