### PR TITLE
[P4 1196] Provide ability for STC user to update move documents

### DIFF
--- a/app/move/controllers/update/document.js
+++ b/app/move/controllers/update/document.js
@@ -1,0 +1,59 @@
+const { get } = require('lodash')
+
+const moveService = require('../../../../common/services/move')
+const DocumentUploadController = require('../create/document')
+
+const UpdateBase = require('./base')
+
+class UpdateDocumentUploadController extends UpdateBase {
+  configure(req, res, next) {
+    const canUploadDocuments = get(
+      req,
+      'session.currentLocation.can_upload_documents'
+    )
+    if (!canUploadDocuments) {
+      const error = new Error(
+        'Document upload is not possible for this location'
+      )
+      error.statusCode = 404
+      return next(error)
+    }
+    DocumentUploadController.prototype.configure.apply(this, [req, res, next])
+  }
+
+  getUpdateValues(req, res) {
+    const move = req.getMove()
+    if (!move) {
+      return {}
+    }
+    const values = {}
+    if (req.initialStep) {
+      req.sessionModel.set('documents', move.documents)
+    }
+    values.documents = req.sessionModel.get('documents')
+    return values
+  }
+
+  async successHandler(req, res, next) {
+    if (!req.xhr) {
+      try {
+        await moveService.update({
+          id: req.getMoveId(),
+          documents: req.form.values.documents,
+        })
+        return res.redirect(this.getBaseUrl(req))
+      } catch (err) {
+        next(err)
+      }
+    }
+    DocumentUploadController.prototype.successHandler.apply(this, [
+      req,
+      res,
+      next,
+    ])
+  }
+}
+
+UpdateBase.mixin(UpdateDocumentUploadController, DocumentUploadController)
+
+module.exports = UpdateDocumentUploadController

--- a/app/move/controllers/update/document.js
+++ b/app/move/controllers/update/document.js
@@ -35,22 +35,22 @@ class UpdateDocumentUploadController extends UpdateBase {
   }
 
   async successHandler(req, res, next) {
-    if (!req.xhr) {
-      try {
-        await moveService.update({
-          id: req.getMoveId(),
-          documents: req.form.values.documents,
-        })
-        return res.redirect(this.getBaseUrl(req))
-      } catch (err) {
-        next(err)
-      }
+    if (req.xhr) {
+      return DocumentUploadController.prototype.successHandler.apply(this, [
+        req,
+        res,
+        next,
+      ])
     }
-    DocumentUploadController.prototype.successHandler.apply(this, [
-      req,
-      res,
-      next,
-    ])
+    try {
+      await moveService.update({
+        id: req.getMoveId(),
+        documents: req.form.values.documents,
+      })
+      return res.redirect(this.getBaseUrl(req))
+    } catch (err) {
+      next(err)
+    }
   }
 }
 

