### PR TITLE
Update CI workflows

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,6 +73,14 @@ aliases:
     filters:
       tags:
         only: /.*/
+  - &only_master
+    filters:
+      branches:
+        only: master
+  - &ignore_master
+    filters:
+      branches:
+        ignore: master
   - &only_master_and_tags
     filters:
       tags:
@@ -141,12 +149,24 @@ jobs:
 
   end-to-end-test:
     <<: *circle_container
+    parameters:
+      use_review_app:
+        type: string
+        default: ""
     steps:
       - checkout
       - *set_package_version
       - *restore_cache
       - *install_dependencies
       - *save_cache
+      - when:
+          condition: <<parameters.use_review_app>>
+          steps:
+            - run:
+                name: Set Heroku Review Apps URL for Pull Requests
+                command: |
+                  echo "export E2E_BASE_URL=$(sh .circleci/get-review-app-url.sh)" >> $BASH_ENV
+                no_output_timeout: 180s
       - run:
           name: Run E2E tests
           command: npm run test-e2e:ci
@@ -277,36 +297,44 @@ workflows:
       - lint-and-unit-test:
           <<: *all_tags
       - end-to-end-test:
-          <<: *only_master_and_tags
+          <<: *ignore_master
+          name: end-to-end-test-pr
+          use_review_app: 'true'
+      - end-to-end-test:
+          <<: *only_master
+          name: end-to-end-test-master
           requires:
             - deploy-staging
+      - end-to-end-test:
+          <<: *only_deploy_tags
+          name: end-to-end-test-release
+          requires:
+            - deploy-preproduction
       # Docker builds
       - build-docker-image:
-          <<: *only_master_and_tags
+          <<: *only_master
+          name: build-docker-image-master
           staging: 'true'
-          preprod: 'true'
       - build-docker-image:
           <<: *only_deploy_tags
-          name: build-docker-image-production
-          staging: 'true'
+          name: build-docker-image-release
           preprod: 'true'
           production: 'true'
       # Deployment
       - deploy:
-          <<: *only_master_and_tags
+          <<: *only_master
           name: deploy-staging
           env: 'staging'
           requires:
-            - build-docker-image
+            - build-docker-image-master
             - lint-and-unit-test
       - deploy:
-          <<: *only_master_and_tags
+          <<: *only_deploy_tags
           name: deploy-preproduction
           env: 'preprod'
           requires:
-            - build-docker-image
+            - build-docker-image-release
             - lint-and-unit-test
-            - end-to-end-test
       - deploy:
           <<: *only_deploy_tags
           <<: *requires_production_approval
@@ -318,15 +346,11 @@ workflows:
           <<: *only_deploy_tags
           type: approval
           requires:
-            - lint-and-unit-test
-            - end-to-end-test
-            - build-docker-image-production
+            - end-to-end-test-release
       - notify-of-approval:
           <<: *only_deploy_tags
           requires:
-            - lint-and-unit-test
-            - end-to-end-test
-            - build-docker-image-production
+            - end-to-end-test-release
       # Post release
       - publish-release-to-github:
           <<: *only_deploy_tags

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,9 +28,46 @@ aliases:
       key: dependency-cache-{{ checksum "package.json" }}
       paths:
         - ./node_modules
-  - &notify_slack
+  - &set_package_version
+    run:
+      name: Set version
+      command: |
+        echo "export PACKAGE_VERSION=$(grep -m1 version package.json | awk -F: '{ print $2 }' | sed 's/[", ]//g')" >> $BASH_ENV
+  - &notify_slack_on_failure
     slack/notify-on-failure:
       only_for_branches: master
