### PR TITLE
fix: Prevent update court link when move not to court

### DIFF
--- a/app/move/controllers/update/court.js
+++ b/app/move/controllers/update/court.js
@@ -1,0 +1,24 @@
+const { get } = require('lodash')
+
+const AssessmentController = require('./assessment')
+
+class UpdateCourtController extends AssessmentController {
+  // TODO: replace this with a centralised more form-wizard-based protection
+  configure(req, res, next) {
+    const isCourt =
+      get(res, 'locals.move.to_location.location_type') === 'court'
+
+    if (!isCourt) {
+      const error = new Error(
+        'Updating court information is not possible for this move'
+      )
+      error.statusCode = 404
+
+      return next(error)
+    }
+
+    super.configure(req, res, next)
+  }
+}
+
+module.exports = UpdateCourtController

--- a/app/move/controllers/update/court.test.js
+++ b/app/move/controllers/update/court.test.js
@@ -1,0 +1,79 @@
+const AssessmentController = require('./assessment')
+const CourtController = require('./court')
+
+const controller = new CourtController({ route: '/' })
+const ownProto = Object.getPrototypeOf(controller)
+
+describe('Move controllers', function() {
+  const req = {}
+  let res
+  let nextSpy
+  beforeEach(function() {
+    res = {}
+    nextSpy = sinon.spy()
+    sinon.stub(AssessmentController.prototype, 'configure')
+  })
+  describe('Update court info controller', function() {
+    it('should extend AssessmentController', function() {
+      expect(Object.getPrototypeOf(ownProto)).to.equal(
+        AssessmentController.prototype
+      )
+    })
+
+    context('#configure', function() {
+      context('when the move is not to a court', function() {
+        let args
+        let error
+        beforeEach(function() {
+          args = []
+          error = {}
+          controller.configure(req, res, nextSpy)
+          try {
+            args = nextSpy.getCall(0).args
+            error = args[0]
+          } catch (e) {}
+        })
+
+        it('should call next once with an error', function() {
+          expect(nextSpy).to.be.calledOnce
+          expect(args.length).to.equal(1)
+        })
+
+        it('should set the correct error message', function() {
+          expect(error.message).to.equal(
+            'Updating court information is not possible for this move'
+          )
+        })
+
+        it('should set the correct error statusCode', function() {
+          expect(error.statusCode).to.equal(404)
+        })
+      })
+
+      context('when the move is to a court', function() {
+        beforeEach(function() {
+          res = {
+            locals: {
+              move: {
+                to_location: {
+                  location_type: 'court',
+                },
+              },
+            },
+          }
+          controller.configure(req, res, nextSpy)
+        })
+
+        it('should not call next', function() {
+          expect(nextSpy).to.not.be.called
+        })
+
+        it('should invoke super’s configure', function() {
+          expect(
+            AssessmentController.prototype.configure
+          ).to.be.calledOnceWithExactly(req, res, nextSpy)
+        })
+      })
+    })
+  })
+})

--- a/app/move/controllers/update/index.js
+++ b/app/move/controllers/update/index.js
@@ -1,10 +1,12 @@
 const Assessment = require('./assessment')
+const Court = require('./court')
 const MoveDate = require('./move-date')
 const MoveDetails = require('./move-details')
 const PersonalDetails = require('./personal-details')
 
 module.exports = {
   Assessment,
+  Court,
   MoveDate,
   MoveDetails,
   PersonalDetails,

--- a/app/move/steps/update.js
+++ b/app/move/steps/update.js
@@ -1,5 +1,6 @@
 const {
   Assessment,
+  Court,
   MoveDate,
   MoveDetails,
   PersonalDetails,
@@ -55,7 +56,7 @@ const updateSteps = [
       '/court-information': {
         ...createSteps['/court-information'],
         ...updateStepPropOverrides,
-        controller: Assessment,
+        controller: Court,
       },
     },
   },

--- a/app/move/views/_includes/assessment.njk
+++ b/app/move/views/_includes/assessment.njk
@@ -29,8 +29,8 @@
   </section>
 {% endfor %}
 
-<section class="app-!-position-relative">
-  {% if move.to_location.location_type == 'court' %}
+{% if move.to_location.location_type == 'court' %}
+  <section class="app-!-position-relative">
     {% if move.from_location.location_type == 'prison' and not courtSummary.rows.length %}
       <h2 class="govuk-heading-m govuk-!-margin-bottom-2 govuk-!-margin-top-7">
         {{ t("moves::detail.court_hearings.heading", {
@@ -92,7 +92,8 @@
         }) }}
       {% endif %}
     {% endif %}
-  {% endif %}
 
-  {{ updateLink(updateLinks.court) }}
-</section>
+    {{ updateLink(updateLinks.court) }}
+  </section>
+{% endif %}
+


### PR DESCRIPTION
### Checklist

- [x] If adding new environment variables, they have been documented in the [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md)
- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
