### PR TITLE
refactor: Use common body for filters and results

### DIFF
--- a/app/moves/index.js
+++ b/app/moves/index.js
@@ -15,6 +15,7 @@ const {
   redirectBaseUrl,
   saveUrl,
   setFromLocation,
+  setBodySingleRequests,
   setFilterSingleRequests,
   setPagination,
   setResultsSingleRequests,
@@ -45,7 +46,8 @@ router.get(
 router.get(
   `/:period(week|day)/:date/:locationId(${uuidRegex})`,
   protectRoute('moves:view:proposed'),
-  setFilterSingleRequests,
+  setBodySingleRequests,
+  setFilterSingleRequests('/requested'),
   setDashboardMoveSummary,
   setPagination,
   dashboard
@@ -58,17 +60,19 @@ router.get(
   listAsCards
 )
 router.get(
-  `/:period(week|day)/:date/:locationId(${uuidRegex})/:status(pending|approved|rejected)`,
+  `/:period(week|day)/:date/:locationId(${uuidRegex})/:view(requested)`,
   protectRoute('moves:view:proposed'),
-  setFilterSingleRequests,
+  setBodySingleRequests,
+  setFilterSingleRequests(),
   setResultsSingleRequests,
   setPagination,
   listAsTable
 )
 router.get(
-  `/:period(week|day)/:date/:locationId(${uuidRegex})/:status(pending|approved|rejected)/download.:extension(csv|json)`,
+  `/:period(week|day)/:date/:locationId(${uuidRegex})/:view(requested)/download.:extension(csv|json)`,
   protectRoute('moves:download'),
   protectRoute('moves:view:proposed'),
+  setBodySingleRequests,
   setResultsSingleRequests,
   download
 )

--- a/app/moves/middleware/index.js
+++ b/app/moves/middleware/index.js
@@ -1,5 +1,6 @@
 const redirectBaseUrl = require('./redirect-base-url')
 const saveUrl = require('./save-url')
+const setBodySingleRequests = require('./set-body.single-requests')
 const setDashboardMoveSummary = require('./set-dashboard-move-summary')
 const setFilterSingleRequests = require('./set-filter.single-requests')
 const setFromLocation = require('./set-from-location')
@@ -11,6 +12,7 @@ module.exports = {
   redirectBaseUrl,
   saveUrl,
   setDashboardMoveSummary,
+  setBodySingleRequests,
   setFromLocation,
   setFilterSingleRequests,
   setResultsOutgoing,

--- a/app/moves/middleware/set-body.single-requests.js
+++ b/app/moves/middleware/set-body.single-requests.js
@@ -1,0 +1,15 @@
+function setBodySingleRequests(req, res, next) {
+  const { locationId } = req.params
+  const { dateRange } = res.locals
+  const { status } = req.query
+
+  req.body = {
+    status,
+    createdAtDate: dateRange,
+    fromLocationId: locationId,
+  }
+
+  next()
+}
+
+module.exports = setBodySingleRequests

--- a/app/moves/middleware/set-body.single-requests.test.js
+++ b/app/moves/middleware/set-body.single-requests.test.js
@@ -1,0 +1,38 @@
+const middleware = require('./set-body.single-requests')
+
+describe('Moves middleware', function() {
+  describe('#setBodySingleRequests()', function() {
+    let mockRes, mockReq, nextSpy
+
+    beforeEach(function() {
+      nextSpy = sinon.spy()
+      mockRes = {
+        locals: {
+          dateRange: ['2020-10-10', '2020-10-10'],
+        },
+      }
+      mockReq = {
+        params: {
+          locationId: '7ebc8717-ff5b-4be0-8515-3e308e92700f',
+        },
+        query: {
+          status: 'pending',
+        },
+      }
+
+      middleware(mockReq, mockRes, nextSpy)
+    })
+
+    it('should assign req.body correctly', function() {
+      expect(mockReq.body).to.deep.equal({
+        status: 'pending',
+        createdAtDate: ['2020-10-10', '2020-10-10'],
+        fromLocationId: '7ebc8717-ff5b-4be0-8515-3e308e92700f',
+      })
+    })
+
+    it('should call next', function() {
+      expect(nextSpy).to.be.calledOnceWithExactly()
+    })
+  })
+})

--- a/app/moves/middleware/set-results.single-requests.js
+++ b/app/moves/middleware/set-results.single-requests.js
@@ -2,19 +2,8 @@ const presenters = require('../../../common/presenters')
 const singleRequestService = require('../../../common/services/single-request')
 
 async function setResultsSingleRequests(req, res, next) {
-  const { dateRange } = res.locals
-  const { status, locationId } = req.params
-
-  if (!dateRange) {
-    return next()
-  }
-
   try {
-    const singleRequests = await singleRequestService.getAll({
-      status,
-      createdAtDate: dateRange,
-      fromLocationId: locationId,
-    })
+    const singleRequests = await singleRequestService.getAll(req.body)
 
     req.results = {
       active: singleRequests,

--- a/app/moves/middleware/set-results.single-requests.test.js
+++ b/app/moves/middleware/set-results.single-requests.test.js
@@ -20,31 +20,50 @@ describe('Moves middleware', function() {
       sinon.stub(singleRequestService, 'getAll')
       sinon.stub(presenters, 'singleRequestsToTableComponent').returnsArg(0)
       next = sinon.stub()
-      res = {
-        locals: {
-          status: 'proposed',
-        },
-      }
+      res = {}
       req = {
-        params: {
+        body: {
           status: 'proposed',
-          locationId: '123',
+          createdAtDate: ['2019-01-01', '2019-01-07'],
+          fromLocationId: '123',
         },
       }
     })
 
-    context('with no date range', function() {
+    context('when service resolves', function() {
       beforeEach(async function() {
+        singleRequestService.getAll.resolves(mockActiveMoves)
         await middleware(req, res, next)
       })
 
-      it('should not call service', function() {
-        expect(singleRequestService.getAll).not.to.have.been.called
+      it('should call the data service with request body', function() {
+        expect(singleRequestService.getAll).to.have.been.calledOnceWithExactly({
+          status: 'proposed',
+          createdAtDate: ['2019-01-01', '2019-01-07'],
+          fromLocationId: '123',
+        })
       })
 
-      it('should not request properties', function() {
-        expect(req).not.to.have.property('results')
-        expect(req).not.to.have.property('resultsAsTable')
+      it('should set results on req', function() {
+        expect(req).to.have.property('results')
+        expect(req.results).to.deep.equal({
+          active: mockActiveMoves,
+          cancelled: [],
+        })
+      })
+
+      it('should set resultsAsTable on req', function() {
+        expect(req).to.have.property('resultsAsTable')
+        expect(req.resultsAsTable).to.deep.equal({
+          active: mockActiveMoves,
+          cancelled: [],
+        })
+      })
+
+      it('should call singleRequestsToTableComponent presenter', function() {
+        expect(
+          presenters.singleRequestsToTableComponent
+        ).to.be.calledOnceWithExactly(mockActiveMoves)
       })
 
       it('should call next', function() {
@@ -52,70 +71,21 @@ describe('Moves middleware', function() {
       })
     })
 
-    context('with date range', function() {
-      beforeEach(function() {
-        res.locals.dateRange = ['2019-01-01', '2019-01-07']
+    context('when service rejects', function() {
+      const mockError = new Error('Error!')
+
+      beforeEach(async function() {
+        singleRequestService.getAll.rejects(mockError)
+        await middleware(req, res, next)
       })
 
-      context('when service resolves', function() {
-        beforeEach(async function() {
-          singleRequestService.getAll.resolves(mockActiveMoves)
-          await middleware(req, res, next)
-        })
-
-        it('should call the data service', function() {
-          expect(
-            singleRequestService.getAll
-          ).to.have.been.calledOnceWithExactly({
-            status: 'proposed',
-            createdAtDate: ['2019-01-01', '2019-01-07'],
-            fromLocationId: '123',
-          })
-        })
-
-        it('should set results on req', function() {
-          expect(req).to.have.property('results')
-          expect(req.results).to.deep.equal({
-            active: mockActiveMoves,
-            cancelled: [],
-          })
-        })
-
-        it('should set resultsAsTable on req', function() {
-          expect(req).to.have.property('resultsAsTable')
-          expect(req.resultsAsTable).to.deep.equal({
-            active: mockActiveMoves,
-            cancelled: [],
-          })
-        })
-
-        it('should call singleRequestsToTableComponent presenter', function() {
-          expect(
-            presenters.singleRequestsToTableComponent
-          ).to.be.calledOnceWithExactly(mockActiveMoves)
-        })
-
-        it('should call next', function() {
-          expect(next).to.have.been.calledOnceWithExactly()
-        })
+      it('should not request properties', function() {
+        expect(req).not.to.have.property('results')
+        expect(req).not.to.have.property('resultsAsTable')
       })
 
-      context('when service rejects', function() {
-        const mockError = new Error('Error!')
-
-        beforeEach(async function() {
-          singleRequestService.getAll.rejects(mockError)
-          await middleware(req, res, next)
-        })
-
-        it('should not request properties', function() {
-          expect(req).not.to.have.property('results')
-          expect(req).not.to.have.property('resultsAsTable')
-        })
-
-        it('should call next with error', function() {
-          expect(next).to.have.been.calledOnceWithExactly(mockError)
-        })
+      it('should call next with error', function() {
+        expect(next).to.have.been.calledOnceWithExactly(mockError)
       })
     })
   })

--- a/common/middleware/set-primary-navigation.js
+++ b/common/middleware/set-primary-navigation.js
@@ -6,7 +6,7 @@ const permissions = require('./permissions')
 const baseRegex =
   '^\\/moves\\/(day|week)(\\/\\d{4}-\\d{2}-\\d{2})(\\/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})?'
 const homeRegex = new RegExp(`${baseRegex}$`)
-const proposedRegex = new RegExp(`${baseRegex}\\/(pending|approved|rejected)$`)
+const proposedRegex = new RegExp(`${baseRegex}\\/requested$`)
 const outgoingRegex = new RegExp(`${baseRegex}\\/outgoing$`)
 
 function setPrimaryNavigation(req, res, next) {
@@ -28,7 +28,7 @@ function setPrimaryNavigation(req, res, next) {
   if (permissions.check('moves:view:proposed', userPermissions)) {
     items.push({
       text: req.t('primary_navigation.single_requests'),
-      href: `/moves/week/${date}${locationInUrl}/pending`,
+      href: `/moves/week/${date}${locationInUrl}/requested?status=pending`,
       active: proposedRegex.test(REQUEST_PATH),
     })
   }

--- a/common/middleware/set-primary-navigation.test.js
+++ b/common/middleware/set-primary-navigation.test.js
@@ -65,7 +65,7 @@ describe('#setPrimaryNavigation()', function() {
             },
             {
               active: false,
-              href: '/moves/week/2020-05-10/12345/pending',
+              href: '/moves/week/2020-05-10/12345/requested?status=pending',
               text: 'primary_navigation.single_requests',
             },
             {
@@ -94,7 +94,7 @@ describe('#setPrimaryNavigation()', function() {
               },
               {
                 active: false,
-                href: '/moves/week/2020-05-10/12345/pending',
+                href: '/moves/week/2020-05-10/12345/requested?status=pending',
                 text: 'primary_navigation.single_requests',
               },
               {
@@ -110,7 +110,8 @@ describe('#setPrimaryNavigation()', function() {
         statuses.forEach(status => {
           context(`on ${status} page`, function() {
             beforeEach(function() {
-              res.locals.REQUEST_PATH = `/moves/day/2020-04-16/8fadb516-f10a-45b1-91b7-a256196829f9/${status}`
+              res.locals.REQUEST_PATH =
+                '/moves/day/2020-04-16/8fadb516-f10a-45b1-91b7-a256196829f9/requested'
               middleware(req, res, nextSpy)
             })
 
@@ -123,7 +124,7 @@ describe('#setPrimaryNavigation()', function() {
                 },
                 {
                   active: true,
-                  href: '/moves/week/2020-05-10/12345/pending',
+                  href: '/moves/week/2020-05-10/12345/requested?status=pending',
                   text: 'primary_navigation.single_requests',
                 },
                 {
@@ -152,7 +153,7 @@ describe('#setPrimaryNavigation()', function() {
               },
               {
                 active: false,
-                href: '/moves/week/2020-05-10/12345/pending',
+                href: '/moves/week/2020-05-10/12345/requested?status=pending',
                 text: 'primary_navigation.single_requests',
               },
               {
@@ -186,7 +187,7 @@ describe('#setPrimaryNavigation()', function() {
             },
             {
               active: false,
-              href: '/moves/week/2020-05-10/pending',
+              href: '/moves/week/2020-05-10/requested?status=pending',
               text: 'primary_navigation.single_requests',
             },
             {
@@ -214,7 +215,7 @@ describe('#setPrimaryNavigation()', function() {
               },
               {
                 active: false,
-                href: '/moves/week/2020-05-10/pending',
+                href: '/moves/week/2020-05-10/requested?status=pending',
                 text: 'primary_navigation.single_requests',
               },
               {
@@ -226,9 +227,9 @@ describe('#setPrimaryNavigation()', function() {
           })
         })
 
-        context('on proposed page', function() {
+        context('on requested page', function() {
           beforeEach(function() {
-            res.locals.REQUEST_PATH = '/moves/day/2020-04-16/pending'
+            res.locals.REQUEST_PATH = '/moves/day/2020-04-16/requested'
             middleware(req, res, nextSpy)
           })
 
@@ -241,7 +242,7 @@ describe('#setPrimaryNavigation()', function() {
               },
               {
                 active: true,
-                href: '/moves/week/2020-05-10/pending',
+                href: '/moves/week/2020-05-10/requested?status=pending',
                 text: 'primary_navigation.single_requests',
               },
               {
@@ -268,7 +269,7 @@ describe('#setPrimaryNavigation()', function() {
               },
               {
                 active: false,
-                href: '/moves/week/2020-05-10/pending',
+                href: '/moves/week/2020-05-10/requested?status=pending',
                 text: 'primary_navigation.single_requests',
               },
               {

--- a/common/services/single-request.js
+++ b/common/services/single-request.js
@@ -37,6 +37,10 @@ const singleRequestService = {
           'filter[cancellation_reason]': 'rejected',
         }
         break
+      default:
+        statusFilter = {
+          'filter[status]': status,
+        }
     }
 
     return moveService.getAll({

--- a/common/services/single-request.test.js
+++ b/common/services/single-request.test.js
@@ -291,6 +291,30 @@ describe('Single request service', function() {
             expect(moves).to.deep.equal(mockMoves)
           })
         })
+
+        context('with any other status', function() {
+          beforeEach(async function() {
+            moves = await singleRequestService.getAll({
+              status: 'other',
+            })
+          })
+
+          it('should call moves.getAll with correct filter', function() {
+            expect(moveService.getAll).to.be.calledOnceWithExactly({
+              isAggregation: false,
+              filter: {
+                'filter[status]': 'other',
+                'filter[move_type]': 'prison_transfer',
+                'sort[by]': 'created_at',
+                'sort[direction]': 'desc',
+              },
+            })
+          })
+
+          it('should return moves', function() {
+            expect(moves).to.deep.equal(mockMoves)
+          })
+        })
       })
     })
   })


### PR DESCRIPTION
## Proposed changes

This refactor moves the shared body of filtering a set of results
and displaying the filter to a common middleware that precedes both
middleware responsible for setting the filter and the results.

This means that we reduce the places we need to have this code and
can move in a direction to share the setting of filters and results
going forward.

This change also amends how single requests are "filtered". Previously
this was done as part of the URL path which meant a bit more heavy
lifting around middleware. This moves to a query based approach
which means we can share the code across other parts of the application
to handle filtering and sorting.

**Note:** This work is the start to move the dashboard summary panels to the 
root of the application and to support single requests by a single location or by all locations.