+  - &notify_slack_on_release_start
+    slack/notify:
+      channel: $BUILD_NOTIFICATIONS_CHANNEL_ID
+      title: 'Frontend v${PACKAGE_VERSION} is being prepared for release :building_construction:'
+      title_link: 'https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/blob/master/CHANGELOG.md'
+      message: A new release was created by ${CIRCLE_USERNAME}
+      footer: Click the title to view the changes
+      include_project_field: false
+      include_job_number_field: false
+      include_visit_job_action: false
+      color: '#1d70b8'
+      mentions: here
+  - &notify_slack_of_approval
+    slack/approval:
+      channel: $BUILD_NOTIFICATIONS_CHANNEL_ID
+      message: 'Frontend v${PACKAGE_VERSION} *requires your approval* before it can be deployed :eyes:'
+      include_project_field: false
+      include_job_number_field: false
+      color: '#912b88'
+      mentions: $BUILD_NOTIFICATIONS_MENTION_ID
+  - &notify_slack_on_release_end
+    slack/notify:
+      channel: $BUILD_NOTIFICATIONS_CHANNEL_ID
+      title: 'Frontend v${PACKAGE_VERSION} has been deployed :rocket:'
+      title_link: https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/releases/tag/v${PACKAGE_VERSION}
+      message: This release was successfully deployed to production
+      footer: Click the title to view the release notes
+      include_project_field: false
+      include_job_number_field: false
+      include_visit_job_action: false
+      color: '#28a197'
+      mentions: here
   # Common filters
   - &all_tags
     filters:
@@ -58,14 +95,20 @@ commands:
     parameters:
       env:
         type: string
+      notify_slack:
+        type: string
+        default: ""
     steps:
       - checkout
-
+      - *set_package_version
+      - when:
+          condition: <<parameters.notify_slack>>
+          steps:
+            - *notify_slack_on_release_start
       - setup_remote_docker:
           docker_layer_caching: true
-
       - run:
-          name: build docker image
+          name: Build docker image
           command: |
             export BUILD_DATE=$(date -Is) >> $BASH_ENV
             source $BASH_ENV
@@ -78,9 +121,8 @@ commands:
               --build-arg APP_BUILD_TAG=${CIRCLE_BRANCH} \
               --build-arg APP_GIT_COMMIT=${CIRCLE_SHA1} \
               -t app .
-
       - run:
-          name: push docker image
+          name: Push docker image
           command: |
             login="$(aws ecr get-login --region ${AWS_DEFAULT_REGION} --no-include-email)"
             ${login}
@@ -98,15 +140,14 @@ commands:
         type: string
     steps:
       - checkout
-
+      - *set_package_version
       - run:
-          name: kubectl use context
+          name: Set k8s context
           command: |
             setup-kube-auth
             kubectl config use-context << parameters.env >>
-
       - deploy:
-          name: rolling update image to << parameters.env >>
+          name: Deploy image to << parameters.env >>
           command: |
             export BUILD_DATE=$(date -Is) >> $BASH_ENV
             source $BASH_ENV
@@ -120,10 +161,18 @@ commands:
                     kubernetes.io/change-cause="${BUILD_DATE} set image ${CIRCLE_PROJECT_REPONAME}:${CIRCLE_SHA1} via CircleCI"
 
 jobs:
+  notify-of-approval:
+    <<: *circle_container
+    steps:
+      - checkout
+      - *set_package_version
+      - *notify_slack_of_approval
+
   build_and_test:
     <<: *circle_container
     steps:
       - checkout
+      - *set_package_version
       - *restore_cache
       - *install_dependencies
       - *save_cache
@@ -159,12 +208,13 @@ jobs:
           path: reports
       - store_artifacts:
           path: coverage
-      - *notify_slack
+      - *notify_slack_on_failure
 
   e2e_test:
     <<: *circle_container
     steps:
       - checkout
+      - *set_package_version
       - *restore_cache
       - *install_dependencies
       - *save_cache
@@ -175,7 +225,7 @@ jobs:
           path: reports/testcafe
       - store_artifacts:
           path: artifacts
-      - *notify_slack
+      - *notify_slack_on_failure
 
   publish_release_to_github:
     <<: *circle_container
@@ -217,15 +267,17 @@ jobs:
     steps:
       - build_for_k8s:
           env: 'production'
+          notify_slack: 'true'
 
   deploy_production:
     <<: *cloud_container
     steps:
       - deploy_to_k8s:
           env: 'production'
+      - *notify_slack_on_release_end
 
 workflows:
-  pecs-frontend:
+  frontend:
     jobs:
       - build_and_test:
           <<: *all_tags
@@ -256,6 +308,10 @@ workflows:
       - production_approval:
           <<: *only_deploy_tags
           type: approval
