### PR TITLE
fix: Ensure move date is valid before processing

### DIFF
--- a/app/move/controllers/create/move-date.js
+++ b/app/move/controllers/create/move-date.js
@@ -1,4 +1,10 @@
-const { format, startOfToday, startOfTomorrow, parseISO } = require('date-fns')
+const {
+  format,
+  startOfToday,
+  startOfTomorrow,
+  parseISO,
+  isValid: isValidDate,
+} = require('date-fns')
 
 const filters = require('../../../../config/nunjucks/filters')
 
@@ -36,7 +42,9 @@ class MoveDateController extends CreateBaseController {
       moveDate = dateType === 'today' ? startOfToday() : startOfTomorrow()
     }
 
-    req.form.values.date = format(moveDate, 'yyyy-MM-dd')
+    req.form.values.date = isValidDate(moveDate)
+      ? format(moveDate, 'yyyy-MM-dd')
+      : undefined
 
     next()
   }

--- a/app/move/controllers/create/move-date.test.js
+++ b/app/move/controllers/create/move-date.test.js
@@ -119,24 +119,51 @@ describe('Move controllers', function() {
             date_type: 'custom',
             date_custom: '2019-10-17',
           }
-
-          controller.process(req, {}, nextSpy)
         })
 
-        it('should set the value of date field to the custom date', function() {
-          expect(req.form.values.date).to.equal('2019-10-17')
+        context('with valid date', function() {
+          beforeEach(function() {
+            controller.process(req, {}, nextSpy)
+          })
+
+          it('should set the value of date field to the custom date', function() {
+            expect(req.form.values.date).to.equal('2019-10-17')
+          })
+
+          it('should store the value of custom date', function() {
+            expect(req.form.values.date_custom).to.equal('2019-10-17')
+          })
+
+          it('should set date type to custom', function() {
+            expect(req.form.values.date_type).to.equal('custom')
+          })
+
+          it('should call next without error', function() {
+            expect(nextSpy).to.be.calledOnceWithExactly()
+          })
         })
 
-        it('should store the value of custom date', function() {
-          expect(req.form.values.date_custom).to.equal('2019-10-17')
-        })
+        context('with invalid date', function() {
+          beforeEach(function() {
+            req.form.values.date_custom = 'foo'
+            controller.process(req, {}, nextSpy)
+          })
 
-        it('should set date type to custom', function() {
-          expect(req.form.values.date_type).to.equal('custom')
-        })
+          it('should not set value for date field', function() {
+            expect(req.form.values.date).to.be.undefined
+          })
 
-        it('should call next without error', function() {
-          expect(nextSpy).to.be.calledOnceWithExactly()
+          it('should store the value of custom date', function() {
+            expect(req.form.values.date_custom).to.equal('foo')
+          })
+
+          it('should set date type to custom', function() {
+            expect(req.form.values.date_type).to.equal('custom')
+          })
+
+          it('should call next without error', function() {
+            expect(nextSpy).to.be.calledOnceWithExactly()
+          })
         })
       })
 


### PR DESCRIPTION
This fixes an error where date-fns returns an error if an invalid
date is passed to `format()`.

This caused the move details step to through an error when trying to
format the move date to be of the type expected by the API.

This fixes sentry error #BOOK-A-SECURE-MOVE-FRONTEND-1H