### PR TITLE
refactor: Stop using res.locals for date range

### DIFF
--- a/app/allocations/middleware.js
+++ b/app/allocations/middleware.js
@@ -49,7 +49,7 @@ function setPagination(req, res, next) {
   next()
 }
 async function setAllocationsSummary(req, res, next) {
-  const { dateRange } = res.locals
+  const { dateRange } = req.params
   const value = await allocationService.getCount({ dateRange })
   res.locals.allocationsSummary = [
     {
@@ -65,7 +65,7 @@ async function setAllocationsByDateAndFilter(req, res, next) {
   const additionalFilters = queryString.parse(req._parsedOriginalUrl.query, {
     parseBooleans: true,
   })
-  const { dateRange } = res.locals
+  const { dateRange } = req.params
   res.locals.allocations = await allocationService.getByStatus({
     dateRange,
     additionalFilters,
@@ -104,8 +104,7 @@ function addTotalAllocationsToFilter(
 }
 async function setAllocationTypeNavigation(req, res, next) {
   const { baseUrl } = req
-  const { dateRange } = res.locals
-  const { locationId, period, date } = req.params
+  const { dateRange, locationId, period, date } = req.params
   const currentFilter = queryString.parse(req._parsedOriginalUrl.query, {
     parseBooleans: true,
   })

--- a/app/allocations/middleware.test.js
+++ b/app/allocations/middleware.test.js
@@ -8,19 +8,16 @@ describe('#setAllocationsSummary', function() {
   beforeEach(async function() {
     sinon.stub(allocationService, 'getCount').returns(18)
     next = sinon.stub()
-    locals = {
-      dateRange: ['2020-01-01', '2020-01-10'],
-    }
+    locals = {}
     await middleware.setAllocationsSummary(
       {
         params: {
           date: '2020-01-01',
+          dateRange: ['2020-01-01', '2020-01-10'],
         },
         t: sinon.stub().returnsArg(0),
       },
-      {
-        locals,
-      },
+      { locals },
       next
     )
   })
@@ -195,12 +192,11 @@ describe('#setAllocationsByDateAndFilter', function() {
         _parsedOriginalUrl: {
           query: 'complete_in_full=true',
         },
-      },
-      {
-        locals: {
+        params: {
           dateRange: ['2020-01-01', null],
         },
       },
+      { locals: {} },
       next
     )
   })
@@ -220,9 +216,7 @@ describe('#setAllocationTypeNavigation', function() {
     let locals
     beforeEach(async function() {
       sinon.stub(allocationService, 'getCount').resolves(1)
-      locals = {
-        dateRange: ['2019-12-30', '2020-01-05'],
-      }
+      locals = {}
       next = sinon.stub()
       await middleware.setAllocationTypeNavigation(
         {
@@ -231,6 +225,7 @@ describe('#setAllocationTypeNavigation', function() {
             locationId: 123,
             period: 'week',
             date: '2020-01-01',
+            dateRange: ['2019-12-30', '2020-01-05'],
           },
           _parsedOriginalUrl: {
             query: '?filter[complete_in_full]=true&createdBy=456',
@@ -255,7 +250,6 @@ describe('#setAllocationTypeNavigation', function() {
     })
     it('takes the resulting counts and calculates the total', function() {
       expect(locals).to.deep.equal({
-        dateRange: ['2019-12-30', '2020-01-05'],
         allocationTypeNavigation: [
           {
             label: 'total',

--- a/app/moves/controllers/download.js
+++ b/app/moves/controllers/download.js
@@ -4,8 +4,7 @@ const presenters = require('../../../common/presenters')
 
 module.exports = function download(req, res, next) {
   const { results } = req
-  const { extension } = req.params
-  const { dateRange } = res.locals
+  const { dateRange, extension } = req.params
   const moves = [...results.active, ...results.cancelled]
   const currentTimestamp = format(new Date(), 'yyyy-MM-dd HH:mm:ss')
   const filename = req.t('moves::download_filename', {

--- a/app/moves/controllers/download.test.js
+++ b/app/moves/controllers/download.test.js
@@ -29,6 +29,7 @@ describe('Moves controllers', function() {
         params: {
           date: '2018-10-10',
           period: 'week',
+          dateRange: mockDateRange,
         },
         results: {
           active: activeMovesStub,
@@ -40,9 +41,7 @@ describe('Moves controllers', function() {
         send: sinon.stub(),
         json: sinon.stub(),
         setHeader: sinon.stub(),
-        locals: {
-          dateRange: mockDateRange,
-        },
+        locals: {},
       }
       nextSpy = sinon.spy()
       sinon.stub(presenters, 'movesToCSV')

--- a/app/moves/index.js
+++ b/app/moves/index.js
@@ -2,7 +2,7 @@
 const router = require('express').Router()
 
 // Local dependencies
-const { setDateRange, setDatePeriod } = require('../../common/middleware')
+const { setDateRange } = require('../../common/middleware')
 const { protectRoute } = require('../../common/middleware/permissions')
 
 const {
@@ -28,7 +28,6 @@ const uuidRegex =
 
 // Define param middleware
 router.param('locationId', setFromLocation)
-router.param('period', setDatePeriod)
 router.param('date', setDateRange)
 
 // Define shared middleware

--- a/app/moves/middleware/set-body.single-requests.js
+++ b/app/moves/middleware/set-body.single-requests.js
@@ -1,7 +1,6 @@
 function setBodySingleRequests(req, res, next) {
-  const { locationId } = req.params
-  const { dateRange } = res.locals
   const { status } = req.query
+  const { dateRange, locationId } = req.params
 
   req.body = {
     status,

--- a/app/moves/middleware/set-body.single-requests.test.js
+++ b/app/moves/middleware/set-body.single-requests.test.js
@@ -6,13 +6,10 @@ describe('Moves middleware', function() {
 
     beforeEach(function() {
       nextSpy = sinon.spy()
-      mockRes = {
-        locals: {
-          dateRange: ['2020-10-10', '2020-10-10'],
-        },
-      }
+      mockRes = {}
       mockReq = {
         params: {
+          dateRange: ['2020-10-10', '2020-10-10'],
           locationId: '7ebc8717-ff5b-4be0-8515-3e308e92700f',
         },
         query: {

--- a/app/moves/middleware/set-pagination.js
+++ b/app/moves/middleware/set-pagination.js
@@ -1,4 +1,6 @@
 const { format } = require('date-fns')
+const { isEmpty } = require('lodash')
+const querystring = require('qs')
 
 const { getPeriod } = require('../../../common/helpers/date-utils')
 const { DATE_FORMATS } = require('../../../config')
@@ -12,11 +14,18 @@ function setPagination(req, res, next) {
   const nextPeriod = getPeriod(date, interval)
 
   const locationInUrl = locationId ? `/${locationId}` : ''
+  const queryInUrl = !isEmpty(req.query)
+    ? `?${querystring.stringify(req.query)}`
+    : ''
 
   res.locals.pagination = {
-    todayUrl: `${req.baseUrl}/${period}/${today}${locationInUrl}/${view}`,
-    nextUrl: `${req.baseUrl}/${period}/${nextPeriod}${locationInUrl}/${view}`,
-    prevUrl: `${req.baseUrl}/${period}/${previousPeriod}${locationInUrl}/${view}`,
+    todayUrl: `${req.baseUrl}/${period}/${today}${locationInUrl}/${view +
+      queryInUrl}`,
+    nextUrl: `${req.baseUrl}/${period}/${nextPeriod}${locationInUrl}/${view +
+      queryInUrl}`,
+    prevUrl: `${
+      req.baseUrl
+    }/${period}/${previousPeriod}${locationInUrl}/${view + queryInUrl}`,
   }
 
   next()

--- a/app/moves/middleware/set-pagination.js
+++ b/app/moves/middleware/set-pagination.js
@@ -1,27 +1,22 @@
 const { format } = require('date-fns')
 
-const {
-  getDateFromParams,
-  getPeriod,
-  dateFormat,
-} = require('../../../common/helpers/date-utils')
+const { getPeriod } = require('../../../common/helpers/date-utils')
+const { DATE_FORMATS } = require('../../../config')
 
 function setPagination(req, res, next) {
-  const { locationId = '', period, status, view } = req.params
-  const today = format(new Date(), dateFormat)
-  const baseDate = getDateFromParams(req)
+  const { date, locationId = '', period, view } = req.params
+  const today = format(new Date(), DATE_FORMATS.URL_PARAM)
   const interval = period === 'week' ? 7 : 1
 
-  const previousPeriod = getPeriod(baseDate, -interval)
-  const nextPeriod = getPeriod(baseDate, interval)
+  const previousPeriod = getPeriod(date, -interval)
+  const nextPeriod = getPeriod(date, interval)
 
   const locationInUrl = locationId ? `/${locationId}` : ''
-  const viewInUrl = status || view ? `/${status || view}` : ''
 
   res.locals.pagination = {
-    todayUrl: `${req.baseUrl}/${period}/${today}${locationInUrl}${viewInUrl}`,
-    nextUrl: `${req.baseUrl}/${period}/${nextPeriod}${locationInUrl}${viewInUrl}`,
-    prevUrl: `${req.baseUrl}/${period}/${previousPeriod}${locationInUrl}${viewInUrl}`,
+    todayUrl: `${req.baseUrl}/${period}/${today}${locationInUrl}/${view}`,
+    nextUrl: `${req.baseUrl}/${period}/${nextPeriod}${locationInUrl}/${view}`,
+    prevUrl: `${req.baseUrl}/${period}/${previousPeriod}${locationInUrl}/${view}`,
   }
 
   next()

--- a/app/moves/middleware/set-pagination.test.js
+++ b/app/moves/middleware/set-pagination.test.js
@@ -3,6 +3,7 @@ const middleware = require('./set-pagination')
 describe('Moves middleware', function() {
   describe('#setPagination()', function() {
     const mockDate = '2019-10-10'
+    const mockView = 'requested'
     let req, res, nextSpy
 
     beforeEach(function() {
@@ -14,6 +15,7 @@ describe('Moves middleware', function() {
         baseUrl: '/moves',
         params: {
           date: mockDate,
+          view: mockView,
         },
       }
       nextSpy = sinon.spy()
@@ -36,19 +38,19 @@ describe('Moves middleware', function() {
 
         it('should set correct today link', function() {
           expect(res.locals.pagination.todayUrl).to.equal(
-            '/moves/day/2019-10-10'
+            `/moves/day/2019-10-10/${mockView}`
           )
         })
 
         it('should set correct next link', function() {
           expect(res.locals.pagination.nextUrl).to.equal(
-            '/moves/day/2019-10-11'
+            `/moves/day/2019-10-11/${mockView}`
           )
         })
 
         it('should set correct previous link', function() {
           expect(res.locals.pagination.prevUrl).to.equal(
-            '/moves/day/2019-10-09'
+            `/moves/day/2019-10-09/${mockView}`
           )
         })
 
@@ -69,19 +71,19 @@ describe('Moves middleware', function() {
 
         it('should set correct today link', function() {
           expect(res.locals.pagination.todayUrl).to.equal(
-            '/moves/week/2019-10-10'
+            `/moves/week/2019-10-10/${mockView}`
           )
         })
 
         it('should set correct next link', function() {
           expect(res.locals.pagination.nextUrl).to.equal(
-            '/moves/week/2019-10-17'
+            `/moves/week/2019-10-17/${mockView}`
           )
         })
 
         it('should set correct previous link', function() {
           expect(res.locals.pagination.prevUrl).to.equal(
-            '/moves/week/2019-10-03'
+            `/moves/week/2019-10-03/${mockView}`
           )
         })
 
@@ -105,19 +107,19 @@ describe('Moves middleware', function() {
 
         it('should set correct today link', function() {
           expect(res.locals.pagination.todayUrl).to.equal(
-            '/moves/day/2019-10-10/12345'
+            `/moves/day/2019-10-10/12345/${mockView}`
           )
         })
 
         it('should set correct next link', function() {
           expect(res.locals.pagination.nextUrl).to.equal(
-            '/moves/day/2019-10-11/12345'
+            `/moves/day/2019-10-11/12345/${mockView}`
           )
         })
 
         it('should set correct previous link', function() {
           expect(res.locals.pagination.prevUrl).to.equal(
-            '/moves/day/2019-10-09/12345'
+            `/moves/day/2019-10-09/12345/${mockView}`
           )
         })
 
@@ -139,19 +141,19 @@ describe('Moves middleware', function() {
 
         it('should set correct today link', function() {
           expect(res.locals.pagination.todayUrl).to.equal(
-            '/moves/week/2019-10-10/12345'
+            `/moves/week/2019-10-10/12345/${mockView}`
           )
         })
 
         it('should set correct next link', function() {
           expect(res.locals.pagination.nextUrl).to.equal(
-            '/moves/week/2019-10-17/12345'
+            `/moves/week/2019-10-17/12345/${mockView}`
           )
         })
 
         it('should set correct previous link', function() {
           expect(res.locals.pagination.prevUrl).to.equal(
-            '/moves/week/2019-10-03/12345'
+            `/moves/week/2019-10-03/12345/${mockView}`
           )
         })
 

--- a/app/moves/middleware/set-pagination.test.js
+++ b/app/moves/middleware/set-pagination.test.js
@@ -13,6 +13,7 @@ describe('Moves middleware', function() {
       }
       req = {
         baseUrl: '/moves',
+        query: {},
         params: {
           date: mockDate,
           view: mockView,
@@ -160,6 +161,42 @@ describe('Moves middleware', function() {
         it('should call next', function() {
           expect(nextSpy).to.be.calledOnceWithExactly()
         })
+      })
+    })
+
+    context('with query', function() {
+      beforeEach(function() {
+        req.params.period = 'day'
+        req.query = {
+          status: 'approved',
+        }
+        middleware(req, res, nextSpy)
+      })
+
+      it('should contain pagination on locals', function() {
+        expect(res.locals).to.have.property('pagination')
+      })
+
+      it('should set correct today link', function() {
+        expect(res.locals.pagination.todayUrl).to.equal(
+          `/moves/day/2019-10-10/${mockView}?status=approved`
+        )
+      })
+
+      it('should set correct next link', function() {
+        expect(res.locals.pagination.nextUrl).to.equal(
+          `/moves/day/2019-10-11/${mockView}?status=approved`
+        )
+      })
+
+      it('should set correct previous link', function() {
+        expect(res.locals.pagination.prevUrl).to.equal(
+          `/moves/day/2019-10-09/${mockView}?status=approved`
+        )
+      })
+
+      it('should call next', function() {
+        expect(nextSpy).to.be.calledOnceWithExactly()
       })
     })
   })

--- a/app/moves/middleware/set-results.outgoing.js
+++ b/app/moves/middleware/set-results.outgoing.js
@@ -13,8 +13,7 @@ function makeMultipleRequests(service, dateRange, locationIdBatches) {
 }
 
 async function setResultsOutgoing(req, res, next) {
-  const { dateRange } = res.locals
-  const { locationId } = req.params
+  const { dateRange, locationId } = req.params
 
   if (!dateRange) {
     return next()

--- a/app/moves/middleware/set-results.outgoing.test.js
+++ b/app/moves/middleware/set-results.outgoing.test.js
@@ -29,7 +29,7 @@ describe('Moves middleware', function() {
         .stub(presenters, 'moveToCardComponent')
         .callsFake(() => moveToCardComponentMapStub)
       nextSpy = sinon.spy()
-      res = { locals: {} }
+      res = {}
       req = {
         session: {
           user: {},
@@ -59,11 +59,7 @@ describe('Moves middleware', function() {
 
     context('when move date exists', function() {
       beforeEach(function() {
-        res = {
-          locals: {
-            dateRange: ['2010-10-10', '2010-10-11'],
-          },
-        }
+        req.params.dateRange = ['2010-10-10', '2010-10-11']
       })
 
       context('when API call returns successfully', function() {
@@ -88,14 +84,14 @@ describe('Moves middleware', function() {
               expect(req.session.user.locations).to.have.length(75)
               expect(moveService.getActive).to.have.callCount(2)
               expect(moveService.getActive).to.be.calledWithExactly({
-                dateRange: res.locals.dateRange,
+                dateRange: req.params.dateRange,
                 fromLocationId: req.session.user.locations
                   .map(location => location.id)
                   .slice(0, 40)
                   .join(','),
               })
               expect(moveService.getActive).to.be.calledWithExactly({
-                dateRange: res.locals.dateRange,
+                dateRange: req.params.dateRange,
                 fromLocationId: req.session.user.locations
                   .map(location => location.id)
                   .slice(40)
@@ -104,14 +100,14 @@ describe('Moves middleware', function() {
 
               expect(moveService.getCancelled).to.have.callCount(2)
               expect(moveService.getCancelled).to.be.calledWithExactly({
-                dateRange: res.locals.dateRange,
+                dateRange: req.params.dateRange,
                 fromLocationId: req.session.user.locations
                   .map(location => location.id)
                   .slice(0, 40)
                   .join(','),
               })
               expect(moveService.getCancelled).to.be.calledWithExactly({
-                dateRange: res.locals.dateRange,
+                dateRange: req.params.dateRange,
                 fromLocationId: req.session.user.locations
                   .map(location => location.id)
                   .slice(40)
@@ -196,11 +192,11 @@ describe('Moves middleware', function() {
 
             it('should call API with move date and location ID', function() {
               expect(moveService.getActive).to.be.calledOnceWithExactly({
-                dateRange: res.locals.dateRange,
+                dateRange: req.params.dateRange,
                 fromLocationId: mockCurrentLocation,
               })
               expect(moveService.getCancelled).to.be.calledOnceWithExactly({
-                dateRange: res.locals.dateRange,
+                dateRange: req.params.dateRange,
                 fromLocationId: mockCurrentLocation,
               })
             })
@@ -258,11 +254,11 @@ describe('Moves middleware', function() {
 
             it('should call API with move date and location ID', function() {
               expect(moveService.getActive).to.be.calledOnceWithExactly({
-                dateRange: res.locals.dateRange,
+                dateRange: req.params.dateRange,
                 fromLocationId: mockCurrentLocation,
               })
               expect(moveService.getCancelled).to.be.calledOnceWithExactly({
-                dateRange: res.locals.dateRange,
+                dateRange: req.params.dateRange,
                 fromLocationId: mockCurrentLocation,
               })
             })

--- a/common/helpers/date-utils.js
+++ b/common/helpers/date-utils.js
@@ -6,16 +6,19 @@ const {
   startOfWeek,
   endOfWeek,
   isValid: isValidDate,
+  isDate,
 } = require('date-fns')
 
-const dateFormat = 'yyyy-MM-dd'
-const weekStartsOn = 1
+const { DATE_FORMATS } = require('../../config/index')
 
 module.exports = {
-  dateFormat,
+  dateFormat: DATE_FORMATS.URL_PARAM,
   getPeriod: (date, interval) => {
     const method = interval >= 0 ? addDays : subDays
-    return format(method(parseISO(date), Math.abs(interval)), dateFormat)
+    return format(
+      method(parseISO(date), Math.abs(interval)),
+      DATE_FORMATS.URL_PARAM
+    )
   },
   getDateFromParams: req => {
     const date = req.params.date
@@ -25,18 +28,36 @@ module.exports = {
     if (!validDate) {
       return null
     }
-    return format(parsedDate, dateFormat)
+    return format(parsedDate, DATE_FORMATS.URL_PARAM)
   },
-  getDateRange: (period, date) => {
-    let startDate
-    let endDate
-    if (period === 'week') {
-      startDate = startOfWeek(parseISO(date), { weekStartsOn })
-      endDate = endOfWeek(parseISO(date), { weekStartsOn })
-    } else {
-      startDate = parseISO(date)
-      endDate = startDate
+  getDateRange: (date, timePeriod) => {
+    const parsedDate = isDate(date) ? date : parseISO(date)
+
+    if (!isValidDate(parsedDate)) {
+      return [undefined, undefined]
     }
-    return [format(startDate, dateFormat), format(endDate, dateFormat)]
+
+    let dateFrom
+    let dateTo
+
+    switch (timePeriod) {
+      case 'week':
+        dateFrom = startOfWeek(parsedDate, {
+          weekStartsOn: DATE_FORMATS.WEEK_STARTS_ON,
+        })
+        dateTo = endOfWeek(parsedDate, {
+          weekStartsOn: DATE_FORMATS.WEEK_STARTS_ON,
+        })
+        break
+      default:
+        dateFrom = parsedDate
+        dateTo = parsedDate
+        break
+    }
+
+    return [
+      format(dateFrom, DATE_FORMATS.URL_PARAM),
+      format(dateTo, DATE_FORMATS.URL_PARAM),
+    ]
   },
 }

--- a/common/helpers/date-utils.test.js
+++ b/common/helpers/date-utils.test.js
@@ -5,7 +5,7 @@ const {
   getDateRange,
 } = require('./date-utils')
 
-describe('the date utils', function() {
+describe('Date helpers', function() {
   describe('dateFormat', function() {
     it('exposes dateFormat for convenience', function() {
       expect(dateFormat).to.exist
@@ -39,27 +39,126 @@ describe('the date utils', function() {
       expect(getDateFromParams(req)).to.equal('2010-01-01')
     })
   })
+
   describe('#getDateRange', function() {
-    context('with period as week', function() {
-      it('on a Monday, it returns the next 7 days', function() {
-        expect(getDateRange('week', '2020-03-09')).to.deep.equal([
-          '2020-03-09',
-          '2020-03-15',
-        ])
+    const mockDate = '2017-08-10'
+
+    beforeEach(function() {
+      this.clock = sinon.useFakeTimers(new Date(mockDate).getTime())
+    })
+
+    afterEach(function() {
+      this.clock.restore()
+    })
+
+    context('without time period', function() {
+      context('without date', function() {
+        it('should return undefined', function() {
+          expect(getDateRange()).to.deep.equal([undefined, undefined])
+        })
       })
-      it('on any other day, returns the range of 7 days starting from prev Monday', function() {
-        expect(getDateRange('week', '2020-03-06')).to.deep.equal([
-          '2020-03-02',
-          '2020-03-08',
-        ])
+
+      context('with date', function() {
+        it('should return given date for both dates', function() {
+          expect(getDateRange(new Date(2020, 3, 20), undefined)).to.deep.equal([
+            '2020-04-20',
+            '2020-04-20',
+          ])
+        })
       })
     })
-    context('with period as day', function() {
-      it('returns the same date in from and to', function() {
-        expect(getDateRange('day', '2020-03-09')).to.deep.equal([
-          '2020-03-09',
-          '2020-03-09',
-        ])
+
+    context('with time period of `day`', function() {
+      context('without date', function() {
+        it('should return undefined', function() {
+          expect(getDateRange(undefined, 'day')).to.deep.equal([
+            undefined,
+            undefined,
+          ])
+        })
+      })
+
+      context('with date', function() {
+        context('with a Monday', function() {
+          it('should return given date for both dates', function() {
+            expect(getDateRange(new Date(2020, 2, 9), 'day')).to.deep.equal([
+              '2020-03-09',
+              '2020-03-09',
+            ])
+          })
+        })
+
+        context('with another day of the week', function() {
+          it('should return given date for both dates', function() {
+            expect(getDateRange(new Date(2020, 2, 6), 'day')).to.deep.equal([
+              '2020-03-06',
+              '2020-03-06',
+            ])
+          })
+        })
+      })
+    })
+
+    context('with time period of `week`', function() {
+      context('without date', function() {
+        it('should return dates for this week', function() {
+          expect(getDateRange(undefined, 'week')).to.deep.equal([
+            undefined,
+            undefined,
+          ])
+        })
+      })
+
+      context('with date', function() {
+        context('with a Monday', function() {
+          it('should return Monday and end of week', function() {
+            expect(getDateRange(new Date(2020, 2, 9), 'week')).to.deep.equal([
+              '2020-03-09',
+              '2020-03-15',
+            ])
+          })
+        })
+
+        context('with another day of the week', function() {
+          it('should return start and end of that week', function() {
+            expect(getDateRange(new Date(2020, 2, 6), 'week')).to.deep.equal([
+              '2020-03-02',
+              '2020-03-08',
+            ])
+          })
+        })
+      })
+    })
+
+    context('with an invalid date', function() {
+      const inputs = ['foo', '2020-20-10', false, null]
+
+      inputs.forEach(input => {
+        context(`with "${input}"`, function() {
+          it('should return undefined dates', function() {
+            expect(getDateRange(input)).to.deep.equal([undefined, undefined])
+          })
+        })
+      })
+    })
+
+    context('with different date formats', function() {
+      context('with date string', function() {
+        it('should return correct dates', function() {
+          expect(getDateRange('2014-11-05')).to.deep.equal([
+            '2014-11-05',
+            '2014-11-05',
+          ])
+        })
+      })
+
+      context('with date object', function() {
+        it('should return correct dates', function() {
+          expect(getDateRange(new Date(2020, 2, 9), undefined)).to.deep.equal([
+            '2020-03-09',
+            '2020-03-09',
+          ])
+        })
       })
     })
   })

--- a/common/middleware/set-date-range.js
+++ b/common/middleware/set-date-range.js
@@ -1,15 +1,24 @@
-const {
-  getDateFromParams,
-  getDateRange,
-} = require('../../common/helpers/date-utils')
+const dateHelpers = require('../../common/helpers/date-utils')
 
-function setDateRange(req, res, next) {
+function setDateRange(req, res, next, date) {
   const { period } = req.params
-  const date = getDateFromParams(req)
-  if (!date) {
-    return res.redirect(req.baseUrl)
+  const dateRange = dateHelpers.getDateRange(date, period)
+
+  if (!dateRange[0] && !dateRange[1]) {
+    const error = new Error('Invalid date')
+    error.statusCode = 404
+
+    return next(error)
   }
-  res.locals.dateRange = getDateRange(period, date)
+
+  req.params.dateRange = dateRange
+
+  // TODO: Move these to the controller to move away
+  // from setting `res.locals` in middleware
+  res.locals.dateRange = dateRange
+  res.locals.period = period
+
   next()
 }
+
 module.exports = setDateRange

--- a/config/index.js
+++ b/config/index.js
@@ -53,6 +53,8 @@ module.exports = {
     SHORT: 'd M yyyy',
     LONG: 'd MMM yyyy',
     WITH_DAY: 'EEEE d MMM yyyy',
+    URL_PARAM: 'yyyy-MM-dd',
+    WEEK_STARTS_ON: 1,
   },
   FILE_UPLOADS: {
     UPLOAD_DIR: '.tmp/uploads/',

--- a/package-lock.json
+++ b/package-lock.json
@@ -20530,9 +20530,9 @@
       "dev": true
     },
     "qs": {
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.0.tgz",
-      "integrity": "sha512-27RP4UotQORTpmNQDX8BHPukOnBP3p1uUJY5UnDhaJB+rMt9iMsok724XL+UHU23bEFOHRMQ2ZhI99qOWUMGFA=="
+      "version": "6.9.4",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.4.tgz",
+      "integrity": "sha512-A1kFqHekCTM7cz0udomYUoYNWjBebHm/5wzU/XqrBRBNWectVH0QIiN+NEcZ0Dte5hvzHwbr8+XQmguPhJ6WdQ=="
     },
     "query-string": {
       "version": "6.12.1",

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "npm-run-all": "4.1.5",
     "nunjucks": "3.2.1",
     "pluralize": "8.0.0",
+    "qs": "6.9.4",
     "query-string": "6.12.1",
     "redis": "3.0.2",
     "response-time": "2.3.2",


### PR DESCRIPTION
## Proposed changes

This is part of a wider piece of work to stop using `res.locals`
through middleware. This technique makes it harder to see where something
in a view is coming from.

This also refactors some of the date utils to make use of app wide
configuration and improve how dates are handled.

Helps to address #451 