+          requires:
+          - e2e_test
+      - notify-of-approval:
+          <<: *only_deploy_tags
           requires:
           - e2e_test
       - publish_release_to_github:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,7 +87,7 @@ aliases:
         ignore: /.*/
   - &requires_production_approval
     requires:
-    - production_approval
+      - approval
 
 jobs:
   notify-of-approval:
@@ -97,7 +97,7 @@ jobs:
       - *set_package_version
       - *notify_slack_of_approval
 
-  build_and_test:
+  lint-and-unit-test:
     <<: *circle_container
     steps:
       - checkout
@@ -139,7 +139,7 @@ jobs:
           path: coverage
       - *notify_slack_on_failure
 
-  e2e_test:
+  end-to-end-test:
     <<: *circle_container
     steps:
       - checkout
@@ -156,7 +156,7 @@ jobs:
           path: artifacts
       - *notify_slack_on_failure
 
-  publish_release_to_github:
+  publish-release-to-github:
     <<: *circle_container
     steps:
       - checkout
@@ -271,56 +271,63 @@ jobs:
             - *notify_slack_on_release_end
 
 workflows:
-  frontend:
+  continuous-deployment:
     jobs:
-      - build_and_test:
+      # Tests
+      - lint-and-unit-test:
           <<: *all_tags
+      - end-to-end-test:
+          <<: *only_master_and_tags
+          requires:
+            - deploy-staging
+      # Docker builds
       - build-docker-image:
           <<: *only_master_and_tags
           staging: 'true'
           preprod: 'true'
-          requires:
-          - build_and_test
-      - deploy:
-          <<: *only_master_and_tags
-          name: deploy-staging
-          env: 'staging'
-          requires:
-            - build-docker-image
-            - build_and_test
-      - deploy:
-          <<: *only_master_and_tags
-          name: deploy-preproduction
-          env: 'preprod'
-          requires:
-            - build-docker-image
-            - build_and_test
-            - e2e_test
-      - e2e_test:
-          <<: *only_master_and_tags
-          requires:
-          - deploy_staging
       - build-docker-image:
           <<: *only_deploy_tags
           name: build-docker-image-production
           staging: 'true'
           preprod: 'true'
           production: 'true'
-      - production_approval:
-          <<: *only_deploy_tags
-          type: approval
+      # Deployment
+      - deploy:
+          <<: *only_master_and_tags
+          name: deploy-staging
+          env: 'staging'
           requires:
-          - e2e_test
-      - notify-of-approval:
-          <<: *only_deploy_tags
+            - build-docker-image
+            - lint-and-unit-test
+      - deploy:
+          <<: *only_master_and_tags
+          name: deploy-preproduction
+          env: 'preprod'
           requires:
-          - e2e_test
-      - publish_release_to_github:
-          <<: *only_deploy_tags
-          <<: *requires_production_approval
+            - build-docker-image
+            - lint-and-unit-test
+            - end-to-end-test
       - deploy:
           <<: *only_deploy_tags
           <<: *requires_production_approval
           name: deploy-production
           env: 'production'
           notify_slack: 'true'
+      # Production approval
+      - approval:
+          <<: *only_deploy_tags
+          type: approval
+          requires:
+            - lint-and-unit-test
+            - end-to-end-test
+            - build-docker-image-production
+      - notify-of-approval:
+          <<: *only_deploy_tags
+          requires:
+            - lint-and-unit-test
+            - end-to-end-test
+            - build-docker-image-production
+      # Post release
+      - publish-release-to-github:
+          <<: *only_deploy_tags
+          <<: *requires_production_approval

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,77 +89,6 @@ aliases:
     requires:
     - production_approval
 
