### PR TITLE
chore: Add missing attributes to prison transfer reason model

### DIFF
--- a/common/lib/api-client/models.js
+++ b/common/lib/api-client/models.js
@@ -174,8 +174,9 @@ module.exports = {
   },
   prison_transfer_reason: {
     attributes: {
-      title: '',
+      disabled_at: '',
       key: '',
+      title: '',
     },
     options: {
       cache: true,


### PR DESCRIPTION
This adds the `disabled_at` attribute to the prison transfer model.

This removes the warnings that devour issues when the model doesn't
contain an attribute that is returned.