### PR TITLE
fix: Update end-to-end tests to support new "home" dashboard

### DIFF
--- a/test/e2e/pages/dashboard.js
+++ b/test/e2e/pages/dashboard.js
@@ -1,0 +1,18 @@
+import { Selector } from 'testcafe'
+
+import Page from './page'
+
+class DashboardPage extends Page {
+  constructor() {
+    super()
+
+    this.nodes = {
+      singleRequestsSection: Selector('h2')
+        .withText('Single requests this week')
+        .parent('section'),
+      singleRequestsLink: Selector('a').withText('sent for review'),
+    }
+  }
+}
+
+export default DashboardPage

--- a/test/e2e/pages/index.js
+++ b/test/e2e/pages/index.js
@@ -1,5 +1,6 @@
 import CancelMovePage from './cancel-move'
 import CreateMovePage from './create-move'
+import DashboardPage from './dashboard'
 import MoveDetailPage from './move-detail'
 import MovesDashboardPage from './moves-dashboard'
 import Page from './page'
@@ -10,6 +11,7 @@ const moveDetailPage = new MoveDetailPage()
 const movesDashboardPage = new MovesDashboardPage()
 const createMovePage = new CreateMovePage()
 const cancelMovePage = new CancelMovePage()
+const dashboardPage = new DashboardPage()
 
 export {
   page,
@@ -17,5 +19,6 @@ export {
   movesDashboardPage,
   createMovePage,
   cancelMovePage,
+  dashboardPage,
   UpdateMovePage,
 }

--- a/test/e2e/smoke.test.js
+++ b/test/e2e/smoke.test.js
@@ -6,7 +6,7 @@ import {
   ocaUser,
 } from './_roles'
 import { movesByDay } from './_routes'
-import { page, movesDashboardPage } from './pages'
+import { dashboardPage, page, movesDashboardPage } from './pages'
 
 const users = [
   {
@@ -40,11 +40,13 @@ const usersWhoHaveADashboard = [
     name: 'OCA user',
     role: ocaUser,
     username: 'End-to-end OCA',
-    homeButton: movesDashboardPage.nodes.filterContainer,
+    homeSection: dashboardPage.nodes.singleRequestsSection,
+    homeButton: dashboardPage.nodes.singleRequestsLink,
+    timePeriod: 'This week',
   },
 ]
 
-fixture('Smoke tests')
+fixture.only('Smoke tests')
 
 users.forEach(user => {
   test.before(async t => {
@@ -84,17 +86,17 @@ usersWhoHaveADashboard.forEach(user => {
       .expect(page.nodes.appHeader.exists)
       .ok()
       .expect(page.nodes.username.innerText)
-      .eql(user.username)
+      .contains(user.username)
+      .expect(page.nodes.pageHeading.innerText)
+      .eql('Your overview')
+      .expect(user.homeSection.exists)
+      .ok()
       .expect(user.homeButton.exists)
       .ok()
       // Navigate
+      .click(user.homeButton)
       .expect(page.nodes.pageHeading.innerText)
-      .eql('This week')
-      .click(movesDashboardPage.nodes.pagination.previousLink)
-      .click(movesDashboardPage.nodes.pagination.nextLink)
-      .click(movesDashboardPage.nodes.pagination.thisWeekLink)
-      .expect(page.nodes.pageHeading.innerText)
-      .eql('This week')
+      .eql(user.timePeriod)
       // Sign out
       .click(page.nodes.signOutLink)
       .expect(page.nodes.signInHeader.exists)


### PR DESCRIPTION
The root dashboard was changed to remove the pagination and to act
more like a springboard into other parts of the service. This broke the
existing smoke tests.

This change adapts the smoke tests to cater for a different style of
dashboard and introduces a new page object to deal with them.