### PR TITLE
[P4-1467] Filter single requests correctly

### DIFF
--- a/app/moves/index.js
+++ b/app/moves/index.js
@@ -54,7 +54,7 @@ router.get(
   list
 )
 router.get(
-  `/:period(week|day)/:date/:locationId(${uuidRegex})/:status(proposed|requested,accepted,completed|rejected)`,
+  `/:period(week|day)/:date/:locationId(${uuidRegex})/:status(pending|approved|rejected)`,
   protectRoute('moves:view:proposed'),
   setMoveTypeNavigation,
   setMovesByDateRangeAndStatus,

--- a/app/moves/middleware/set-dashboard-move-summary.js
+++ b/app/moves/middleware/set-dashboard-move-summary.js
@@ -1,26 +1,21 @@
-const { find, reject } = require('lodash')
+const { find, reject, sumBy } = require('lodash')
 
 const presenters = require('../../../common/presenters')
 
 function setDashboardMoveSummary(req, res, next) {
-  let totalMoves = {
+  const { moveTypeNavigation } = res.locals
+  const totalMoves = {
     label: 'moves::dashboard.filter.total',
     filter: 'total',
-    href: find(res.locals.moveTypeNavigation, { filter: 'proposed' }).href,
+    href: find(moveTypeNavigation, { filter: 'pending' }).href,
+    value: sumBy(moveTypeNavigation, 'value'),
   }
-  totalMoves.value = res.locals.moveTypeNavigation.reduce(
-    (accumulator, moveType) => {
-      return (accumulator += moveType.value)
-    },
-    0
-  )
-  totalMoves = presenters.moveTypesToFilterComponent(totalMoves)
+
   res.locals.dashboardMoveSummary = [
-    totalMoves,
-    ...reject(res.locals.moveTypeNavigation, {
-      filter: 'proposed',
-    }),
+    presenters.moveTypesToFilterComponent(totalMoves),
+    ...reject(moveTypeNavigation, { filter: 'pending' }),
   ]
+
   next()
 }
 

--- a/app/moves/middleware/set-dashboard-move-summary.test.js
+++ b/app/moves/middleware/set-dashboard-move-summary.test.js
@@ -10,9 +10,9 @@ describe('Moves middleware', function() {
         locals = {
           moveTypeNavigation: [
             {
-              filter: 'proposed',
+              filter: 'pending',
               value: 8,
-              href: '/proposed',
+              href: '/pending',
             },
             {
               filter: 'rejected',
@@ -58,15 +58,28 @@ describe('Moves middleware', function() {
           locals.dashboardMoveSummary.find(type => {
             return type.filter === 'total'
           }).href
-        ).to.equal('/proposed')
+        ).to.equal('/pending')
       })
 
       it('drops the proposed moves', function() {
-        expect(
-          locals.dashboardMoveSummary.find(type => {
-            return type.filter === 'proposed'
-          })
-        ).not.to.exist
+        expect(locals.dashboardMoveSummary).to.deep.equal([
+          {
+            filter: 'total',
+            value: 15,
+            href: '/pending',
+            label: 'sent for review',
+          },
+          {
+            filter: 'rejected',
+            value: 5,
+            href: '/rejected',
+          },
+          {
+            filter: 'approved',
+            value: 2,
+            href: '/approved',
+          },
+        ])
       })
 
       it('calls next', function() {

--- a/app/moves/middleware/set-moves-by-date-range-and-status.js
+++ b/app/moves/middleware/set-moves-by-date-range-and-status.js
@@ -1,4 +1,4 @@
-const moveService = require('../../../common/services/move')
+const singleRequestService = require('../../../common/services/single-request')
 
 async function setMovesByDateRangeAndStatus(req, res, next) {
   const { dateRange } = res.locals
@@ -9,13 +9,11 @@ async function setMovesByDateRangeAndStatus(req, res, next) {
   }
 
   try {
-    res.locals.movesByRangeAndStatus = await moveService.getMovesByDateRangeAndStatus(
-      {
-        dateRange,
-        status,
-        fromLocationId: locationId,
-      }
-    )
+    res.locals.movesByRangeAndStatus = await singleRequestService.getAll({
+      status,
+      createdAtDate: dateRange,
+      fromLocationId: locationId,
+    })
 
     next()
   } catch (error) {

--- a/common/middleware/set-primary-navigation.js
+++ b/common/middleware/set-primary-navigation.js
@@ -6,7 +6,7 @@ const permissions = require('./permissions')
 const baseRegex =
   '^\\/moves\\/(day|week)(\\/\\d{4}-\\d{2}-\\d{2})(\\/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})?'
 const homeRegex = new RegExp(`${baseRegex}$`)
-const proposedRegex = new RegExp(`${baseRegex}\\/proposed$`)
+const proposedRegex = new RegExp(`${baseRegex}\\/(pending|accepted|rejected)$`)
 const outgoingRegex = new RegExp(`${baseRegex}\\/outgoing$`)
 
 function setPrimaryNavigation(req, res, next) {
@@ -28,7 +28,7 @@ function setPrimaryNavigation(req, res, next) {
   if (permissions.check('moves:view:proposed', userPermissions)) {
     items.push({
       text: req.t('primary_navigation.single_requests'),
-      href: `/moves/week/${date}${locationInUrl}/proposed`,
+      href: `/moves/week/${date}${locationInUrl}/pending`,
       active: proposedRegex.test(REQUEST_PATH),
     })
   }

--- a/common/middleware/set-primary-navigation.test.js
+++ b/common/middleware/set-primary-navigation.test.js
@@ -65,7 +65,7 @@ describe('#setPrimaryNavigation()', function() {
             },
             {
               active: false,
-              href: '/moves/week/2020-05-10/12345/proposed',
+              href: '/moves/week/2020-05-10/12345/pending',
               text: 'primary_navigation.single_requests',
             },
             {
@@ -94,7 +94,7 @@ describe('#setPrimaryNavigation()', function() {
               },
               {
                 active: false,
-                href: '/moves/week/2020-05-10/12345/proposed',
+                href: '/moves/week/2020-05-10/12345/pending',
                 text: 'primary_navigation.single_requests',
               },
               {
@@ -106,31 +106,33 @@ describe('#setPrimaryNavigation()', function() {
           })
         })
 
-        context('on proposed page', function() {
-          beforeEach(function() {
-            res.locals.REQUEST_PATH =
-              '/moves/day/2020-04-16/8fadb516-f10a-45b1-91b7-a256196829f9/proposed'
-            middleware(req, res, nextSpy)
-          })
+        const statuses = ['pending', 'accepted', 'rejected']
+        statuses.forEach(status => {
+          context(`on ${status} page`, function() {
+            beforeEach(function() {
+              res.locals.REQUEST_PATH = `/moves/day/2020-04-16/8fadb516-f10a-45b1-91b7-a256196829f9/${status}`
+              middleware(req, res, nextSpy)
+            })
 
-          it('should set active state', function() {
-            expect(res.locals.primaryNavigation).to.deep.equal([
-              {
-                active: false,
-                href: '/moves',
-                text: 'primary_navigation.home',
-              },
-              {
-                active: true,
-                href: '/moves/week/2020-05-10/12345/proposed',
-                text: 'primary_navigation.single_requests',
-              },
-              {
-                active: false,
-                href: '/moves/day/2020-05-10/12345/outgoing',
-                text: 'primary_navigation.outgoing',
-              },
-            ])
+            it('should set active state', function() {
+              expect(res.locals.primaryNavigation).to.deep.equal([
+                {
+                  active: false,
+                  href: '/moves',
+                  text: 'primary_navigation.home',
+                },
+                {
+                  active: true,
+                  href: '/moves/week/2020-05-10/12345/pending',
+                  text: 'primary_navigation.single_requests',
+                },
+                {
+                  active: false,
+                  href: '/moves/day/2020-05-10/12345/outgoing',
+                  text: 'primary_navigation.outgoing',
+                },
+              ])
+            })
           })
         })
 
@@ -150,7 +152,7 @@ describe('#setPrimaryNavigation()', function() {
               },
               {
                 active: false,
-                href: '/moves/week/2020-05-10/12345/proposed',
+                href: '/moves/week/2020-05-10/12345/pending',
                 text: 'primary_navigation.single_requests',
               },
               {
@@ -184,7 +186,7 @@ describe('#setPrimaryNavigation()', function() {
             },
             {
               active: false,
-              href: '/moves/week/2020-05-10/proposed',
+              href: '/moves/week/2020-05-10/pending',
               text: 'primary_navigation.single_requests',
             },
             {
@@ -212,7 +214,7 @@ describe('#setPrimaryNavigation()', function() {
               },
               {
                 active: false,
-                href: '/moves/week/2020-05-10/proposed',
+                href: '/moves/week/2020-05-10/pending',
                 text: 'primary_navigation.single_requests',
               },
               {
@@ -226,7 +228,7 @@ describe('#setPrimaryNavigation()', function() {
 
         context('on proposed page', function() {
           beforeEach(function() {
-            res.locals.REQUEST_PATH = '/moves/day/2020-04-16/proposed'
+            res.locals.REQUEST_PATH = '/moves/day/2020-04-16/pending'
             middleware(req, res, nextSpy)
           })
 
@@ -239,7 +241,7 @@ describe('#setPrimaryNavigation()', function() {
               },
               {
                 active: true,
-                href: '/moves/week/2020-05-10/proposed',
+                href: '/moves/week/2020-05-10/pending',
                 text: 'primary_navigation.single_requests',
               },
               {
@@ -266,7 +268,7 @@ describe('#setPrimaryNavigation()', function() {
               },
               {
                 active: false,
-                href: '/moves/week/2020-05-10/proposed',
+                href: '/moves/week/2020-05-10/pending',
                 text: 'primary_navigation.single_requests',
               },
               {

--- a/common/presenters/move-type-for-filter.js
+++ b/common/presenters/move-type-for-filter.js
@@ -1,7 +1,7 @@
 const i18n = require('../../config/i18n')
 
 function moveTypesToFilterComponent(item) {
-  item.label = i18n.t(item.label)
+  item.label = i18n.t(item.label).toLowerCase()
   return item
 }
 module.exports = moveTypesToFilterComponent

--- a/common/services/index.js
+++ b/common/services/index.js
@@ -3,6 +3,7 @@ const courtHearing = require('./court-hearing')
 const move = require('./move')
 const person = require('./person')
 const referenceData = require('./reference-data')
+const singleRequest = require('./single-request')
 
 module.exports = {
   allocation,
@@ -10,4 +11,5 @@ module.exports = {
   move,
   person,
   referenceData,
+  singleRequest,
 }

--- a/common/services/move.js
+++ b/common/services/move.js
@@ -21,16 +21,25 @@ const moveService = {
     })
   },
 
-  getAll({ filter, combinedData = [], page = 1 } = {}) {
+  getAll({
+    filter = {},
+    combinedData = [],
+    page = 1,
+    isAggregation = false,
+  } = {}) {
     return apiClient
       .findAll('move', {
         ...filter,
         page,
-        per_page: 100,
+        per_page: isAggregation ? 1 : 100,
       })
       .then(response => {
-        const { data, links } = response
+        const { data, links, meta } = response
         const moves = [...combinedData, ...data]
+
+        if (isAggregation) {
+          return meta.pagination.total_objects
+        }
 
         if (!links.next) {
           return moves.map(move => ({

--- a/common/services/move.test.js
+++ b/common/services/move.test.js
@@ -173,11 +173,21 @@ describe('Move Service', function() {
     const mockResponse = {
       data: mockMoves,
       links: {},
+      meta: {
+        pagination: {
+          total_objects: 10,
+        },
+      },
     }
     const mockMultiPageResponse = {
       data: mockMoves,
       links: {
         next: 'http://next-page.com',
+      },
+      meta: {
+        pagination: {
+          total_objects: 10,
+        },
       },
     }
     const mockFilter = {
@@ -232,6 +242,31 @@ describe('Move Service', function() {
             page: 1,
             per_page: 100,
           })
+        })
+
+        it('should return moves', function() {
+          expect(moves).to.deep.equal(mockMoves)
+        })
+      })
+
+      context('with aggregation', function() {
+        beforeEach(async function() {
+          moves = await moveService.getAll({
+            filter: mockFilter,
+            isAggregation: true,
+          })
+        })
+
+        it('should call the API client with only one per page', function() {
+          expect(apiClient.findAll).to.be.calledOnceWithExactly('move', {
+            ...mockFilter,
+            page: 1,
+            per_page: 1,
+          })
+        })
+
+        it('should return a count', function() {
+          expect(moves).to.equal(10)
         })
       })
     })
@@ -298,6 +333,27 @@ describe('Move Service', function() {
             page: 2,
             per_page: 100,
           })
+        })
+      })
+
+      context('with aggregation', function() {
+        beforeEach(async function() {
+          moves = await moveService.getAll({
+            filter: mockFilter,
+            isAggregation: true,
+          })
+        })
+
+        it('should call the API client with only one per page', function() {
+          expect(apiClient.findAll).to.be.calledOnceWithExactly('move', {
+            ...mockFilter,
+            page: 1,
+            per_page: 1,
+          })
+        })
+
+        it('should return a count', function() {
+          expect(moves).to.equal(10)
         })
       })
     })

--- a/common/services/single-request.js
+++ b/common/services/single-request.js
@@ -1,0 +1,53 @@
+const { pickBy } = require('lodash')
+
+const moveService = require('./move')
+
+const singleRequestService = {
+  getAll({
+    status,
+    moveDate = [],
+    createdAtDate = [],
+    fromLocationId,
+    toLocationId,
+    isAggregation = false,
+  } = {}) {
+    const [moveDateFrom, moveDateTo] = moveDate
+    const [createdAtFrom, createdAtTo] = createdAtDate
+
+    let statusFilter
+    switch (status) {
+      case 'pending':
+        statusFilter = {
+          'filter[status]': 'proposed',
+        }
+        break
+      case 'accepted':
+        statusFilter = {
+          'filter[status]': 'requested,accepted,completed',
+        }
+        break
+      case 'rejected':
+        statusFilter = {
+          'filter[status]': 'cancelled',
+          'filter[cancellation_reason]': 'rejected',
+        }
+        break
+    }
+
+    return moveService.getAll({
+      isAggregation,
+      filter: pickBy({
+        ...statusFilter,
+        'filter[from_location_id]': fromLocationId,
+        'filter[to_location_id]': toLocationId,
+        'filter[date_from]': moveDateFrom,
+        'filter[date_to]': moveDateTo,
+        'filter[created_at_from]': createdAtFrom,
+        'filter[created_at_to]': createdAtTo,
+        'filter[move_type]': 'prison_transfer',
+      }),
+    })
+  },
+}
+
+module.exports = singleRequestService

--- a/common/services/single-request.test.js
+++ b/common/services/single-request.test.js
@@ -1,0 +1,223 @@
+const moveService = require('./move')
+const singleRequestService = require('./single-request')
+
+const mockMoves = [
+  {
+    id: '12345',
+    status: 'requested',
+    person: {
+      name: 'Tom Jones',
+    },
+  },
+  {
+    id: '67890',
+    status: 'cancelled',
+    person: {
+      name: 'Steve Bloggs',
+    },
+  },
+]
+
+describe('Single request service', function() {
+  describe('#getAll()', function() {
+    let moves
+
+    beforeEach(async function() {
+      sinon.stub(moveService, 'getAll').resolves(mockMoves)
+    })
+
+    context('without arguments', function() {
+      beforeEach(async function() {
+        moves = await singleRequestService.getAll()
+      })
+
+      it('should call moves.getAll with default filter', function() {
+        expect(moveService.getAll).to.be.calledOnceWithExactly({
+          isAggregation: false,
+          filter: {
+            'filter[move_type]': 'prison_transfer',
+          },
+        })
+      })
+
+      it('should return moves', function() {
+        expect(moves).to.deep.equal(mockMoves)
+      })
+    })
+
+    describe('arguments', function() {
+      const mockMoveDateRange = ['2019-10-10', '2019-10-11']
+      const mockCreatedDateRange = ['2020-10-10', '2020-10-11']
+      const mockFromLocationId = 'b695d0f0-af8e-4b97-891e-92020d6820b9'
+      const mockToLocationId = 'b195d0f0-df8e-4b97-891e-92020d6820b9'
+
+      context('with all arguments', function() {
+        beforeEach(async function() {
+          moves = await singleRequestService.getAll({
+            status: 'pending',
+            moveDate: mockMoveDateRange,
+            createdAtDate: mockCreatedDateRange,
+            fromLocationId: mockFromLocationId,
+            toLocationId: mockToLocationId,
+          })
+        })
+
+        it('should call moves.getAll with correct args', function() {
+          expect(moveService.getAll).to.be.calledOnceWithExactly({
+            isAggregation: false,
+            filter: {
+              'filter[status]': 'proposed',
+              'filter[date_from]': mockMoveDateRange[0],
+              'filter[date_to]': mockMoveDateRange[1],
+              'filter[created_at_from]': mockCreatedDateRange[0],
+              'filter[created_at_to]': mockCreatedDateRange[1],
+              'filter[from_location_id]': mockFromLocationId,
+              'filter[to_location_id]': mockToLocationId,
+              'filter[move_type]': 'prison_transfer',
+            },
+          })
+        })
+
+        it('should return moves', function() {
+          expect(moves).to.deep.equal(mockMoves)
+        })
+      })
+
+      context('with some arguments', function() {
+        beforeEach(async function() {
+          moves = await singleRequestService.getAll({
+            createdAtDate: mockCreatedDateRange,
+            fromLocationId: mockFromLocationId,
+          })
+        })
+
+        it('should call moves.getAll with correct args', function() {
+          expect(moveService.getAll).to.be.calledOnceWithExactly({
+            isAggregation: false,
+            filter: {
+              'filter[created_at_from]': mockCreatedDateRange[0],
+              'filter[created_at_to]': mockCreatedDateRange[1],
+              'filter[from_location_id]': mockFromLocationId,
+              'filter[move_type]': 'prison_transfer',
+            },
+          })
+        })
+
+        it('should return moves', function() {
+          expect(moves).to.deep.equal(mockMoves)
+        })
+      })
+
+      context('with aggregation', function() {
+        beforeEach(async function() {
+          moves = await singleRequestService.getAll({
+            isAggregation: true,
+            fromLocationId: mockFromLocationId,
+          })
+        })
+
+        it('should call moves.getAll with correct args', function() {
+          expect(moveService.getAll).to.be.calledOnceWithExactly({
+            isAggregation: true,
+            filter: {
+              'filter[from_location_id]': mockFromLocationId,
+              'filter[move_type]': 'prison_transfer',
+            },
+          })
+        })
+
+        it('should return moves', function() {
+          expect(moves).to.deep.equal(mockMoves)
+        })
+      })
+
+      describe('statuses', function() {
+        context('with no status', function() {
+          beforeEach(async function() {
+            moves = await singleRequestService.getAll()
+          })
+
+          it('should call moves.getAll without status', function() {
+            expect(moveService.getAll).to.be.calledOnceWithExactly({
+              isAggregation: false,
+              filter: {
+                'filter[move_type]': 'prison_transfer',
+              },
+            })
+          })
+
+          it('should return moves', function() {
+            expect(moves).to.deep.equal(mockMoves)
+          })
+        })
+
+        context('with pending status', function() {
+          beforeEach(async function() {
+            moves = await singleRequestService.getAll({
+              status: 'pending',
+            })
+          })
+
+          it('should call moves.getAll with correct statuses', function() {
+            expect(moveService.getAll).to.be.calledOnceWithExactly({
+              isAggregation: false,
+              filter: {
+                'filter[status]': 'proposed',
+                'filter[move_type]': 'prison_transfer',
+              },
+            })
+          })
+
+          it('should return moves', function() {
+            expect(moves).to.deep.equal(mockMoves)
+          })
+        })
+
+        context('with accepted status', function() {
+          beforeEach(async function() {
+            moves = await singleRequestService.getAll({
+              status: 'accepted',
+            })
+          })
+
+          it('should call moves.getAll with correct statuses', function() {
+            expect(moveService.getAll).to.be.calledOnceWithExactly({
+              isAggregation: false,
+              filter: {
+                'filter[status]': 'requested,accepted,completed',
+                'filter[move_type]': 'prison_transfer',
+              },
+            })
+          })
+
+          it('should return moves', function() {
+            expect(moves).to.deep.equal(mockMoves)
+          })
+        })
+
+        context('with rejected status', function() {
+          beforeEach(async function() {
+            moves = await singleRequestService.getAll({
+              status: 'rejected',
+            })
+          })
+
+          it('should call moves.getAll with correct statuses', function() {
+            expect(moveService.getAll).to.be.calledOnceWithExactly({
+              isAggregation: false,
+              filter: {
+                'filter[status]': 'cancelled',
+                'filter[cancellation_reason]': 'rejected',
+                'filter[move_type]': 'prison_transfer',
+              },
+            })
+          })
+
+          it('should return moves', function() {
+            expect(moves).to.deep.equal(mockMoves)
+          })
+        })
+      })
+    })
+  })
+})

--- a/locales/en/statuses.json
+++ b/locales/en/statuses.json
@@ -1,4 +1,5 @@
 {
+  "pending": "pending review",
   "proposed": "Move pending review",
   "requested": "Move requested",
   "accepted": "Move accepted",


### PR DESCRIPTION
## Proposed changes

Single requests were previously making use of existing moves services and URLs and passing a list of statuses directly from the URL to the API.

The problem with this is that to correctly filter down the moves to only display single requests we actually need to pass other filters to the API, like `move_type`. It also wasn't using the correct statuses within the existing URLs.

This work abstracts that work to a single requests service so that if statuses/filters change within the API they are contained within one place in this app.

That allows us to display moves based on filters in the UI and keep that abstraction away from URLs/controllers/middleware.

There should be no major difference in the screens for this change apart from the URL changes.

This is also a start to try and split the single requests work into its own sub-app as the way of displaying them feels separate enough to moves to warrant a new area within this app.