### PR TITLE
[P4 1287] Single allocation view

### DIFF
--- a/app/allocation/controllers/view.js
+++ b/app/allocation/controllers/view.js
@@ -1,0 +1,25 @@
+const presenters = require('../../../common/presenters')
+
+module.exports = function view(req, res) {
+  const { allocation } = res.locals
+  const { moves } = allocation
+  const locals = {
+    dashboardUrl: '/allocations',
+    allocationDetails: presenters.allocationToMetaListComponent(allocation),
+    allocationSummary: presenters.allocationToSummaryListComponent(allocation),
+    allocationPeople: {
+      emptySlots: moves.filter(move => !move.person).length,
+      filledSlots: moves
+        .filter(move => move.person)
+        .map(move => {
+          const { person } = move
+          if (!person.fullname) {
+            person.fullname = `${person.first_names} ${person.last_name}`
+          }
+          return person
+        })
+        .map(presenters.personToCardComponent()),
+    },
+  }
+  res.render('allocation/views/view', locals)
+}

--- a/app/allocation/controllers/view.test.js
+++ b/app/allocation/controllers/view.test.js
@@ -1,0 +1,104 @@
+const presenters = require('../../../common/presenters')
+
+const handler = require('./view')
+
+describe('view allocation', function() {
+  let locals
+  let render
+  let output
+  beforeEach(function() {
+    sinon.stub(presenters, 'allocationToMetaListComponent').returns({})
+    sinon.stub(presenters, 'allocationToSummaryListComponent').returns({})
+    render = sinon.stub()
+    locals = {
+      allocation: {
+        id: '06464fbd-b78a-4e47-b65c-8ab3c3867196',
+        type: 'allocations',
+        moves_count: 22,
+        date: '2020-05-06',
+        prisoner_category: 'c',
+        sentence_length: 'long',
+        complex_cases: [
+          {
+            title: 'Segregated prisoners',
+            answer: true,
+          },
+          {
+            title: 'Self harm / prisoners on ACCT',
+            answer: true,
+          },
+          {
+            title: 'Mental health issues',
+            answer: false,
+          },
+          {
+            title: 'Integrated Drug Treatment System',
+            answer: false,
+          },
+        ],
+        complete_in_full: false,
+        other_criteria: 'no',
+        created_at: '2020-05-01T10:44:00+01:00',
+        updated_at: '2020-05-01T10:44:00+01:00',
+        from_location: {
+          title: 'BERWYN (HMP)',
+          location_type: 'prison',
+        },
+        to_location: {
+          title: 'GARTREE (HMP)',
+          location_type: 'prison',
+        },
+        moves: [
+          {},
+          {},
+          {
+            person: {
+              first_names: 'John',
+              last_name: 'Doe',
+            },
+          },
+        ],
+      },
+    }
+    handler(
+      {},
+      {
+        locals,
+        render,
+      }
+    )
+    output = render.firstCall.lastArg
+  })
+  it('creates allocationDetails on locals with the result of the correct presenter', function() {
+    expect(output.allocationDetails).to.exist
+    expect(
+      presenters.allocationToMetaListComponent
+    ).to.have.been.calledOnceWithExactly(locals.allocation)
+  })
+  it('creates allocationSummary on locals with the result of the correct presenter', function() {
+    expect(output.allocationSummary).to.exist
+    expect(
+      presenters.allocationToSummaryListComponent
+    ).to.have.been.calledOnceWithExactly(locals.allocation)
+  })
+  it('calls render with the template', function() {
+    expect(render).to.have.been.calledWithExactly('allocation/views/view', {
+      allocationDetails: {},
+      allocationSummary: {},
+      allocationPeople: {
+        emptySlots: 2,
+        filledSlots: [
+          {
+            href: undefined,
+            image_alt: 'JOHN DOE',
+            image_path: undefined,
+            meta: { items: [] },
+            tags: { items: [] },
+            title: { text: 'JOHN DOE' },
+          },
+        ],
+      },
+      dashboardUrl: '/allocations',
+    })
+  })
+})

--- a/app/allocation/fields/sentence-length.js
+++ b/app/allocation/fields/sentence-length.js
@@ -14,15 +14,15 @@ const sentenceLength = {
   items: [
     {
       value: 'null',
-      text: 'fields::sentence_length.items.any',
+      text: 'fields::sentence_length.items.length',
     },
     {
       value: 'short',
-      text: 'fields::sentence_length.items.short',
+      text: 'fields::sentence_length.items.length_short',
     },
     {
       value: 'long',
-      text: 'fields::sentence_length.items.long',
+      text: 'fields::sentence_length.items.length_long',
     },
   ],
 }

