### PR TITLE
[P4 1276] cancel allocation without specifying a reason

### DIFF
--- a/app/allocation/controllers/cancel.js
+++ b/app/allocation/controllers/cancel.js
@@ -1,0 +1,21 @@
+const FormWizardController = require('../../../common/controllers/form-wizard')
+const allocationService = require('../../../common/services/allocation')
+
+class CancelController extends FormWizardController {
+  async successHandler(req, res, next) {
+    const { id: allocationId } = res.locals.allocation
+
+    try {
+      await allocationService.cancel(allocationId)
+
+      req.journeyModel.reset()
+      req.sessionModel.reset()
+
+      res.redirect(`/allocation/${allocationId}`)
+    } catch (error) {
+      next(error)
+    }
+  }
+}
+
+module.exports = CancelController

--- a/app/allocation/controllers/cancel.test.js
+++ b/app/allocation/controllers/cancel.test.js
@@ -1,0 +1,76 @@
+const allocationService = require('../../../common/services/allocation')
+
+const CancelController = require('./cancel')
+
+const controller = new CancelController({ route: '/' })
+const mockAllocation = {
+  id: '123',
+}
+describe('Cancel controller', function() {
+  describe('#successHandler()', function() {
+    let req, res, nextSpy
+
+    beforeEach(function() {
+      nextSpy = sinon.spy()
+      req = {
+        form: {
+          options: {
+            allFields: {},
+          },
+        },
+        sessionModel: {
+          reset: sinon.stub(),
+          toJSON: () => {},
+        },
+        journeyModel: {
+          reset: sinon.stub(),
+        },
+      }
+      res = {
+        redirect: sinon.stub(),
+        locals: {
+          allocation: mockAllocation,
+        },
+      }
+    })
+
+    context('happy path', function() {
+      beforeEach(async function() {
+        sinon.stub(allocationService, 'cancel').resolves({})
+        await controller.successHandler(req, res, nextSpy)
+      })
+
+      it('should cancel the allocation', function() {
+        expect(allocationService.cancel).to.be.calledWithExactly(
+          mockAllocation.id
+        )
+      })
+
+      it('should reset the journey', function() {
+        expect(req.journeyModel.reset).to.have.been.calledOnce
+      })
+
+      it('should reset the session', function() {
+        expect(req.sessionModel.reset).to.have.been.calledOnce
+      })
+
+      it('should redirect correctly', function() {
+        expect(res.redirect).to.have.been.calledOnce
+        expect(res.redirect).to.have.been.calledWith('/allocation/123')
+      })
+    })
+
+    context('unhappy path', function() {
+      const errorMock = new Error('500!')
+
+      beforeEach(async function() {
+        sinon.stub(allocationService, 'cancel').throws(errorMock)
+        await controller.successHandler(req, res, nextSpy)
+      })
+
+      it('should call next with the error', function() {
+        expect(nextSpy).to.be.calledWith(errorMock)
+      })
+    })
+  })
+})

--- a/app/allocation/controllers/index.js
+++ b/app/allocation/controllers/index.js
@@ -1,3 +1,4 @@
+const CancelController = require('./cancel')
 const AllocationCriteriaController = require('./create/allocation-criteria')
 const AllocationDetailsController = require('./create/allocation-details')
 const Save = require('./create/save')
@@ -7,7 +8,10 @@ const createControllers = {
   AllocationDetailsController,
   Save,
 }
-
+const cancelControllers = {
+  CancelController,
+}
 module.exports = {
+  cancelControllers,
   createControllers,
 }

