### PR TITLE
fix(single requests): Show agreement status with receiving prison

### DIFF
--- a/app/move/fields/move-agreed-by.js
+++ b/app/move/fields/move-agreed-by.js
@@ -11,7 +11,7 @@ const moveAgreedBy = {
   validate: 'required',
   dependent: {
     field: 'move_agreed',
-    value: 'yes',
+    value: 'true',
   },
 }
 

--- a/app/move/fields/move-agreed.js
+++ b/app/move/fields/move-agreed.js
@@ -11,12 +11,12 @@ const moveAgreed = {
   items: [
     {
       id: 'move_agreed',
-      value: 'yes',
+      value: 'true',
       text: 'Yes',
       conditional: 'move_agreed_by',
     },
     {
-      value: 'no',
+      value: 'false',
       text: 'No',
     },
   ],

--- a/common/presenters/move-to-meta-list-component.js
+++ b/common/presenters/move-to-meta-list-component.js
@@ -1,6 +1,7 @@
 const { isToday, isTomorrow, isYesterday, parseISO } = require('date-fns')
 const { get } = require('lodash')
 
+const { create: createFields } = require('../../app/move/fields')
 const i18n = require('../../config/i18n')
 const filters = require('../../config/nunjucks/filters')
 
@@ -35,6 +36,8 @@ function moveToMetaListComponent(
     to_location: toLocation,
     additional_information: additionalInfo,
     prison_transfer_reason: prisonTransferReason = {},
+    move_agreed: moveAgreed,
+    move_agreed_by: moveAgreedBy,
   } = {},
   actions = {}
 ) {
@@ -50,6 +53,16 @@ function moveToMetaListComponent(
   const prisonTransferReasonSuffix = additionalInfo
     ? ` — ${additionalInfo}`
     : ''
+  const agreedLabel = i18n.t('moves::detail.agreement_status.agreed', {
+    context: moveAgreedBy ? 'with_name' : '',
+    name: moveAgreedBy,
+  })
+  const notAgreedLabel = i18n.t('moves::detail.agreement_status.not_agreed')
+  const agreementLabel =
+    moveAgreed === true ||
+    moveAgreed === createFields.move_agreed.items[0].value
+      ? agreedLabel
+      : notAgreedLabel
 
   Object.keys(actions).forEach(key => {
     actions[key] = {
@@ -116,6 +129,14 @@ function moveToMetaListComponent(
         text: showPrisonTransferReason
           ? prisonTransferReason.title + prisonTransferReasonSuffix
           : undefined,
+      },
+    },
+    {
+      key: {
+        text: i18n.t('fields::move_agreed.label'),
+      },
+      value: {
+        text: moveAgreed !== undefined ? agreementLabel : undefined,
       },
     },
   ]

--- a/common/presenters/move-to-meta-list-component.test.js
+++ b/common/presenters/move-to-meta-list-component.test.js
@@ -39,7 +39,7 @@ describe('Presenters', function() {
       describe('response', function() {
         it('should contain items list', function() {
           expect(transformedResponse).to.have.property('items')
-          expect(transformedResponse.items.length).to.equal(7)
+          expect(transformedResponse.items.length).to.equal(8)
         })
 
         it('should contain from location as first item', function() {
@@ -100,8 +100,17 @@ describe('Presenters', function() {
           })
         })
 
-        it('should contain time due as seventh item', function() {
+        it('should contain transfer type as seventh item', function() {
           const item = transformedResponse.items[6]
+
+          expect(item).to.deep.equal({
+            key: { text: '__translated__' },
+            value: { text: undefined },
+          })
+        })
+
+        it('should contain agreement status as eigth item', function() {
+          const item = transformedResponse.items[7]
 
           expect(item).to.deep.equal({
             key: { text: '__translated__' },
@@ -145,8 +154,12 @@ describe('Presenters', function() {
           )
         })
 
+        it('should translate agreement status type label', function() {
+          expect(i18n.t).to.be.calledWithExactly('fields::move_agreed.label')
+        })
+
         it('should translate correct number of times', function() {
-          expect(i18n.t).to.be.callCount(7)
+          expect(i18n.t).to.be.callCount(10)
         })
       })
     })
@@ -555,6 +568,191 @@ describe('Presenters', function() {
             value: {
               text: undefined,
             },
+          })
+        })
+      })
+    })
+
+    context('with agreement status', function() {
+      let transformedResponse
+
+      beforeEach(function() {
+        i18n.t.returnsArg(0)
+      })
+
+      context('with true status', function() {
+        context('without name', function() {
+          beforeEach(function() {
+            transformedResponse = moveToMetaListComponent({
+              ...mockMove,
+              move_agreed: true,
+            })
+          })
+
+          it('should not add additional information to transfer reason', function() {
+            expect(transformedResponse.items[7]).to.deep.equal({
+              key: { text: 'fields::move_agreed.label' },
+              value: {
+                text: 'moves::detail.agreement_status.agreed',
+              },
+            })
+          })
+
+          it('should translate agreed label correctly', function() {
+            expect(i18n.t).to.be.calledWithExactly(
+              'moves::detail.agreement_status.agreed',
+              {
+                context: '',
+                name: undefined,
+              }
+            )
+          })
+        })
+
+        context('with name', function() {
+          beforeEach(function() {
+            transformedResponse = moveToMetaListComponent({
+              ...mockMove,
+              move_agreed: true,
+              move_agreed_by: 'Jon Doe',
+            })
+          })
+
+          it('should not add additional information to transfer reason', function() {
+            expect(transformedResponse.items[7]).to.deep.equal({
+              key: { text: 'fields::move_agreed.label' },
+              value: {
+                text: 'moves::detail.agreement_status.agreed',
+              },
+            })
+          })
+
+          it('should translate agreed label correctly', function() {
+            expect(i18n.t).to.be.calledWithExactly(
+              'moves::detail.agreement_status.agreed',
+              {
+                context: 'with_name',
+                name: 'Jon Doe',
+              }
+            )
+          })
+        })
+      })
+
+      context('with false status', function() {
+        context('without name', function() {
+          beforeEach(function() {
+            transformedResponse = moveToMetaListComponent({
+              ...mockMove,
+              move_agreed: false,
+            })
+          })
+
+          it('should not add additional information to transfer reason', function() {
+            expect(transformedResponse.items[7]).to.deep.equal({
+              key: { text: 'fields::move_agreed.label' },
+              value: {
+                text: 'moves::detail.agreement_status.not_agreed',
+              },
+            })
+          })
+
+          it('should translate agreed label correctly', function() {
+            expect(i18n.t).to.be.calledWithExactly(
+              'moves::detail.agreement_status.agreed',
+              {
+                context: '',
+                name: undefined,
+              }
+            )
+          })
+        })
+
+        context('with name', function() {
+          beforeEach(function() {
+            transformedResponse = moveToMetaListComponent({
+              ...mockMove,
+              move_agreed: false,
+              move_agreed_by: 'Jon Doe',
+            })
+          })
+
+          it('should not add additional information to transfer reason', function() {
+            expect(transformedResponse.items[7]).to.deep.equal({
+              key: { text: 'fields::move_agreed.label' },
+              value: {
+                text: 'moves::detail.agreement_status.not_agreed',
+              },
+            })
+          })
+
+          it('should translate agreed label correctly', function() {
+            expect(i18n.t).to.be.calledWithExactly(
+              'moves::detail.agreement_status.agreed',
+              {
+                context: 'with_name',
+                name: 'Jon Doe',
+              }
+            )
+          })
+        })
+      })
+
+      context('with status that matches `yes` from field`', function() {
+        context('without name', function() {
+          beforeEach(function() {
+            transformedResponse = moveToMetaListComponent({
+              ...mockMove,
+              move_agreed: 'true',
+            })
+          })
+
+          it('should not add additional information to transfer reason', function() {
+            expect(transformedResponse.items[7]).to.deep.equal({
+              key: { text: 'fields::move_agreed.label' },
+              value: {
+                text: 'moves::detail.agreement_status.agreed',
+              },
+            })
+          })
+
+          it('should translate agreed label correctly', function() {
+            expect(i18n.t).to.be.calledWithExactly(
+              'moves::detail.agreement_status.agreed',
+              {
+                context: '',
+                name: undefined,
+              }
+            )
+          })
+        })
+
+        context('with name', function() {
+          beforeEach(function() {
+            transformedResponse = moveToMetaListComponent({
+              ...mockMove,
+              move_agreed: 'true',
+              move_agreed_by: 'Jon Doe',
+            })
+          })
+
+          it('should not add additional information to transfer reason', function() {
+            expect(transformedResponse.items[7]).to.deep.equal({
+              key: { text: 'fields::move_agreed.label' },
+              value: {
+                text: 'moves::detail.agreement_status.agreed',
+              },
+            })
+          })
+
+          it('should translate agreed label correctly', function() {
+            expect(i18n.t).to.be.calledWithExactly(
+              'moves::detail.agreement_status.agreed',
+              {
+                context: 'with_name',
+                name: 'Jon Doe',
+              }
+            )
           })
         })
       })

--- a/common/services/move.js
+++ b/common/services/move.js
@@ -7,6 +7,7 @@ const personService = require('../services/person')
 const noMoveIdMessage = 'No move ID supplied'
 const moveService = {
   format(data) {
+    const booleansAndNulls = ['move_agreed']
     const relationships = [
       'to_location',
       'from_location',
@@ -15,6 +16,11 @@ const moveService = {
     ]
 
     return mapValues(pickBy(data), (value, key) => {
+      if (booleansAndNulls.includes(key)) {
+        try {
+          value = JSON.parse(value)
+        } catch (e) {}
+      }
       if (relationships.includes(key) && typeof value === 'string') {
         return { id: value }
       }

--- a/common/services/move.test.js
+++ b/common/services/move.test.js
@@ -51,8 +51,8 @@ describe('Move Service', function() {
     let formatted
 
     context('when relationship fields are a string', function() {
-      beforeEach(async function() {
-        formatted = await moveService.format({
+      beforeEach(function() {
+        formatted = moveService.format({
           date: '2010-10-10',
           to_location: mockToLocationId,
           from_location: mockFromLocationId,
@@ -91,8 +91,8 @@ describe('Move Service', function() {
     })
 
     context('when relationship fields are not a string', function() {
-      beforeEach(async function() {
-        formatted = await moveService.format({
+      beforeEach(function() {
+        formatted = moveService.format({
           date: '2010-10-10',
           to_location: {
             id: mockToLocationId,
@@ -139,8 +139,8 @@ describe('Move Service', function() {
     })
 
     context('with falsey values', function() {
-      beforeEach(async function() {
-        formatted = await moveService.format({
+      beforeEach(function() {
+        formatted = moveService.format({
           date: '2010-10-10',
           to_location: {
             id: mockToLocationId,
@@ -174,6 +174,22 @@ describe('Move Service', function() {
           },
           empty_array: [],
         })
+      })
+    })
+
+    context('with strings that be booleans', function() {
+      it('should `false` string as boolean', function() {
+        const formatted = moveService.format({
+          move_agreed: 'false',
+        })
+        expect(formatted.move_agreed).to.equal(false)
+      })
+
+      it('should `true` string as boolean', function() {
+        const formatted = moveService.format({
+          move_agreed: 'true',
+        })
+        expect(formatted.move_agreed).to.equal(true)
       })
     })
   })

--- a/locales/en/fields.json
+++ b/locales/en/fields.json
@@ -215,7 +215,7 @@
     "label": "Reason for move"
   },
   "move_agreed": {
-    "label": "Move agreement status"
+    "label": "Transfer status"
   },
   "move_agreed_by": {
     "label": "Name of person who agreed the move"

--- a/locales/en/moves.json
+++ b/locales/en/moves.json
@@ -143,6 +143,11 @@
       "heading": "Supporting documents",
       "heading_plural": "Supporting documents ({{count}})",
       "empty": "No documents uploaded"
+    },
+    "agreement_status": {
+      "agreed": "Agreed with receiving prison",
+      "agreed_with_name": "Agreed by {{name}}",
+      "not_agreed": "Not agreed with receiving prison"
     }
   },
   "cancel": {


### PR DESCRIPTION
## Proposed changes

This adds a new item to the summary panel to show the status of
the prison transfer with the receiving prison.

It will show the person's name if it has been entered when creating
the transfer request.

## Screenshots

| Before | After |
| ------ | ----- |
| <kbd><img src="https://user-images.githubusercontent.com/3327997/81589324-425b5e00-93b1-11ea-848f-b2b4441b7251.png"></kbd> | <kbd><img src="https://user-images.githubusercontent.com/3327997/81589193-222b9f00-93b1-11ea-90b5-5637ae20b02d.png"></kbd> |
| <kbd><img src="https://user-images.githubusercontent.com/3327997/81589324-425b5e00-93b1-11ea-848f-b2b4441b7251.png"></kbd> | <kbd><img src="https://user-images.githubusercontent.com/3327997/81589448-5901b500-93b1-11ea-8e1f-e9dedc577e07.png"></kbd> |

