### PR TITLE
Show confirmation message after updating move [P4 1353]

### DIFF
--- a/app/move/controllers/update/assessment.js
+++ b/app/move/controllers/update/assessment.js
@@ -1,4 +1,4 @@
-const { pick } = require('lodash')
+const { isEqual, pick } = require('lodash')
 
 const personService = require('../../../../common/services/person')
 const Assessment = require('../create/assessment')
@@ -28,7 +28,6 @@ class UpdateAssessmentController extends UpdateBase {
 
   async saveValues(req, res, next) {
     try {
-      const personId = req.getPersonId()
       const person = req.getPerson()
       const assessments = person.assessment_answers || []
       const fieldKeys = Object.keys(req.form.options.fields)
@@ -49,10 +48,11 @@ class UpdateAssessmentController extends UpdateBase {
       // TODO: don't set assessments if not from prison?
       // fromLocationType !== 'prison'
 
-      const originalKeys = getAnswerKeys(assessments)
-      const updatedKeys = getAnswerKeys(updatedAssessments)
+      const oldKeys = getAnswerKeys(assessments)
+      const newKeys = getAnswerKeys(updatedAssessments)
 
-      if (JSON.stringify(originalKeys) !== JSON.stringify(updatedKeys)) {
+      if (!isEqual(oldKeys, newKeys)) {
+        const personId = req.getPersonId()
         await personService.update({
           id: personId,
           assessment_answers: updatedAssessments,

--- a/app/move/controllers/update/assessment.js
+++ b/app/move/controllers/update/assessment.js
@@ -57,6 +57,8 @@ class UpdateAssessmentController extends UpdateBase {
           id: personId,
           assessment_answers: updatedAssessments,
         })
+
+        this.setFlash(req)
       }
 
       next()

--- a/app/move/controllers/update/assessment.test.js
+++ b/app/move/controllers/update/assessment.test.js
@@ -5,8 +5,6 @@ const MixinProto = CreateAssessment.prototype
 const AssessmentController = require('./assessment')
 const UpdateBaseController = require('./base')
 
-// TODO: figure out how to proxyquire lodash without breaking it elsewhere
-
 const controller = new AssessmentController({ route: '/' })
 const ownProto = Object.getPrototypeOf(controller)
 

--- a/app/move/controllers/update/assessment.test.js
+++ b/app/move/controllers/update/assessment.test.js
@@ -79,6 +79,7 @@ describe('Move controllers', function() {
       let nextSpy
       beforeEach(function() {
         sinon.stub(personService, 'update').resolves()
+        sinon.stub(controller, 'setFlash')
         req = {
           getPersonId: sinon.stub().returns('#personId'),
           getPerson: sinon.stub().returns({
@@ -180,6 +181,11 @@ describe('Move controllers', function() {
           await controller.saveValues(req, res, nextSpy)
           expect(personService.update).to.not.be.called
         })
+
+        it('should not set the confirmation message', async function() {
+          await controller.saveValues(req, res, nextSpy)
+          expect(controller.setFlash).to.not.be.called
+        })
       })
 
       context('When assessment answers have changed', function() {
@@ -198,6 +204,11 @@ describe('Move controllers', function() {
             ],
             id: '#personId',
           })
+        })
+
+        it('should set the confirmation message', async function() {
+          await controller.saveValues(req, res, nextSpy)
+          expect(controller.setFlash).to.be.calledOnceWithExactly(req)
         })
       })
 

--- a/app/move/controllers/update/base.js
+++ b/app/move/controllers/update/base.js
@@ -1,5 +1,6 @@
-const { get, keys } = require('lodash')
+const { get, isEqual, keys, pick } = require('lodash')
 
+const moveService = require('../../../../common/services/move')
 const personService = require('../../../../common/services/person')
 const CreateBaseController = require('../create/base')
 
@@ -92,6 +93,27 @@ class UpdateBaseController extends CreateBaseController {
     const person = req.getPerson()
     const fields = keys(get(req, 'form.options.fields'))
     return personService.unformat(person, fields)
+  }
+
+  async saveMove(req, res, next) {
+    try {
+      const fields = this.saveFields || Object.keys(req.form.options.fields)
+      const newValues = pick(req.form.values, fields)
+      const oldValues = pick(req.getMove(), fields)
+      if (!isEqual(newValues, oldValues)) {
+        const id = req.getMoveId()
+        const data = {
+          id,
+          ...newValues,
+        }
+
+        await moveService.update(data)
+      }
+
+      next()
+    } catch (error) {
+      next(error)
+    }
   }
 }
 

--- a/app/move/controllers/update/base.js
+++ b/app/move/controllers/update/base.js
@@ -1,7 +1,8 @@
-const { get, isEqual, keys, pick } = require('lodash')
+const { get, isEqual, keys, map, pick } = require('lodash')
 
 const moveService = require('../../../../common/services/move')
 const personService = require('../../../../common/services/person')
+const filters = require('../../../../config/nunjucks/filters')
 const CreateBaseController = require('../create/base')
 
 class UpdateBaseController extends CreateBaseController {
@@ -118,10 +119,18 @@ class UpdateBaseController extends CreateBaseController {
   }
 
   setFlash(req, category) {
+    const suppliers = get(req.getMove(), 'from_location.suppliers')
+    const supplierNames =
+      suppliers && suppliers.length
+        ? map(suppliers, 'name')
+        : [req.t('supplier_fallback')]
+    const supplier = filters.oxfordJoin(supplierNames)
     category = category || this.flashKey || req.form.options.key
     req.flash('success', {
       title: req.t(`moves::update_flash.categories.${category}.heading`),
-      content: req.t(`moves::update_flash.categories.${category}.message`),
+      content: req.t(`moves::update_flash.categories.${category}.message`, {
+        supplier,
+      }),
     })
   }
 }

--- a/app/move/controllers/update/base.js
+++ b/app/move/controllers/update/base.js
@@ -75,10 +75,11 @@ class UpdateBaseController extends CreateBaseController {
       }
 
       try {
+        const initialValues = this.getUpdateValues(req, res)
         if (req.initialStep) {
-          values = this.getUpdateValues(req, res)
+          values = initialValues
         }
-        this.protectReadOnlyFields(req, values)
+        this.protectReadOnlyFields(req, initialValues)
       } catch (error) {
         return callback(error)
       }

--- a/app/move/controllers/update/base.js
+++ b/app/move/controllers/update/base.js
@@ -108,12 +108,21 @@ class UpdateBaseController extends CreateBaseController {
         }
 
         await moveService.update(data)
+        this.setFlash(req)
       }
 
       next()
     } catch (error) {
       next(error)
     }
+  }
+
+  setFlash(req, category) {
+    category = category || this.flashKey || req.form.options.key
+    req.flash('success', {
+      title: req.t(`moves::update_flash.categories.${category}.heading`),
+      content: req.t(`moves::update_flash.categories.${category}.message`),
+    })
   }
 }
 

--- a/app/move/controllers/update/base.test.js
+++ b/app/move/controllers/update/base.test.js
@@ -574,6 +574,7 @@ describe('Move controllers', function() {
     const res = {}
     let nextSpy
     beforeEach(async function() {
+      sinon.stub(controller, 'setFlash')
       sinon.stub(moveService, 'update').resolves()
       req = {
         getMoveId: sinon.stub().returns('#moveId'),
@@ -607,6 +608,10 @@ describe('Move controllers', function() {
         expect(moveService.update).to.not.be.called
       })
 
+      it('should not set the confirmation message', async function() {
+        expect(controller.setFlash).to.not.be.called
+      })
+
       it('should invoke next with no error', async function() {
         expect(nextSpy).to.be.calledOnceWithExactly()
       })
@@ -625,6 +630,10 @@ describe('Move controllers', function() {
         })
       })
 
+      it('should set the confirmation message', async function() {
+        expect(controller.setFlash).to.be.calledOnceWithExactly(req)
+      })
+
       it('should invoke next with no error', async function() {
         expect(nextSpy).to.be.calledOnceWithExactly()
       })
@@ -641,5 +650,68 @@ describe('Move controllers', function() {
         expect(nextSpy).to.be.calledOnceWithExactly(error)
       })
     })
+  })
+
+  describe('#setFlash', function() {
+    let req
+    beforeEach(async function() {
+      req = {
+        t: sinon.stub().returnsArg(0),
+        flash: sinon.spy(),
+        form: {
+          options: {
+            key: 'optionsKey',
+          },
+        },
+      }
+    })
+
+    context('when passed an explicit key', function() {
+      beforeEach(async function() {
+        controller.flashKey = 'flashKey'
+        await controller.setFlash(req, 'categoryKey')
+      })
+
+      it('should set confirmation message using explicit key', async function() {
+        expect(req.flash).to.be.calledOnceWithExactly('success', {
+          title: 'moves::update_flash.categories.categoryKey.heading',
+          content: 'moves::update_flash.categories.categoryKey.message',
+        })
+      })
+    })
+
+    context(
+      'when passed no explicit key but has a flashKey property',
+      function() {
+        beforeEach(async function() {
+          controller.flashKey = 'flashKey'
+          await controller.setFlash(req)
+        })
+
+        it('should set confirmation message using explicit key', async function() {
+          expect(req.flash).to.be.calledOnceWithExactly('success', {
+            title: 'moves::update_flash.categories.flashKey.heading',
+            content: 'moves::update_flash.categories.flashKey.message',
+          })
+        })
+      }
+    )
+
+    context(
+      'when passed no explicit key and has no flashKey property',
+      function() {
+        beforeEach(async function() {
+          delete controller.flashKey
+          await controller.setFlash(req)
+        })
+
+        it('should set confirmation message using explicit key', async function() {
+          expect(req.flash).to.be.calledOnceWithExactly('success', {
+            title: 'moves::update_flash.categories.optionsKey.heading',
+            content: 'moves::update_flash.categories.optionsKey.message',
+          })
+        })
+      }
+    )
   })
 })