-commands:
-  build_for_k8s:
-    description: 'Builds a Docker image for staging/production and pushes to ECR'
-    parameters:
-      env:
-        type: string
-      notify_slack:
-        type: string
-        default: ""
-    steps:
-      - checkout
-      - *set_package_version
-      - when:
-          condition: <<parameters.notify_slack>>
-          steps:
-            - *notify_slack_on_release_start
-      - setup_remote_docker:
-          docker_layer_caching: true
-      - run:
-          name: Build docker image
-          command: |
-            export BUILD_DATE=$(date -Is) >> $BASH_ENV
-            source $BASH_ENV
-
-            docker build \
-              --label build.git.sha=${CIRCLE_SHA1} \
-              --label build.git.branch=${CIRCLE_BRANCH} \
-              --label build.date=${BUILD_DATE} \
-              --build-arg APP_BUILD_DATE=${BUILD_DATE} \
-              --build-arg APP_BUILD_TAG=${CIRCLE_BRANCH} \
-              --build-arg APP_GIT_COMMIT=${CIRCLE_SHA1} \
-              -t app .
-      - run:
-          name: Push docker image
-          command: |
-            login="$(aws ecr get-login --region ${AWS_DEFAULT_REGION} --no-include-email)"
-            ${login}
-
-            docker tag app "${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${CIRCLE_PROJECT_REPONAME}:${CIRCLE_SHA1}"
-            docker push "${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${CIRCLE_PROJECT_REPONAME}:${CIRCLE_SHA1}"
-
-            docker tag app "${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${CIRCLE_PROJECT_REPONAME}:<< parameters.env >>.latest"
-            docker push "${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${CIRCLE_PROJECT_REPONAME}:<< parameters.env >>.latest"
-
-  deploy_to_k8s:
-    description: 'Deploys a previously built Docker image to staging/production k8s environment'
-    parameters:
-      env:
-        type: string
-    steps:
-      - checkout
-      - *set_package_version
-      - run:
-          name: Set k8s context
-          command: |
-            setup-kube-auth
-            kubectl config use-context << parameters.env >>
-      - deploy:
-          name: Deploy image to << parameters.env >>
-          command: |
-            export BUILD_DATE=$(date -Is) >> $BASH_ENV
-            source $BASH_ENV
-
-            kubectl set image -n hmpps-book-secure-move-frontend-<< parameters.env >> \
-                    deployment/hmpps-book-secure-move-frontend-deployment-<< parameters.env >> \
-                    webapp="${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${CIRCLE_PROJECT_REPONAME}:${CIRCLE_SHA1}"
-
-            kubectl annotate -n hmpps-book-secure-move-frontend-<< parameters.env >> \
-                    deployment/hmpps-book-secure-move-frontend-deployment-<< parameters.env >> \
-                    kubernetes.io/change-cause="${BUILD_DATE} set image ${CIRCLE_PROJECT_REPONAME}:${CIRCLE_SHA1} via CircleCI"
-
 jobs:
   notify-of-approval:
     <<: *circle_container
@@ -238,73 +167,145 @@ jobs:
           name: Publish release to GitHub
           command: npm run release:github
 
-  build_staging:
+  build-docker-image:
     <<: *cloud_container
+    parameters:
+      staging:
+        type: string
+        default: ""
+      preprod:
+        type: string
+        default: ""
+      production:
+        type: string
+        default: ""
     steps:
-      - build_for_k8s:
-          env: 'staging'
+      - checkout
+      - *set_package_version
+      - when:
+          condition: <<parameters.production>>
+          steps:
+            - *notify_slack_on_release_start
+      - setup_remote_docker:
+          docker_layer_caching: true
+      - run:
+          name: Build docker image
+          command: |
+            export BUILD_DATE=$(date -Is) >> $BASH_ENV
+            source $BASH_ENV
 
-  deploy_staging:
-    <<: *cloud_container
-    steps:
-      - deploy_to_k8s:
-          env: 'staging'
+            docker build \
+              --label build.git.sha=${CIRCLE_SHA1} \
+              --label build.git.branch=${CIRCLE_BRANCH} \
+              --label build.date=${BUILD_DATE} \
+              --build-arg APP_BUILD_DATE=${BUILD_DATE} \
+              --build-arg APP_BUILD_TAG=${CIRCLE_BRANCH} \
+              --build-arg APP_GIT_COMMIT=${CIRCLE_SHA1} \
+              -t app .
+      - run:
+          name: Login to ECR
+          command: |
+            $(aws ecr get-login --region ${AWS_DEFAULT_REGION} --no-include-email)
+      - run:
+          name: Push docker image to ECR
+          command: |
+            docker tag app "${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${CIRCLE_PROJECT_REPONAME}:${CIRCLE_SHA1}"
+            docker push "${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${CIRCLE_PROJECT_REPONAME}:${CIRCLE_SHA1}"
+      - when:
+          condition: <<parameters.staging>>
+          steps:
+            - run:
+                name: Push staging docker image to ECR
+                command: |
+                  docker tag app "${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${CIRCLE_PROJECT_REPONAME}:staging.latest"
+                  docker push "${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${CIRCLE_PROJECT_REPONAME}:staging.latest"
+      - when:
+          condition: <<parameters.preprod>>
+          steps:
+            - run:
+                name: Push preproduction docker image to ECR
+                command: |
+                  docker tag app "${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${CIRCLE_PROJECT_REPONAME}:preprod.latest"
+                  docker push "${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${CIRCLE_PROJECT_REPONAME}:preprod.latest"
+      - when:
+          condition: <<parameters.production>>
+          steps:
+            - run:
+                name: Push production docker image to ECR
+                command: |
+                  docker tag app "${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${CIRCLE_PROJECT_REPONAME}:production.latest"
+                  docker push "${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${CIRCLE_PROJECT_REPONAME}:production.latest"
 
