### PR TITLE
[P4-1364] [P4-1362] Review a single request (approve/reject)

### DIFF
--- a/app/move/controllers/index.js
+++ b/app/move/controllers/index.js
@@ -1,13 +1,15 @@
 const Cancel = require('./cancel')
 const confirmation = require('./confirmation')
 const create = require('./create')
+const Review = require('./review')
 const update = require('./update')
 const view = require('./view')
 
 module.exports = {
   Cancel,
-  create,
-  view,
-  update,
   confirmation,
+  create,
+  Review,
+  update,
+  view,
 }

--- a/app/move/controllers/review.js
+++ b/app/move/controllers/review.js
@@ -1,0 +1,74 @@
+const { pick } = require('lodash')
+
+const FormWizardController = require('../../../common/controllers/form-wizard')
+const presenters = require('../../../common/presenters')
+const singleRequestService = require('../../../common/services/single-request')
+const filters = require('../../../config/nunjucks/filters')
+
+class ReviewController extends FormWizardController {
+  middlewareSetup() {
+    super.middlewareSetup()
+    this.use(this.updateDateHint)
+  }
+
+  middlewareLocals() {
+    super.middlewareLocals()
+    this.use(this.setMoveSummary)
+  }
+
+  updateDateHint(req, res, next) {
+    const { move_date: moveDate } = req.form.options.fields
+    const { date_to: dateTo, date_from: dateFrom } = res.locals.move
+
+    moveDate.hint.text = req.t(moveDate.hint.text, {
+      context: dateTo ? 'with_date_range' : 'with_date',
+      date: filters.formatDateRange([dateFrom, dateTo], 'and'),
+    })
+
+    next()
+  }
+
+  setMoveSummary(req, res, next) {
+    const { move } = res.locals
+
+    res.locals.person = move.person
+    res.locals.moveSummary = presenters.moveToMetaListComponent(move)
+
+    next()
+  }
+
+  async successHandler(req, res, next) {
+    const { id: moveId } = res.locals.move
+    const data = pick(
+      req.sessionModel.toJSON(),
+      Object.keys(req.form.options.allFields)
+    )
+
+    try {
+      if (data.review_decision === 'reject') {
+        await singleRequestService.reject(moveId, {
+          comment: data.rejection_reason_comment,
+        })
+      }
+
+      if (data.review_decision === 'approve') {
+        await singleRequestService.approve(moveId, {
+          date: data.move_date,
+        })
+      }
+
+      req.journeyModel.reset()
+      req.sessionModel.reset()
+
+      res.redirect(
+        data.review_decision === 'approve'
+          ? `/move/${moveId}/confirmation`
+          : `/move/${moveId}`
+      )
+    } catch (error) {
+      next(error)
+    }
+  }
+}
+
+module.exports = ReviewController