--- a/app/move/controllers/update/base.test.js
+++ b/app/move/controllers/update/base.test.js
@@ -604,15 +604,15 @@ describe('Move controllers', function() {
         await controller.saveMove(req, res, nextSpy)
       })
 
-      it('should call savePerson with expected data', async function() {
+      it('should call savePerson with expected data', function() {
         expect(moveService.update).to.not.be.called
       })
 
-      it('should not set the confirmation message', async function() {
+      it('should not set the confirmation message', function() {
         expect(controller.setFlash).to.not.be.called
       })
 
-      it('should invoke next with no error', async function() {
+      it('should invoke next with no error', function() {
         expect(nextSpy).to.be.calledOnceWithExactly()
       })
     })
@@ -622,7 +622,7 @@ describe('Move controllers', function() {
         await controller.saveMove(req, res, nextSpy)
       })
 
-      it('should call savePerson with expected data', async function() {
+      it('should call savePerson with expected data', function() {
         expect(moveService.update).to.be.calledOnceWithExactly({
           id: '#moveId',
           foo: 'a',
@@ -630,11 +630,11 @@ describe('Move controllers', function() {
         })
       })
 
-      it('should set the confirmation message', async function() {
+      it('should set the confirmation message', function() {
         expect(controller.setFlash).to.be.calledOnceWithExactly(req)
       })
 
-      it('should invoke next with no error', async function() {
+      it('should invoke next with no error', function() {
         expect(nextSpy).to.be.calledOnceWithExactly()
       })
     })
@@ -646,7 +646,7 @@ describe('Move controllers', function() {
         moveService.update.rejects(error)
         await controller.saveMove(req, res, nextSpy)
       })
-      it('should invoke next with the error', async function() {
+      it('should invoke next with the error', function() {
         expect(nextSpy).to.be.calledOnceWithExactly(error)
       })
     })
@@ -672,7 +672,7 @@ describe('Move controllers', function() {
         await controller.setFlash(req, 'categoryKey')
       })
 
-      it('should set confirmation message using explicit key', async function() {
+      it('should set confirmation message using explicit key', function() {
         expect(req.flash).to.be.calledOnceWithExactly('success', {
           title: 'moves::update_flash.categories.categoryKey.heading',
           content: 'moves::update_flash.categories.categoryKey.message',
@@ -688,7 +688,7 @@ describe('Move controllers', function() {
           await controller.setFlash(req)
         })
 
-        it('should set confirmation message using explicit key', async function() {
+        it('should set confirmation message using explicit key', function() {
           expect(req.flash).to.be.calledOnceWithExactly('success', {
             title: 'moves::update_flash.categories.flashKey.heading',
             content: 'moves::update_flash.categories.flashKey.message',
@@ -705,7 +705,7 @@ describe('Move controllers', function() {
           await controller.setFlash(req)
         })
 
-        it('should set confirmation message using explicit key', async function() {
+        it('should set confirmation message using explicit key', function() {
           expect(req.flash).to.be.calledOnceWithExactly('success', {
             title: 'moves::update_flash.categories.optionsKey.heading',
             content: 'moves::update_flash.categories.optionsKey.message',

--- a/app/move/controllers/update/base.test.js
+++ b/app/move/controllers/update/base.test.js
@@ -419,7 +419,7 @@ describe('Move controllers', function() {
     context('when req.initialStep is false', function() {
       it('should not call the getUpdateValues method', function() {
         controller.getValues(req, res, callback)
-        expect(controller.getUpdateValues).to.not.be.called
+        expect(controller.getUpdateValues).to.be.calledOnceWithExactly(req, res)
       })
 
       it('should call the protectReadOnlyFields method with the correct args', function() {
@@ -427,7 +427,7 @@ describe('Move controllers', function() {
         expect(controller.protectReadOnlyFields).to.be.calledOnceWithExactly(
           req,
           {
-            foo: 'bar',
+            baz: 'tastic',
           }
         )
       })

--- a/app/move/controllers/update/move-date.js
+++ b/app/move/controllers/update/move-date.js
@@ -1,12 +1,14 @@
-const { get, pick } = require('lodash')
-
-const moveService = require('../../../../common/services/move')
 const { formatDate } = require('../../../../config/nunjucks/filters')
 const CreateMoveDateController = require('../create/move-date')
 
 const UpdateBase = require('./base')
 
 class UpdateMoveDetailsController extends UpdateBase {
+  constructor(options) {
+    super(options)
+    this.saveFields = ['date']
+  }
+
   getUpdateValues(req, res) {
     const move = req.getMove()
     if (!move) {
@@ -30,23 +32,8 @@ class UpdateMoveDetailsController extends UpdateBase {
     return values
   }
 
-  async saveValues(req, res, next) {
-    try {
-      const id = req.getMoveId()
-      const data = {
-        ...pick(get(req, 'form.values'), ['date', 'date_type', 'date_custom']),
-        id,
-      }
-
-      if (req.getMove().date !== data.date) {
-        await moveService.update(data)
-      }
-
-      // no need to call super
-      next()
-    } catch (error) {
-      next(error)
-    }
+  saveValues(req, res, next) {
+    this.saveMove(req, res, next)
   }
 }
 

--- a/app/move/controllers/update/move-date.test.js
+++ b/app/move/controllers/update/move-date.test.js
@@ -1,4 +1,3 @@
-const moveService = require('../../../../common/services/move')
 const CreateMoveDate = require('../create/move-date')
 
 const UpdateBaseController = require('./base')
@@ -114,63 +113,23 @@ describe('Move controllers', function() {
     })
 
     describe('#saveValues', function() {
-      let req = {}
+      const req = {}
       const res = {}
       let nextSpy
-      beforeEach(function() {
+      beforeEach(async function() {
+        sinon.stub(UpdateBaseController.prototype, 'saveMove')
         nextSpy = sinon.spy()
-        sinon.stub(moveService, 'update').resolves()
-        req = {
-          getMoveId: sinon.stub().returns('#moveId'),
-          getMove: sinon.stub().returns({ date: '2019-10-03' }),
-          form: {
-            values: {
-              date: '2019-10-02',
-              date_type: 'custom',
-              date_custom: '2019-10-02',
-              another_prop: true,
-            },
-          },
-        }
-      })
-
-      it('should call move API with correct values', async function() {
         await controller.saveValues(req, res, nextSpy)
-        expect(moveService.update).to.be.calledOnceWithExactly({
-          id: '#moveId',
-          date: '2019-10-02',
-          date_type: 'custom',
-          date_custom: '2019-10-02',
-        })
       })
 
-      context('should not call move API if date unchanged', function() {
-        beforeEach(function() {
-          req.getMove = sinon.stub().returns({ date: '2019-10-02' })
-        })
-        it('should call move API with correct values', async function() {
-          await controller.saveValues(req, res, nextSpy)
-          expect(moveService.update).to.not.be.called
-        })
+      it('should call base’s saveMove', async function() {
+        expect(
+          UpdateBaseController.prototype.saveMove
+        ).to.be.calledOnceWithExactly(req, res, nextSpy)
       })
 
-      it('should invoke the next method without error', async function() {
-        await controller.saveValues(req, res, nextSpy)
-        expect(nextSpy).to.be.calledOnceWithExactly()
-      })
-
-      context('When the API throws an error', function() {
-        const err = new Error()
-        beforeEach(function() {
-          moveService.update.throws(err)
-        })
-
-        it('should invoke the next method without error', async function() {
-          try {
-            await controller.saveValues(req, res, nextSpy)
-          } catch (e) {}
-          expect(nextSpy).to.be.calledOnceWithExactly(err)
-        })
+      it('should not invoke next itself', async function() {
+        expect(nextSpy).to.not.be.called
       })
     })
   })

--- a/app/move/controllers/update/move-details.js
+++ b/app/move/controllers/update/move-details.js
@@ -1,6 +1,5 @@
 const { get, pick } = require('lodash')
 
-const moveService = require('../../../../common/services/move')
 const CreateMoveDetailsController = require('../create/move-details')
 
 const UpdateBase = require('./base')
@@ -23,21 +22,8 @@ class UpdateMoveDetailsController extends UpdateBase {
     return values
   }
 
-  async saveValues(req, res, next) {
-    try {
-      const id = req.getMoveId()
-      const data = {
-        id,
-        ...pick(get(req, 'form.values'), ['move_type', 'to_location']),
-      }
-      // TODO; short-circuit if no need to update
-      await moveService.update(data)
-
-      // no need to call super
-      next()
-    } catch (error) {
-      next(error)
-    }
+  saveValues(req, res, next) {
+    this.saveMove(req, res, next)
   }
 }
 

--- a/app/move/controllers/update/move-details.test.js
+++ b/app/move/controllers/update/move-details.test.js
@@ -1,4 +1,3 @@
-const moveService = require('../../../../common/services/move')
 const CreateMoveDetails = require('../create/move-details')
 
 const UpdateBaseController = require('./base')
@@ -117,50 +116,23 @@ describe('Move controllers', function() {
     })
 
     describe('#saveValues', function() {
-      let req = {}
+      const req = {}
       const res = {}
       let nextSpy
-      beforeEach(function() {
+      beforeEach(async function() {
+        sinon.stub(UpdateBaseController.prototype, 'saveMove')
         nextSpy = sinon.spy()
-        sinon.stub(moveService, 'update').resolves()
-        req = {
-          getMoveId: sinon.stub().returns('#moveId'),
-          form: {
-            values: {
-              move_type: '#move_type',
-              to_location: '#to_location',
-              another_prop: true,
-            },
-          },
-        }
-      })
-
-      it('should call move API with correct values', async function() {
         await controller.saveValues(req, res, nextSpy)
-        expect(moveService.update).to.be.calledOnceWithExactly({
-          id: '#moveId',
-          move_type: '#move_type',
-          to_location: '#to_location',
-        })
       })
 
-      it('should invoke the next method without error', async function() {
-        await controller.saveValues(req, res, nextSpy)
-        expect(nextSpy).to.be.calledOnceWithExactly()
+      it('should call base’s saveMove', async function() {
+        expect(
+          UpdateBaseController.prototype.saveMove
+        ).to.be.calledOnceWithExactly(req, res, nextSpy)
       })
 
-      context('When the API throws an error', function() {
-        const err = new Error()
-        beforeEach(function() {
-          moveService.update.throws(err)
-        })
-
-        it('should invoke the next method without error', async function() {
-          try {
-            await controller.saveValues(req, res, nextSpy)
-          } catch (e) {}
-          expect(nextSpy).to.be.calledOnceWithExactly(err)
-        })
+      it('should not invoke next itself', async function() {
+        expect(nextSpy).to.not.be.called
       })
     })
   })

--- a/app/move/controllers/update/personal-details.js
+++ b/app/move/controllers/update/personal-details.js
@@ -24,6 +24,7 @@ class UpdatePersonalDetailsController extends UpdateBase {
           id,
           ...newData,
         })
+        this.setFlash(req)
       }
 
       next()

--- a/app/move/controllers/update/personal-details.test.js
+++ b/app/move/controllers/update/personal-details.test.js
@@ -43,6 +43,7 @@ describe('Move controllers', function() {
       const res = {}
       let nextSpy
       beforeEach(async function() {
+        sinon.stub(controller, 'setFlash')
         sinon.stub(personService, 'unformat').returns({})
         sinon.stub(personService, 'update').resolves()
         req = {
@@ -77,6 +78,10 @@ describe('Move controllers', function() {
           expect(personService.update).to.not.be.called
         })
 
+        it('should set the confirmation message', async function() {
+          expect(controller.setFlash).to.not.be.called
+        })
+
         it('should invoke next with no error', async function() {
           expect(nextSpy).to.be.calledOnceWithExactly()
         })
@@ -102,6 +107,10 @@ describe('Move controllers', function() {
             foo: 'a',
             bar: 'b',
           })
+        })
+
+        it('should set the confirmation message', async function() {
+          expect(controller.setFlash).to.be.calledOnceWithExactly(req)
         })
 
         it('should invoke next with no error', async function() {

--- a/app/move/controllers/update/personal-details.test.js
+++ b/app/move/controllers/update/personal-details.test.js
@@ -43,49 +43,82 @@ describe('Move controllers', function() {
       const res = {}
       let nextSpy
       beforeEach(async function() {
-        sinon.stub(CreatePersonalDetails.prototype, 'saveValues')
-        sinon.stub(personService, 'update').resolves()
         sinon.stub(personService, 'unformat').returns({})
+        sinon.stub(personService, 'update').resolves()
         req = {
           getPersonId: sinon.stub().returns('#personId'),
           getPerson: sinon.stub().returns({
             id: '#personId',
-            identifiers: [
-              {
-                identifier_type: 'foo',
-              },
-            ],
           }),
           form: {
+            options: {
+              fields: {
+                foo: {},
+                bar: {},
+              },
+            },
             values: {
-              bar: 'baz',
+              foo: 'a',
+              bar: 'b',
+              baz: 'c',
             },
           },
         }
-        nextSpy = sinon.spy()
-
-        await controller.saveValues(req, res, nextSpy)
+        nextSpy = sinon.stub()
       })
 
-      it('should call unformat with expected identifier fields', async function() {
-        expect(personService.unformat).to.be.calledOnceWithExactly(
-          {
+      context('when the values have not changed', function() {
+        beforeEach(async function() {
+          personService.unformat.returns({ foo: 'a', bar: 'b' })
+          await controller.saveValues(req, res, nextSpy)
+        })
+
+        it('should call savePerson with expected data', async function() {
+          expect(personService.update).to.not.be.called
+        })
+
+        it('should invoke next with no error', async function() {
+          expect(nextSpy).to.be.calledOnceWithExactly()
+        })
+      })
+
+      context('when the values have changed', function() {
+        beforeEach(async function() {
+          await controller.saveValues(req, res, nextSpy)
+        })
+        it('should call unformat with expected field keys', async function() {
+          expect(personService.unformat).to.be.calledOnceWithExactly(
+            {
+              id: '#personId',
+            },
+            ['foo', 'bar'],
+            { date: [] }
+          )
+        })
+
+        it('should call savePerson with expected data', async function() {
+          expect(personService.update).to.be.calledOnceWithExactly({
             id: '#personId',
-            identifiers: [
-              {
-                identifier_type: 'foo',
-              },
-            ],
-          },
-          ['foo']
-        )
+            foo: 'a',
+            bar: 'b',
+          })
+        })
+
+        it('should invoke next with no error', async function() {
+          expect(nextSpy).to.be.calledOnceWithExactly()
+        })
       })
 
-      it('should yield to CreatePersonalDetails’s saveValue', async function() {
-        expect(personService.update).to.not.be.called
-        expect(
-          CreatePersonalDetails.prototype.saveValues
-        ).to.be.calledOnceWithExactly(req, res, nextSpy)
+      context('when an error is thrown', function() {
+        let error
+        beforeEach(async function() {
+          error = new Error()
+          personService.update.rejects(error)
+          await controller.saveValues(req, res, nextSpy)
+        })
+        it('should invoke next with the error', async function() {
+          expect(nextSpy).to.be.calledOnceWithExactly(error)
+        })
       })
     })
   })

--- a/app/move/index.js
+++ b/app/move/index.js
@@ -66,12 +66,11 @@ router.use(
 
 if (FEATURE_FLAGS.EDITABILITY) {
   updateSteps.forEach(updateJourney => {
-    const steps = updateJourney.steps
-    const key = Object.keys(steps)[0]
+    const { key, steps } = updateJourney
     const updateStepConfig = {
       ...updateConfig,
-      name: 'update-a-move' + key,
-      journeyName: 'update-a-move' + key,
+      name: `update-move-${key}`,
+      journeyName: `update-move-${key}`,
     }
     router.use(
       '/:moveId/edit',

--- a/app/move/steps/update.js
+++ b/app/move/steps/update.js
@@ -85,4 +85,10 @@ const updateSteps = [
   },
 ]
 
+updateSteps.forEach(updateJourney => {
+  const { key, steps } = updateJourney
+  const firstStepKey = Object.keys(steps)[0]
+  steps[firstStepKey].key = key
+})
+
 module.exports = updateSteps

--- a/app/move/steps/update.js
+++ b/app/move/steps/update.js
@@ -30,7 +30,7 @@ const updateSteps = [
   // TODO: reenable when redirect api available
   // {
   //   key: 'move',
-  //   role: 'move:update',
+  //   permission: 'move:update',
   //   steps: {
   //     '/move-details': {
   //       ...createSteps['/move-details'],

--- a/locales/en/moves.json
+++ b/locales/en/moves.json
@@ -191,7 +191,7 @@
     }
   },
   "update_flash": {
-    "supplier_message": "This move has been updated with the supplier",
+    "supplier_message": "This move has been updated with {{ supplier }}",
     "categories": {
       "court": {
         "heading": "Information for the court updated",

--- a/locales/en/moves.json
+++ b/locales/en/moves.json
@@ -189,5 +189,34 @@
       "personal_details": "personal details",
       "risk": "risk information"
     }
+  },
+  "update_flash": {
+    "supplier_message": "This move has been updated with the supplier",
+    "categories": {
+      "court": {
+        "heading": "Information for the court updated",
+        "message": "$t(moves::update_flash.supplier_message)"
+      },
+      "date": {
+        "heading": "Move date updated",
+        "message": "$t(moves::update_flash.supplier_message)"
+      },
+      "health": {
+        "heading": "Health affecting transport updated",
+        "message": "$t(moves::update_flash.supplier_message)"
+      },
+      "move": {
+        "heading": "Move location updated",
+        "message": "$t(moves::update_flash.supplier_message)"
+      },
+      "personal_details": {
+        "heading": "Personal details updated",
+        "message": "$t(moves::update_flash.supplier_message)"
+      },
+      "risk": {
+        "heading": "Risk information updated",
+        "message": "$t(moves::update_flash.supplier_message)"
+      }
+    }
   }
 }


### PR DESCRIPTION
If any values on a move are changed, we now display a confirmation message that they have been saved on the move view page.


![Move_details_for_SHIELDSY__PHOEBE](https://user-images.githubusercontent.com/4856/80721582-4dcba100-8af6-11ea-9064-16ed89f32d1e.png)


### Checklist

- [x] If adding new environment variables, they have been documented in the [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md)
- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
