### PR TITLE
refactor: Handle redirecting of different move types

### DIFF
--- a/app/moves/constants.js
+++ b/app/moves/constants.js
@@ -1,0 +1,10 @@
+const CONSTANTS = {
+  DEFAULTS: {
+    QUERY: {
+      requested: { status: 'pending' },
+      outgoing: {},
+    },
+  },
+}
+
+module.exports = CONSTANTS

--- a/app/moves/constants.js
+++ b/app/moves/constants.js
@@ -4,6 +4,10 @@ const CONSTANTS = {
       requested: { status: 'pending' },
       outgoing: {},
     },
+    TIME_PERIOD: {
+      requested: 'week',
+      outgoing: 'day',
+    },
   },
 }
 

--- a/app/moves/index.js
+++ b/app/moves/index.js
@@ -5,6 +5,7 @@ const router = require('express').Router()
 const { setDateRange } = require('../../common/middleware')
 const { protectRoute } = require('../../common/middleware/permissions')
 
+const { DEFAULTS } = require('./constants')
 const {
   dashboard,
   download,
@@ -13,6 +14,7 @@ const {
 } = require('./controllers')
 const {
   redirectBaseUrl,
+  redirectDefaultQuery,
   saveUrl,
   setFromLocation,
   setBodySingleRequests,
@@ -29,6 +31,7 @@ const uuidRegex =
 // Define param middleware
 router.param('locationId', setFromLocation)
 router.param('date', setDateRange)
+router.param('view', redirectDefaultQuery(DEFAULTS.QUERY))
 
 // Define shared middleware
 router.use('^([^.]+)$', saveUrl)

--- a/app/moves/index.js
+++ b/app/moves/index.js
@@ -15,6 +15,7 @@ const {
 const {
   redirectBaseUrl,
   redirectDefaultQuery,
+  redirectView,
   saveUrl,
   setFromLocation,
   setBodySingleRequests,
@@ -91,6 +92,8 @@ router.get(
   setResultsOutgoing,
   download
 )
+router.get('/:view(outgoing|requested)', redirectView(DEFAULTS.TIME_PERIOD))
+
 // Export
 module.exports = {
   router,

--- a/app/moves/middleware/index.js
+++ b/app/moves/middleware/index.js
@@ -1,5 +1,6 @@
 const redirectBaseUrl = require('./redirect-base-url')
 const redirectDefaultQuery = require('./redirect-default-query')
+const redirectView = require('./redirect-view')
 const saveUrl = require('./save-url')
 const setBodySingleRequests = require('./set-body.single-requests')
 const setDashboardMoveSummary = require('./set-dashboard-move-summary')
@@ -12,6 +13,7 @@ const setResultsSingleRequests = require('./set-results.single-requests')
 module.exports = {
   redirectBaseUrl,
   redirectDefaultQuery,
+  redirectView,
   saveUrl,
   setDashboardMoveSummary,
   setBodySingleRequests,

--- a/app/moves/middleware/index.js
+++ b/app/moves/middleware/index.js
@@ -1,4 +1,5 @@
 const redirectBaseUrl = require('./redirect-base-url')
+const redirectDefaultQuery = require('./redirect-default-query')
 const saveUrl = require('./save-url')
 const setBodySingleRequests = require('./set-body.single-requests')
 const setDashboardMoveSummary = require('./set-dashboard-move-summary')
@@ -10,6 +11,7 @@ const setResultsSingleRequests = require('./set-results.single-requests')
 
 module.exports = {
   redirectBaseUrl,
+  redirectDefaultQuery,
   saveUrl,
   setDashboardMoveSummary,
   setBodySingleRequests,

--- a/app/moves/middleware/redirect-default-query.js
+++ b/app/moves/middleware/redirect-default-query.js
@@ -1,0 +1,16 @@
+const { isEmpty } = require('lodash')
+const querystring = require('qs')
+
+function redirectDefaultQuery(defaults = {}) {
+  return function handleQueryRedirect(req, res, next, view) {
+    const query = defaults[view]
+
+    if (!isEmpty(query) && isEmpty(req.query)) {
+      return res.redirect(`${req.originalUrl}?${querystring.stringify(query)}`)
+    }
+
+    next()
+  }
+}
+
+module.exports = redirectDefaultQuery

--- a/app/moves/middleware/redirect-default-query.test.js
+++ b/app/moves/middleware/redirect-default-query.test.js
@@ -1,0 +1,110 @@
+const middleware = require('./redirect-default-query')
+
+describe('Moves middleware', function() {
+  describe('#redirectDefaultQuery()', function() {
+    let mockReq, mockRes, nextSpy
+    const mockDefaults = {
+      foo: {
+        status: 'approved',
+        sortby: 'date',
+        sortdir: 'desc',
+      },
+    }
+
+    beforeEach(function() {
+      nextSpy = sinon.spy()
+      mockReq = {
+        originalUrl: '/original/url',
+        params: {},
+        query: {},
+      }
+      mockRes = {
+        redirect: sinon.stub(),
+      }
+    })
+
+    context('without defaults', function() {
+      beforeEach(function() {
+        middleware()(mockReq, mockRes, nextSpy, 'foo')
+      })
+
+      it('should not redirect', function() {
+        expect(mockRes.redirect).not.to.be.called
+      })
+
+      it('should call next', function() {
+        expect(nextSpy).to.be.calledOnceWithExactly()
+      })
+    })
+
+    context('without defaults', function() {
+      context('with default query that exists', function() {
+        context('with existing query', function() {
+          beforeEach(function() {
+            mockReq.query = {
+              foo: 'bar',
+            }
+            middleware(mockDefaults)(mockReq, mockRes, nextSpy, 'foo')
+          })
+
+          it('should not redirect', function() {
+            expect(mockRes.redirect).not.to.be.called
+          })
+
+          it('should call next', function() {
+            expect(nextSpy).to.be.calledOnceWithExactly()
+          })
+        })
+
+        context('without existing query', function() {
+          beforeEach(function() {
+            middleware(mockDefaults)(mockReq, mockRes, nextSpy, 'foo')
+          })
+
+          it('should redirect', function() {
+            expect(mockRes.redirect).to.be.calledOnceWithExactly(
+              '/original/url?status=approved&sortby=date&sortdir=desc'
+            )
+          })
+
+          it('should not call next', function() {
+            expect(nextSpy).not.to.be.called
+          })
+        })
+      })
+
+      context('with default query missing', function() {
+        context('with existing query', function() {
+          beforeEach(function() {
+            mockReq.query = {
+              foo: 'bar',
+            }
+            middleware(mockDefaults)(mockReq, mockRes, nextSpy, 'bar')
+          })
+
+          it('should not redirect', function() {
+            expect(mockRes.redirect).not.to.be.called
+          })
+
+          it('should call next', function() {
+            expect(nextSpy).to.be.calledOnceWithExactly()
+          })
+        })
+
+        context('without existing query', function() {
+          beforeEach(function() {
+            middleware(mockDefaults)(mockReq, mockRes, nextSpy, 'bar')
+          })
+
+          it('should not redirect', function() {
+            expect(mockRes.redirect).not.to.be.called
+          })
+
+          it('should call next', function() {
+            expect(nextSpy).to.be.calledOnceWithExactly()
+          })
+        })
+      })
+    })
+  })
+})

--- a/app/moves/middleware/redirect-view.js
+++ b/app/moves/middleware/redirect-view.js
@@ -1,0 +1,29 @@
+const { format } = require('date-fns')
+const { get, isEmpty } = require('lodash')
+const querystring = require('qs')
+
+const { DATE_FORMATS } = require('../../../config')
+
+function redirectView(defaults = {}) {
+  return function handleViewRedirect(req, res, next) {
+    const { view } = req.params
+
+    if (!view) {
+      return next()
+    }
+
+    const today = format(new Date(), DATE_FORMATS.URL_PARAM)
+    const timePeriod = defaults[view] || 'day'
+    const currentLocationId = get(req.session, 'currentLocation.id')
+    const locationInUrl = currentLocationId ? `/${currentLocationId}` : ''
+    const queryInUrl = !isEmpty(req.query)
+      ? `?${querystring.stringify(req.query)}`
+      : ''
+
+    return res.redirect(
+      `${req.baseUrl}/${timePeriod}/${today}${locationInUrl}/${view}${queryInUrl}`
+    )
+  }
+}
+
+module.exports = redirectView

--- a/app/moves/middleware/redirect-view.test.js
+++ b/app/moves/middleware/redirect-view.test.js
@@ -1,0 +1,139 @@
+const middleware = require('./redirect-view')
+
+describe('Moves middleware', function() {
+  describe('#redirectView()', function() {
+    let mockReq, mockRes, nextSpy
+    const mockDate = '2017-08-10'
+    const mockDefaults = {
+      foo: 'week',
+    }
+
+    beforeEach(function() {
+      this.clock = sinon.useFakeTimers(new Date(mockDate).getTime())
+      nextSpy = sinon.spy()
+      mockReq = {
+        baseUrl: '/base/url',
+        params: {},
+        query: {},
+        session: {},
+      }
+      mockRes = {
+        redirect: sinon.stub(),
+      }
+    })
+
+    afterEach(function() {
+      this.clock.restore()
+    })
+
+    context('without view', function() {
+      beforeEach(function() {
+        middleware()(mockReq, mockRes, nextSpy)
+      })
+
+      it('should not redirect', function() {
+        expect(mockRes.redirect).not.to.be.called
+      })
+
+      it('should call next', function() {
+        expect(nextSpy).to.be.calledOnceWithExactly()
+      })
+    })
+
+    context('with view', function() {
+      beforeEach(function() {
+        mockReq.params.view = 'foo'
+      })
+
+      context('without defaults', function() {
+        beforeEach(function() {
+          middleware()(mockReq, mockRes, nextSpy)
+        })
+
+        it('should redirect with default time period', function() {
+          expect(mockRes.redirect).to.be.calledOnceWithExactly(
+            `${mockReq.baseUrl}/day/${mockDate}/foo`
+          )
+        })
+
+        it('should not call next', function() {
+          expect(nextSpy).not.to.be.called
+        })
+      })
+
+      context('with defaults', function() {
+        context('with default that exists', function() {
+          beforeEach(function() {
+            middleware(mockDefaults)(mockReq, mockRes, nextSpy)
+          })
+
+          it('should redirect with that time period', function() {
+            expect(mockRes.redirect).to.be.calledOnceWithExactly(
+              `${mockReq.baseUrl}/week/${mockDate}/foo`
+            )
+          })
+
+          it('should not call next', function() {
+            expect(nextSpy).not.to.be.called
+          })
+        })
+
+        context('with default that does not exist', function() {
+          beforeEach(function() {
+            mockReq.params.view = 'bar'
+            middleware(mockDefaults)(mockReq, mockRes, nextSpy)
+          })
+
+          it('should contain location ID', function() {
+            expect(mockRes.redirect).to.be.calledOnceWithExactly(
+              `${mockReq.baseUrl}/day/${mockDate}/bar`
+            )
+          })
+
+          it('should not call next', function() {
+            expect(nextSpy).not.to.be.called
+          })
+        })
+      })
+
+      context('with location', function() {
+        beforeEach(function() {
+          mockReq.session.currentLocation = {
+            id: '12345',
+          }
+          middleware(mockDefaults)(mockReq, mockRes, nextSpy)
+        })
+
+        it('should redirect with that time period', function() {
+          expect(mockRes.redirect).to.be.calledOnceWithExactly(
+            `${mockReq.baseUrl}/week/${mockDate}/12345/foo`
+          )
+        })
+
+        it('should not call next', function() {
+          expect(nextSpy).not.to.be.called
+        })
+      })
+
+      context('with existing query', function() {
+        beforeEach(function() {
+          mockReq.query = {
+            fizz: 'buzz',
+            foo: 'bar',
+          }
+          middleware(mockDefaults)(mockReq, mockRes, nextSpy)
+        })
+
+        it('should contain existing query', function() {
+          expect(mockRes.redirect).to.be.calledOnceWithExactly(
+            `${mockReq.baseUrl}/week/${mockDate}/foo?fizz=buzz&foo=bar`
+          )
+        })
+
+        it('should not call next', function() {
+          expect(nextSpy).not.to.be.called
+        })
+      })
+    })
+  })
+})

--- a/common/middleware/set-primary-navigation.js
+++ b/common/middleware/set-primary-navigation.js
@@ -1,4 +1,3 @@
-const { format } = require('date-fns')
 const { get } = require('lodash')
 
 const permissions = require('./permissions')
@@ -6,38 +5,32 @@ const permissions = require('./permissions')
 const baseRegex =
   '^\\/moves\\/(day|week)(\\/\\d{4}-\\d{2}-\\d{2})(\\/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})?'
 const homeRegex = new RegExp(`${baseRegex}$`)
-const proposedRegex = new RegExp(`${baseRegex}\\/requested$`)
-const outgoingRegex = new RegExp(`${baseRegex}\\/outgoing$`)
 
 function setPrimaryNavigation(req, res, next) {
-  const { TODAY, REQUEST_PATH } = res.locals
-  const date = format(TODAY, 'yyyy-MM-dd')
   const userPermissions = get(req.session, 'user.permissions')
-  const locationId = get(res.locals, 'CURRENT_LOCATION.id')
-  const locationInUrl = locationId ? `/${locationId}` : ''
   const items = []
 
   if (permissions.check('moves:view:dashboard', userPermissions)) {
     items.push({
       text: req.t('primary_navigation.home'),
       href: '/moves',
-      active: homeRegex.test(REQUEST_PATH),
+      active: homeRegex.test(req.path),
     })
   }
 
   if (permissions.check('moves:view:proposed', userPermissions)) {
     items.push({
       text: req.t('primary_navigation.single_requests'),
-      href: `/moves/week/${date}${locationInUrl}/requested?status=pending`,
-      active: proposedRegex.test(REQUEST_PATH),
+      href: '/moves/requested',
+      active: req.path.endsWith('/requested'),
     })
   }
 
   if (permissions.check('moves:view:outgoing', userPermissions)) {
     items.push({
       text: req.t('primary_navigation.outgoing'),
-      href: `/moves/day/${date}${locationInUrl}/outgoing`,
-      active: outgoingRegex.test(REQUEST_PATH),
+      href: '/moves/outgoing',
+      active: req.path.endsWith('/outgoing'),
     })
   }
 

--- a/common/middleware/set-primary-navigation.test.js
+++ b/common/middleware/set-primary-navigation.test.js
@@ -6,6 +6,7 @@ describe('#setPrimaryNavigation()', function() {
   beforeEach(function() {
     nextSpy = sinon.spy()
     req = {
+      path: '',
       session: {
         user: {
           permissions: [],
@@ -14,10 +15,7 @@ describe('#setPrimaryNavigation()', function() {
       t: sinon.stub().returnsArg(0),
     }
     res = {
-      locals: {
-        TODAY: new Date(2020, 4, 10),
-        REQUEST_PATH: '',
-      },
+      locals: {},
     }
   })
 
@@ -44,141 +42,95 @@ describe('#setPrimaryNavigation()', function() {
       ]
     })
 
-    context('with location', function() {
+    describe('navigation items', function() {
       beforeEach(function() {
-        res.locals.CURRENT_LOCATION = {
-          id: '12345',
-        }
-      })
-
-      describe('navigation items', function() {
-        beforeEach(function() {
-          middleware(req, res, nextSpy)
-        })
-
-        it('should set items correctly', function() {
-          expect(res.locals.primaryNavigation).to.deep.equal([
-            {
-              active: false,
-              href: '/moves',
-              text: 'primary_navigation.home',
-            },
-            {
-              active: false,
-              href: '/moves/week/2020-05-10/12345/requested?status=pending',
-              text: 'primary_navigation.single_requests',
-            },
-            {
-              active: false,
-              href: '/moves/day/2020-05-10/12345/outgoing',
-              text: 'primary_navigation.outgoing',
-            },
-          ])
-        })
-      })
-
-      describe('active state', function() {
-        context('on home page', function() {
-          beforeEach(function() {
-            res.locals.REQUEST_PATH =
-              '/moves/day/2020-04-16/8fadb516-f10a-45b1-91b7-a256196829f9'
-            middleware(req, res, nextSpy)
-          })
-
-          it('should set active state', function() {
-            expect(res.locals.primaryNavigation).to.deep.equal([
-              {
-                active: true,
-                href: '/moves',
-                text: 'primary_navigation.home',
-              },
-              {
-                active: false,
-                href: '/moves/week/2020-05-10/12345/requested?status=pending',
-                text: 'primary_navigation.single_requests',
-              },
-              {
-                active: false,
-                href: '/moves/day/2020-05-10/12345/outgoing',
-                text: 'primary_navigation.outgoing',
-              },
-            ])
-          })
-        })
-
-        const statuses = ['pending', 'approved', 'rejected']
-        statuses.forEach(status => {
-          context(`on ${status} page`, function() {
-            beforeEach(function() {
-              res.locals.REQUEST_PATH =
-                '/moves/day/2020-04-16/8fadb516-f10a-45b1-91b7-a256196829f9/requested'
-              middleware(req, res, nextSpy)
-            })
-
-            it('should set active state', function() {
-              expect(res.locals.primaryNavigation).to.deep.equal([
-                {
-                  active: false,
-                  href: '/moves',
-                  text: 'primary_navigation.home',
-                },
-                {
-                  active: true,
-                  href: '/moves/week/2020-05-10/12345/requested?status=pending',
-                  text: 'primary_navigation.single_requests',
-                },
-                {
-                  active: false,
-                  href: '/moves/day/2020-05-10/12345/outgoing',
-                  text: 'primary_navigation.outgoing',
-                },
-              ])
-            })
-          })
-        })
-
-        context('on outgoing page', function() {
-          beforeEach(function() {
-            res.locals.REQUEST_PATH =
-              '/moves/day/2020-04-16/8fadb516-f10a-45b1-91b7-a256196829f9/outgoing'
-            middleware(req, res, nextSpy)
-          })
-
-          it('should set active state', function() {
-            expect(res.locals.primaryNavigation).to.deep.equal([
-              {
-                active: false,
-                href: '/moves',
-                text: 'primary_navigation.home',
-              },
-              {
-                active: false,
-                href: '/moves/week/2020-05-10/12345/requested?status=pending',
-                text: 'primary_navigation.single_requests',
-              },
-              {
-                active: true,
-                href: '/moves/day/2020-05-10/12345/outgoing',
-                text: 'primary_navigation.outgoing',
-              },
-            ])
-          })
-        })
-      })
-
-      it('should call next', function() {
         middleware(req, res, nextSpy)
-        expect(nextSpy).to.be.calledOnceWithExactly()
+      })
+
+      it('should set items correctly', function() {
+        expect(res.locals.primaryNavigation).to.deep.equal([
+          {
+            active: false,
+            href: '/moves',
+            text: 'primary_navigation.home',
+          },
+          {
+            active: false,
+            href: '/moves/requested',
+            text: 'primary_navigation.single_requests',
+          },
+          {
+            active: false,
+            href: '/moves/outgoing',
+            text: 'primary_navigation.outgoing',
+          },
+        ])
       })
     })
 
-    context('without location', function() {
-      describe('navigation items', function() {
+    describe('active state', function() {
+      context('on home page', function() {
         beforeEach(function() {
+          req.path =
+            '/moves/day/2020-04-16/8fadb516-f10a-45b1-91b7-a256196829f9'
           middleware(req, res, nextSpy)
         })
 
-        it('should set items correctly', function() {
+        it('should set active state', function() {
+          expect(res.locals.primaryNavigation).to.deep.equal([
+            {
+              active: true,
+              href: '/moves',
+              text: 'primary_navigation.home',
+            },
+            {
+              active: false,
+              href: '/moves/requested',
+              text: 'primary_navigation.single_requests',
+            },
+            {
+              active: false,
+              href: '/moves/outgoing',
+              text: 'primary_navigation.outgoing',
+            },
+          ])
+        })
+      })
+
+      context('on requested page', function() {
+        beforeEach(function() {
+          req.path = '/moves/day/2020-04-16/requested'
+          middleware(req, res, nextSpy)
+        })
+
+        it('should set active state', function() {
+          expect(res.locals.primaryNavigation).to.deep.equal([
+            {
+              active: false,
+              href: '/moves',
+              text: 'primary_navigation.home',
+            },
+            {
+              active: true,
+              href: '/moves/requested',
+              text: 'primary_navigation.single_requests',
+            },
+            {
+              active: false,
+              href: '/moves/outgoing',
+              text: 'primary_navigation.outgoing',
+            },
+          ])
+        })
+      })
+
+      context('on outgoing page', function() {
+        beforeEach(function() {
+          req.path = '/moves/day/2020-04-16/outgoing'
+          middleware(req, res, nextSpy)
+        })
+
+        it('should set active state', function() {
           expect(res.locals.primaryNavigation).to.deep.equal([
             {
               active: false,
@@ -187,105 +139,22 @@ describe('#setPrimaryNavigation()', function() {
             },
             {
               active: false,
-              href: '/moves/week/2020-05-10/requested?status=pending',
+              href: '/moves/requested',
               text: 'primary_navigation.single_requests',
             },
             {
-              active: false,
-              href: '/moves/day/2020-05-10/outgoing',
+              active: true,
+              href: '/moves/outgoing',
               text: 'primary_navigation.outgoing',
             },
           ])
         })
       })
+    })
 
-      describe('active state', function() {
-        context('on home page', function() {
-          beforeEach(function() {
-            res.locals.REQUEST_PATH = '/moves/day/2020-04-16'
-            middleware(req, res, nextSpy)
-          })
-
-          it('should set active state', function() {
-            expect(res.locals.primaryNavigation).to.deep.equal([
-              {
-                active: true,
-                href: '/moves',
-                text: 'primary_navigation.home',
-              },
-              {
-                active: false,
-                href: '/moves/week/2020-05-10/requested?status=pending',
-                text: 'primary_navigation.single_requests',
-              },
-              {
-                active: false,
-                href: '/moves/day/2020-05-10/outgoing',
-                text: 'primary_navigation.outgoing',
-              },
-            ])
-          })
-        })
-
-        context('on requested page', function() {
-          beforeEach(function() {
-            res.locals.REQUEST_PATH = '/moves/day/2020-04-16/requested'
-            middleware(req, res, nextSpy)
-          })
-
-          it('should set active state', function() {
-            expect(res.locals.primaryNavigation).to.deep.equal([
-              {
-                active: false,
-                href: '/moves',
-                text: 'primary_navigation.home',
-              },
-              {
-                active: true,
-                href: '/moves/week/2020-05-10/requested?status=pending',
-                text: 'primary_navigation.single_requests',
-              },
-              {
-                active: false,
-                href: '/moves/day/2020-05-10/outgoing',
-                text: 'primary_navigation.outgoing',
-              },
-            ])
-          })
-        })
-
-        context('on outgoing page', function() {
-          beforeEach(function() {
-            res.locals.REQUEST_PATH = '/moves/day/2020-04-16/outgoing'
-            middleware(req, res, nextSpy)
-          })
-
-          it('should set active state', function() {
-            expect(res.locals.primaryNavigation).to.deep.equal([
-              {
-                active: false,
-                href: '/moves',
-                text: 'primary_navigation.home',
-              },
-              {
-                active: false,
-                href: '/moves/week/2020-05-10/requested?status=pending',
-                text: 'primary_navigation.single_requests',
-              },
-              {
-                active: true,
-                href: '/moves/day/2020-05-10/outgoing',
-                text: 'primary_navigation.outgoing',
-              },
-            ])
-          })
-        })
-      })
-
-      it('should call next', function() {
-        middleware(req, res, nextSpy)
-        expect(nextSpy).to.be.calledOnceWithExactly()
-      })
+    it('should call next', function() {
+      middleware(req, res, nextSpy)
+      expect(nextSpy).to.be.calledOnceWithExactly()
     })
   })
 })


### PR DESCRIPTION
## Proposed changes

This changes the way default URLs are handled within the moves app. Now each "view" has a default time period which is handled at the base router level.

This simplifies the main navigation and any other areas where we will need to link to the default
view for a particular list of moves.