--- a/app/move/controllers/update/document.test.js
+++ b/app/move/controllers/update/document.test.js
@@ -1,0 +1,267 @@
+const moveService = require('../../../../common/services/move')
+const CreateDocument = require('../create/document')
+
+const UpdateBaseController = require('./base')
+const DocumentController = require('./document')
+
+const MixinProto = CreateDocument.prototype
+
+const controller = new DocumentController({ route: '/' })
+const ownProto = Object.getPrototypeOf(controller)
+
+describe('Move controllers', function() {
+  describe('Update documents controller', function() {
+    it('should extend UpdateBaseController', function() {
+      expect(Object.getPrototypeOf(ownProto)).to.equal(
+        UpdateBaseController.prototype
+      )
+    })
+
+    describe('When mixing in create controller', function() {
+      it('should copy middlewareSetup from CreateDocument', function() {
+        expect(controller.middlewareSetup).to.exist.and.equal(
+          MixinProto.middlewareSetup
+        )
+      })
+
+      it('should copy setNextStep from CreateDocument', function() {
+        expect(controller.setNextStep).to.exist.and.equal(
+          MixinProto.setNextStep
+        )
+      })
+
+      it('should copy saveValues from CreateDocument', function() {
+        expect(controller.saveValues).to.exist.and.equal(MixinProto.saveValues)
+      })
+
+      it('should copy errorHandler from CreateDocument', function() {
+        expect(controller.errorHandler).to.exist.and.equal(
+          MixinProto.errorHandler
+        )
+      })
+
+      it('should only have the expected methods of its own', function() {
+        const ownMethods = ['configure', 'getUpdateValues', 'successHandler']
+        const mixedinMethods = Object.getOwnPropertyNames(MixinProto)
+        const ownProps = Object.getOwnPropertyNames(ownProto).filter(
+          prop => !mixedinMethods.includes(prop) || ownMethods.includes(prop)
+        )
+        expect(ownProps).to.deep.equal(ownMethods)
+      })
+    })
+
+    describe('#configure', function() {
+      const req = {
+        session: {
+          currentLocation: {},
+        },
+      }
+      const res = {}
+      let nextSpy
+      beforeEach(async function() {
+        sinon.stub(MixinProto, 'configure')
+        nextSpy = sinon.spy()
+      })
+
+      context('When current location does allow uploads', function() {
+        beforeEach(function() {
+          req.session.currentLocation.can_upload_documents = true
+          controller.configure(req, res, nextSpy)
+        })
+
+        it('should not call next', function() {
+          expect(nextSpy).to.not.be.called
+        })
+
+        it('should invoke mixin’s configure', function() {
+          expect(MixinProto.configure).to.be.calledOnceWithExactly(
+            req,
+            res,
+            nextSpy
+          )
+        })
+      })
+
+      context('When current location does not allow uploads', function() {
+        let args
+        let error
+        beforeEach(function() {
+          args = []
+          error = {}
+          req.session.currentLocation.can_upload_documents = false
+          controller.configure(req, res, nextSpy)
+          try {
+            args = nextSpy.getCall(0).args
+            error = args[0]
+          } catch (e) {}
+        })
+
+        it('should not invoke mixin’s configure', function() {
+          expect(MixinProto.configure).to.not.be.called
+        })
+
+        it('should call next once with an error', function() {
+          expect(nextSpy).to.be.calledOnce
+          expect(args.length).to.equal(1)
+        })
+
+        it('should set the correct error message', function() {
+          expect(error.message).to.equal(
+            'Document upload is not possible for this location'
+          )
+        })
+
+        it('should set the correct error statusCode', function() {
+          expect(error.statusCode).to.equal(404)
+        })
+      })
+    })
+
+    describe('#getUpdateValues', function() {
+      let req = {}
+      const res = {}
+      const documents = [{ id: 'foo' }, { id: 'bar' }]
+      beforeEach(function() {
+        req = {
+          getMove: sinon.stub(),
+          sessionModel: {
+            set: sinon.stub(),
+            get: sinon.stub().returns(documents),
+          },
+        }
+      })
+
+      context('When no move exists', function() {
+        it('should return an empty object', function() {
+          expect(controller.getUpdateValues(req, res)).to.deep.equal({})
+        })
+      })
+
+      context('When a move exists', function() {
+        const move = { id: '#move', documents }
+        let values
+        beforeEach(function() {
+          req.getMove.returns(move)
+        })
+        context('When not inital step', function() {
+          beforeEach(function() {
+            values = controller.getUpdateValues(req, res)
+          })
+
+          it('should not copy the documents from the move to the session', function() {
+            expect(req.sessionModel.set).to.not.be.called
+          })
+
+          it('should get the move’s documents correctly', function() {
+            expect(req.sessionModel.get).to.be.calledOnceWithExactly(
+              'documents'
+            )
+          })
+
+          it('should return the move’s documents', function() {
+            expect(values.documents).to.equal(documents)
+          })
+        })
+
+        context('When inital step', function() {
+          beforeEach(function() {
+            req.initialStep = true
+            controller.getUpdateValues(req, res)
+          })
+
+          it('should copy the documents from the move to the session', function() {
+            expect(req.sessionModel.set).to.be.calledOnceWithExactly(
+              'documents',
+              documents
+            )
+          })
+        })
+      })
+    })
+
+    describe('#successHandler', function() {
+      let req = {}
+      let res = {}
+      let nextSpy
+      const documents = [{ id: 'foo' }, { id: 'bar' }]
+
+      beforeEach(async function() {
+        req = {
+          getMoveId: sinon.stub().returns('__moveId__'),
+          form: {
+            values: {
+              documents,
+            },
+          },
+        }
+        res = {
+          redirect: sinon.stub(),
+        }
+        sinon.stub(moveService, 'update').resolves({})
+        sinon.stub(controller, 'getBaseUrl').returns('__url__')
+        sinon.stub(MixinProto, 'successHandler')
+        nextSpy = sinon.spy()
+      })
+
+      context('When saving changed documents', function() {
+        beforeEach(async function() {
+          await controller.successHandler(req, res, nextSpy)
+        })
+        it('should update the move', async function() {
+          expect(moveService.update).to.be.calledOnceWithExactly({
+            id: '__moveId__',
+            documents,
+          })
+        })
+
+        it('should redirect back to the move view', async function() {
+          expect(controller.getBaseUrl).to.be.calledOnceWithExactly(req)
+          expect(res.redirect).to.be.calledOnceWithExactly('__url__')
+        })
+
+        it('should not invoke mixin’s successHandler', async function() {
+          expect(MixinProto.successHandler).to.not.be.called
+        })
+
+        it('should not invoke next', async function() {
+          expect(nextSpy).to.not.be.called
+        })
+      })
+
+      context('When saving fails', function() {
+        const error = new Error('boom')
+        beforeEach(async function() {
+          moveService.update.throws(error)
+          await controller.successHandler(req, res, nextSpy)
+        })
+
+        it('should invoke next with error', async function() {
+          expect(nextSpy).to.be.calledOnceWithExactly(error)
+        })
+      })
+
+      context('When it’s an XHR request', function() {
+        beforeEach(async function() {
+          req.xhr = true
+          await controller.successHandler(req, res, nextSpy)
+        })
+
+        it('should not update the move', async function() {
+          expect(moveService.update).to.not.be.called
+        })
+
+        it('should invoke mixin’s successHandler', async function() {
+          expect(MixinProto.successHandler).to.be.calledOnceWithExactly(
+            req,
+            res,
+            nextSpy
+          )
+        })
+
+        it('should not invoke next', async function() {
+          expect(nextSpy).to.not.be.called
+        })
+      })
+    })
+  })
+})