--- a/app/move/controllers/review.test.js
+++ b/app/move/controllers/review.test.js
@@ -1,0 +1,357 @@
+const FormWizardController = require('../../../common/controllers/form-wizard')
+const presenters = require('../../../common/presenters')
+const singleRequestService = require('../../../common/services/single-request')
+const filters = require('../../../config/nunjucks/filters')
+
+const ReviewController = require('./review')
+
+const controller = new ReviewController({ route: '/' })
+
+const mockMove = {
+  id: '123456789',
+  person: {
+    fullname: 'Full name',
+  },
+}
+
+describe('Move controllers', function() {
+  describe('Review controller', function() {
+    describe('#middlewareSetup()', function() {
+      beforeEach(function() {
+        sinon.stub(FormWizardController.prototype, 'middlewareSetup')
+        sinon.stub(controller, 'use')
+        sinon.stub(controller, 'updateDateHint')
+
+        controller.middlewareSetup()
+      })
+
+      it('should call parent method', function() {
+        expect(FormWizardController.prototype.middlewareSetup).to.have.been
+          .calledOnce
+      })
+
+      it('should call setCourtCaseItems middleware', function() {
+        expect(controller.use.firstCall).to.have.been.calledWith(
+          controller.updateDateHint
+        )
+      })
+
+      it('should call correct number of middleware', function() {
+        expect(controller.use.callCount).to.equal(1)
+      })
+    })
+
+    describe('#middlewareLocals()', function() {
+      beforeEach(function() {
+        sinon.stub(FormWizardController.prototype, 'middlewareLocals')
+        sinon.stub(controller, 'use')
+        sinon.stub(controller, 'setMoveSummary')
+
+        controller.middlewareLocals()
+      })
+
+      it('should call parent method', function() {
+        expect(FormWizardController.prototype.middlewareLocals).to.have.been
+          .calledOnce
+      })
+
+      it('should call setCourtCaseItems middleware', function() {
+        expect(controller.use.firstCall).to.have.been.calledWith(
+          controller.setMoveSummary
+        )
+      })
+
+      it('should call correct number of middleware', function() {
+        expect(controller.use.callCount).to.equal(1)
+      })
+    })
+
+    describe('#updateDateHint()', function() {
+      let mockReq, mockRes, nextSpy
+
+      beforeEach(function() {
+        sinon.stub(filters, 'formatDateRange')
+        nextSpy = sinon.spy()
+
+        mockReq = {
+          t: sinon.stub().returns('new.translation.key'),
+          form: {
+            options: {
+              fields: {
+                move_date: {
+                  hint: {
+                    text: 'original.translation.key',
+                  },
+                },
+              },
+            },
+          },
+        }
+        mockRes = {
+          locals: {
+            move: {
+              date_from: '1 Jan',
+            },
+          },
+        }
+      })
+
+      context('with only from date', function() {
+        beforeEach(function() {
+          filters.formatDateRange
+            .withArgs(['1 Jan', undefined], 'and')
+            .returns('1 Jan')
+          controller.updateDateHint(mockReq, mockRes, nextSpy)
+        })
+
+        it('should translate new hint text', function() {
+          expect(mockReq.t).to.be.calledOnceWithExactly(
+            'original.translation.key',
+            {
+              context: 'with_date',
+              date: '1 Jan',
+            }
+          )
+        })
+
+        it('should update field hint', function() {
+          expect(mockReq.form.options.fields.move_date).to.deep.equal({
+            hint: {
+              text: 'new.translation.key',
+            },
+          })
+        })
+      })
+
+      context('with from and to date', function() {
+        beforeEach(function() {
+          filters.formatDateRange
+            .withArgs(['1 Jan', '2 Feb'], 'and')
+            .returns('1 Jan and 2 Feb')
+          mockRes.locals.move.date_to = '2 Feb'
+
+          controller.updateDateHint(mockReq, mockRes, nextSpy)
+        })
+
+        it('should translate new hint text', function() {
+          expect(mockReq.t).to.be.calledOnceWithExactly(
+            'original.translation.key',
+            {
+              context: 'with_date_range',
+              date: '1 Jan and 2 Feb',
+            }
+          )
+        })
+
+        it('should update field hint', function() {
+          expect(mockReq.form.options.fields.move_date).to.deep.equal({
+            hint: {
+              text: 'new.translation.key',
+            },
+          })
+        })
+      })
+
+      it('should call next', function() {
+        controller.updateDateHint(mockReq, mockRes, nextSpy)
+        expect(nextSpy).to.be.calledOnceWithExactly()
+      })
+    })
+
+    describe('#setMoveSummary()', function() {
+      let mockRes, nextSpy
+
+      beforeEach(function() {
+        sinon.stub(presenters, 'moveToMetaListComponent').returnsArg(0)
+        nextSpy = sinon.spy()
+        mockRes = {
+          locals: {
+            move: {
+              person: {
+                id: '1',
+              },
+              foo: 'bar',
+            },
+          },
+        }
+
+        controller.setMoveSummary({}, mockRes, nextSpy)
+      })
+
+      it('should call presenter', function() {
+        expect(presenters.moveToMetaListComponent).to.be.calledOnceWithExactly(
+          mockRes.locals.move
+        )
+      })
+
+      it('should update locals', function() {
+        expect(mockRes.locals).to.deep.equal({
+          ...mockRes.locals,
+          person: mockRes.locals.move.person,
+          moveSummary: mockRes.locals.move,
+        })
+      })
+
+      it('should call next', function() {
+        expect(nextSpy).to.be.calledOnceWithExactly()
+      })
+    })
+
+    describe('#successHandler()', function() {
+      let req, res, nextSpy
+
+      beforeEach(function() {
+        sinon.stub(singleRequestService, 'approve')
+        sinon.stub(singleRequestService, 'reject')
+        nextSpy = sinon.spy()
+        req = {
+          form: {
+            options: {
+              allFields: {
+                move_date: {},
+                review_decision: {},
+                rejection_reason_comment: {},
+              },
+            },
+          },
+          sessionModel: {
+            reset: sinon.stub(),
+          },
+          journeyModel: {
+            reset: sinon.stub(),
+          },
+        }
+        res = {
+          redirect: sinon.stub(),
+          locals: {
+            move: mockMove,
+          },
+        }
+      })
+
+      context('with approval', function() {
+        const mockValues = {
+          move_date: '2020-10-10',
+          review_decision: 'approve',
+        }
+
+        beforeEach(function() {
+          req.sessionModel.toJSON = () => mockValues
+        })
+
+        context('when service resolves', function() {
+          beforeEach(async function() {
+            singleRequestService.approve.resolves({})
+            await controller.successHandler(req, res, nextSpy)
+          })
+
+          it('should approve move', function() {
+            expect(singleRequestService.approve).to.be.calledOnceWithExactly(
+              mockMove.id,
+              {
+                date: mockValues.move_date,
+              }
+            )
+          })
+
+          it('should not reject move', function() {
+            expect(singleRequestService.reject).not.to.be.called
+          })
+
+          it('should reset the journey', function() {
+            expect(req.journeyModel.reset).to.have.been.calledOnce
+          })
+
+          it('should reset the session', function() {
+            expect(req.sessionModel.reset).to.have.been.calledOnce
+          })
+
+          it('should redirect correctly', function() {
+            expect(res.redirect).to.have.been.calledOnce
+            expect(res.redirect).to.have.been.calledWith(
+              '/move/123456789/confirmation'
+            )
+          })
+        })
+
+        context('when service rejects', function() {
+          const errorMock = new Error('Problem')
+
+          beforeEach(async function() {
+            singleRequestService.approve.throws(errorMock)
+            await controller.successHandler(req, res, nextSpy)
+          })
+
+          it('should call next with the error', function() {
+            expect(nextSpy).to.be.calledOnceWithExactly(errorMock)
+          })
+
+          it('should not redirect', function() {
+            expect(res.redirect).not.to.have.been.called
+          })
+        })
+      })
+
+      context('with rejection', function() {
+        const mockValues = {
+          review_decision: 'reject',
+          rejection_reason_comment: 'No space at prison',
+        }
+
+        beforeEach(function() {
+          req.sessionModel.toJSON = () => mockValues
+        })
+
+        context('when service resolves', function() {
+          beforeEach(async function() {
+            singleRequestService.reject.resolves({})
+            await controller.successHandler(req, res, nextSpy)
+          })
+
+          it('should approve move', function() {
+            expect(singleRequestService.reject).to.be.calledOnceWithExactly(
+              mockMove.id,
+              {
+                comment: mockValues.rejection_reason_comment,
+              }
+            )
+          })
+
+          it('should not reject move', function() {
+            expect(singleRequestService.approve).not.to.be.called
+          })
+
+          it('should reset the journey', function() {
+            expect(req.journeyModel.reset).to.have.been.calledOnce
+          })
+
+          it('should reset the session', function() {
+            expect(req.sessionModel.reset).to.have.been.calledOnce
+          })
+
+          it('should redirect correctly', function() {
+            expect(res.redirect).to.have.been.calledOnce
+            expect(res.redirect).to.have.been.calledWith('/move/123456789')
+          })
+        })
+
+        context('when service rejects', function() {
+          const errorMock = new Error('Problem')
+
+          beforeEach(async function() {
+            singleRequestService.reject.throws(errorMock)
+            await controller.successHandler(req, res, nextSpy)
+          })
+
+          it('should call next with the error', function() {
+            expect(nextSpy).to.be.calledOnceWithExactly(errorMock)
+          })
+
+          it('should not redirect', function() {
+            expect(res.redirect).not.to.have.been.called
+          })
+        })
+      })
+    })
+  })
+})