-  build_preprod:
+  deploy:
     <<: *cloud_container
+    parameters:
+      env:
+        type: string
+      notify_slack:
+        type: string
+        default: ""
     steps:
-      - build_for_k8s:
-          env: 'preprod'
+      - checkout
+      - *set_package_version
+      - run:
+          name: Set k8s context
+          command: |
+            setup-kube-auth
+            kubectl config use-context << parameters.env >>
+      - deploy:
+          name: Deploy image to << parameters.env >>
+          command: |
+            export BUILD_DATE=$(date -Is) >> $BASH_ENV
+            source $BASH_ENV
 
-  deploy_preprod:
-    <<: *cloud_container
-    steps:
-      - deploy_to_k8s:
-          env: 'preprod'
+            kubectl set image -n hmpps-book-secure-move-frontend-<< parameters.env >> \
+                    deployment/hmpps-book-secure-move-frontend-deployment-<< parameters.env >> \
+                    webapp="${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${CIRCLE_PROJECT_REPONAME}:${CIRCLE_SHA1}"
 
-  build_production:
-    <<: *cloud_container
-    steps:
-      - build_for_k8s:
-          env: 'production'
-          notify_slack: 'true'
-
-  deploy_production:
-    <<: *cloud_container
-    steps:
-      - deploy_to_k8s:
-          env: 'production'
-      - *notify_slack_on_release_end
+            kubectl annotate -n hmpps-book-secure-move-frontend-<< parameters.env >> \
+                    deployment/hmpps-book-secure-move-frontend-deployment-<< parameters.env >> \
+                    kubernetes.io/change-cause="${BUILD_DATE} set image ${CIRCLE_PROJECT_REPONAME}:${CIRCLE_SHA1} via CircleCI"
+      - when:
+          condition: <<parameters.notify_slack>>
+          steps:
+            - *notify_slack_on_release_end
 
 workflows:
   frontend:
     jobs:
       - build_and_test:
           <<: *all_tags
-      - build_staging:
+      - build-docker-image:
           <<: *only_master_and_tags
-      - build_preprod:
-          <<: *only_master_and_tags
+          staging: 'true'
+          preprod: 'true'
           requires:
           - build_and_test
-      - deploy_staging:
+      - deploy:
           <<: *only_master_and_tags
+          name: deploy-staging
+          env: 'staging'
           requires:
-          - build_and_test
-          - build_staging
-      - deploy_preprod:
+            - build-docker-image
+            - build_and_test
+      - deploy:
           <<: *only_master_and_tags
+          name: deploy-preproduction
+          env: 'preprod'
           requires:
-          - build_preprod
-          - e2e_test
+            - build-docker-image
+            - build_and_test
+            - e2e_test
       - e2e_test:
           <<: *only_master_and_tags
           requires:
           - deploy_staging
-      - build_production:
+      - build-docker-image:
           <<: *only_deploy_tags
-          requires:
-          - build_and_test
+          name: build-docker-image-production
+          staging: 'true'
+          preprod: 'true'
+          production: 'true'
       - production_approval:
           <<: *only_deploy_tags
           type: approval
@@ -317,6 +318,9 @@ workflows:
       - publish_release_to_github:
           <<: *only_deploy_tags
           <<: *requires_production_approval