--- a/app/move/controllers/update/document.test.js
+++ b/app/move/controllers/update/document.test.js
@@ -70,7 +70,7 @@ describe('Move controllers', function() {
         })
 
         it('should not call next', function() {
-          expect(nextSpy).to.not.be.called
+          expect(nextSpy).not.to.be.called
         })
 
         it('should invoke mixin’s configure', function() {
@@ -97,7 +97,7 @@ describe('Move controllers', function() {
         })
 
         it('should not invoke mixin’s configure', function() {
-          expect(MixinProto.configure).to.not.be.called
+          expect(MixinProto.configure).not.to.be.called
         })
 
         it('should call next once with an error', function() {
@@ -149,7 +149,7 @@ describe('Move controllers', function() {
           })
 
           it('should not copy the documents from the move to the session', function() {
-            expect(req.sessionModel.set).to.not.be.called
+            expect(req.sessionModel.set).not.to.be.called
           })
 
           it('should get the move’s documents correctly', function() {
@@ -220,11 +220,11 @@ describe('Move controllers', function() {
         })
 
         it('should not invoke mixin’s successHandler', async function() {
-          expect(MixinProto.successHandler).to.not.be.called
+          expect(MixinProto.successHandler).not.to.be.called
         })
 
         it('should not invoke next', async function() {
-          expect(nextSpy).to.not.be.called
+          expect(nextSpy).not.to.be.called
         })
       })
 
@@ -247,7 +247,7 @@ describe('Move controllers', function() {
         })
 
         it('should not update the move', async function() {
-          expect(moveService.update).to.not.be.called
+          expect(moveService.update).not.to.be.called
         })
 
         it('should invoke mixin’s successHandler', async function() {
@@ -259,7 +259,7 @@ describe('Move controllers', function() {
         })
 
         it('should not invoke next', async function() {
-          expect(nextSpy).to.not.be.called
+          expect(nextSpy).not.to.be.called
         })
       })
     })

--- a/app/move/controllers/update/index.js
+++ b/app/move/controllers/update/index.js
@@ -1,5 +1,6 @@
 const Assessment = require('./assessment')
 const Court = require('./court')
+const Document = require('./document')
 const MoveDate = require('./move-date')
 const MoveDetails = require('./move-details')
 const PersonalDetails = require('./personal-details')
@@ -7,6 +8,7 @@ const PersonalDetails = require('./personal-details')
 module.exports = {
   Assessment,
   Court,
+  Document,
   MoveDate,
   MoveDetails,
   PersonalDetails,

--- a/app/move/steps/update.js
+++ b/app/move/steps/update.js
@@ -1,6 +1,7 @@
 const {
   Assessment,
   Court,
+  Document,
   MoveDate,
   MoveDetails,
   PersonalDetails,
@@ -79,6 +80,17 @@ const updateSteps = [
         ...createSteps['/health-information'],
         ...updateStepPropOverrides,
         controller: Assessment,
+      },
+    },
+  },
+  {
+    key: 'document',
+    permission: 'move:update',
+    steps: {
+      '/document': {
+        ...createSteps['/document'],
+        ...updateStepPropOverrides,
+        controller: Document,
       },
     },
   },

--- a/app/move/views/view.njk
+++ b/app/move/views/view.njk
@@ -116,40 +116,44 @@
   {% include "move/views/_includes/assessment.njk" %}
 
   {% if move.from_location.can_upload_documents %}
-    <h2 class="govuk-heading-m govuk-!-margin-top-7">
-      {{ t("moves::detail.documents.heading", {
-        count: move.documents.length if move.documents.length > 1
-      }) }}
-    </h2>
+    <section class="app-!-position-relative">
+      <h2 class="govuk-heading-m govuk-!-margin-top-7">
+        {{ t("moves::detail.documents.heading", {
+          count: move.documents.length if move.documents.length > 1
+        }) }}
+      </h2>
 
-    {% if move.documents | length %}
-      <ul class="govuk-list">
-        {% for document in move.documents %}
-          <li class="govuk-!-margin-bottom-3">
-            <a href="{{ document.url }}"
-              class="govuk-link"
-              target="_blank"
-              aria-labelledby="document-{{ loop.index }}">
-              {{- document.filename -}}
-            </a>
-            <span class="govuk-body-s">
-              ({{ document.filesize | filesize }})
-            </span>
-            <div class="govuk-hint govuk-!-font-size-16 govuk-!-margin-bottom-0" id="document-{{ loop.index }}">
-              ({{ t("opens_new_window") }})
-            </div>
-          </li>
-        {% endfor %}
-      </ul>
-    {% else %}
-      {{ appMessage({
-        classes: "app-message--muted",
-        allowDismiss: false,
-        content: {
-          html: t("moves::detail.documents.empty")
-        }
-      }) }}
-    {% endif %}
+      {% if move.documents | length %}
+        <ul class="govuk-list">
+          {% for document in move.documents %}
+            <li class="govuk-!-margin-bottom-3">
+              <a href="{{ document.url }}"
+                class="govuk-link"
+                target="_blank"
+                aria-labelledby="document-{{ loop.index }}">
+                {{- document.filename -}}
+              </a>
+              <span class="govuk-body-s">
+                ({{ document.filesize | filesize }})
+              </span>
+              <div class="govuk-hint govuk-!-font-size-16 govuk-!-margin-bottom-0" id="document-{{ loop.index }}">
+                ({{ t("opens_new_window") }})
+              </div>
+            </li>
+          {% endfor %}
+        </ul>
+      {% else %}
+        {{ appMessage({
+          classes: "app-message--muted",
+          allowDismiss: false,
+          content: {
+            html: t("moves::detail.documents.empty")
+          }
+        }) }}
+      {% endif %}
+
+      {{ updateLink(updateLinks.document) }}
+    </section>
   {% endif %}
 
   {% if canAccess("move:cancel") and move.status == "requested" %}

--- a/common/lib/permissions.js
+++ b/common/lib/permissions.js
@@ -29,8 +29,10 @@ const secureTrainingCentrePermissions = [
   'move:create',
   'move:create:court_appearance',
   'move:cancel',
-  'move:update',
 ]
+if (FEATURE_FLAGS.EDITABILITY) {
+  secureTrainingCentrePermissions.push('move:update')
+}
 
 const supplierPermissions = [
   'moves:view:all',

--- a/common/lib/permissions.js
+++ b/common/lib/permissions.js
@@ -29,6 +29,7 @@ const secureTrainingCentrePermissions = [
   'move:create',
   'move:create:court_appearance',
   'move:cancel',
+  'move:update',
 ]
 
 const supplierPermissions = [

--- a/common/lib/user.test.js
+++ b/common/lib/user.test.js
@@ -156,14 +156,16 @@ describe('User class', function() {
       })
 
       it('should contain correct permission', function() {
-        expect(permissions).to.deep.equal([
+        const stcPermissions = [
           'moves:view:outgoing',
           'moves:download',
           'move:view',
           'move:create',
           'move:create:court_appearance',
           'move:cancel',
-        ])
+          'move:update',
+        ]
+        expect(permissions).to.deep.equal(stcPermissions)
       })
     })
 

--- a/common/lib/user.test.js
+++ b/common/lib/user.test.js
@@ -163,8 +163,10 @@ describe('User class', function() {
           'move:create',
           'move:create:court_appearance',
           'move:cancel',
-          'move:update',
         ]
+        if (FEATURE_FLAGS.EDITABILITY) {
+          stcPermissions.push('move:update')
+        }
         expect(permissions).to.deep.equal(stcPermissions)
       })
     })

