### PR TITLE
fix: Ensure fillinAutocomplete e2e helper can change its value

### DIFF
--- a/test/e2e/_helpers.js
+++ b/test/e2e/_helpers.js
@@ -229,7 +229,7 @@ async function selectOption({ options, value }) {
  * @returns {string} - value of the selected item
  */
 export async function fillAutocomplete({ selector, value }) {
-  await t.click(selector)
+  await t.click(selector).pressKey('ctrl+a delete')
 
   const optionsSelector = '.autocomplete__menu .autocomplete__option'
   const autocompleteMenuOptions = await selector.parent().find(optionsSelector)


### PR DESCRIPTION
The autocomplete filters the options based on what is in the input. The presence of any previous input meant that only one matching option was returned from focusing the field - the very same currently selected option!

The fix is to zap the input first.

### Checklist

- [x] If adding new environment variables, they have been documented in the [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md)
- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
