### PR TITLE
Add download and print links to single requests dashboard

### DIFF
--- a/app/moves/controllers/dashboard.js
+++ b/app/moves/controllers/dashboard.js
@@ -1,3 +1,5 @@
 module.exports = function dashboard(req, res) {
-  res.render('moves/views/dashboard')
+  res.render('moves/views/dashboard', {
+    pageTitle: 'moves::dashboard.dashboard',
+  })
 }

--- a/app/moves/views/dashboard.njk
+++ b/app/moves/views/dashboard.njk
@@ -1,8 +1,10 @@
 {% extends "layouts/list-view.njk" %}
 
-{% block headerGridColumnClass %}govuk-grid-column-full{% endblock %}
+{% block headerActions %}{% endblock %}
 
-{% block headerActions %}
+{% block headerLinks %}{% endblock %}
+
+{% block pageContent %}
   {{ appFilter({
     items: dashboardMoveSummary,
     classes: "app-filter--stacked"

--- a/app/moves/views/dashboard.njk
+++ b/app/moves/views/dashboard.njk
@@ -5,8 +5,16 @@
 {% block headerLinks %}{% endblock %}
 
 {% block pageContent %}
-  {{ appFilter({
-    items: dashboardMoveSummary,
-    classes: "app-filter--stacked"
-  }) }}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-one-half">
+      <h2 class="govuk-heading-m govuk-!-margin-bottom-3">
+        {{ t("primary_navigation.single_requests") }}
+      </h2>
+
+      {{ appFilter({
+        items: dashboardMoveSummary,
+        classes: "app-filter--stacked"
+      }) }}
+    </div>
+  </div>
 {% endblock %}

--- a/app/moves/views/list-by-status.njk
+++ b/app/moves/views/list-by-status.njk
@@ -1,28 +1,16 @@
 {% extends "layouts/list-view.njk" %}
 
-{% block headerGridColumnClass %}govuk-grid-column-full{% endblock %}
-
-{% block headerActions %}
-  {% if canAccess('move:create') %}
-    {{ govukButton({
-      isStartButton: true,
-      text: t("actions::create_move"),
-      href: "/move/new",
-      classes: "govuk-!-margin-top-2 app-print--hide"
-    }) }}
-  {% endif %}
-  {{ appFilter({
-    items: moveTypeNavigation
-  }) }}
-{% endblock %}
-
 {% block pageContent %}
-{% if moves.length %}
-  {{ govukTable({
-    rows: moves,
-    head: movesHeads
-  }) }}
-{% else %}
+  {% if moves.length %}
+    {{ appFilter({
+      items: moveTypeNavigation
+    }) }}
+
+    {{ govukTable({
+      rows: moves,
+      head: movesHeads
+    }) }}
+  {% else %}
     {{ appMessage({
       classes: "app-message--muted govuk-!-margin-top-7",
       allowDismiss: false,
@@ -30,5 +18,5 @@
         html: t("moves::dashboard.single_moves_no_results")
       }
     }) }}
-{% endif %}
+  {% endif %}
 {% endblock %}

--- a/app/moves/views/list.njk
+++ b/app/moves/views/list.njk
@@ -1,36 +1,5 @@
 {% extends "layouts/list-view.njk" %}
 
-{% block headerActions %}
-  {% if canAccess('move:create') %}
-    {{ govukButton({
-      isStartButton: true,
-      text: t("actions::create_move"),
-      href: "/move/new",
-      classes: "govuk-!-margin-top-2 app-print--hide"
-    }) }}
-  {% endif %}
-{% endblock %}
-
-{% block headerNav %}
-  <div class="govuk-grid-column-one-third">
-    <ul class="govuk-list govuk-!-font-size-16 app-!-float-right app-print--hide">
-      {% if canAccess('moves:download') %}
-        <li>
-          <a href="{{ REQUEST_PATH }}/download.csv" class="app-icon app-icon--download">
-            {{ t("actions::download_csv") }}
-          </a>
-        </li>
-      {% endif %}
-
-      <li>
-        <a href="javascript:window.print()" class="app-icon app-icon--print">
-          {{ t("actions::print_move_list") }}
-        </a>
-      </li>
-    </ul>
-  </div>
-{% endblock %}
-
 {% block pageContent %}
   {% for destination in destinations %}
     <div class="

--- a/common/templates/layouts/list-view.njk
+++ b/common/templates/layouts/list-view.njk
@@ -21,20 +21,19 @@
 {% block content %}
 
   {% block pageHeader %}
-    <header class="govuk-grid-row">
-      <div class="{% block headerGridColumnClass %}govuk-grid-column-two-thirds{% endblock %}">
-        <span class="govuk-caption-xl">{{ t(pageTitle, {
-          context: "with_date"
-        }) }}</span>
-
-        {% block dateTitle %}
-          <h1 class="govuk-heading-xl govuk-!-margin-bottom-2">
-            {{ appTime({
-              datetime: datetime,
-              text: displayDate
-            }) }}
-          </h1>
-        {% endblock %}
+    <header class="govuk-grid-row govuk-!-margin-bottom-7">
+      <div class="govuk-grid-column-two-thirds">
+        <span class="govuk-caption-xl">
+          {{ t(pageTitle, {
+            context: "with_date"
+          }) }}
+        </span>
+        <h1 class="govuk-heading-xl govuk-!-margin-bottom-2">
+          {{ appTime({
+            datetime: datetime,
+            text: displayDate
+          }) }}
+        </h1>
 
         {% block dateNavigation %}
           {{ appPagination({
@@ -54,10 +53,37 @@
           }) }}
         {% endblock %}
 
-        {% block headerActions %}{% endblock %}
+        {% block headerActions %}
+          {% if canAccess('move:create') %}
+            {{ govukButton({
+              isStartButton: true,
+              text: t("actions::create_move"),
+              href: "/move/new",
+              classes: "govuk-!-margin-top-2 govuk-!-margin-bottom-0 app-print--hide"
+            }) }}
+          {% endif %}
+        {% endblock %}
       </div>
 
-      {% block headerNav %}{% endblock %}
+      {% block headerLinks %}
+        <div class="govuk-grid-column-one-third">
+          <ul class="govuk-list govuk-!-font-size-16 app-!-float-right app-print--hide">
+            {% if canAccess('moves:download') %}
+              <li>
+                <a href="{{ REQUEST_PATH }}/download.csv" class="app-icon app-icon--download">
+                  {{ t("actions::download_csv") }}
+                </a>
+              </li>
+            {% endif %}
+
+            <li>
+              <a href="javascript:window.print()" class="app-icon app-icon--print">
+                {{ t("actions::print_move_list") }}
+              </a>
+            </li>
+          </ul>
+        </div>
+      {% endblock %}
     </header>
   {% endblock %}
 

--- a/common/templates/layouts/list-view.njk
+++ b/common/templates/layouts/list-view.njk
@@ -14,6 +14,7 @@
 
 {% block pageTitle %}
   {{ t(pageTitle, {
+    context: "with_date",
     date: displayDate
   }) }}
 {% endblock %}

--- a/locales/en/moves.json
+++ b/locales/en/moves.json
@@ -97,14 +97,17 @@
     }
   },
   "dashboard": {
+    "dashboard": "Dashboard",
+    "dashboard_with_date": "Dashboard for {{date}}",
     "outgoing_moves": "Outgoing moves",
     "outgoing_moves_with_date": "Outgoing moves for {{date}}",
     "cancelled_moves": "{{count}} cancelled moves",
     "move_to": "Move to",
     "no_results": "No moves requested",
-    "single_moves": "Single moves",
-    "single_moves_no_results": "No moves proposed",
     "created_at": "Created at",
+    "single_moves": "Single requests sent",
+    "single_moves_with_date": "Single requests sent {{date}}",
+    "single_moves_no_results": "No single requests",
     "move_type": "Move type",
     "filter": {
       "proposed": "proposed",

--- a/locales/en/moves.json
+++ b/locales/en/moves.json
@@ -102,18 +102,19 @@
     "outgoing_moves": "Outgoing moves",
     "outgoing_moves_with_date": "Outgoing moves for {{date}}",
     "cancelled_moves": "{{count}} cancelled moves",
-    "move_to": "Move to",
     "no_results": "No moves requested",
-    "created_at": "Created at",
     "single_moves": "Single requests sent",
     "single_moves_with_date": "Single requests sent {{date}}",
     "single_moves_no_results": "No single requests",
+    "move_to": "Move to",
+    "earliest_move_date": "Earliest date of travel",
+    "created_at": "Sent on",
     "move_type": "Move type",
     "filter": {
-      "proposed": "proposed",
+      "proposed": "pending review",
       "approved": "approved",
       "rejected": "rejected",
-      "total": "single requests"
+      "total": "sent for review"
     }
   },
   "detail": {

--- a/locales/en/statuses.json
+++ b/locales/en/statuses.json
@@ -1,5 +1,5 @@
 {
-  "proposed": "Move pending",
+  "proposed": "Move pending review",
   "requested": "Move requested",
   "accepted": "Move accepted",
   "completed": "Move completed",


### PR DESCRIPTION
## Proposed changes

This set of changes includes adding back in the download (if a user has permission to download) and print links that appear on the other dashboards for the single requests page.

It also includes some updates to the content to make things more consistency across the different screens.

## Screenshots

*Click screenshots to enlarge*

### "Home"

| Before | After |
| ------ | ----- |
| <kbd><img src="https://user-images.githubusercontent.com/3327997/80610102-d7b13680-8a30-11ea-960a-63179280a917.png"></kbd> | <kbd><img src="https://user-images.githubusercontent.com/3327997/80609493-0b3f9100-8a30-11ea-9322-ce580cf075e2.png"></kbd> |

### Single requests

| Before | After |
| ------ | ----- |
| <kbd><img src="https://user-images.githubusercontent.com/3327997/80610027-bfd9b280-8a30-11ea-9fc9-62f509561e01.png"></kbd> | <kbd><img src="https://user-images.githubusercontent.com/3327997/80611665-d08b2800-8a32-11ea-8706-190a6b8fec5d.png"></kbd> |
| <kbd><img src="https://user-images.githubusercontent.com/3327997/80609924-9a4ca900-8a30-11ea-8500-f5b70b512caa.png"></kbd> | <kbd><img src="https://user-images.githubusercontent.com/3327997/80609821-79845380-8a30-11ea-98af-340fea45eee7.png"></kbd> |
