### PR TITLE
fix: Update how from and to dates are handled in the summary panel

### DIFF
--- a/common/presenters/move-to-meta-list-component.js
+++ b/common/presenters/move-to-meta-list-component.js
@@ -12,24 +12,16 @@ function isRelativeDate(date) {
   )
 }
 
-function formatDateRange(dateFrom, dateTo) {
-  if (dateTo) {
-    return filters.formatDateRange([dateFrom, dateTo])
+function _formatDate(date) {
+  if (!date) {
+    return
   }
-  return `${i18n.t('from')} ${filters.formatDateAsRelativeDay(dateFrom)}`
-}
 
-function setDateToDisplay({ date, dateFrom, dateTo }) {
-  if (date) {
-    const dateWithDay = filters.formatDateWithDay(date)
-    return isRelativeDate(date)
-      ? `${dateWithDay} (${filters.formatDateAsRelativeDay(date)})`
-      : dateWithDay
-  }
-  if (dateFrom) {
-    return formatDateRange(dateFrom, dateTo)
-  }
-  return null
+  const dateWithDay = filters.formatDateWithDay(date)
+
+  return isRelativeDate(date)
+    ? `${dateWithDay} (${filters.formatDateAsRelativeDay(date)})`
+    : dateWithDay
 }
 
 function moveToMetaListComponent(
@@ -81,9 +73,25 @@ function moveToMetaListComponent(
         text: i18n.t('fields::date_type.label'),
       },
       value: {
-        text: setDateToDisplay({ date, dateFrom, dateTo }),
+        text: _formatDate(date),
       },
       action: actions.date,
+    },
+    {
+      key: {
+        text: i18n.t('fields::date_from.label'),
+      },
+      value: {
+        text: date ? undefined : _formatDate(dateFrom),
+      },
+    },
+    {
+      key: {
+        text: i18n.t('fields::date_to.label'),
+      },
+      value: {
+        text: date ? undefined : _formatDate(dateTo),
+      },
     },
     {
       key: {


### PR DESCRIPTION
Previously we were combining the from and to date into the one date
row on the right hand move summary panel.

We've decided to split this into separate rows to give a clearer picture
of the situation.

This also fixes a bug where the mock date happened to be tomorrow and
we weren't mocking the date formatters which caused the text to be
different and the tests to start failing.

## Screenshots

### With only a move date (or all dates)

*No changes - posting for visual reference to other states*

| Before | After |
| ------ | ----- |
| <kbd><img src="https://user-images.githubusercontent.com/3327997/80694473-78086900-8acc-11ea-805f-39a90f228511.png"></kbd> | <kbd><img src="https://user-images.githubusercontent.com/3327997/80694473-78086900-8acc-11ea-805f-39a90f228511.png"></kbd> |

### With only a from date

| Before | After |
| ------ | ----- |
| <kbd><img src="https://user-images.githubusercontent.com/3327997/80694900-08df4480-8acd-11ea-90c9-59c80beff0d3.png"></kbd> | <kbd><img src="https://user-images.githubusercontent.com/3327997/80694785-e6e5c200-8acc-11ea-8e18-0b1b60051a0e.png"></kbd> |

### With both from and to date

| Before | After |
| ------ | ----- |
| <kbd><img src="https://user-images.githubusercontent.com/3327997/80694842-f82ece80-8acc-11ea-827a-a09d756933a4.png"></kbd> | <kbd><img src="https://user-images.githubusercontent.com/3327997/80694741-d7667900-8acc-11ea-9849-3414112195ca.png"></kbd> |