--- a/app/allocation/index.js
+++ b/app/allocation/index.js
@@ -5,6 +5,7 @@ const FormWizardController = require('../../common/controllers/form-wizard')
 const { protectRoute } = require('../../common/middleware/permissions')
 
 const confirmation = require('./controllers/create/confirmation')
+const view = require('./controllers/view')
 const { createFields } = require('./fields')
 const { setAllocation } = require('./middleware')
 const { createSteps } = require('./steps')
@@ -33,7 +34,7 @@ router.get(
   protectRoute('allocation:create'),
   confirmation
 )
-
+router.get('/:allocationId', protectRoute('allocations:view'), view)
 // Export
 module.exports = {
   router,

--- a/app/allocation/views/view.njk
+++ b/app/allocation/views/view.njk
@@ -1,0 +1,93 @@
+{% extends "layouts/two-column.njk" %}
+
+{% set additionalContainerClass = "sticky-sidebar-container" %}
+
+{% block pageTitle %}
+  {{ t("allocations::view.page_title") }}
+{% endblock %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+    text: t("actions::back_to_dashboard"),
+    classes: "app-print--hide",
+    href: dashboardUrl
+  }) }}
+
+  <a href="javascript:window.print()" class="app-!-float-right app-print--hide govuk-!-margin-top-3 app-icon app-icon--print">
+    {{ t("actions::print_move_detail") }}
+  </a>
+
+  {{ super() }}
+{% endblock %}
+
+{% block contentHeader %}
+  <header class="govuk-!-margin-bottom-8 govuk-!-padding-left-0 govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l govuk-!-margin-bottom-1">
+      {{ t("allocations::view.heading", {
+        count: allocation.moves_count,
+        from_location: allocation.from_location.title,
+        to_location: allocation.to_location.title,
+        date: allocation.date | formatDate
+      })}}
+    </h1>
+  </header>
+{% endblock %}
+
+{% block contentMain %}
+  <section>
+    <h2 class="govuk-heading-m govuk-!-margin-bottom-1">{{ t("allocations::view.criteria_for_allocation") }}</h2>
+    <span class="govuk-caption-m govuk-!-margin-bottom-4">
+      {{ t("allocations::view.created_at") }}
+      {{ allocation.created_at | formatDateAsRelativeDay }}
+      {{ allocation.created_at | formatTime }}
+    </span>
+
+    {{ govukSummaryList(allocationDetails) }}
+
+    {% if allocation.complete_in_full and allocationPeople.emptySlots %}
+      {{ govukWarningText({
+        text: t("allocations::view.complete_in_full"),
+        iconFallbackText: "Warning"
+      }) }}
+    {% endif %}
+  </section>
+
+  <section class="govuk-!-margin-top-8">
+    <h2 class="govuk-heading-m govuk-!-margin-bottom-1">{{ t("allocations::view.people.heading") }}</h2>
+    <h3 class="govuk-heading-s">{{ t("allocations::view.people.slots_filled", {
+      slots_filled: allocationPeople.filledSlots.length,
+      total_slots: allocation.moves_count,
+      person_or_people: t('person', {
+        count: allocation.moves_count
+      })
+    }) }}</h3>
+  </section>
+
+  {% for i in range(0, allocationPeople.emptySlots) -%}
+    <div class="app-border-top-1">
+      {{ appMessage({
+        classes: "app-message--muted govuk-!-margin-top-3 govuk-!-margin-bottom-3 govuk-!-padding-right-8",
+        allowDismiss: false,
+        content: {
+          html: t("allocations::view.people.empty_slot")
+        }
+      }) }}
+    </div>
+  {%- endfor %}
+
+  {% for slot in allocationPeople.filledSlots %}
+    {{ appCard(slot) }}
+  {% endfor %}
+
+{% endblock %}
+
+{% block contentSidebar %}
+  <div class="sticky-sidebar">
+    <div class="sticky-sidebar__inner">
+      <h3 class="govuk-heading-m app-border-top-2 app-border--blue govuk-!-padding-top-4 govuk-!-margin-bottom-3">
+        {{ t("allocations::view.allocation_details") }}
+      </h3>
+      {{ appMetaList(allocationSummary) }}
+    </div>
+  </div>
+{% endblock %}