-      - deploy_production:
+      - deploy:
           <<: *only_deploy_tags
           <<: *requires_production_approval
+          name: deploy-production
+          env: 'production'
+          notify_slack: 'true'

--- a/.circleci/get-review-app-url.sh
+++ b/.circleci/get-review-app-url.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+GITHUB_DEPLOYMENTS_URL="https://api.github.com/repos/ministryofjustice/hmpps-book-secure-move-frontend/deployments"
+
+while true
+do
+  DEPLOYED_SHA=$(curl --silent -XGET -H "Authorization: token ${GITHUB_API_TOKEN}" $GITHUB_DEPLOYMENTS_URL | jq -r '.[0].sha')
+  if [ "$DEPLOYED_SHA" = "$CIRCLE_SHA1" ]; then
+    break
+  fi
+  sleep 5
+done
+
+GITHUB_DEPLOYMENT_STATUS_URL=$(curl --silent -XGET -H "Authorization: token ${GITHUB_API_TOKEN}" $GITHUB_DEPLOYMENTS_URL | jq -r '.[0].statuses_url')
+
+while true
+do
+  GITHUB_DEPLOYMENT_STATUS=$(curl --silent -XGET -H 'Accept: application/vnd.github.flash-preview+json' -H "Authorization: token ${GITHUB_API_TOKEN}" $GITHUB_DEPLOYMENT_STATUS_URL | jq -r '.[0].state == "success"')
+  if [ "$GITHUB_DEPLOYMENT_STATUS" = "true" ]; then
+    break
+  fi
+  sleep 5
+done
+
+# Output Review App URL
+curl --silent -XGET -H "Authorization: token ${GITHUB_API_TOKEN}" $GITHUB_DEPLOYMENTS_URL | jq -r '.[0].payload.web_url' | sed 's:/*$::'


### PR DESCRIPTION
## Proposed changes

This set of changes updates the continuous deployment workflow we use. It adds:

- further slack notifications to notify team channels of deployments and users who need to approve those deployments
- end-to-end testing on Pull Requests

This comes with some updates to the existing continuous deployment workflows, see the screenshots for exact differences.

In summary:

- pull requests run end-to-end tests against Heroku review apps
- master deploys to staging and runs end-to-end tests against staging
- pre-production is now **only** deployed as part of the release workflow and end-to-end tests are run against pre-production for releases

Closes #434

## Screenshots

*Click images to enlarge them*

### Circle CI

| Before | After |
| ------ | ----- |
| <kbd><img src="https://user-images.githubusercontent.com/3327997/81559099-bfbda900-9386-11ea-990c-c9c05c9c1b14.png"></kbd> | <kbd><img src="https://user-images.githubusercontent.com/3327997/81562118-34dfad00-938c-11ea-8dff-46dc9c9d88a1.png"></kbd> |
| <kbd><img src="https://user-images.githubusercontent.com/3327997/81562486-d7982b80-938c-11ea-9f70-6282e9fbe6e0.png"></kbd> | <kbd><img src="https://user-images.githubusercontent.com/3327997/81562220-5fca0100-938c-11ea-9f06-aec0248debec.png"></kbd> |
| <kbd><img src="https://user-images.githubusercontent.com/3327997/81562338-94d65380-938c-11ea-8c4e-c4b55a5fa7ef.png"></kbd> | <kbd><img src="https://user-images.githubusercontent.com/3327997/81562861-6c9b2480-938d-11ea-8915-b7d77ae638c7.png"></kbd> |

### Slack notifications

<kbd><img width="417" alt="Screenshot 2020-05-09 at 09 16 32" src="https://user-images.githubusercontent.com/3327997/81563311-02cf4a80-938e-11ea-91d0-15bdd15879f7.png"></kbd>

<kbd><img width="555" alt="Screenshot 2020-05-09 at 09 16 55" src="https://user-images.githubusercontent.com/3327997/81563420-22ff0980-938e-11ea-9864-f7dc0edc1f87.png"></kbd>

<kbd><img width="446" alt="Screenshot 2020-05-09 at 09 17 07" src="https://user-images.githubusercontent.com/3327997/81563301-ff3bc380-938d-11ea-8b67-ad5970022316.png"></kbd>