--- a/app/allocation/controllers/view.js
+++ b/app/allocation/controllers/view.js
@@ -3,8 +3,15 @@ const presenters = require('../../../common/presenters')
 module.exports = function view(req, res) {
   const { allocation } = res.locals
   const { moves } = allocation
+  const bannerStatuses = ['cancelled']
   const locals = {
     dashboardUrl: '/allocations',
+    /* eslint-disable indent */
+    messageTitle: bannerStatuses.includes(allocation.status)
+      ? req.t(`allocations::statuses.${allocation.status}`)
+      : undefined,
+    /* eslint-enable indent */
+    messageContent: req.t('allocations::statuses.description'),
     allocationDetails: presenters.allocationToMetaListComponent(allocation),
     allocationSummary: presenters.allocationToSummaryListComponent(allocation),
     allocationPeople: {

--- a/app/allocation/controllers/view.test.js
+++ b/app/allocation/controllers/view.test.js
@@ -3,102 +3,142 @@ const presenters = require('../../../common/presenters')
 const handler = require('./view')
 
 describe('view allocation', function() {
-  let locals
-  let render
-  let output
-  beforeEach(function() {
-    sinon.stub(presenters, 'allocationToMetaListComponent').returns({})
-    sinon.stub(presenters, 'allocationToSummaryListComponent').returns({})
-    render = sinon.stub()
-    locals = {
-      allocation: {
-        id: '06464fbd-b78a-4e47-b65c-8ab3c3867196',
-        type: 'allocations',
-        moves_count: 22,
-        date: '2020-05-06',
-        prisoner_category: 'c',
-        sentence_length: 'long',
-        complex_cases: [
-          {
-            title: 'Segregated prisoners',
-            answer: true,
-          },
-          {
-            title: 'Self harm / prisoners on ACCT',
-            answer: true,
-          },
-          {
-            title: 'Mental health issues',
-            answer: false,
-          },
-          {
-            title: 'Integrated Drug Treatment System',
-            answer: false,
-          },
-        ],
-        complete_in_full: false,
-        other_criteria: 'no',
-        created_at: '2020-05-01T10:44:00+01:00',
-        updated_at: '2020-05-01T10:44:00+01:00',
-        from_location: {
-          title: 'BERWYN (HMP)',
-          location_type: 'prison',
-        },
-        to_location: {
-          title: 'GARTREE (HMP)',
-          location_type: 'prison',
-        },
-        moves: [
-          {},
-          {},
-          {
-            person: {
-              first_names: 'John',
-              last_name: 'Doe',
-            },
-          },
-        ],
+  const allocationExample = {
+    id: '06464fbd-b78a-4e47-b65c-8ab3c3867196',
+    type: 'allocations',
+    moves_count: 22,
+    date: '2020-05-06',
+    prisoner_category: 'c',
+    sentence_length: 'long',
+    complex_cases: [
+      {
+        title: 'Segregated prisoners',
+        answer: true,
       },
-    }
-    handler(
+      {
+        title: 'Self harm / prisoners on ACCT',
+        answer: true,
+      },
+      {
+        title: 'Mental health issues',
+        answer: false,
+      },
+      {
+        title: 'Integrated Drug Treatment System',
+        answer: false,
+      },
+    ],
+    complete_in_full: false,
+    other_criteria: 'no',
+    created_at: '2020-05-01T10:44:00+01:00',
+    updated_at: '2020-05-01T10:44:00+01:00',
+    from_location: {
+      title: 'BERWYN (HMP)',
+      location_type: 'prison',
+    },
+    to_location: {
+      title: 'GARTREE (HMP)',
+      location_type: 'prison',
+    },
+    moves: [
+      {},
       {},
       {
-        locals,
-        render,
-      }
-    )
-    output = render.firstCall.lastArg
-  })
-  it('creates allocationDetails on locals with the result of the correct presenter', function() {
-    expect(output.allocationDetails).to.exist
-    expect(
-      presenters.allocationToMetaListComponent
-    ).to.have.been.calledOnceWithExactly(locals.allocation)
-  })
-  it('creates allocationSummary on locals with the result of the correct presenter', function() {
-    expect(output.allocationSummary).to.exist
-    expect(
-      presenters.allocationToSummaryListComponent
-    ).to.have.been.calledOnceWithExactly(locals.allocation)
-  })
-  it('calls render with the template', function() {
-    expect(render).to.have.been.calledWithExactly('allocation/views/view', {
-      allocationDetails: {},
-      allocationSummary: {},
-      allocationPeople: {
-        emptySlots: 2,
-        filledSlots: [
-          {
-            href: undefined,
-            image_alt: 'JOHN DOE',
-            image_path: undefined,
-            meta: { items: [] },
-            tags: { items: [] },
-            title: { text: 'JOHN DOE' },
-          },
-        ],
+        person: {
+          first_names: 'John',
+          last_name: 'Doe',
+        },
       },
-      dashboardUrl: '/allocations',
+    ],
+  }
+
+  context('Active allocation', function() {
+    let locals
+    let render
+    let output
+    beforeEach(function() {
+      sinon.stub(presenters, 'allocationToMetaListComponent').returns({})
+      sinon.stub(presenters, 'allocationToSummaryListComponent').returns({})
+      render = sinon.stub()
+      locals = { allocation: { ...allocationExample } }
+      handler(
+        {
+          t: sinon.stub().returnsArg(0),
+        },
+        {
+          locals,
+          render,
+        }
+      )
+      output = render.firstCall.lastArg
+    })
+    it('creates allocationDetails on locals with the result of the correct presenter', function() {
+      expect(output.allocationDetails).to.exist
+      expect(
+        presenters.allocationToMetaListComponent
+      ).to.have.been.calledOnceWithExactly(locals.allocation)
+    })
+    it('creates allocationSummary on locals with the result of the correct presenter', function() {
+      expect(output.allocationSummary).to.exist
+      expect(
+        presenters.allocationToSummaryListComponent
+      ).to.have.been.calledOnceWithExactly(locals.allocation)
+    })
+    it('does not create a message banner if the status is not cancelled', function() {
+      expect(output.messageTitle).to.be.undefined
+    })
+    it('calls render with the template', function() {
+      expect(render).to.have.been.calledWithExactly('allocation/views/view', {
+        allocationDetails: {},
+        allocationSummary: {},
+        allocationPeople: {
+          emptySlots: 2,
+          filledSlots: [
+            {
+              href: undefined,
+              image_alt: 'JOHN DOE',
+              image_path: undefined,
+              meta: { items: [] },
+              tags: { items: [] },
+              title: { text: 'JOHN DOE' },
+            },
+          ],
+        },
+        messageContent: 'allocations::statuses.description',
+        messageTitle: undefined,
+        dashboardUrl: '/allocations',
+      })
+    })
+  })
+  context('Cancelled allocation', function() {
+    let locals
+    let render
+    let output
+    beforeEach(function() {
+      sinon.stub(presenters, 'allocationToMetaListComponent').returns({})
+      sinon.stub(presenters, 'allocationToSummaryListComponent').returns({})
+      render = sinon.stub()
+      locals = { allocation: { ...allocationExample } }
+      locals.allocation.status = 'cancelled'
+      handler(
+        {
+          t: sinon.stub().returnsArg(0),
+        },
+        {
+          locals,
+          render,
+        }
+      )
+      output = render.firstCall.lastArg
+    })
+    it('does create a message banner title if the status is cancelled', function() {
+      expect(output.messageTitle).not.to.be.undefined
+      expect(output.messageTitle).to.equal('allocations::statuses.cancelled')
+    })
+    it('does create a message banner content if the status is cancelled', function() {
+      expect(output.messageContent).to.equal(
+        'allocations::statuses.description'
+      )
     })
   })
 })

--- a/app/allocation/index.js
+++ b/app/allocation/index.js
@@ -6,9 +6,9 @@ const { protectRoute } = require('../../common/middleware/permissions')
 
 const confirmation = require('./controllers/create/confirmation')
 const view = require('./controllers/view')
-const { createFields } = require('./fields')
+const { cancelFields, createFields } = require('./fields')
 const { setAllocation } = require('./middleware')
-const { createSteps } = require('./steps')
+const { cancelSteps, createSteps } = require('./steps')
 
 const wizardConfig = {
   controller: FormWizardController,
@@ -35,6 +35,21 @@ router.get(
   confirmation
 )
 router.get('/:allocationId', protectRoute('allocations:view'), view)
+const cancelConfig = {
+  ...wizardConfig,
+  controller: FormWizardController,
+  name: 'cancel-an-allocation',
+  templatePath: 'allocation/views/cancel/',
+  template: '../../../form-wizard',
+  journeyName: 'cancel-an-allocation',
+  journeyPageTitle: 'actions::cancel_allocation',
+}
+router.use(
+  '/:allocationId/cancel',
+  protectRoute('allocation:create'),
+  wizard(cancelSteps, cancelFields, cancelConfig)
+)
+
 // Export
 module.exports = {
   router,

--- a/app/allocation/steps/cancel.js
+++ b/app/allocation/steps/cancel.js
@@ -1,0 +1,15 @@
+const { cancelControllers } = require('../controllers')
+
+module.exports = {
+  '/': {
+    entryPoint: true,
+    reset: true,
+    resetJourney: true,
+    skip: true,
+    next: 'reason',
+  },
+  '/reason': {
+    controller: cancelControllers.CancelController,
+    pageTitle: 'allocations::allocation_cancel_reasons.page_title',
+  },
+}

--- a/app/allocation/steps/index.js
+++ b/app/allocation/steps/index.js
@@ -1,5 +1,7 @@
+const cancelSteps = require('./cancel')
 const createSteps = require('./create')
 
 module.exports = {
+  cancelSteps,
   createSteps,
 }

--- a/app/allocation/views/view.njk
+++ b/app/allocation/views/view.njk
@@ -18,6 +18,20 @@
   </a>
 
   {{ super() }}
+
+  {% if messageTitle %}
+    {{ appMessage({
+      allowDismiss: false,
+      classes: "app-message--temporary",
+      title: {
+        text: messageTitle
+      },
+      content: {
+        text: messageContent
+      }
+    }) }}
+  {% endif %}
+
 {% endblock %}
 
 {% block contentHeader %}
@@ -79,6 +93,14 @@
     {{ appCard(slot) }}
   {% endfor %}
 
+
+  {% if allocation.status != "cancelled" %}
+    <p class="govuk-!-margin-top-9 govuk-!-margin-bottom-0">
+      <a href="{{ allocation.id }}/cancel" class="app-link--destructive">
+        {{ t("actions::cancel_allocation") }}
+      </a>
+    </p>
+  {%- endif %}
 {% endblock %}
 
 {% block contentSidebar %}

--- a/app/allocations/middleware.js
+++ b/app/allocations/middleware.js
@@ -1,5 +1,5 @@
 const { format } = require('date-fns')
-const { cloneDeep, isEqual, mapValues } = require('lodash')
+const { mapValues } = require('lodash')
 const queryString = require('query-string')
 
 const {
@@ -9,17 +9,6 @@ const {
 } = require('../../common/helpers/date-utils')
 const presenters = require('../../common/presenters')
 const allocationService = require('../../common/services/allocation')
-
-const allocationTypeNavigationConfig = [
-  {
-    label: 'allocations::complete',
-    filter: { complete_in_full: true },
-  },
-  {
-    label: 'allocations::incomplete',
-    filter: { complete_in_full: false },
-  },
-]
 
 // TODO: refactor this to be common with the /moves pagination.
 //  It differs only in the output of the url
@@ -49,14 +38,14 @@ function setPagination(req, res, next) {
   next()
 }
 async function setAllocationsSummary(req, res, next) {
-  const { dateRange } = req.params
-  const value = await allocationService.getCount({ dateRange })
+  const { dateRange } = res.locals
+  const allocationsCount = await allocationService.getCount({ dateRange })
   res.locals.allocationsSummary = [
     {
       active: false,
-      label: req.t('allocations::dashboard.labels.single_requests'),
+      label: req.t('allocations::dashboard.labels.allocations'),
       href: `/allocations/week/${getDateFromParams(req)}/outgoing`,
-      value,
+      value: allocationsCount,
     },
   ]
   next()
@@ -72,66 +61,18 @@ async function setAllocationsByDateAndFilter(req, res, next) {
   })
   next()
 }
-function getAllocationTypeMetadata(params, allocationType) {
-  const { baseUrl, dateRange, period, date, currentFilter } = params
-  return allocationService
-    .getCount({ dateRange, additionalFilters: allocationType.filter })
-    .then(count => {
-      return {
-        ...allocationType,
-        value: count,
-        active: isEqual(allocationType.filter, currentFilter),
-        href: `${baseUrl}/${period}/${date}/outgoing?${queryString.stringify(
-          allocationType.filter
-        )}`,
-      }
-    })
-}
-function addTotalAllocationsToFilter(
-  allocationTypes,
-  { baseUrl, period, date, currentFilter }
-) {
-  const totalAllocationItem = {
-    label: 'allocations::total',
-    filter: null,
-    value: allocationTypes.reduce((accumulator, item) => {
-      return (accumulator += item.value)
-    }, 0),
-    active: isEqual({}, currentFilter),
-    href: `${baseUrl}/${period}/${date}/outgoing`,
-  }
-  return [totalAllocationItem, ...allocationTypes]
-}
 async function setAllocationTypeNavigation(req, res, next) {
-  const { baseUrl } = req
-  const { dateRange, locationId, period, date } = req.params
-  const currentFilter = queryString.parse(req._parsedOriginalUrl.query, {
-    parseBooleans: true,
-  })
+  const { dateRange } = res.locals
   try {
-    res.locals.allocationTypeNavigation = await Promise.all(
-      cloneDeep(allocationTypeNavigationConfig).map(
-        getAllocationTypeMetadata.bind(null, {
-          baseUrl,
-          dateRange,
-          locationId,
-          period,
-          date,
-          currentFilter,
-        })
-      )
-    ).then(allocationTypes => {
-      const allocationTypesWithTotal = addTotalAllocationsToFilter(
-        allocationTypes,
-        {
-          baseUrl,
-          period,
-          date,
-          currentFilter,
-        }
-      )
-      return allocationTypesWithTotal.map(presenters.moveTypesToFilterComponent)
-    })
+    const count = await allocationService.getCount({ dateRange })
+    res.locals.allocationTypeNavigation = [
+      {
+        label: 'allocations::total',
+        filter: null,
+        value: count,
+        active: false,
+      },
+    ].map(presenters.moveTypesToFilterComponent)
     next()
   } catch (error) {
     next(error)
@@ -142,7 +83,5 @@ module.exports = {
   setPagination,
   setAllocationsSummary,
   setAllocationsByDateAndFilter,
-  getAllocationTypeMetadata,
-  addTotalAllocationsToFilter,
   setAllocationTypeNavigation,
 }

--- a/common/lib/api-client/models.js
+++ b/common/lib/api-client/models.js
@@ -43,7 +43,7 @@ module.exports = {
         jsonApi: 'hasMany',
         type: 'events',
       },
-      allocations: {
+      allocation: {
         jsonApi: 'hasOne',
         type: 'allocations',
       },

--- a/common/lib/api-client/models.js
+++ b/common/lib/api-client/models.js
@@ -222,6 +222,7 @@ module.exports = {
       other_criteria: '',
       created_at: '',
       updated_at: '',
+      status: '',
       moves: {
         jsonApi: 'hasMany',
         type: 'moves',
@@ -248,7 +249,6 @@ module.exports = {
       event_name: '',
       timestamp: '',
       notes: '',
-      cancel_reason: '',
       to_location: {
         jsonApi: 'hasOne',
         type: 'locations',

--- a/common/lib/api-client/models.js
+++ b/common/lib/api-client/models.js
@@ -43,6 +43,10 @@ module.exports = {
         jsonApi: 'hasMany',
         type: 'events',
       },
+      allocations: {
+        jsonApi: 'hasOne',
+        type: 'allocations',
+      },
     },
   },
   image: {
@@ -222,6 +226,10 @@ module.exports = {
         jsonApi: 'hasMany',
         type: 'moves',
       },
+      events: {
+        jsonApi: 'hasMany',
+        type: 'events',
+      },
     },
   },
   allocation_complex_case: {
@@ -240,6 +248,7 @@ module.exports = {
       event_name: '',
       timestamp: '',
       notes: '',
+      cancel_reason: '',
       to_location: {
         jsonApi: 'hasOne',
         type: 'locations',

--- a/common/lib/permissions.js
+++ b/common/lib/permissions.js
@@ -58,6 +58,8 @@ const ocaPermissions = [
   'move:create:prison_transfer',
 ]
 const pmuPermissions = [
+  'allocations:view',
+  'allocation:create',
   'dashboard:view',
   'locations:all',
   'moves:view:proposed',

--- a/common/lib/user.test.js
+++ b/common/lib/user.test.js
@@ -230,6 +230,8 @@ describe('User class', function() {
 
       it('should contain correct permission', function() {
         expect(permissions).to.deep.equal([
+          'allocations:view',
+          'allocation:create',
           'dashboard:view',
           'locations:all',
           'moves:view:proposed',
@@ -270,6 +272,8 @@ describe('User class', function() {
 
       it('should contain correct permission', function() {
         const allPermissions = [
+          'allocation:create',
+          'allocations:view',
           'moves:view:outgoing',
           'moves:download',
           'move:review',

--- a/common/presenters/allocations-to-table.js
+++ b/common/presenters/allocations-to-table.js
@@ -42,13 +42,6 @@ const tableConfig = [
       text: data => filters.formatDate(data.date),
     },
   },
-  {
-    head: 'allocations::progress',
-    // todo: this field does not exist yet and it might end up having a different name or format
-    row: {
-      text: 'progress',
-    },
-  },
 ]
 
 function allocationsToTable(allocations) {

--- a/common/presenters/allocations-to-table.test.js
+++ b/common/presenters/allocations-to-table.test.js
@@ -119,10 +119,6 @@ describe('#allocationsToTable', function() {
         text: '3 May 2020',
       })
     })
-    xit('returns progress on the sixth cell', function() {
-      // define this when we have agreed on this field's format
-      expect(output.rowsForAllocationTable[0][5]).to.deep.equal()
-    })
     it('returns one head row with all the cells', function() {
       expect(output.headerForAllocationTable).to.deep.equal([
         {
@@ -139,9 +135,6 @@ describe('#allocationsToTable', function() {
         },
         {
           text: 'date',
-        },
-        {
-          text: 'allocations::progress',
         },
       ])
     })

--- a/common/services/allocation.js
+++ b/common/services/allocation.js
@@ -1,3 +1,4 @@
+const dateFunctions = require('date-fns')
 const { mapKeys, mapValues } = require('lodash')
 
 const apiClient = require('../lib/api-client')()
@@ -8,6 +9,17 @@ function urlKeyToFilter(additionalFilters) {
   })
 }
 const allocationService = {
+  cancel(allocationId) {
+    const timestamp = dateFunctions.formatISO(new Date())
+    return apiClient
+      .one('allocation', allocationId)
+      .all('event')
+      .post({
+        event_name: 'cancel',
+        timestamp,
+      })
+      .then(response => response.data)
+  },
   format(data) {
     const booleansAndNulls = ['complete_in_full', 'sentence_length']
     const relationships = ['to_location', 'from_location']

--- a/common/services/allocation.test.js
+++ b/common/services/allocation.test.js
@@ -1,6 +1,30 @@
 const apiClient = require('../lib/api-client')()
 
 const allocationService = require('./allocation')
+describe('cancel', function() {
+  let outcome
+  beforeEach(async function() {
+    sinon.stub(apiClient, 'post').resolves({
+      data: {
+        events: [],
+      },
+    })
+    sinon.spy(apiClient, 'one')
+    sinon.spy(apiClient, 'all')
+    outcome = await allocationService.cancel('123')
+  })
+  it('calls the service to post an event', function() {
+    expect(apiClient.post).to.have.been.calledOnceWithExactly({
+      event_name: 'cancel',
+      timestamp: sinon.match.string,
+    })
+  })
+  it('returns the data', function() {
+    expect(outcome).to.deep.equal({
+      events: [],
+    })
+  })
+})
 describe('format', function() {
   let output
   beforeEach(function() {

--- a/locales/en/allocations.json
+++ b/locales/en/allocations.json
@@ -1,7 +1,11 @@
 {
   "dashboard": {
     "heading": "Allocations",
-    "labels": { "single_requests": "single requests" },
+    "labels": {
+      "single_requests": "single requests",
+      "pending": "pending",
+      "allocations": "allocations"
+    },
     "no_results": "No allocations found"
   },
   "complete": "complete",

--- a/locales/en/allocations.json
+++ b/locales/en/allocations.json
@@ -61,5 +61,9 @@
   },
   "allocation_cancel_reasons": {
     "page_title": "Are you sure you want to cancel this allocation?"
+  },
+  "statuses": {
+    "cancelled": "Allocation cancelled",
+    "description": "Reason — Allocation was cancelled"
   }
 }

--- a/locales/en/allocations.json
+++ b/locales/en/allocations.json
@@ -18,8 +18,7 @@
   "progress": "Progress",
   "confirmation": {
     "page_title": "Allocation requested",
-    "detail":
-      "The request for {{moves_count}} {{people}} from {{from_location}} to {{to_location}} on {{date}} has been sent",
+    "detail": "The request for {{moves_count}} {{people}} from {{from_location}} to {{to_location}} on {{date}} has been sent",
     "view_all": "View all allocations",
     "view_by_from_location": "View {{from_location}} overview"
   },
@@ -59,5 +58,8 @@
       "move_to": "Move to",
       "date": "Date"
     }
+  },
+  "allocation_cancel_reasons": {
+    "page_title": "Are you sure you want to cancel this allocation?"
   }
 }

--- a/locales/en/fields.json
+++ b/locales/en/fields.json
@@ -277,5 +277,18 @@
   "complex_cases": {
     "label": "Prisoners with complex cases",
     "hint": "Complex cases must be discussed with the receiving prison. This includes:"
+  },
+  "cancel_allocation_reason": {
+    "label": "Why do you want to cancel this allocation?",
+    "items": {
+      "error": "Made in error",
+      "error_hint": "For example, there’s a mistake or the allocation no longer needs to move",
+      "supplier_declined": "Supplier declined to complete this allocation",
+      "supplier_declined_hint": "For example, the request was made late",
+      "lack_of_space": "Lack of space at receiving establishment",
+      "unfilled": "Sending establishment failed to fill allocation",
+      "other": "Another reason",
+      "details": "Give details"
+    }
   }
 }

--- a/test/fixtures/api-client/allocation.findAll.json
+++ b/test/fixtures/api-client/allocation.findAll.json
@@ -27,6 +27,9 @@
           "type": "locations"
         }
       },
+      "events": {
+        "data": []
+      },
       "moves": {
         "data": [
           {

--- a/test/fixtures/api-client/allocation.findAll.json
+++ b/test/fixtures/api-client/allocation.findAll.json
@@ -11,7 +11,8 @@
       "complete_in_full": false,
       "other_criteria": null,
       "created_at": "2020-05-12T09:59:09+01:00",
-      "updated_at": "2020-05-12T09:59:09+01:00"
+      "updated_at": "2020-05-12T09:59:09+01:00",
+      "status": ""
     },
     "relationships": {
       "from_location": {

--- a/test/fixtures/api-client/event.create.json
+++ b/test/fixtures/api-client/event.create.json
@@ -5,7 +5,8 @@
     "attributes": {
       "event_name": "redirect",
       "timestamp": "2020-05-01T11:33:00+01:00",
-      "notes": "requested by Alex"
+      "notes": "requested by Alex",
+      "cancel_reason": ""
     },
     "relationships": {
       "to_location": {

--- a/test/fixtures/api-client/move.find.json
+++ b/test/fixtures/api-client/move.find.json
@@ -64,7 +64,8 @@
       },
       "events": {
         "data": []
-      }
+      },
+      "allocation": {}
     }
   },
   "included": [

--- a/test/fixtures/api-client/move.findAll.json
+++ b/test/fixtures/api-client/move.findAll.json
@@ -65,7 +65,8 @@
         },
         "events": {
           "data": []
-        }
+        },
+        "allocation": {}
       }
     },
     {
@@ -125,7 +126,8 @@
         },
         "events": {
           "data": []
-        }
+        },
+        "allocation": {}
       }
     },
     {
@@ -175,7 +177,8 @@
         },
         "events": {
           "data": []
-        }
+        },
+        "allocation": {}
       }
     },
     {
@@ -243,7 +246,8 @@
         },
         "events": {
           "data": []
-        }
+        },
+        "allocation": {}
       }
     },
     {
@@ -293,7 +297,8 @@
         },
         "events": {
           "data": []
-        }
+        },
+        "allocation": {}
       }
     },
     {
@@ -361,7 +366,8 @@
         },
         "events": {
           "data": []
-        }
+        },
+        "allocation": {}
       }
     },
     {
@@ -421,7 +427,8 @@
         },
         "events": {
           "data": []
-        }
+        },
+        "allocation": {}
       }
     },
     {
@@ -471,7 +478,8 @@
         },
         "events": {
           "data": []
-        }
+        },
+        "allocation": {}
       }
     },
     {
@@ -539,7 +547,8 @@
         },
         "events": {
           "data": []
-        }
+        },
+        "allocation": {}
       }
     },
     {
@@ -599,7 +608,8 @@
         },
         "events": {
           "data": []
-        }
+        },
+        "allocation": {}
       }
     },
     {
@@ -667,7 +677,8 @@
         },
         "events": {
           "data": []
-        }
+        },
+        "allocation": {}
       }
     },
     {
@@ -717,7 +728,8 @@
         },
         "events": {
           "data": []
-        }
+        },
+        "allocation": {}
       }
     },
     {
@@ -777,7 +789,8 @@
         },
         "events": {
           "data": []
-        }
+        },
+        "allocation": {}
       }
     },
     {
@@ -827,7 +840,8 @@
         },
         "events": {
           "data": []
-        }
+        },
+        "allocation": {}
       }
     },
     {
@@ -887,7 +901,8 @@
         },
         "events": {
           "data": []
-        }
+        },
+        "allocation": {}
       }
     },
     {
@@ -955,7 +970,8 @@
         },
         "events": {
           "data": []
-        }
+        },
+        "allocation": {}
       }
     },
     {
@@ -1023,7 +1039,8 @@
         },
         "events": {
           "data": []
-        }
+        },
+        "allocation": {}
       }
     },
     {
@@ -1073,7 +1090,8 @@
         },
         "events": {
           "data": []
-        }
+        },
+        "allocation": {}
       }
     },
     {
@@ -1141,7 +1159,8 @@
         },
         "events": {
           "data": []
-        }
+        },
+        "allocation": {}
       }
     },
     {
@@ -1209,7 +1228,8 @@
         },
         "events": {
           "data": []
-        }
+        },
+        "allocation": {}
       }
     }
   ],


