### PR TITLE
fix: Only display move agreed status for single requests

### DIFF
--- a/common/presenters/move-to-meta-list-component.js
+++ b/common/presenters/move-to-meta-list-component.js
@@ -1,5 +1,5 @@
 const { isToday, isTomorrow, isYesterday, parseISO } = require('date-fns')
-const { get } = require('lodash')
+const { get, isNil } = require('lodash')
 
 const moveAgreedField = require('../../app/move/fields/move-agreed')
 const i18n = require('../../config/i18n')
@@ -135,7 +135,10 @@ function moveToMetaListComponent(
         text: i18n.t('fields::move_agreed.label'),
       },
       value: {
-        text: moveAgreed !== undefined ? agreementLabel : undefined,
+        text:
+          !isNil(moveAgreed) && moveType === 'prison_transfer'
+            ? agreementLabel
+            : undefined,
       },
     },
   ]

--- a/common/presenters/move-to-meta-list-component.test.js
+++ b/common/presenters/move-to-meta-list-component.test.js
@@ -580,16 +580,17 @@ describe('Presenters', function() {
         i18n.t.returnsArg(0)
       })
 
-      context('with true status', function() {
+      context('with `true` value', function() {
         context('without name', function() {
           beforeEach(function() {
             transformedResponse = moveToMetaListComponent({
               ...mockMove,
+              move_type: 'prison_transfer',
               move_agreed: true,
             })
           })
 
-          it('should not add additional information to transfer reason', function() {
+          it('should set move agreed item', function() {
             expect(transformedResponse.items[7]).to.deep.equal({
               key: { text: 'fields::move_agreed.label' },
               value: {
@@ -613,12 +614,13 @@ describe('Presenters', function() {
           beforeEach(function() {
             transformedResponse = moveToMetaListComponent({
               ...mockMove,
+              move_type: 'prison_transfer',
               move_agreed: true,
               move_agreed_by: 'Jon Doe',
             })
           })
 
-          it('should not add additional information to transfer reason', function() {
+          it('should set move agreed item', function() {
             expect(transformedResponse.items[7]).to.deep.equal({
               key: { text: 'fields::move_agreed.label' },
               value: {
@@ -637,18 +639,37 @@ describe('Presenters', function() {
             )
           })
         })
+
+        context('when not a prison transfer', function() {
+          beforeEach(function() {
+            transformedResponse = moveToMetaListComponent({
+              ...mockMove,
+              move_agreed: true,
+            })
+          })
+
+          it('should not set move agreed item', function() {
+            expect(transformedResponse.items[7]).to.deep.equal({
+              key: { text: 'fields::move_agreed.label' },
+              value: {
+                text: undefined,
+              },
+            })
+          })
+        })
       })
 
-      context('with false status', function() {
+      context('with `false` value', function() {
         context('without name', function() {
           beforeEach(function() {
             transformedResponse = moveToMetaListComponent({
               ...mockMove,
+              move_type: 'prison_transfer',
               move_agreed: false,
             })
           })
 
-          it('should not add additional information to transfer reason', function() {
+          it('should set move agreed item', function() {
             expect(transformedResponse.items[7]).to.deep.equal({
               key: { text: 'fields::move_agreed.label' },
               value: {
@@ -672,12 +693,13 @@ describe('Presenters', function() {
           beforeEach(function() {
             transformedResponse = moveToMetaListComponent({
               ...mockMove,
+              move_type: 'prison_transfer',
               move_agreed: false,
               move_agreed_by: 'Jon Doe',
             })
           })
 
-          it('should not add additional information to transfer reason', function() {
+          it('should set move agreed item', function() {
             expect(transformedResponse.items[7]).to.deep.equal({
               key: { text: 'fields::move_agreed.label' },
               value: {
@@ -696,18 +718,37 @@ describe('Presenters', function() {
             )
           })
         })
+
+        context('when not a prison transfer', function() {
+          beforeEach(function() {
+            transformedResponse = moveToMetaListComponent({
+              ...mockMove,
+              move_agreed: false,
+            })
+          })
+
+          it('should not set move agreed item', function() {
+            expect(transformedResponse.items[7]).to.deep.equal({
+              key: { text: 'fields::move_agreed.label' },
+              value: {
+                text: undefined,
+              },
+            })
+          })
+        })
       })
 
-      context('with status that matches `yes` from field`', function() {
+      context('with status that matches `yes` from field', function() {
         context('without name', function() {
           beforeEach(function() {
             transformedResponse = moveToMetaListComponent({
               ...mockMove,
+              move_type: 'prison_transfer',
               move_agreed: 'true',
             })
           })
 
-          it('should not add additional information to transfer reason', function() {
+          it('should set move agreed item', function() {
             expect(transformedResponse.items[7]).to.deep.equal({
               key: { text: 'fields::move_agreed.label' },
               value: {
@@ -731,12 +772,13 @@ describe('Presenters', function() {
           beforeEach(function() {
             transformedResponse = moveToMetaListComponent({
               ...mockMove,
+              move_type: 'prison_transfer',
               move_agreed: 'true',
               move_agreed_by: 'Jon Doe',
             })
           })
 
-          it('should not add additional information to transfer reason', function() {
+          it('should set move agreed item', function() {
             expect(transformedResponse.items[7]).to.deep.equal({
               key: { text: 'fields::move_agreed.label' },
               value: {
@@ -753,6 +795,25 @@ describe('Presenters', function() {
                 name: 'Jon Doe',
               }
             )
+          })
+        })
+
+        context('when not a prison transfer', function() {
+          beforeEach(function() {
+            transformedResponse = moveToMetaListComponent({
+              ...mockMove,
+              move_agreed: 'true',
+              move_agreed_by: 'Jon Doe',
+            })
+          })
+
+          it('should not set move agreed item', function() {
+            expect(transformedResponse.items[7]).to.deep.equal({
+              key: { text: 'fields::move_agreed.label' },
+              value: {
+                text: undefined,
+              },
+            })
           })
         })
       })


### PR DESCRIPTION
The logic for displaying this label and value in the summary panel
was checking if it was not undefined. However, the API currently returns
a value of `false` and does not support `null`.

This meant that for all existing court moves this label was being displayed
as "Not agreed". This information is not relevant for these types of moves
so the logic has been updated to only display for prison transfers.