### PR TITLE
fix: Handle how CSRF errors are dealt with

### DIFF
--- a/common/controllers/form-wizard.js
+++ b/common/controllers/form-wizard.js
@@ -26,9 +26,12 @@ class FormController extends Controller {
     }
 
     if (
-      ['SESSION_TIMEOUT', 'MISSING_PREREQ', 'MISSING_LOCATION'].includes(
-        err.code
-      )
+      [
+        'SESSION_TIMEOUT',
+        'CSRF_ERROR',
+        'MISSING_PREREQ',
+        'MISSING_LOCATION',
+      ].includes(err.code)
     ) {
       return res.render('form-wizard-error', {
         journeyName: req.form.options.journeyName.replace('-', '_'),

--- a/common/controllers/form-wizard.test.js
+++ b/common/controllers/form-wizard.test.js
@@ -195,11 +195,45 @@ describe('Form wizard', function() {
       })
     })
 
-    context('when it returns missing prereq error', function() {
+    context('when it returns missing location error', function() {
       let reqMock
 
       beforeEach(function() {
         errorMock.code = 'MISSING_LOCATION'
+        reqMock = {
+          baseUrl: '/journey-base-url-other',
+          form: {
+            options: {
+              journeyName: 'mock-journey',
+            },
+          },
+        }
+
+        controller.errorHandler(errorMock, reqMock, resMock)
+      })
+
+      it('should render the timeout template', function() {
+        expect(resMock.render.args[0][0]).to.equal('form-wizard-error')
+      })
+
+      it('should pass the correct data to the view', function() {
+        expect(resMock.render.args[0][1]).to.deep.equal({
+          journeyBaseUrl: reqMock.baseUrl,
+          errorKey: errorMock.code.toLowerCase(),
+          journeyName: 'mock_journey',
+        })
+      })
+
+      it('should not call parent error handler', function() {
+        expect(FormController.prototype.errorHandler).not.to.be.called
+      })
+    })
+
+    context('when it returns a CSRF error', function() {
+      let reqMock
+
+      beforeEach(function() {
+        errorMock.code = 'CSRF_ERROR'
         reqMock = {
           baseUrl: '/journey-base-url-other',
           form: {

--- a/locales/en/errors.json
+++ b/locales/en/errors.json
@@ -23,7 +23,11 @@
   },
   "tampered_with": {
     "heading": "This form has been tampered with",
-    "content": "Try to submit the form again in a few moments."
+    "content": "Try to reload the page and submit the form again in a few moments."
+  },
+  "csrf_error": {
+    "heading": "$t(errors::tampered_with.heading)",
+    "content": "$t(errors::tampered_with.content)"
   },
   "unauthorized": {
     "heading": "You don’t have permission to view this page",


### PR DESCRIPTION
## Proposed changes

This change improves how CSRF errors are dealt with. At the moment,
they fallback to the default error handler which causes a user to see
a "Page unavailable" page and trigger a sentry error.

This error case is expected and we can provide a better route to handling
it. This change catches the error as part of the form wizard and displays
the form wizard error page. This will also prevent us from seeing this
error in sentry which should be reserved for unexpected errors.

## Before

<kbd><img src="https://user-images.githubusercontent.com/3327997/81070743-952da500-8edb-11ea-8b79-8d5638274460.png"></kbd>

## After

<kbd><img src="https://user-images.githubusercontent.com/3327997/81070784-a4145780-8edb-11ea-882d-d69661faf517.png"></kbd>