### PR DESCRIPTION
This PR contains the redirection of the PMU users to a (temporary?) dashboard, and add the cancellation journey to the allocation view, without specifying a reason yet.

Upon logging in, the PMU user is presented with this dashboard:

<img width="743" alt="Screenshot 2020-05-18 at 12 48 58" src="https://user-images.githubusercontent.com/853989/82212573-aa0e2d80-990a-11ea-8fc9-c5ca2951e939.png">

Clicking on "Allocations" (the single request links does not go anywhere for now):
<img width="756" alt="Screenshot 2020-05-18 at 12 49 20" src="https://user-images.githubusercontent.com/853989/82212662-cca04680-990a-11ea-97be-4ab0f830245a.png">

The single view has now the cancel link:
<img width="684" alt="Screenshot 2020-05-18 at 12 49 35" src="https://user-images.githubusercontent.com/853989/82212693-d9bd3580-990a-11ea-9b80-eb2328e81ce4.png">

Intermediate page that will contain the reason, when it's supported by the BE:
<img width="749" alt="Screenshot 2020-05-18 at 12 49 44" src="https://user-images.githubusercontent.com/853989/82212721-e93c7e80-990a-11ea-9731-12d43a433ef9.png">

Confirmation:
<img width="750" alt="Screenshot 2020-05-18 at 12 53 37" src="https://user-images.githubusercontent.com/853989/82212739-f22d5000-990a-11ea-9ce2-3bd455d0d7cf.png">




### Checklist

- [x] If adding new environment variables, they have been documented in the [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md)
- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