--- a/locales/en/moves.json
+++ b/locales/en/moves.json
@@ -197,6 +197,7 @@
       "court": "information for the court",
       "health": "health information",
       "date": "when this person is moving",
+      "document": "supporting documents",
       "move": "where this person is moving",
       "personal_details": "personal details",
       "risk": "risk information"
@@ -211,6 +212,10 @@
       },
       "date": {
         "heading": "Move date updated",
+        "message": "$t(moves::update_flash.supplier_message)"
+      },
+      "document": {
+        "heading": "Supporting documents updated",
         "message": "$t(moves::update_flash.supplier_message)"
       },
       "health": {

--- a/test/e2e/_helpers.js
+++ b/test/e2e/_helpers.js
@@ -429,16 +429,3 @@ export async function expectStatusCode(url, statusCode, negated = true) {
   await t.expect(getResponseStatus(logger, url) === statusCode)[expectMethod]()
   await t.removeRequestHooks(logger)
 }
-
-/**
- * Check whether a url is protected
- *
- * @param {string} url - URL to check
- *
- * @param {boolean} [negated] - whether to negate the assertion
- *
- * @returns {Promise<boolean>}
- */
-export async function expectForbidden(url, negated) {
-  await expectStatusCode(url, 403, negated)
-}

--- a/test/e2e/_routes.js
+++ b/test/e2e/_routes.js
@@ -8,8 +8,9 @@ const getUpdatePageStub = page => {
     move: 'move-details',
     personal_details: 'personal-details',
     risk: 'risk-information',
+    document: 'document',
   }
-  return updateMap[page]
+  return updateMap[page] || page
 }
 
 export const home = E2E.BASE_URL

