### PR TITLE
fix(edit): Correct the reference to update fields

### DIFF
--- a/app/move/fields/index.js
+++ b/app/move/fields/index.js
@@ -104,7 +104,7 @@ const createFields = {
   violent: assessmentAnswer(),
 }
 const updateFields = {
-  ...cloneDeep(cancelFields),
+  ...cloneDeep(createFields),
   police_national_computer: policeNationalComputerUpdate,
 }
 


### PR DESCRIPTION
In a change made to update the names of the field objects a reference
to the create fields was broken in the update fields object.

This fixes that reference and ensures edit works correctly.