### PR TITLE
Use card component within table layout

### DIFF
--- a/app/moves/controllers/list.js
+++ b/app/moves/controllers/list.js
@@ -20,6 +20,7 @@ module.exports = function list(req, res) {
       presenters.moveToCardComponent({
         showMeta: false,
         showTags: false,
+        showImage: false,
       })
     ),
   }

--- a/app/moves/controllers/list.test.js
+++ b/app/moves/controllers/list.test.js
@@ -52,6 +52,7 @@ describe('Moves controllers', function() {
           expect(presenters.moveToCardComponent).to.be.calledOnceWithExactly({
             showMeta: false,
             showTags: false,
+            showImage: false,
           })
           expect(moveToCardComponentMapStub).to.be.calledTwice
         })
@@ -76,6 +77,7 @@ describe('Moves controllers', function() {
           expect(presenters.moveToCardComponent).to.be.calledOnceWithExactly({
             showMeta: false,
             showTags: false,
+            showImage: false,
           })
           expect(moveToCardComponentMapStub).not.to.be.called
         })

--- a/common/components/card/_card.scss
+++ b/common/components/card/_card.scss
@@ -15,6 +15,11 @@
   }
 }
 
+.app-card--compact {
+  border: 0;
+  padding: 0;
+}
+
 .app-card__aside {
   margin-right: govuk-spacing(4);
 }

--- a/common/presenters/move-to-card-component.js
+++ b/common/presenters/move-to-card-component.js
@@ -2,14 +2,24 @@ const i18n = require('../../config/i18n')
 
 const personToCardComponent = require('./person-to-card-component')
 