--- a/test/e2e/move.update.forbidden.test.js
+++ b/test/e2e/move.update.forbidden.test.js
@@ -1,0 +1,32 @@
+import {
+  createPrisonMove,
+  createOcaMove,
+  createSupplierMove,
+  checkNoUpdateLinks,
+  checkUpdatePagesForbidden,
+} from './_move'
+
+const checkUserCannotUpdate = () => {
+  test('User should not see any update links on move page', async () => {
+    await checkNoUpdateLinks()
+  })
+
+  test('User should not be able to access move update pages', async () => {
+    await checkUpdatePagesForbidden()
+  })
+}
+
+fixture('Existing move - Prison user').beforeEach(async () => {
+  await createPrisonMove()
+})
+checkUserCannotUpdate()
+
+fixture('Existing move - OCA user').beforeEach(async () => {
+  await createOcaMove()
+})
+checkUserCannotUpdate()
+
+fixture('Existing move - Supplier user').beforeEach(async () => {
+  await createSupplierMove()
+})
+checkUserCannotUpdate()

--- a/test/e2e/move.update.forbidden.test.js
+++ b/test/e2e/move.update.forbidden.test.js
@@ -1,3 +1,5 @@
+import { FEATURE_FLAGS } from '../../config'
+
 import {
   createPrisonMove,
   createOcaMove,
@@ -6,27 +8,29 @@ import {
   checkUpdatePagesForbidden,
 } from './_move'
 
-const checkUserCannotUpdate = () => {
-  test('User should not see any update links on move page', async () => {
-    await checkNoUpdateLinks()
-  })
+if (FEATURE_FLAGS.EDITABILITY) {
+  const checkUserCannotUpdate = () => {
+    test('User should not see any update links on move page', async () => {
+      await checkNoUpdateLinks()
+    })
 
-  test('User should not be able to access move update pages', async () => {
-    await checkUpdatePagesForbidden()
+    test('User should not be able to access move update pages', async () => {
+      await checkUpdatePagesForbidden()
+    })
+  }
+
+  fixture('Existing move - Prison user').beforeEach(async () => {
+    await createPrisonMove()
   })
+  checkUserCannotUpdate()
+
+  fixture('Existing move - OCA user').beforeEach(async () => {
+    await createOcaMove()
+  })
+  checkUserCannotUpdate()
+
+  fixture('Existing move - Supplier user').beforeEach(async () => {
+    await createSupplierMove()
+  })
+  checkUserCannotUpdate()
 }
-
-fixture('Existing move - Prison user').beforeEach(async () => {
-  await createPrisonMove()
-})
-checkUserCannotUpdate()
-
-fixture('Existing move - OCA user').beforeEach(async () => {
-  await createOcaMove()
-})
-checkUserCannotUpdate()
-
-fixture('Existing move - Supplier user').beforeEach(async () => {
-  await createSupplierMove()
-})
-checkUserCannotUpdate()

--- a/test/e2e/move.update.police.test.js
+++ b/test/e2e/move.update.police.test.js
@@ -16,7 +16,7 @@ import {
 } from './_move'
 
 if (FEATURE_FLAGS.EDITABILITY) {
-  fixture('Existing move from Police Custody').beforeEach(async () => {
+  fixture('Existing move - Police user').beforeEach(async () => {
     await createPoliceMove()
   })
 

--- a/test/e2e/move.update.stc.test.js
+++ b/test/e2e/move.update.stc.test.js
@@ -2,22 +2,41 @@ import { FEATURE_FLAGS } from '../../config'
 
 import {
   createStcMove,
-  checkNoUpdateLinks,
-  checkUpdatePagesForbidden,
+  checkUpdateLinks,
+  checkUpdatePagesAccessible,
+  checkUpdateDocuments,
 } from './_move'
 
 if (FEATURE_FLAGS.EDITABILITY) {
-  fixture(
-    'Existing move from Secure Training Centre (STC) to Court'
-  ).beforeEach(async () => {
+  fixture('Existing move - STC User').beforeEach(async () => {
     await createStcMove()
   })
 
-  test('User should not see any update links on move page', async () => {
-    await checkNoUpdateLinks()
+  test('User should see expected update links on move page', async () => {
+    await checkUpdateLinks([
+      'personal_details',
+      'risk',
+      'health',
+      'court',
+      'move',
+      'date',
+      'document',
+    ])
   })
 
-  test('User should not be able to access move update pages', async () => {
-    await checkUpdatePagesForbidden()
+  test('User should see be able to access update pages', async () => {
+    await checkUpdatePagesAccessible([
+      'personal_details',
+      'risk',
+      'health',
+      'court',
+      'move',
+      'date',
+      'document',
+    ])
+  })
+
+  test('User should be able to update documents', async t => {
+    await checkUpdateDocuments()
   })
 }

--- a/test/e2e/pages/move-detail.js
+++ b/test/e2e/pages/move-detail.js
@@ -47,6 +47,12 @@ class MoveDetailPage extends Page {
       noHealthInformationMessage: Selector('.app-message').withText(
         'No health affecting transport'
       ),
+      documentList: Selector('#main-content h2')
+        .withText('Supporting documents')
+        .sibling('.govuk-list'),
+      noDocumentsMessage: Selector('.app-message').withText(
+        'No documents uploaded'
+      ),
       getUpdateLink: category => {
         return Selector(`[data-update-link="${category}"]`)
       },


### PR DESCRIPTION
Users with `move:update` permission can now update documents for moves when the current location allows documents.
 
Adds link to move view
![Move_details_for_TREMBLAY__AUSTEN](https://user-images.githubusercontent.com/4856/81801324-228c7d00-950c-11ea-8a75-31465227ab1f.png)

Adds update document view
![Are_there_any_documents_to_upload__-_update_move](https://user-images.githubusercontent.com/4856/81801704-bcecc080-950c-11ea-9396-9cd343d3f63c.png)
(Looks and functions identically to create's document view)


### Checklist

- [x] If adding new environment variables, they have been documented in the [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md)
- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
