### PR TITLE
chore: Add e2e tests for updating move date

### DIFF
--- a/test/e2e/_move.js
+++ b/test/e2e/_move.js
@@ -410,6 +410,21 @@ export async function checkUpdateMoveDetails() {
 }
 
 /**
+ * Change move date and confirm changes on move view page
+ *
+ * @returns {undefined}
+ */
+export async function checkUpdateMoveDate(date = 'Tomorrow') {
+  const updateMovePage = await clickUpdateLink('date')
+
+  const updatedMove = await updateMovePage.fillInDate(date)
+
+  await updateMovePage.submitForm()
+
+  await moveDetailPage.checkMoveDetails(updatedMove)
+}
+
+/**
  * Check that PNC details are uneditable and displayed corectly on the personal details page
  *
  * @returns {undefined}

--- a/test/e2e/move.update.police.test.js
+++ b/test/e2e/move.update.police.test.js
@@ -1,3 +1,5 @@
+import { addDays, format } from 'date-fns'
+
 import { FEATURE_FLAGS } from '../../config'
 
 import {
@@ -99,6 +101,7 @@ if (FEATURE_FLAGS.EDITABILITY) {
   })
 
   test('User should be able to change move date to another date', async () => {
-    await checkUpdateMoveDate(3)
+    const anotherDate = format(addDays(new Date(), 3), 'iiii d MMM yyyy')
+    await checkUpdateMoveDate(anotherDate)
   })
 }

--- a/test/e2e/move.update.police.test.js
+++ b/test/e2e/move.update.police.test.js
@@ -10,6 +10,7 @@ import {
   checkUpdateHealthInformation,
   checkUpdateCourtInformation,
   checkUpdateMoveDetails,
+  checkUpdateMoveDate,
 } from './_move'
 
 if (FEATURE_FLAGS.EDITABILITY) {
@@ -92,4 +93,12 @@ if (FEATURE_FLAGS.EDITABILITY) {
       await checkUpdateMoveDetails()
     }
   )
+
+  test('User should be able to change move date to tomorrow', async () => {
+    await checkUpdateMoveDate()
+  })
+
+  test('User should be able to change move date to another date', async () => {
+    await checkUpdateMoveDate(3)
+  })
 }

--- a/test/e2e/pages/create-move.js
+++ b/test/e2e/pages/create-move.js
@@ -1,4 +1,3 @@
-import { addDays, format } from 'date-fns'
 import faker from 'faker'
 import { omit, pick } from 'lodash'
 import pluralize from 'pluralize'
@@ -251,10 +250,9 @@ class CreateMovePage extends Page {
   /**
    * Fill in date
    *
-   * @param {'Today'|'Tomorrow'|{string}|{number}} dateValue - type of date
+   * @param {'Today'|'Tomorrow'|{string}} dateValue - type of date
    * Any string other than 'Today' or 'Tomorrow' is treated as 'Another date'
-   * and used as is for the date_custom field. If passed as a number, sets
-   * date_custom to current date plus that number of days
+   * and used as is for the date_custom field.
    * @returns {Promise<FormDetails>} - filled in move details
    */
   async fillInDate(dateValue = 'Today') {
@@ -264,11 +262,7 @@ class CreateMovePage extends Page {
     let dateType = dateValue
     if (dateType !== 'Today' && dateType !== 'Tomorrow') {
       dateType = 'Another date'
-
       dateCustom = dateValue
-      if (typeof dateCustom === 'number') {
-        dateCustom = format(addDays(new Date(), dateCustom), 'iiii d MMM yyyy')
-      }
     }
 
     const data = {

--- a/test/e2e/pages/create-move.js
+++ b/test/e2e/pages/create-move.js
@@ -1,3 +1,4 @@
+import { addDays, format } from 'date-fns'
 import faker from 'faker'
 import { omit, pick } from 'lodash'
 import pluralize from 'pluralize'
@@ -28,6 +29,7 @@ class CreateMovePage extends Page {
       courtLocation: Selector('#to_location_court_appearance'),
       prisonLocation: Selector('#to_location_prison_transfer'),
       prisonRecallComments: Selector('#prison_recall_comments'),
+      dateCustom: Selector('[name="date_custom"]'),
       dateType: Selector('[name="date_type"]'),
       dateFrom: Selector('#date_from'),
       hasDateTo: Selector('[name="has_date_to"]'),
@@ -248,17 +250,42 @@ class CreateMovePage extends Page {
 
   /**
    * Fill in date
+   *
+   * @param {'Today'|'Tomorrow'|{string}|{number}} dateValue - type of date
+   * Any string other than 'Today' or 'Tomorrow' is treated as 'Another date'
+   * and used as is for the date_custom field. If passed as a number, sets
+   * date_custom to current date plus that number of days
+   * @returns {Promise<FormDetails>} - filled in move details
    */
-  async fillInDate() {
+  async fillInDate(dateValue = 'Today') {
     await t.expect(this.getCurrentUrl()).contains(`${this.url}/move-date`)
+    let dateCustom
 
-    return fillInForm({
+    let dateType = dateValue
+    if (dateType !== 'Today' && dateType !== 'Tomorrow') {
+      dateType = 'Another date'
+
+      dateCustom = dateValue
+      if (typeof dateCustom === 'number') {
+        dateCustom = format(addDays(new Date(), dateCustom), 'iiii d MMM yyyy')
+      }
+    }
+
+    const data = {
       dateType: {
         selector: this.fields.dateType,
-        value: 'Today',
+        value: dateType,
         type: 'radio',
       },
-    })
+    }
+    if (dateCustom) {
+      data.dateCustom = {
+        selector: this.fields.dateCustom,
+        value: dateCustom,
+      }
+    }
+
+    return fillInForm(data)
   }
 
   /**


### PR DESCRIPTION
Adds e2e tests for checking that move date can be updated.

Extends create-move's `fillInDate` method to allow an optional date type or value to be passed to it.

### Checklist

- [x] If adding new environment variables, they have been documented in the [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md)
- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