-function moveToCardComponent({ showMeta = true, showTags = true } = {}) {
+function moveToCardComponent({
+  isCompact = false,
+  showImage = true,
+  showMeta = true,
+  showTags = true,
+} = {}) {
   return function item({ id, reference, person = {}, status }) {
     const href = `/move/${id}`
     const excludedBadgeStatuses = ['cancelled']
-    const statusBadge = excludedBadgeStatuses.includes(status)
-      ? undefined
-      : { text: i18n.t(`statuses::${status}`) }
-    const personCardComponent = personToCardComponent({ showMeta, showTags })({
+    const statusBadge =
+      excludedBadgeStatuses.includes(status) || isCompact
+        ? undefined
+        : { text: i18n.t(`statuses::${status}`) }
+    const personCardComponent = personToCardComponent({
+      showImage: isCompact ? false : showImage,
+      showMeta: isCompact ? false : showMeta,
+      showTags: isCompact ? false : showTags,
+    })({
       ...person,
       href,
     })
@@ -17,6 +27,7 @@ function moveToCardComponent({ showMeta = true, showTags = true } = {}) {
     return {
       ...personCardComponent,
       status: statusBadge,
+      classes: isCompact ? 'app-card--compact' : '',
       caption: {
         text: i18n.t('moves::move_reference', {
           reference,

--- a/common/presenters/move-to-card-component.test.js
+++ b/common/presenters/move-to-card-component.test.js
@@ -47,6 +47,7 @@ describe('Presenters', function() {
               href: '/move/12345',
             })
             expect(personToCardComponentStub).to.be.calledWithExactly({
+              showImage: true,
               showMeta: true,
               showTags: true,
             })
@@ -55,6 +56,7 @@ describe('Presenters', function() {
           it('should contain correct output', function() {
             expect(transformedResponse).to.deep.equal({
               ...mockPersonCardComponent,
+              classes: '',
               status: {
                 text: '__translated__',
               },
@@ -85,6 +87,26 @@ describe('Presenters', function() {
       })
     })
 
+    context('with image disabled', function() {
+      beforeEach(function() {
+        transformedResponse = moveToCardComponent({
+          showImage: false,
+        })(mockMove)
+      })
+
+      it('should call person to card component correctly', function() {
+        expect(personToCardComponentItemStub).to.be.calledWithExactly({
+          ...mockMove.person,
+          href: '/move/12345',
+        })
+        expect(personToCardComponentStub).to.be.calledWithExactly({
+          showImage: false,
+          showMeta: true,
+          showTags: true,
+        })
+      })
+    })
+
     context('with meta disabled', function() {
       beforeEach(function() {
         transformedResponse = moveToCardComponent({
@@ -98,6 +120,7 @@ describe('Presenters', function() {
           href: '/move/12345',
         })
         expect(personToCardComponentStub).to.be.calledWithExactly({
+          showImage: true,
           showMeta: false,
           showTags: true,
         })
@@ -117,8 +140,74 @@ describe('Presenters', function() {
           href: '/move/12345',
         })
         expect(personToCardComponentStub).to.be.calledWithExactly({
+          showImage: true,
           showMeta: true,
           showTags: false,
+        })
+      })
+    })
+
+    context('with compact design', function() {
+      beforeEach(function() {
+        transformedResponse = moveToCardComponent({
+          isCompact: true,
+        })(mockMove)
+      })
+
+      it('should call person to card component correctly', function() {
+        expect(personToCardComponentItemStub).to.be.calledWithExactly({
+          ...mockMove.person,
+          href: '/move/12345',
+        })
+        expect(personToCardComponentStub).to.be.calledWithExactly({
+          showImage: false,
+          showMeta: false,
+          showTags: false,
+        })
+      })
+
+      it('should contain correct output', function() {
+        expect(transformedResponse).to.deep.equal({
+          ...mockPersonCardComponent,
+          classes: 'app-card--compact',
+          status: undefined,
+          caption: {
+            text: '__translated__',
+          },
+        })
+      })
+    })
+
+    context('with compact design and all others disabled', function() {
+      beforeEach(function() {
+        transformedResponse = moveToCardComponent({
+          isCompact: true,
+          showImage: true,
+          showMeta: true,
+          showTags: true,
+        })(mockMove)
+      })
+
+      it('should call person to card component correctly', function() {
+        expect(personToCardComponentItemStub).to.be.calledWithExactly({
+          ...mockMove.person,
+          href: '/move/12345',
+        })
+        expect(personToCardComponentStub).to.be.calledWithExactly({
+          showImage: false,
+          showMeta: false,
+          showTags: false,
+        })
+      })
+
+      it('should contain correct output', function() {
+        expect(transformedResponse).to.deep.equal({
+          ...mockPersonCardComponent,
+          classes: 'app-card--compact',
+          status: undefined,
+          caption: {
+            text: '__translated__',
+          },
         })
       })
     })
@@ -143,6 +232,7 @@ describe('Presenters', function() {
         it('should contain correct output', function() {
           expect(transformedResponse).to.deep.equal({
             ...mockPersonCardComponent,
+            classes: '',
             status: undefined,
             caption: {
               text: '__translated__',

--- a/common/presenters/moves-to-table.js
+++ b/common/presenters/moves-to-table.js
@@ -1,5 +1,7 @@
+const componentService = require('../../common/services/component')
 const filters = require('../../config/nunjucks/filters')
 
+const moveToCardComponent = require('./move-to-card-component')
 const tablePresenters = require('./table')
 
 const tableConfig = [
@@ -11,7 +13,8 @@ const tableConfig = [
       },
     },
     row: data => {
-      return `<a href="/move/${data.id}">${data.person.fullname}</a> (${data.person.identifiers[0].value})`
+      const card = moveToCardComponent({ isCompact: true })(data)
+      return componentService.getComponent('appCard', card)
     },
   },
   {

--- a/common/presenters/moves-to-table.test.js
+++ b/common/presenters/moves-to-table.test.js
@@ -1,6 +1,7 @@
 const proxyquire = require('proxyquire')
 
 const componentService = require('../../common/services/component')
+const filters = require('../../config/nunjucks/filters')
 
 const tablePresenters = require('./table')
 
@@ -109,6 +110,8 @@ describe('#movesToTable', function() {
     sinon.stub(tablePresenters, 'objectToTableHead').callsFake(arg => {
       return { html: arg.head }
     })
+    sinon.stub(filters, 'formatDate').returnsArg(0)
+    sinon.stub(filters, 'formatDateRange').returnsArg(0)
     sinon.stub(componentService, 'getComponent').returnsArg(0)
     output = presenter([])
   })
@@ -141,22 +144,22 @@ describe('#movesToTable', function() {
     })
     it('returns html with createdAt on the second cell', function() {
       expect(output.moves[0][1]).to.deep.equal({
-        html: '20 Apr 2020',
+        html: mockMoves[0].created_at,
       })
     })
     it('returns toLocation on the third cell', function() {
       expect(output.moves[0][2]).to.deep.equal({
-        html: 'ALBANY (HMP)',
+        html: mockMoves[0].to_location.title,
       })
     })
     it('returns the date range on the fourth cell', function() {
       expect(output.moves[0][3]).to.deep.equal({
-        html: '28 Sep 2020',
+        html: mockMoves[0].date_from,
       })
     })
     it('returns the move type on the fifth cell', function() {
       expect(output.moves[0][4]).to.deep.equal({
-        html: 'MAPPA',
+        html: mockMoves[0].prison_transfer_reason,
       })
     })
     it('returns a row per record', function() {

--- a/common/presenters/person-to-card-component.js
+++ b/common/presenters/person-to-card-component.js
@@ -5,7 +5,11 @@ const filters = require('../../config/nunjucks/filters')
 
 const assessmentToTagList = require('./assessment-to-tag-list')
 
-function personToCardComponent({ showMeta = true, showTags = true } = {}) {
+function personToCardComponent({
+  showImage = true,
+  showMeta = true,
+  showTags = true,
+} = {}) {
   return function item({
     href,
     gender,
@@ -14,8 +18,12 @@ function personToCardComponent({ showMeta = true, showTags = true } = {}) {
     date_of_birth: dateOfBirth,
     assessment_answers: assessmentAnswers,
   }) {
-    const meta = {}
-    const tags = {}
+    const card = {
+      href,
+      title: {
+        text: fullname.toUpperCase(),
+      },
+    }
 
     if (showMeta) {
       const dateOfBirthLabel = i18n.t('age', {
@@ -34,23 +42,23 @@ function personToCardComponent({ showMeta = true, showTags = true } = {}) {
         },
       ]
 
-      meta.items = filter(metaItems, 'text')
+      card.meta = {
+        items: filter(metaItems, 'text'),
+      }
     }
 
     if (showTags) {
-      tags.items = assessmentToTagList(assessmentAnswers, href)
+      card.tags = {
+        items: assessmentToTagList(assessmentAnswers, href),
+      }
     }
 
-    return {
-      href,
-      meta,
-      tags,
-      image_path: imageUrl,
-      image_alt: fullname.toUpperCase(),
-      title: {
-        text: fullname.toUpperCase(),
-      },
+    if (showImage) {
+      card.image_path = imageUrl
+      card.image_alt = fullname.toUpperCase()
     }
+
+    return card
   }
 }
 

--- a/common/presenters/person-to-card-component.test.js
+++ b/common/presenters/person-to-card-component.test.js
@@ -340,8 +340,7 @@ describe('Presenters', function() {
       })
 
       it('should not contain meta items', function() {
-        expect(transformedResponse).to.have.property('meta')
-        expect(transformedResponse.meta.items).to.be.undefined
+        expect(transformedResponse).not.to.have.property('meta')
       })
 
       it('should contain href', function() {
@@ -366,8 +365,36 @@ describe('Presenters', function() {
       })
 
       it('should not contain tags items', function() {
-        expect(transformedResponse).to.have.property('tags')
-        expect(transformedResponse.tags.items).to.be.undefined
+        expect(transformedResponse).not.to.have.property('tags')
+      })
+
+      it('should contain href', function() {
+        expect(transformedResponse).to.have.property('href')
+      })
+
+      it('should contain title', function() {
+        expect(transformedResponse).to.have.property('title')
+      })
+
+      it('should contain meta', function() {
+        expect(transformedResponse).to.have.property('meta')
+        expect(transformedResponse.meta.items.length).to.equal(2)
+      })
+    })
+
+    context('with image disabled', function() {
+      beforeEach(function() {
+        transformedResponse = personToCardComponent({
+          showImage: false,
+        })(mockPerson)
+      })
+
+      it('should not contain an image path', function() {
+        expect(transformedResponse).not.to.have.property('image_path')
+      })
+
+      it('should not contain image alt', function() {
+        expect(transformedResponse).not.to.have.property('image_alt')
       })
 
       it('should contain href', function() {

--- a/common/services/move.js
+++ b/common/services/move.js
@@ -59,6 +59,8 @@ const moveService = {
         'filter[created_at_from]': createdAtFrom,
         'filter[created_at_to]': createdAtTo,
         'filter[from_location_id]': fromLocationId,
+        'sort[by]': 'created_at',
+        'sort[direction]': 'desc',
       },
     })
   },

--- a/common/services/move.test.js
+++ b/common/services/move.test.js
@@ -508,6 +508,8 @@ describe('Move Service', function() {
             'filter[created_at_from]': mockDateRange[0],
             'filter[created_at_to]': mockDateRange[1],
             'filter[from_location_id]': mockFromLocationId,
+            'sort[by]': 'created_at',
+            'sort[direction]': 'desc',
           },
         })
       })
@@ -526,6 +528,8 @@ describe('Move Service', function() {
             'filter[created_at_from]': undefined,
             'filter[created_at_to]': undefined,
             'filter[from_location_id]': undefined,
+            'sort[by]': 'created_at',
+            'sort[direction]': 'desc',
           },
         })
       })

--- a/locales/en/moves.json
+++ b/locales/en/moves.json
@@ -1,6 +1,7 @@
 {
   "download_filename": "Moves on {{date}} (Downloaded {{timestamp}})",
-  "move_reference": "Move reference: {{reference}}",
+  "move_reference": "Reference: {{reference}}",
+  "move_reference_compact": "<span class=\"govuk-visally-hidden\">Reference: </span>{{reference}}",
   "steps": {
     "person_search": {
       "heading": "Who is being moved?",


### PR DESCRIPTION
This change make use of re-using the card component when displaying
moves within a table layout. This means we can have more consistency between different layouts
when displaying a person's information.

The word "Move" was also removed from the reference label so it could be displayed better in the table layout. This update occurs across existing dashboards and layouts too.

This change also includes an update to the ordering so that they are ordered by the latest created move.

## Screenshots

*Click image to enlarge*

| Before | After |
| ------ | ----- |
| <kbd><img src="https://user-images.githubusercontent.com/3327997/80633008-fffc5d80-8a4f-11ea-981d-f0db8ac35cbf.png"></kbd> | <kbd><img src="https://user-images.githubusercontent.com/3327997/80632584-63d25680-8a4f-11ea-9088-7d57efd20e7e.png"></kbd> |
| <kbd><img src="https://user-images.githubusercontent.com/3327997/80630420-186a7900-8a4c-11ea-9524-21e45e4c936e.png"></kbd> | <kbd><img src="https://user-images.githubusercontent.com/3327997/80630451-2a4c1c00-8a4c-11ea-9969-0715caa6e82b.png"></kbd> |