### PR TITLE
Update button text for single requests

### DIFF
--- a/app/move/controllers/create/base.js
+++ b/app/move/controllers/create/base.js
@@ -40,13 +40,19 @@ class CreateBaseController extends FormWizardController {
   }
 
   setButtonText(req, res, next) {
+    const toLocation = req.sessionModel.get('to_location') || {}
+    const fromLocation = req.session.currentLocation || {}
     const nextStep = this.getNextStep(req, res)
     const steps = Object.keys(req.form.options.steps)
     const lastStep = steps[steps.length - 1]
+    const saveButtonText =
+      toLocation.location_type === 'prison' &&
+      fromLocation.location_type === 'prison'
+        ? 'actions::send_for_review'
+        : 'actions::request_move'
     const buttonText = nextStep.includes(lastStep)
-      ? 'actions::request_move'
+      ? saveButtonText
       : 'actions::continue'
-
     req.form.options.buttonText = req.form.options.buttonText || buttonText
 
     next()

--- a/app/move/controllers/create/base.test.js
+++ b/app/move/controllers/create/base.test.js
@@ -108,6 +108,10 @@ describe('Move controllers', function() {
               },
             },
           },
+          session: {},
+          sessionModel: {
+            get: sinon.stub(),
+          },
         }
         sinon.stub(FormController.prototype, 'getNextStep')
       })
@@ -120,7 +124,7 @@ describe('Move controllers', function() {
           controller.setButtonText(req, {}, nextSpy)
         })
 
-        it('should set cancel url correctly', function() {
+        it('should set button text correctly', function() {
           expect(req.form.options.buttonText).to.equal('Override button text')
         })
 
@@ -137,7 +141,7 @@ describe('Move controllers', function() {
             controller.setButtonText(req, {}, nextSpy)
           })
 
-          it('should set cancel url correctly', function() {
+          it('should set button text correctly', function() {
             expect(req.form.options.buttonText).to.equal('actions::continue')
           })
 
@@ -149,18 +153,49 @@ describe('Move controllers', function() {
         context('when step is penultimate step', function() {
           beforeEach(function() {
             FormController.prototype.getNextStep.returns('/last-step')
-
-            controller.setButtonText(req, {}, nextSpy)
+            req.session.currentLocation = {
+              location_type: 'prison',
+            }
           })
 
-          it('should set cancel url correctly', function() {
-            expect(req.form.options.buttonText).to.equal(
-              'actions::request_move'
-            )
+          context('with single requests', function() {
+            beforeEach(function() {
+              req.sessionModel.get.withArgs('to_location').returns({
+                location_type: 'prison',
+              })
+
+              controller.setButtonText(req, {}, nextSpy)
+            })
+
+            it('should set button text correctly', function() {
+              expect(req.form.options.buttonText).to.equal(
+                'actions::send_for_review'
+              )
+            })
+
+            it('should call next', function() {
+              expect(nextSpy).to.be.calledOnceWithExactly()
+            })
           })
 
-          it('should call next', function() {
-            expect(nextSpy).to.be.calledOnceWithExactly()
+          context('with single requests', function() {
+            beforeEach(function() {
+              req.sessionModel.get.withArgs('to_location').returns({
+                location_type: 'court',
+              })
+
+              controller.setButtonText(req, {}, nextSpy)
+            })
+
+            it('should set button text correctly', function() {
+              expect(req.form.options.buttonText).to.equal(
+                'actions::request_move'
+              )
+            })
+
+            it('should call next', function() {
+              expect(nextSpy).to.be.calledOnceWithExactly()
+            })
           })
         })
       })

--- a/locales/en/actions.json
+++ b/locales/en/actions.json
@@ -10,6 +10,7 @@
   "back_to_dashboard": "$t(actions::back) to dashboard",
   "back_to_move": "$t(actions::back) to move",
   "request_move": "Request move",
+  "send_for_review": "Send for review",
   "search": "Search",
   "search_again": "Search again",
   "continue": "Continue",


### PR DESCRIPTION
## Proposed changes

This updates the text used for the final step for single requests. Previously the text suggested the move was going to be requested with a supplier. This updates the text to be clearer about what is happening after submission.

## Screenshots

| Before | After |
| ------ | ----- |
| <kbd><img src="https://user-images.githubusercontent.com/3327997/81693909-8fded600-9458-11ea-83ab-c5f32ea248a0.png"></kbd> | <kbd><img src="https://user-images.githubusercontent.com/3327997/81694015-b3098580-9458-11ea-98ec-ffee0f5e1fba.png"></kbd> |