--- a/app/move/controllers/view.js
+++ b/app/move/controllers/view.js
@@ -14,12 +14,7 @@ module.exports = function view(req, res) {
     cancellation_reason: cancellationReason,
     cancellation_reason_comment: cancellationComments,
   } = move
-  const reason =
-    cancellationReason === 'other'
-      ? cancellationComments
-      : req.t(`fields::cancellation_reason.items.${cancellationReason}.label`)
   const bannerStatuses = ['cancelled']
-
   const userPermissions = get(req.session, 'user.permissions')
   const updateUrls = getUpdateUrls(updateSteps, move.id, userPermissions)
   const updateActions = getUpdateLinks(updateSteps, updateUrls)
@@ -50,11 +45,11 @@ module.exports = function view(req, res) {
       'court'
     ),
     messageTitle: bannerStatuses.includes(status)
-      ? req.t('statuses::' + status)
+      ? req.t('statuses::' + status, { context: cancellationReason })
       : undefined,
     messageContent: req.t('statuses::description', {
-      context: status,
-      reason,
+      context: cancellationReason,
+      comment: cancellationComments,
     }),
     updateLinks: updateActions,
     urls,

--- a/app/move/controllers/view.test.js
+++ b/app/move/controllers/view.test.js
@@ -266,62 +266,32 @@ describe('Move controllers', function() {
       let params
 
       beforeEach(function() {
+        req.t.returns('__translated__')
         res.locals.move = {
           ...mockMove,
           status: 'cancelled',
           cancellation_reason: 'made_in_error',
+          cancellation_reason_comment: 'Reason for cancelling comments',
         }
+
+        controller(req, res)
+        params = res.render.args[0][1]
       })
 
-      context('when cancellation reason is not "other"', function() {
-        beforeEach(function() {
-          req.t.returns('__translated__')
+      it('should contain a message title param', function() {
+        expect(params).to.have.property('messageTitle')
+      })
 
-          controller(req, res)
-          params = res.render.args[0][1]
-        })
-
-        it('should contain a message title param', function() {
-          expect(params).to.have.property('messageTitle')
-        })
-
-        it('should contain a message content param', function() {
-          expect(params).to.have.property('messageContent')
-          expect(params.messageContent).to.equal('statuses::description')
-        })
-
-        it('should call correct translation', function() {
-          expect(req.t.thirdCall).to.be.calledWithExactly(
-            'statuses::description',
-            {
-              context: 'cancelled',
-              reason: 'fields::cancellation_reason.items.made_in_error.label',
-            }
-          )
+      it('should call correct translation', function() {
+        expect(req.t).to.be.calledWithExactly('statuses::description', {
+          context: 'made_in_error',
+          comment: 'Reason for cancelling comments',
         })
       })
 
-      context('when cancellation reason is "other"', function() {
-        beforeEach(function() {
-          res.locals.move = {
-            ...mockMove,
-            status: 'cancelled',
-            cancellation_reason: 'other',
-            cancellation_reason_comments: 'Another reason for cancelling',
-          }
-
-          controller(req, res)
-          params = res.render.args[0][1]
-        })
-
-        it('should contain a message title param', function() {
-          expect(params).to.have.property('messageTitle')
-        })
-
-        it('should contain a message content param', function() {
-          expect(params).to.have.property('messageContent')
-          expect(params.messageContent).to.equal('statuses::description')
-        })
+      it('should contain a message content param', function() {
+        expect(params).to.have.property('messageContent')
+        expect(params.messageContent).to.equal('statuses::description')
       })
     })
   })

--- a/app/move/fields/index.js
+++ b/app/move/fields/index.js
@@ -30,16 +30,17 @@ const people = require('./people')
 const policeNationalComputer = require('./police-national-computer')
 const policeNationalComputerUpdate = require('./police-national-computer.update')
 const prisonTransferType = require('./prison-transfer-type')
+const reviewFields = require('./review')
 const shouldSaveCourtHearings = require('./should-save-court-hearings')
 const toLocation = require('./to-location')
 const toLocationCourtAppearance = require('./to-location-court-appearance')
 const toLocationPrisonTransfer = require('./to-location-prison-transfer')
 
-const cancel = {
+const cancelFields = {
   cancellation_reason: cancellationReason,
   cancellation_reason_comment: cancellationReasonComment,
 }
-const create = {
+const createFields = {
   concealed_items: assessmentAnswer(),
   court_hearing__comments: courtHearingComments,
   court_hearing__court_case: courtHearingCourtCase,
@@ -102,13 +103,14 @@ const create = {
   wheelchair: assessmentAnswer(),
   violent: assessmentAnswer(),
 }
-const update = {
-  ...cloneDeep(create),
+const updateFields = {
+  ...cloneDeep(cancelFields),
   police_national_computer: policeNationalComputerUpdate,
 }
 
 module.exports = {
-  cancel,
-  create,
-  update,
+  cancelFields,
+  createFields,
+  reviewFields,
+  updateFields,
 }

--- a/app/move/fields/review/index.js
+++ b/app/move/fields/review/index.js
@@ -1,0 +1,9 @@
+const moveDate = require('./move-date')
+const rejectionReasonComment = require('./rejection-reason-comment')
+const reviewDecision = require('./review-decision')
+
+module.exports = {
+  move_date: moveDate,
+  review_decision: reviewDecision,
+  rejection_reason_comment: rejectionReasonComment,
+}

--- a/app/move/fields/review/move-date.js
+++ b/app/move/fields/review/move-date.js
@@ -1,0 +1,24 @@
+const { cloneDeep } = require('lodash')
+
+const commonDateField = require('../common.date')
+
+const moveDate = {
+  ...cloneDeep(commonDateField),
+  validate: [...commonDateField.validate, 'required', 'after'],
+  skip: true,
+  dependent: {
+    field: 'review_decision',
+    value: 'approve',
+  },
+  id: 'move_date',
+  name: 'move_date',
+  label: {
+    text: 'fields::move_date.label',
+    classes: 'govuk-label--s',
+  },
+  hint: {
+    text: 'fields::move_date.hint',
+  },
+}
+
+module.exports = moveDate

--- a/app/move/fields/review/rejection-reason-comment.js
+++ b/app/move/fields/review/rejection-reason-comment.js
@@ -1,0 +1,17 @@
+const rejectionReasonComment = {
+  name: 'rejection_reason_comment',
+  skip: true,
+  rows: 3,
+  component: 'govukTextarea',
+  classes: 'govuk-input--width-20',
+  label: {
+    text: 'fields::rejection_reason_comment.label',
+    classes: 'govuk-label--s',
+  },
+  dependent: {
+    field: 'review_decision',
+    value: 'reject',
+  },
+}
+
+module.exports = rejectionReasonComment

--- a/app/move/fields/review/review-decision.js
+++ b/app/move/fields/review/review-decision.js
@@ -1,0 +1,26 @@
+const reviewDecision = {
+  validate: 'required',
+  component: 'govukRadios',
+  name: 'review_decision',
+  fieldset: {
+    legend: {
+      text: 'fields::review_decision.label',
+      classes: 'govuk-fieldset__legend--m',
+    },
+  },
+  items: [
+    {
+      id: 'review_decision',
+      value: 'approve',
+      text: 'fields::review_decision.items.approve.label',
+      conditional: 'move_date',
+    },
+    {
+      value: 'reject',
+      text: 'fields::review_decision.items.reject.label',
+      conditional: ['rejection_reason_comment'],
+    },
+  ],
+}
+
+module.exports = reviewDecision

--- a/app/move/index.js
+++ b/app/move/index.js
@@ -9,14 +9,16 @@ const { FEATURE_FLAGS } = require('../../config')
 
 const { confirmation, create, update, view } = require('./controllers')
 const {
-  cancel: cancelFields,
-  create: createFields,
-  update: updateFields,
+  cancelFields,
+  createFields,
+  reviewFields,
+  updateFields,
 } = require('./fields')
 const { setMove } = require('./middleware')
 const {
   cancel: cancelSteps,
   create: createSteps,
+  review: reviewSteps,
   update: updateSteps,
 } = require('./steps')
 
@@ -45,6 +47,11 @@ const cancelConfig = {
   name: 'cancel-move',
   journeyName: 'cancel-move',
 }
+const reviewConfig = {
+  ...wizardConfig,
+  name: 'review-move',
+  journeyName: 'review-move',
+}
 
 // Define param middleware
 router.param('moveId', setMove)
@@ -56,12 +63,16 @@ router.use(
   wizard(createSteps, createFields, createConfig)
 )
 router.get('/:moveId', protectRoute('move:view'), view)
-
 router.get('/:moveId/confirmation', protectRoute('move:create'), confirmation)
 router.use(
   '/:moveId/cancel',
   protectRoute('move:cancel'),
   wizard(cancelSteps, cancelFields, cancelConfig)
+)
+router.use(
+  '/:moveId/review',
+  protectRoute('move:review'),
+  wizard(reviewSteps, reviewFields, reviewConfig)
 )
 
 if (FEATURE_FLAGS.EDITABILITY) {

--- a/app/move/steps/index.js
+++ b/app/move/steps/index.js
@@ -1,9 +1,11 @@
 const cancel = require('./cancel')
 const create = require('./create')
+const review = require('./review')
 const update = require('./update')
 
 module.exports = {
   cancel,
   create,
+  review,
   update,
 }

--- a/app/move/steps/review.js
+++ b/app/move/steps/review.js
@@ -1,0 +1,18 @@
+const { Review } = require('../controllers')
+
+module.exports = {
+  '/': {
+    entryPoint: true,
+    resetJourney: true,
+    skip: true,
+    next: 'decision',
+  },
+  '/decision': {
+    backLink: null,
+    template: 'move/views/review',
+    pageTitle: 'moves::review.steps.decision.heading',
+    buttonText: 'actions::confirm_and_save',
+    fields: ['move_date', 'rejection_reason_comment', 'review_decision'],
+    controller: Review,
+  },
+}

--- a/app/move/views/review.njk
+++ b/app/move/views/review.njk
@@ -1,0 +1,40 @@
+{% extends "form-wizard.njk" %}
+
+{% block customGtagConfig %}
+  gtag('set', {'page_title': 'Review move'});
+{% endblock %}
+
+{% block innerPageTitle %}
+  {{ t("moves::review.page_title", { name: move.person.fullname | upper }) }}
+{% endblock %}
+
+{% block pageHeading %}
+  <h1 class="govuk-heading-xl govuk-!-margin-bottom-1">
+    {{ t("moves::review.page_title", { name: move.person.fullname | upper }) }}
+  </h1>
+  <span class="govuk-caption-xl govuk-!-margin-bottom-8">
+    {{ t("moves::move_reference", {
+      reference: move.reference
+    }) }}
+  </span>
+{% endblock %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+    text: t("actions::back_to_move"),
+    href: "/move/" + move.id
+  }) }}
+
+  {{ super() }}
+{% endblock %}
+
+{% block summaryPanelContent %}
+  {{ super() }}
+
+  <p class="govuk-!-margin-top-3 govuk-!-margin-bottom-0">
+    <a href="/move/{{ move.id }}">
+      {{ t("actions::view_more_information") }}
+    </a>
+  </p>
+{% endblock %}
+

--- a/app/move/views/view.njk
+++ b/app/move/views/view.njk
@@ -37,11 +37,35 @@
       }
     }) }}
   {% endif %}
+
+  {% if move.status == "proposed" %}
+    {% set html %}
+      <p>{{ t("messages::pending_review.content") }}</p>
+
+      {% if canAccess("move:review") %}
+        {{ govukButton({
+          href: move.id + "/review",
+          text: t("actions::review")
+        }) }}
+      {% endif %}
+    {% endset %}
+
+    {{ appMessage({
+      allowDismiss: false,
+      classes: "app-message--instruction",
+      title: {
+        text: t("messages::pending_review.heading")
+      },
+      content: {
+        html: html
+      }
+    }) }}
+  {% endif %}
 {% endblock %}
 
 {% block contentHeader %}
   <header class="govuk-!-margin-bottom-8">
-    {% if not messageTitle %}
+    {% if not messageTitle and move.status != "proposed" %}
       <div class="govuk-!-margin-bottom-2">
         {{ mojBadge({
           text: t("statuses::" + move.status)

--- a/common/components/message/_message.scss
+++ b/common/components/message/_message.scss
@@ -113,3 +113,17 @@ $_message-border-width: 5px;
     color: govuk-colour("white");
   }
 }
+
+.app-message--instruction {
+  background-color: govuk-tint(govuk-colour("light-blue"), 75);
+  border-width: 0;
+  padding: $_message-padding + $_message-border-width;
+
+  .app-message__heading + * {
+    margin-top: govuk-spacing(4);
+  }
+
+  * + * {
+    margin-top: govuk-spacing(3);
+  }
+}

--- a/common/lib/permissions.js
+++ b/common/lib/permissions.js
@@ -54,7 +54,7 @@ const ocaPermissions = [
   'move:create:court_appearance',
   'move:create:prison_transfer',
 ]
-const pmuPermissions = ['allocations:view', 'allocation:create']
+const pmuPermissions = ['allocations:view', 'allocation:create', 'move:review']
 
 const permissionsByRole = {
   ROLE_PECS_POLICE: policePermissions,

--- a/common/lib/user.test.js
+++ b/common/lib/user.test.js
@@ -219,6 +219,20 @@ describe('User class', function() {
       })
     })
 
+    context('when user has ROLE_PECS_PMU', function() {
+      beforeEach(function() {
+        permissions = user.getPermissions(['ROLE_PECS_PMU'])
+      })
+
+      it('should contain correct permission', function() {
+        expect(permissions).to.deep.equal([
+          'allocations:view',
+          'allocation:create',
+          'move:review',
+        ])
+      })
+    })
+
     context('when user has ROLE_PECS_SUPPLIER role', function() {
       beforeEach(function() {
         permissions = user.getPermissions(['ROLE_PECS_SUPPLIER'])
@@ -252,6 +266,7 @@ describe('User class', function() {
         const allPermissions = [
           'moves:view:outgoing',
           'moves:download',
+          'move:review',
           'move:view',
           'move:create',
           'move:create:court_appearance',

--- a/common/presenters/move-to-meta-list-component.js
+++ b/common/presenters/move-to-meta-list-component.js
@@ -1,7 +1,7 @@
 const { isToday, isTomorrow, isYesterday, parseISO } = require('date-fns')
 const { get } = require('lodash')
 
-const { create: createFields } = require('../../app/move/fields')
+const moveAgreedField = require('../../app/move/fields/move-agreed')
 const i18n = require('../../config/i18n')
 const filters = require('../../config/nunjucks/filters')
 
@@ -59,8 +59,7 @@ function moveToMetaListComponent(
   })
   const notAgreedLabel = i18n.t('moves::detail.agreement_status.not_agreed')
   const agreementLabel =
-    moveAgreed === true ||
-    moveAgreed === createFields.move_agreed.items[0].value
+    moveAgreed === true || moveAgreed === moveAgreedField.items[0].value
       ? agreedLabel
       : notAgreedLabel
 

--- a/common/services/single-request.js
+++ b/common/services/single-request.js
@@ -1,7 +1,10 @@
 const { pickBy } = require('lodash')
 
+const apiClient = require('../lib/api-client')()
+
 const moveService = require('./move')
 
+const noMoveIdMessage = 'No move ID supplied'
 const singleRequestService = {
   getAll({
     status,
@@ -51,6 +54,35 @@ const singleRequestService = {
         'sort[direction]': sortDirection,
       }),
     })
+  },
+
+  approve(id, { date } = {}) {
+    if (!id) {
+      return Promise.reject(new Error(noMoveIdMessage))
+    }
+
+    return apiClient
+      .update('move', {
+        id,
+        date,
+        status: 'requested',
+      })
+      .then(response => response.data)
+  },
+
+  reject(id, { comment } = {}) {
+    if (!id) {
+      return Promise.reject(new Error(noMoveIdMessage))
+    }
+
+    return apiClient
+      .update('move', {
+        id,
+        status: 'cancelled',
+        cancellation_reason: 'rejected',
+        cancellation_reason_comment: comment,
+      })
+      .then(response => response.data)
   },
 }
 

--- a/common/services/single-request.test.js
+++ b/common/services/single-request.test.js
@@ -1,6 +1,17 @@
+const apiClient = require('../lib/api-client')()
+
 const moveService = require('./move')
 const singleRequestService = require('./single-request')
 
+const mockMove = {
+  id: 'b695d0f0-af8e-4b97-891e-92020d6820b9',
+  status: 'requested',
+  person: {
+    id: 'f6e1f57c-7d07-41d2-afee-1662f5103e2d',
+    first_names: 'Steve Jones',
+    last_name: 'Bloggs',
+  },
+}
 const mockMoves = [
   {
     id: '12345',
@@ -279,6 +290,134 @@ describe('Single request service', function() {
           it('should return moves', function() {
             expect(moves).to.deep.equal(mockMoves)
           })
+        })
+      })
+    })
+  })
+
+  describe('#approve()', function() {
+    context('without move ID', function() {
+      it('should reject with error', function() {
+        return expect(singleRequestService.approve()).to.be.rejectedWith(
+          'No move ID supplied'
+        )
+      })
+    })
+
+    context('with move ID', function() {
+      const mockId = 'b695d0f0-af8e-4b97-891e-92020d6820b9'
+      const mockResponse = {
+        data: {
+          ...mockMove,
+          status: 'requested',
+        },
+      }
+      let move
+
+      beforeEach(async function() {
+        sinon.stub(apiClient, 'update').resolves(mockResponse)
+      })
+
+      context('without data args', function() {
+        beforeEach(async function() {
+          move = await singleRequestService.approve(mockId)
+        })
+
+        it('should call update method with data', function() {
+          expect(apiClient.update).to.be.calledOnceWithExactly('move', {
+            id: mockId,
+            date: undefined,
+            status: 'requested',
+          })
+        })
+
+        it('should return move', function() {
+          expect(move).to.deep.equal(mockResponse.data)
+        })
+      })
+
+      context('with data args', function() {
+        beforeEach(async function() {
+          move = await singleRequestService.approve(mockId, {
+            date: '2020-10-10',
+          })
+        })
+
+        it('should call update method with data', function() {
+          expect(apiClient.update).to.be.calledOnceWithExactly('move', {
+            id: mockId,
+            date: '2020-10-10',
+            status: 'requested',
+          })
+        })
+
+        it('should return move', function() {
+          expect(move).to.deep.equal(mockResponse.data)
+        })
+      })
+    })
+  })
+
+  describe('#reject()', function() {
+    context('without move ID', function() {
+      it('should reject with error', function() {
+        return expect(singleRequestService.reject()).to.be.rejectedWith(
+          'No move ID supplied'
+        )
+      })
+    })
+
+    context('with move ID', function() {
+      const mockId = 'b695d0f0-af8e-4b97-891e-92020d6820b9'
+      const mockResponse = {
+        data: {
+          ...mockMove,
+          status: 'cancelled',
+        },
+      }
+      let move
+
+      beforeEach(async function() {
+        sinon.stub(apiClient, 'update').resolves(mockResponse)
+      })
+
+      context('without data args', function() {
+        beforeEach(async function() {
+          move = await singleRequestService.reject(mockId)
+        })
+
+        it('should call update method with data', function() {
+          expect(apiClient.update).to.be.calledOnceWithExactly('move', {
+            id: mockId,
+            status: 'cancelled',
+            cancellation_reason: 'rejected',
+            cancellation_reason_comment: undefined,
+          })
+        })
+
+        it('should return move', function() {
+          expect(move).to.deep.equal(mockResponse.data)
+        })
+      })
+
+      context('with data args', function() {
+        beforeEach(async function() {
+          move = await singleRequestService.reject(mockId, {
+            comment: 'Reason for rejecting',
+          })
+        })
+
+        it('should call update method with data', function() {
+          expect(apiClient.update).to.be.calledOnceWithExactly('move', {
+            id: mockId,
+            status: 'cancelled',
+            cancellation_reason: 'rejected',
+            cancellation_reason_comment: 'Reason for rejecting',
+          })
+        })
+
+        it('should return move', function() {
+          expect(move).to.deep.equal(mockResponse.data)
         })
       })
     })

--- a/common/templates/form-wizard.njk
+++ b/common/templates/form-wizard.njk
@@ -32,9 +32,11 @@
 
   <header class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <h1 class="govuk-heading-xl">
-        {{ t(options.pageTitle) }}
-      </h1>
+      {% block pageHeading %}
+        <h1 class="govuk-heading-xl">
+          {{ t(options.pageTitle) }}
+        </h1>
+      {% endblock %}
     </div>
   </header>
 {% endblock %}
@@ -88,17 +90,19 @@
   {% if person %}
     <div class="sticky-sidebar">
       <div class="sticky-sidebar__inner">
-        <h3 class="govuk-heading-m app-border-top-2 app-border--blue govuk-!-padding-top-4 govuk-!-margin-bottom-3">
-          {{ person.fullname | upper }}
-        </h3>
+        {% block summaryPanelContent %}
+          <h3 class="govuk-heading-m app-border-top-2 app-border--blue govuk-!-padding-top-4 govuk-!-margin-bottom-3">
+            {{ person.fullname | upper }}
+          </h3>
 
-        {% if person.image_url %}
-          <div class="govuk-!-width-one-half govuk-!-margin-bottom-3">
-            <img src="{{ person.image_url }}" alt="{{ person.fullname | upper }}">
-          </div>
-        {% endif %}
+          {% if person.image_url %}
+            <div class="govuk-!-width-one-half govuk-!-margin-bottom-3">
+              <img src="{{ person.image_url }}" alt="{{ person.fullname | upper }}">
+            </div>
+          {% endif %}
 
-        {{ appMetaList(moveSummary) }}
+          {{ appMetaList(moveSummary) }}
+        {% endblock %}
       </div>
     </div>
   {% endif %}

--- a/config/nunjucks/filters.js
+++ b/config/nunjucks/filters.js
@@ -55,7 +55,7 @@ function formatDate(value, formattedDateStr = DATE_FORMATS.LONG) {
  * @example {{ ["2019-02-21", "2019-02-28"] | formatDateRange }}
  * @example {{ "2019-02-21" | formatDateRange("DD/MM/YY") }}
  */
-function formatDateRange(value) {
+function formatDateRange(value, delimiter = 'to') {
   const dates = filter(value)
 
   if (!value || !Array.isArray(value) || dates.length === 0) {
@@ -78,7 +78,7 @@ function formatDateRange(value) {
   )
   const formattedEndDate = formatDate(endDate)
 
-  return `${formattedStartDate} to ${formattedEndDate}`
+  return `${formattedStartDate} ${delimiter} ${formattedEndDate}`
 }
 
 /**

--- a/config/nunjucks/filters.test.js
+++ b/config/nunjucks/filters.test.js
@@ -271,6 +271,53 @@ describe('Nunjucks filters', function() {
         )
       })
     })
+
+    context('with custom delimiter', function() {
+      const mockStartDate = new Date('2019-11-01')
+
+      context('with one date', function() {
+        it('should not contain delimiter', function() {
+          expect(formatDateRange([mockStartDate], 'and')).to.equal('1 Nov 2019')
+        })
+      })
+
+      context('with two dates', function() {
+        context('when dates span different years', function() {
+          it('should contain both years', function() {
+            expect(
+              formatDateRange([mockStartDate, new Date('2020-01-18')], 'and')
+            ).to.equal('1 Nov 2019 and 18 Jan 2020')
+          })
+        })
+
+        context('when dates span different months', function() {
+          it('should contain both months', function() {
+            expect(
+              formatDateRange([mockStartDate, new Date('2019-12-10')], 'and')
+            ).to.equal('1 Nov and 10 Dec 2019')
+          })
+        })
+
+        context('when dates are in the same month', function() {
+          it('should contain both years', function() {
+            expect(
+              formatDateRange([mockStartDate, new Date('2019-11-10')], 'and')
+            ).to.equal('1 and 10 Nov 2019')
+          })
+        })
+
+        context(
+          'when dates are in the same month of different years',
+          function() {
+            it('should contain both years', function() {
+              expect(
+                formatDateRange([mockStartDate, new Date('2020-11-10')], 'and')
+              ).to.equal('1 Nov 2019 and 10 Nov 2020')
+            })
+          }
+        )
+      })
+    })
   })
 
   describe('#formatDateRangeAsRelativeWeek()', function() {

--- a/locales/en/actions.json
+++ b/locales/en/actions.json
@@ -25,5 +25,6 @@
   "switch_location": "Switch location",
   "confirm_and_save": "Confirm and save",
   "save_and_continue": "Save and continue",
-  "view_more_information": "View more information"
+  "view_more_information": "View more information",
+  "review": "Review"
 }

--- a/locales/en/actions.json
+++ b/locales/en/actions.json
@@ -23,5 +23,7 @@
   "print_move_detail": "Print move",
   "sign_out": "Sign out",
   "switch_location": "Switch location",
-  "save_and_continue": "Save and continue"
+  "confirm_and_save": "Confirm and save",
+  "save_and_continue": "Save and continue",
+  "view_more_information": "View more information"
 }

--- a/locales/en/errors.json
+++ b/locales/en/errors.json
@@ -18,8 +18,10 @@
   "missing_prereq": {
     "heading": "Journey expired",
     "heading_create_move": "This move has been requested",
+    "heading_review_move": "This move has been reviewed",
     "content": "Your journey has been completed.",
-    "content_create_move": "You can view upcoming moves or create a new move from the dashboard."
+    "content_create_move": "You can view upcoming moves or create a new move from the dashboard.",
+    "content_review_move": "You can view upcoming moves from the dashboard."
   },
   "tampered_with": {
     "heading": "This form has been tampered with",

--- a/locales/en/fields.json
+++ b/locales/en/fields.json
@@ -162,6 +162,28 @@
     "required": "Give details",
     "optional": "Give details (optional)"
   },
+  "review_decision": {
+    "label": "Can this move be requested with the supplier?",
+    "label_with_error": "Review decision",
+    "items": {
+      "approve": {
+        "label": "Yes, approve this request"
+      },
+      "reject": {
+        "label": "No, reject this request"
+      }
+    }
+  },
+  "move_date": {
+    "label": "Date of travel",
+    "hint": "$t(fields::date.hint)",
+    "hint_with_date": "Travel has been requested for {{date}}",
+    "hint_with_date_range": "Travel has been requested for between {{date}}"
+  },
+  "rejection_reason_comment": {
+    "label": "Additional information (optional)",
+    "label_with_error": "Additional information"
+  },
   "cancellation_reason": {
     "label": "Why are you cancelling this move request?",
     "items": {

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -8,5 +8,9 @@
   },
   "create_allocation": {
     "heading": "Allocation requested"
+  },
+  "pending_review": {
+    "heading": "Pending review",
+    "content": "This request needs to be reviewed by a member of the Population Management Unit (PMU) before it can be requested with the supplier."
   }
 }

--- a/locales/en/moves.json
+++ b/locales/en/moves.json
@@ -156,10 +156,15 @@
         "heading": "Cancel this move request"
       }
     },
-    "page_title": "Cancel move for ‘{{name}}’",
-    "warning": "You must also contact the supplier to cancel the move request for {{name}}",
-    "panel": {
-      "content": "Reason — {{reason}}"
+    "page_title": "Cancel move for ‘{{-name}}’",
+    "warning": "You must also contact the supplier to cancel the move request for {{name}}"
+  },
+  "review": {
+    "page_title": "Review request for ‘{{-name}}’",
+    "steps": {
+      "decision": {
+        "heading": "Review this request"
+      }
     }
   },
   "confirmation": {

--- a/locales/en/statuses.json
+++ b/locales/en/statuses.json
@@ -7,6 +7,10 @@
   "accepted": "Move accepted",
   "completed": "Move completed",
   "cancelled": "Move cancelled",
+  "cancelled_rejected": "Single request rejected",
   "description": "",
-  "description_cancelled": "Reason — {{reason}}"
+  "description_made_in_error": "Reason — $t(fields::cancellation_reason.items.made_in_error.label)",
+  "description_supplier_declined_to_move": "Reason — $t(fields::cancellation_reason.items.supplier_declined_to_move.label)",
+  "description_other": "Reason — {{comment}}",
+  "description_rejected": "Comments — {{comment}}"
 }


### PR DESCRIPTION
## Proposed changes

This introduces the ability for a user to approve or reject a single request (a `proposed` move). It uses the form wizard to create a simple one step journey and creates extra service methods to interact with the API.

**NOTE**: This requires two changes to the API to be fully supported. One to extend the cancellation reasons to include `rejected` and another to remove date validation when sending a `PATCH` with `proposed` moves.

## Screenshots

<kbd><img src="https://user-images.githubusercontent.com/3327997/81576794-9873d580-93a0-11ea-8c85-a524c911e9c8.png"></kbd>

<kbd><img src="https://user-images.githubusercontent.com/3327997/81576822-a590c480-93a0-11ea-86b7-c8ac00ad040f.png"></kbd>

<kbd><img src="https://user-images.githubusercontent.com/3327997/81571300-a70abe80-9399-11ea-9449-1a969dae4363.png"></kbd>

<kbd><img src="https://user-images.githubusercontent.com/3327997/81571660-25676080-939a-11ea-8704-ac01dd15cf2d.png"></kbd>