--- a/common/lib/api-client/models.js
+++ b/common/lib/api-client/models.js
@@ -218,6 +218,10 @@ module.exports = {
       other_criteria: '',
       created_at: '',
       updated_at: '',
+      moves: {
+        jsonApi: 'hasMany',
+        type: 'moves',
+      },
     },
   },
   allocation_complex_case: {

--- a/common/presenters/allocation-to-meta-list-component.js
+++ b/common/presenters/allocation-to-meta-list-component.js
@@ -1,0 +1,69 @@
+const i18n = require('../../config/i18n')
+const filters = require('../../config/nunjucks/filters')
+
+function allocationToMetaListComponent(allocation) {
+  const {
+    to_location: toLocation,
+    prisoner_category: prisonerCategory,
+    complex_cases: complexCases,
+    other_criteria: otherCriteria,
+    sentence_length: sentenceLength,
+  } = allocation
+  return {
+    rows: [
+      {
+        key: {
+          text: i18n.t('allocations::view.fields.estate_type'),
+        },
+        value: {
+          // TODO replace with region when we have it
+          text: filters.startCase(toLocation.location_type),
+        },
+      },
+      {
+        key: {
+          text: i18n.t('allocations::view.fields.category'),
+        },
+        value: {
+          text: filters.startCase(prisonerCategory),
+        },
+      },
+      {
+        key: {
+          text: i18n.t('allocations::view.fields.sentence_length.label'),
+        },
+        value: {
+          text: i18n.t('fields::sentence_length.items.length', {
+            context: sentenceLength,
+          }),
+        },
+      },
+      {
+        key: {
+          text: i18n.t('allocations::view.fields.complex_cases'),
+        },
+        value: {
+          /* eslint-disable indent */
+          text: complexCases.length
+            ? filters.oxfordJoin(
+                complexCases
+                  .filter(complexCase => complexCase.answer)
+                  .map(complexCase => complexCase.title)
+              )
+            : i18n.t('allocations::view.fields.none_provided'),
+          /* eslint-enable indent */
+        },
+      },
+      {
+        key: {
+          text: i18n.t('allocations::view.fields.other_criteria'),
+        },
+        value: {
+          text:
+            otherCriteria || i18n.t('allocations::view.fields.none_provided'),
+        },
+      },
+    ],
+  }
+}
+module.exports = allocationToMetaListComponent

--- a/common/presenters/allocation-to-meta-list-component.test.js
+++ b/common/presenters/allocation-to-meta-list-component.test.js
@@ -1,0 +1,114 @@
+const i18n = require('../../config/i18n')
+const filters = require('../../config/nunjucks/filters')
+
+const presenter = require('./allocation-to-meta-list-component')
+
+describe('allocation to meta list component', function() {
+  const mockParams = {
+    to_location: {
+      id: '31c262ba-1bab-4b6e-8c53-f0032eeaea0b',
+      title: 'GARTREE (HMP)',
+      location_type: 'prison',
+    },
+    prisoner_category: 'c',
+    complex_cases: [
+      {
+        key: 'hold_separately',
+        title: 'Segregated prisoners',
+        answer: true,
+        allocation_complex_case_id: 'afa79a37-7c2f-4363-bed6-e1ccf2576901',
+      },
+      {
+        key: 'self_harm',
+        title: 'Self harm / prisoners on ACCT',
+        answer: true,
+        allocation_complex_case_id: 'e8e8af77-198c-4b64-adb1-4aca6af469a7',
+      },
+      {
+        key: 'mental_health_issue',
+        title: 'Mental health issues',
+        answer: false,
+        allocation_complex_case_id: 'c0d196aa-a96d-4296-8349-f52b9909a2b8',
+      },
+      {
+        key: 'under_drug_treatment',
+        title: 'Integrated Drug Treatment System',
+        answer: false,
+        allocation_complex_case_id: '6f35f300-e3ed-4536-8f19-5954fc8b9963',
+      },
+    ],
+    other_criteria: 'Other criteria',
+  }
+  let output
+  beforeEach(function() {
+    sinon.stub(i18n, 't').returnsArg(0)
+    sinon.stub(filters, 'startCase').returnsArg(0)
+    sinon.stub(filters, 'oxfordJoin').returnsArg(0)
+    output = presenter(mockParams)
+  })
+  it('outputs an array', function() {
+    expect(output.rows).to.exist
+    expect(output.rows).to.be.an('array')
+    expect(output.rows.length).to.equal(5)
+  })
+  it('has the estate type as first item', function() {
+    expect(output.rows[0]).to.deep.equal({
+      key: {
+        text: 'allocations::view.fields.estate_type',
+      },
+      value: {
+        text: 'prison',
+      },
+    })
+    expect(filters.startCase).to.have.been.calledWithExactly('prison')
+  })
+  it('has the prisoner category as second item', function() {
+    expect(output.rows[1]).to.deep.equal({
+      key: {
+        text: 'allocations::view.fields.category',
+      },
+      value: {
+        text: 'c',
+      },
+    })
+    expect(filters.startCase).to.have.been.calledWithExactly('c')
+  })
+  it('has the sentence length as third item', function() {
+    expect(output.rows[2]).to.deep.equal({
+      key: {
+        text: 'allocations::view.fields.sentence_length.label',
+      },
+      value: {
+        text: 'fields::sentence_length.items.length',
+      },
+    })
+    expect(filters.oxfordJoin).to.have.been.calledWithExactly([
+      'Segregated prisoners',
+      'Self harm / prisoners on ACCT',
+    ])
+  })
+  it('has the complex cases as fourth item, filtering those whose answer is false', function() {
+    expect(output.rows[3]).to.deep.equal({
+      key: {
+        text: 'allocations::view.fields.complex_cases',
+      },
+      value: {
+        text: ['Segregated prisoners', 'Self harm / prisoners on ACCT'],
+      },
+    })
+    expect(filters.oxfordJoin).to.have.been.calledWithExactly([
+      'Segregated prisoners',
+      'Self harm / prisoners on ACCT',
+    ])
+  })
+  it('has the other criteria as fifth item', function() {
+    expect(output.rows[4]).to.deep.equal({
+      key: {
+        text: 'allocations::view.fields.other_criteria',
+      },
+      value: {
+        text: 'Other criteria',
+      },
+    })
+  })
+})

--- a/common/presenters/allocation-to-summary-list-component.js
+++ b/common/presenters/allocation-to-summary-list-component.js
@@ -1,0 +1,40 @@
+const i18n = require('../../config/i18n')
+const filters = require('../../config/nunjucks/filters')
+
+function allocationToSummaryListComponent(allocation) {
+  const {
+    moves,
+    from_location: fromLocation,
+    to_location: toLocation,
+    date,
+  } = allocation
+  return {
+    items: [
+      {
+        key: {
+          text: i18n.t('allocations::view.sidebar.number_of_prisoners'),
+        },
+        value: { text: moves.length },
+      },
+      {
+        key: {
+          text: i18n.t('allocations::view.sidebar.move_from'),
+        },
+        value: { text: fromLocation.title },
+      },
+      {
+        key: {
+          text: i18n.t('allocations::view.sidebar.move_to'),
+        },
+        value: { text: toLocation.title },
+      },
+      {
+        key: {
+          text: i18n.t('allocations::view.sidebar.date'),
+        },
+        value: { text: filters.formatDateAsRelativeDay(date) },
+      },
+    ],
+  }
+}
+module.exports = allocationToSummaryListComponent

--- a/common/presenters/allocation-to-summary-list-component.test.js
+++ b/common/presenters/allocation-to-summary-list-component.test.js
@@ -1,0 +1,94 @@
+const i18n = require('../../config/i18n')
+const filters = require('../../config/nunjucks/filters')
+
+const presenter = require('./allocation-to-summary-list-component')
+
+describe('allocation to meta list component', function() {
+  const mockParams = {
+    from_location: {
+      id: 'ed286eb6-7bd6-4cb8-aaf6-02406fb42b88',
+      type: 'locations',
+      key: 'bwi',
+      title: 'BERWYN (HMP)',
+      location_type: 'prison',
+      nomis_agency_id: 'BWI',
+      can_upload_documents: false,
+      disabled_at: null,
+      suppliers: [],
+    },
+    to_location: {
+      id: '31c262ba-1bab-4b6e-8c53-f0032eeaea0b',
+      type: 'locations',
+      key: 'gti',
+      title: 'GARTREE (HMP)',
+      location_type: 'prison',
+      nomis_agency_id: 'GTI',
+      can_upload_documents: false,
+      disabled_at: null,
+      suppliers: [],
+    },
+    date: '2020-05-06',
+    moves: [
+      {},
+      {},
+      {
+        person: {
+          first_names: 'John',
+          last_name: 'Doe',
+        },
+      },
+    ],
+  }
+  let output
+  beforeEach(function() {
+    sinon.stub(i18n, 't').returnsArg(0)
+    sinon.stub(filters, 'formatDateAsRelativeDay').returnsArg(0)
+    output = presenter(mockParams)
+  })
+  it('outputs an array', function() {
+    expect(output.items).to.exist
+    expect(output.items).to.be.an('array')
+    expect(output.items.length).to.equal(4)
+  })
+  it('has the number of prisoners as first item', function() {
+    expect(output.items[0]).to.deep.equal({
+      key: {
+        text: 'allocations::view.sidebar.number_of_prisoners',
+      },
+      value: {
+        text: 3,
+      },
+    })
+  })
+  it('has the move from as second item', function() {
+    expect(output.items[1]).to.deep.equal({
+      key: {
+        text: 'allocations::view.sidebar.move_from',
+      },
+      value: {
+        text: 'BERWYN (HMP)',
+      },
+    })
+  })
+  it('has the move to as third item', function() {
+    expect(output.items[2]).to.deep.equal({
+      key: {
+        text: 'allocations::view.sidebar.move_to',
+      },
+      value: {
+        text: 'GARTREE (HMP)',
+      },
+    })
+  })
+  it('has the date as fourth item', function() {
+    expect(output.items[3]).to.deep.equal({
+      key: {
+        text: 'allocations::view.sidebar.date',
+      },
+      value: {
+        text: '2020-05-06',
+      },
+    })
+    expect(filters.formatDateAsRelativeDay).to.calledWithExactly('2020-05-06')
+  })
+})

--- a/common/presenters/allocations-to-table.js
+++ b/common/presenters/allocations-to-table.js
@@ -6,9 +6,15 @@ const tableConfig = [
   {
     head: 'allocations::move_size',
     row: {
-      text: 'moves_count',
       attributes: {
         scope: 'row',
+      },
+      html: data => {
+        const content = `${data.moves_count} ${filters.pluralize(
+          'person',
+          data.moves_count
+        )}`
+        return `<a href="/allocation/${data.id}">${content}</a>`
       },
     },
   },

--- a/common/presenters/allocations-to-table.test.js
+++ b/common/presenters/allocations-to-table.test.js
@@ -92,7 +92,8 @@ describe('#allocationsToTable', function() {
     })
     it('returns the total moves count on the first cell', function() {
       expect(output.rowsForAllocationTable[0][0]).to.deep.equal({
-        text: 3,
+        html:
+          '<a href="/allocation/8567f1a5-2201-4bc2-b655-f6526401303a">3 people</a>',
         attributes: {
           scope: 'row',
         },

--- a/common/presenters/index.js
+++ b/common/presenters/index.js
@@ -1,3 +1,5 @@
+const allocationToMetaListComponent = require('./allocation-to-meta-list-component')
+const allocationToSummaryListComponent = require('./allocation-to-summary-list-component')
 const allocationsToTable = require('./allocations-to-table')
 const assessmentAnswerToTag = require('./assessment-answer-to-tag')
 const assessmentAnswersByCategory = require('./assessment-answers-by-category')
@@ -19,6 +21,8 @@ const timetableToTableComponent = require('./timetable-to-table-component')
 
 module.exports = {
   allocationsToTable,
+  allocationToMetaListComponent,
+  allocationToSummaryListComponent,
   assessmentAnswerToTag,
   assessmentAnswersByCategory,
   assessmentCategoryToPanelComponent,

--- a/locales/en/actions.json
+++ b/locales/en/actions.json
@@ -16,6 +16,7 @@
   "continue": "Continue",
   "restart": "Restart",
   "cancel": "Cancel",
+  "cancel_allocation": "Cancel allocation",
   "cancel_move": "Cancel this move",
   "cancel_move_confirmation": "Cancel move",
   "download": "Download moves",

--- a/locales/en/allocations.json
+++ b/locales/en/allocations.json
@@ -38,10 +38,7 @@
       "none_provided": "None provided",
       "other_criteria": "Other criteria",
       "sentence_length": {
-        "label": "Time left to serve",
-        "value": "Any length of sentence",
-        "value_short": "16 months or less to serve",
-        "value_long": "16 months or longer to serve"
+        "label": "Time left to serve"
       }
     },
     "complete_in_full": "This allocation should be filled in full - consider prisoners that are the next best for this allocation",

--- a/locales/en/allocations.json
+++ b/locales/en/allocations.json
@@ -24,5 +24,39 @@
   },
   "allocation_criteria": {
     "page_title": "Allocation criteria"
+  },
+  "view": {
+    "page_title": "View allocation",
+    "heading": "{{count}} person from {{from_location}} to {{to_location}}, {{date}}",
+    "heading_plural": "{{count}} people from {{from_location}} to {{to_location}}, {{date}}",
+    "criteria_for_allocation": "Criteria for allocation",
+    "created_at": "Created {{datetime}}",
+    "fields": {
+      "estate_type": "Estate type",
+      "category": "Category",
+      "complex_cases": "Complex cases for prisons to agree",
+      "none_provided": "None provided",
+      "other_criteria": "Other criteria",
+      "sentence_length": {
+        "label": "Time left to serve",
+        "value": "Any length of sentence",
+        "value_short": "16 months or less to serve",
+        "value_long": "16 months or longer to serve"
+      }
+    },
+    "complete_in_full": "This allocation should be filled in full - consider prisoners that are the next best for this allocation",
+    "people": {
+      "slots_filled": "{{slots_filled}} of {{total_slots}} {{person_or_people}} allocated",
+      "heading": "People for allocation",
+      "empty_slot": "Person to be allocated"
+    },
+    "cancel_allocation": "Cancel allocation",
+    "allocation_details": "Allocation details",
+    "sidebar": {
+      "number_of_prisoners": "Number of people",
+      "move_from": "Move from",
+      "move_to": "Move to",
+      "date": "Date"
+    }
   }
 }

--- a/locales/en/default.json
+++ b/locales/en/default.json
@@ -9,6 +9,8 @@
   "or": "or",
   "reason": "Reason",
   "location": "Location",
+  "person": "person",
+  "person_plural": "people",
   "age_with_date_of_birth": "{{date_of_birth}} (Age {{age}})",
   "supplier_fallback": "the supplier",
   "opens_new_window": "Opens in a new window",

--- a/locales/en/fields.json
+++ b/locales/en/fields.json
@@ -260,9 +260,9 @@
   "sentence_length": {
     "label": "Sentence length",
     "items": {
-      "long": "Over 16 months only",
-      "short": "Under 16 months only",
-      "any": "Any sentence"
+      "length_long": "Over 16 months",
+      "length_short": "16 months or less",
+      "length": "Any time to serve"
     }
   },
   "complete_in_full": {

--- a/test/fixtures/api-client/allocation.findAll.json
+++ b/test/fixtures/api-client/allocation.findAll.json
@@ -1,80 +1,336 @@
 {
-  "data": [
-    {
-      "id": "0e180146-d911-49d8-a62e-63ea5cec7ba5",
-      "type": "allocations",
-      "attributes": {
-        "moves_count": 2,
-        "date": "2020-04-20",
-        "created_at": "2020-04-20T10:44:37+01:00",
-        "updated_at": "2020-04-20T10:44:37+01:00",
-        "prisoner_category": "c",
-        "sentence_length": "short",
-        "complex_cases": null,
-        "complete_in_full": true,
-        "other_criteria": null
-      },
-      "relationships": {
-        "from_location": {
-          "data": {
-            "id": "8387e205-97d1-4023-83c5-4f16f0c479d0",
-            "type": "locations"
-          }
-        },
-        "to_location": {
-          "data": {
-            "id": "9efd0df4-70b2-411f-8df8-8bb09b2eafe0",
-            "type": "locations"
-          }
+  "data": {
+    "id": "7b0b47a6-3354-4c87-b08e-5a2329c19472",
+    "type": "allocations",
+    "attributes": {
+      "moves_count": 3,
+      "date": "2020-05-15",
+      "prisoner_category": "b",
+      "sentence_length": "short",
+      "complex_cases": [],
+      "complete_in_full": false,
+      "other_criteria": null,
+      "created_at": "2020-05-12T09:59:09+01:00",
+      "updated_at": "2020-05-12T09:59:09+01:00"
+    },
+    "relationships": {
+      "from_location": {
+        "data": {
+          "id": "331e07a3-b68b-4684-b94f-dbb06a8fffdf",
+          "type": "locations"
         }
+      },
+      "to_location": {
+        "data": {
+          "id": "68302c7f-6c2c-462f-84d0-e469dfdc4377",
+          "type": "locations"
+        }
+      },
+      "moves": {
+        "data": [
+          {
+            "id": "7e2d435d-3dcf-44c5-892d-0b64af9d3a7b",
+            "type": "moves"
+          },
+          {
+            "id": "161416bd-125f-4bca-8196-9c5942e998ff",
+            "type": "moves"
+          },
+          {
+            "id": "e7db502e-996b-4030-b56d-7f3c7243432a",
+            "type": "moves"
+          }
+        ]
       }
     }
-  ],
+  },
   "included": [
     {
-      "id": "8387e205-97d1-4023-83c5-4f16f0c479d0",
+      "id": "331e07a3-b68b-4684-b94f-dbb06a8fffdf",
       "type": "locations",
       "attributes": {
-        "key": "kmi",
-        "title": "KIRKHAM (HMP)",
+        "key": "key_5",
+        "title": "HMP Lake Steven",
         "location_type": "prison",
-        "nomis_agency_id": "KMI",
+        "nomis_agency_id": "PEI",
         "can_upload_documents": false,
         "disabled_at": null,
         "suppliers": []
       }
     },
     {
-      "id": "9efd0df4-70b2-411f-8df8-8bb09b2eafe0",
+      "id": "68302c7f-6c2c-462f-84d0-e469dfdc4377",
       "type": "locations",
       "attributes": {
-        "key": "nmi",
-        "title": "NOTTINGHAM (HMP)",
+        "key": "key_6",
+        "title": "HMP North Alden",
         "location_type": "prison",
-        "nomis_agency_id": "NMI",
+        "nomis_agency_id": "PEI",
         "can_upload_documents": false,
         "disabled_at": null,
         "suppliers": []
       }
-    }
-  ],
-  "links": {
-    "self": "http://localhost:5000/api/v1/allocations?filter%5Bdate_from%5D=2020-04-20&filter%5Bdate_to%5D=2020-04-26&page%5Bnumber%5D=1&page%5Bsize%5D=1&per_page=1",
-    "first": "http://localhost:5000/api/v1/allocations?filter%5Bdate_from%5D=2020-04-20&filter%5Bdate_to%5D=2020-04-26&page%5Bnumber%5D=1&page%5Bsize%5D=1&per_page=1",
-    "prev": null,
-    "next": "http://localhost:5000/api/v1/allocations?filter%5Bdate_from%5D=2020-04-20&filter%5Bdate_to%5D=2020-04-26&page%5Bnumber%5D=2&page%5Bsize%5D=1&per_page=1",
-    "last": "http://localhost:5000/api/v1/allocations?filter%5Bdate_from%5D=2020-04-20&filter%5Bdate_to%5D=2020-04-26&page%5Bnumber%5D=14&page%5Bsize%5D=1&per_page=1"
-  },
-  "meta": {
-    "pagination": {
-      "per_page": 10,
-      "total_pages": 1,
-      "total_objects": 1,
-      "links": {
-        "first": "/api/v1/allocations",
-        "last": "/api/v1/allocations",
-        "next": "/api/v1/allocations"
+    },
+    {
+      "id": "7e2d435d-3dcf-44c5-892d-0b64af9d3a7b",
+      "type": "moves",
+      "attributes": {
+        "reference": "PYF2413M",
+        "status": "requested",
+        "updated_at": "2020-05-12T09:59:10+01:00",
+        "created_at": "2020-05-12T09:54:10+01:00",
+        "time_due": "2020-05-12T09:59:10+01:00",
+        "date": "2020-05-15",
+        "move_type": "court_appearance",
+        "additional_information": "some more info about the move that the supplier might need to know",
+        "cancellation_reason": null,
+        "cancellation_reason_comment": null,
+        "move_agreed": false,
+        "move_agreed_by": null,
+        "date_from": "2020-05-07",
+        "date_to": null
+      },
+      "relationships": {
+        "person": {
+          "data": {
+            "id": "70288445-506d-453f-843c-70987918002e",
+            "type": "people"
+          }
+        },
+        "from_location": {
+          "data": {
+            "id": "331e07a3-b68b-4684-b94f-dbb06a8fffdf",
+            "type": "locations"
+          }
+        },
+        "to_location": {
+          "data": {
+            "id": "68302c7f-6c2c-462f-84d0-e469dfdc4377",
+            "type": "locations"
+          }
+        },
+        "documents": {
+          "data": []
+        },
+        "court_hearings": {
+          "data": []
+        },
+        "allocation": {
+          "data": {
+            "id": "7b0b47a6-3354-4c87-b08e-5a2329c19472",
+            "type": "allocations"
+          }
+        }
+      }
+    },
+    {
+      "id": "70288445-506d-453f-843c-70987918002e",
+      "type": "people",
+      "attributes": {
+        "first_names": "Blaine",
+        "last_name": "Lindgren",
+        "date_of_birth": "1980-10-20",
+        "assessment_answers": [],
+        "identifiers": [
+          {
+            "identifier_type": "police_national_computer",
+            "value": "AB/1234567"
+          },
+          {
+            "identifier_type": "prison_number",
+            "value": "ABCDEFG"
+          }
+        ],
+        "gender_additional_information": null
+      },
+      "relationships": {
+        "ethnicity": {
+          "data": {
+            "id": "e842d3e7-b263-4a7b-8ac9-835c2b6b4d5f",
+            "type": "ethnicities"
+          }
+        },
+        "gender": {
+          "data": {
+            "id": "ba7ac468-207f-488e-b0dd-a016b8167aef",
+            "type": "genders"
+          }
+        }
+      }
+    },
+    {
+      "id": "161416bd-125f-4bca-8196-9c5942e998ff",
+      "type": "moves",
+      "attributes": {
+        "reference": "KYH3429C",
+        "status": "requested",
+        "updated_at": "2020-05-12T09:59:10+01:00",
+        "created_at": "2020-05-12T09:53:10+01:00",
+        "time_due": "2020-05-12T09:59:10+01:00",
+        "date": "2020-05-15",
+        "move_type": "court_appearance",
+        "additional_information": "some more info about the move that the supplier might need to know",
+        "cancellation_reason": null,
+        "cancellation_reason_comment": null,
+        "move_agreed": false,
+        "move_agreed_by": null,
+        "date_from": "2020-05-06",
+        "date_to": null
+      },
+      "relationships": {
+        "person": {
+          "data": {
+            "id": "2135676c-10e9-487e-9be6-1256899fbd4d",
+            "type": "people"
+          }
+        },
+        "from_location": {
+          "data": {
+            "id": "331e07a3-b68b-4684-b94f-dbb06a8fffdf",
+            "type": "locations"
+          }
+        },
+        "to_location": {
+          "data": {
+            "id": "68302c7f-6c2c-462f-84d0-e469dfdc4377",
+            "type": "locations"
+          }
+        },
+        "documents": {
+          "data": []
+        },
+        "court_hearings": {
+          "data": []
+        },
+        "allocation": {
+          "data": {
+            "id": "7b0b47a6-3354-4c87-b08e-5a2329c19472",
+            "type": "allocations"
+          }
+        }
+      }
+    },
+    {
+      "id": "2135676c-10e9-487e-9be6-1256899fbd4d",
+      "type": "people",
+      "attributes": {
+        "first_names": "Melodee",
+        "last_name": "Reinger",
+        "date_of_birth": "1980-10-20",
+        "assessment_answers": [],
+        "identifiers": [
+          {
+            "identifier_type": "police_national_computer",
+            "value": "AB/1234567"
+          },
+          {
+            "identifier_type": "prison_number",
+            "value": "ABCDEFG"
+          }
+        ],
+        "gender_additional_information": null
+      },
+      "relationships": {
+        "ethnicity": {
+          "data": {
+            "id": "a705957a-bee1-4bc5-a4cf-5c2f30259214",
+            "type": "ethnicities"
+          }
+        },
+        "gender": {
+          "data": {
+            "id": "40429c3a-f6af-4f34-a6a7-4b0e6a233e91",
+            "type": "genders"
+          }
+        }
+      }
+    },
+    {
+      "id": "e7db502e-996b-4030-b56d-7f3c7243432a",
+      "type": "moves",
+      "attributes": {
+        "reference": "UER9683N",
+        "status": "requested",
+        "updated_at": "2020-05-12T09:59:10+01:00",
+        "created_at": "2020-05-12T09:52:10+01:00",
+        "time_due": "2020-05-12T09:59:10+01:00",
+        "date": "2020-05-15",
+        "move_type": "court_appearance",
+        "additional_information": "some more info about the move that the supplier might need to know",
+        "cancellation_reason": null,
+        "cancellation_reason_comment": null,
+        "move_agreed": false,
+        "move_agreed_by": null,
+        "date_from": "2020-05-05",
+        "date_to": null
+      },
+      "relationships": {
+        "person": {
+          "data": {
+            "id": "3b95da49-e5fd-449c-88c2-7c45dc6b4fd7",
+            "type": "people"
+          }
+        },
+        "from_location": {
+          "data": {
+            "id": "331e07a3-b68b-4684-b94f-dbb06a8fffdf",
+            "type": "locations"
+          }
+        },
+        "to_location": {
+          "data": {
+            "id": "68302c7f-6c2c-462f-84d0-e469dfdc4377",
+            "type": "locations"
+          }
+        },
+        "documents": {
+          "data": []
+        },
+        "court_hearings": {
+          "data": []
+        },
+        "allocation": {
+          "data": {
+            "id": "7b0b47a6-3354-4c87-b08e-5a2329c19472",
+            "type": "allocations"
+          }
+        }
+      }
+    },
+    {
+      "id": "3b95da49-e5fd-449c-88c2-7c45dc6b4fd7",
+      "type": "people",
+      "attributes": {
+        "first_names": "Xochitl",
+        "last_name": "Grimes",
+        "date_of_birth": "1980-10-20",
+        "assessment_answers": [],
+        "identifiers": [
+          {
+            "identifier_type": "police_national_computer",
+            "value": "AB/1234567"
+          },
+          {
+            "identifier_type": "prison_number",
+            "value": "ABCDEFG"
+          }
+        ],
+        "gender_additional_information": null
+      },
+      "relationships": {
+        "ethnicity": {
+          "data": {
+            "id": "82720351-7122-4012-a4eb-56210e654223",
+            "type": "ethnicities"
+          }
+        },
+        "gender": {
+          "data": {
+            "id": "0837c48b-86d1-44dc-82bd-e8467452d5b2",
+            "type": "genders"
+          }
+        }
       }
     }
-  }
+  ]
 }


### PR DESCRIPTION
The links cancel and remove from allocations are dummies; so is the allocation history tab.

It has been tried only with fake data, which may explain why there is no picture and no meta data returned from the backend.

With empty slots:
<img width="684" alt="Screenshot 2020-05-12 at 14 42 18" src="https://user-images.githubusercontent.com/853989/81701404-ddac0c00-9461-11ea-986e-7fd42bbeb20f.png">
With filled slots:
<img width="694" alt="Screenshot 2020-05-12 at 14 42 29" src="https://user-images.githubusercontent.com/853989/81701412-e270c000-9461-11ea-9028-f3356e2102cd.png">

### Checklist

- [x] If adding new environment variables, they have been documented in the [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md)
- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
