### PR TITLE
Allow PMU users to view all single requests

### DIFF
--- a/app/allocations/middleware.js
+++ b/app/allocations/middleware.js
@@ -5,7 +5,7 @@ const queryString = require('query-string')
 const {
   dateFormat,
   getDateFromParams,
-  getPeriod,
+  getRelativeDate,
 } = require('../../common/helpers/date-utils')
 const presenters = require('../../common/presenters')
 const allocationService = require('../../common/services/allocation')
@@ -30,8 +30,8 @@ function setPagination(req, res, next) {
   const baseDate = getDateFromParams(req)
   const interval = period === 'week' ? 7 : 1
 
-  const previousPeriod = getPeriod(baseDate, -interval)
-  const nextPeriod = getPeriod(baseDate, interval)
+  const previousPeriod = getRelativeDate(baseDate, -interval)
+  const nextPeriod = getRelativeDate(baseDate, interval)
   const viewInUrl = view ? `${view}` : ''
 
   const urlPeriods = {

--- a/app/locations/middleware.js
+++ b/app/locations/middleware.js
@@ -24,7 +24,7 @@ function setLocation(req, res, next) {
 function setAllLocations(req, res, next) {
   const { permissions = [] } = req.session.user || {}
 
-  if (!permissions.includes('moves:view:all')) {
+  if (!permissions.includes('locations:all')) {
     return next()
   }
 

--- a/app/locations/middleware.test.js
+++ b/app/locations/middleware.test.js
@@ -234,7 +234,7 @@ describe('Locations middleware', function() {
     context('when locationId is found in user locations', function() {
       beforeEach(function() {
         req.session.user = {
-          permissions: ['moves:view:all'],
+          permissions: ['locations:all'],
         }
 
         middleware.setAllLocations(req, {}, nextSpy)

--- a/app/locations/views/locations.njk
+++ b/app/locations/views/locations.njk
@@ -15,8 +15,8 @@
     </h1>
   </header>
 
-  {% if locations | length %}
-    {% if canAccess("moves:view:all") %}
+  {% if locations | length or canAccess("locations:all") %}
+    {% if canAccess("locations:all") %}
       <p class="govuk-list govuk-!-font-size-24 govuk-!-font-weight-bold">
         <a href="/locations/all">{{ t("locations::view_all_locations") }}</a>
       </p>

--- a/app/move/index.js
+++ b/app/move/index.js
@@ -63,7 +63,11 @@ router.use(
   wizard(createSteps, createFields, createConfig)
 )
 router.get('/:moveId', protectRoute('move:view'), view)
-router.get('/:moveId/confirmation', protectRoute('move:create'), confirmation)
+router.get(
+  '/:moveId/confirmation',
+  protectRoute(['move:create', 'move:review']),
+  confirmation
+)
 router.use(
   '/:moveId/cancel',
   protectRoute('move:cancel'),

--- a/app/moves/constants.js
+++ b/app/moves/constants.js
@@ -1,17 +1,30 @@
 const { setPagination } = require('./middleware')
 
-const CONSTANTS = {
-  DEFAULTS: {
-    QUERY: {
-      requested: { status: 'pending' },
-      outgoing: {},
-    },
-    TIME_PERIOD: {
-      requested: 'week',
-      outgoing: 'day',
-    },
+const uuidRegex =
+  '[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}'
+const dateRegex = '[0-9]{4}-[0-9]{2}-[0-9]{2}'
+
+const MOUNTPATH = '/moves'
+const COLLECTION_BASE_PATH = `/:period(week|day)/:date(${dateRegex})/:locationId(${uuidRegex})?`
+const COLLECTION_VIEW_PATH = '/:view(outgoing|requested)'
+const COLLECTION_MIDDLEWARE = [
+  setPagination(MOUNTPATH + COLLECTION_BASE_PATH + COLLECTION_VIEW_PATH),
+]
+const DEFAULTS = {
+  QUERY: {
+    requested: { status: 'pending' },
+    outgoing: {},
   },
-  COLLECTION_MIDDLEWARE: [setPagination],
+  TIME_PERIOD: {
+    requested: 'week',
+    outgoing: 'day',
+  },
 }
 
-module.exports = CONSTANTS
+module.exports = {
+  COLLECTION_BASE_PATH,
+  COLLECTION_MIDDLEWARE,
+  COLLECTION_VIEW_PATH,
+  DEFAULTS,
+  MOUNTPATH,
+}

--- a/app/moves/constants.js
+++ b/app/moves/constants.js
@@ -1,3 +1,5 @@
+const { setPagination } = require('./middleware')
+
 const CONSTANTS = {
   DEFAULTS: {
     QUERY: {
@@ -9,6 +11,7 @@ const CONSTANTS = {
       outgoing: 'day',
     },
   },
+  COLLECTION_MIDDLEWARE: [setPagination],
 }
 
 module.exports = CONSTANTS

--- a/app/moves/controllers/list-as-cards.js
+++ b/app/moves/controllers/list-as-cards.js
@@ -3,7 +3,7 @@ const { get } = require('lodash')
 const permissions = require('../../../common/middleware/permissions')
 
 module.exports = function listAsCards(req, res) {
-  const { params, resultsAsCards, session } = req
+  const { pagination, params, resultsAsCards, session } = req
   const userPermissions = get(session, 'user.permissions')
   const canViewMove = permissions.check('move:view', userPermissions)
   const template =
@@ -11,6 +11,7 @@ module.exports = function listAsCards(req, res) {
       ? 'moves/views/list-as-cards'
       : 'moves/views/download'
   const locals = {
+    pagination,
     resultsAsCards,
     pageTitle: 'moves::dashboard.outgoing_moves',
   }

--- a/app/moves/controllers/list-as-cards.test.js
+++ b/app/moves/controllers/list-as-cards.test.js
@@ -10,6 +10,10 @@ const mockCancelledMovesByDate = [
   { foo: 'bar', status: 'cancelled' },
   { fizz: 'buzz', status: 'cancelled' },
 ]
+const mockPagination = {
+  next: '/next',
+  prev: '/prev',
+}
 
 describe('Moves controllers', function() {
   describe('#listAsCards()', function() {
@@ -17,6 +21,7 @@ describe('Moves controllers', function() {
 
     beforeEach(function() {
       req = {
+        pagination: mockPagination,
         params: {},
         resultsAsCards: {
           active: mockActiveMovesByDate,
@@ -45,6 +50,17 @@ describe('Moves controllers', function() {
           active: mockActiveMovesByDate,
           cancelled: mockCancelledMovesByDate,
         })
+      })
+
+      it('should contain pagination property', function() {
+        const params = res.render.args[0][1]
+        expect(params).to.have.property('pagination')
+        expect(params.pagination).to.deep.equal(mockPagination)
+      })
+
+      it('should contain correct number of properties', function() {
+        const params = res.render.args[0][1]
+        expect(Object.keys(params)).to.have.length(3)
       })
     })
 

--- a/app/moves/controllers/list-as-table.js
+++ b/app/moves/controllers/list-as-table.js
@@ -1,11 +1,12 @@
 const { find, sumBy } = require('lodash')
 
 module.exports = function listAsTable(req, res) {
-  const { filter, resultsAsTable } = req
+  const { filter, pagination, resultsAsTable } = req
   const activeFilter = find(filter, { active: true }) || {}
 
   res.render('moves/views/list-as-table', {
     filter,
+    pagination,
     resultsAsTable,
     pageTitle: 'moves::dashboard.single_moves',
     activeContext: activeFilter.status,

--- a/app/moves/index.js
+++ b/app/moves/index.js
@@ -6,7 +6,13 @@ const viewRouter = require('express').Router({ mergeParams: true })
 const { setDateRange } = require('../../common/middleware')
 const { protectRoute } = require('../../common/middleware/permissions')
 
-const { COLLECTION_MIDDLEWARE, DEFAULTS } = require('./constants')
+const {
+  COLLECTION_MIDDLEWARE,
+  COLLECTION_BASE_PATH,
+  COLLECTION_VIEW_PATH,
+  DEFAULTS,
+  MOUNTPATH,
+} = require('./constants')
 const { download, listAsCards, listAsTable } = require('./controllers')
 const {
   redirectBaseUrl,
@@ -19,9 +25,6 @@ const {
   setResultsSingleRequests,
   setResultsOutgoing,
 } = require('./middleware')
-
-const uuidRegex =
-  '[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}'
 
 // Define param middleware
 router.param('locationId', setFromLocation)
@@ -62,14 +65,11 @@ viewRouter.get(
 )
 
 router.get('/', redirectBaseUrl)
-router.get('/:view(outgoing|requested)', redirectView(DEFAULTS.TIME_PERIOD))
-router.use(
-  `/:period(week|day)/:date([0-9]{4}-[0-9]{2}-[0-9]{2})/:locationId(${uuidRegex})?`,
-  viewRouter
-)
+router.get(COLLECTION_VIEW_PATH, redirectView(DEFAULTS.TIME_PERIOD))
+router.use(COLLECTION_BASE_PATH, viewRouter)
 
 // Export
 module.exports = {
   router,
-  mountpath: '/moves',
+  mountpath: MOUNTPATH,
 }

--- a/app/moves/middleware/set-pagination.js
+++ b/app/moves/middleware/set-pagination.js
@@ -1,34 +1,37 @@
 const { format } = require('date-fns')
 const { isEmpty } = require('lodash')
+const pathToRegexp = require('path-to-regexp')
 const querystring = require('qs')
 
-const { getPeriod } = require('../../../common/helpers/date-utils')
+const dateHelpers = require('../../../common/helpers/date-utils')
 const { DATE_FORMATS } = require('../../../config')
 
-function setPagination(req, res, next) {
-  const { date, locationId = '', period, view } = req.params
-  const today = format(new Date(), DATE_FORMATS.URL_PARAM)
-  const interval = period === 'week' ? 7 : 1
+function setPagination(route) {
+  return function handlePagination(req, res, next) {
+    const { baseUrl, params, path, query } = req
+    const { date, period } = params
+    const matched = pathToRegexp.match(route)(baseUrl + path)
 
-  const previousPeriod = getPeriod(date, -interval)
-  const nextPeriod = getPeriod(date, interval)
+    if (matched) {
+      const today = format(new Date(), DATE_FORMATS.URL_PARAM)
+      const interval = period === 'week' ? 7 : 1
+      const previousDate = dateHelpers.getRelativeDate(date, -interval)
+      const nextDate = dateHelpers.getRelativeDate(date, interval)
+      const compileUrl = pathToRegexp.compile(route)
+      const queryInUrl = !isEmpty(query)
+        ? `?${querystring.stringify(query)}`
+        : ''
 
-  const locationInUrl = locationId ? `/${locationId}` : ''
-  const queryInUrl = !isEmpty(req.query)
-    ? `?${querystring.stringify(req.query)}`
-    : ''
+      req.pagination = {
+        todayUrl: compileUrl({ ...matched.params, date: today }) + queryInUrl,
+        nextUrl: compileUrl({ ...matched.params, date: nextDate }) + queryInUrl,
+        prevUrl:
+          compileUrl({ ...matched.params, date: previousDate }) + queryInUrl,
+      }
+    }
 
-  res.locals.pagination = {
-    todayUrl: `${req.baseUrl}/${period}/${today}${locationInUrl}/${view +
-      queryInUrl}`,
-    nextUrl: `${req.baseUrl}/${period}/${nextPeriod}${locationInUrl}/${view +
-      queryInUrl}`,
-    prevUrl: `${
-      req.baseUrl
-    }/${period}/${previousPeriod}${locationInUrl}/${view + queryInUrl}`,
+    next()
   }
-
-  next()
 }
 
 module.exports = setPagination

--- a/app/moves/middleware/set-pagination.js
+++ b/app/moves/middleware/set-pagination.js
@@ -1,33 +1,22 @@
 const { format } = require('date-fns')
-const { isEmpty } = require('lodash')
-const pathToRegexp = require('path-to-regexp')
-const querystring = require('qs')
 
 const dateHelpers = require('../../../common/helpers/date-utils')
+const urlHelpers = require('../../../common/helpers/url')
 const { DATE_FORMATS } = require('../../../config')
 
 function setPagination(route) {
   return function handlePagination(req, res, next) {
-    const { baseUrl, params, path, query } = req
-    const { date, period } = params
-    const matched = pathToRegexp.match(route)(baseUrl + path)
+    const { date, period } = req.params
 
-    if (matched) {
-      const today = format(new Date(), DATE_FORMATS.URL_PARAM)
-      const interval = period === 'week' ? 7 : 1
-      const previousDate = dateHelpers.getRelativeDate(date, -interval)
-      const nextDate = dateHelpers.getRelativeDate(date, interval)
-      const compileUrl = pathToRegexp.compile(route)
-      const queryInUrl = !isEmpty(query)
-        ? `?${querystring.stringify(query)}`
-        : ''
+    const today = format(new Date(), DATE_FORMATS.URL_PARAM)
+    const interval = period === 'week' ? 7 : 1
+    const prevDate = dateHelpers.getRelativeDate(date, -interval)
+    const nextDate = dateHelpers.getRelativeDate(date, interval)
 
-      req.pagination = {
-        todayUrl: compileUrl({ ...matched.params, date: today }) + queryInUrl,
-        nextUrl: compileUrl({ ...matched.params, date: nextDate }) + queryInUrl,
-        prevUrl:
-          compileUrl({ ...matched.params, date: previousDate }) + queryInUrl,
-      }
+    req.pagination = {
+      todayUrl: urlHelpers.compileFromRoute(route, req, { date: today }),
+      nextUrl: urlHelpers.compileFromRoute(route, req, { date: nextDate }),
+      prevUrl: urlHelpers.compileFromRoute(route, req, { date: prevDate }),
     }
 
     next()

--- a/app/moves/middleware/set-pagination.test.js
+++ b/app/moves/middleware/set-pagination.test.js
@@ -1,4 +1,4 @@
-const pathToRegexp = require('path-to-regexp')
+const urlHelpers = require('../../../common/helpers/url')
 
 const middleware = require('./set-pagination')
 
@@ -7,21 +7,11 @@ describe('Moves middleware', function() {
     const mockToday = '2020-10-10'
     const mockDate = '2019-10-10'
     const mockRoute = '/moves/:date/:locationId?'
-    const mockMatch = {
-      params: {
-        date: '2020-10-10',
-        locationId: '12345',
-        view: 'requested',
-      },
-    }
 
-    let req, res, nextSpy, compileStub
+    let req, res, nextSpy
 
     beforeEach(function() {
-      compileStub = sinon.stub().callsFake(params => params.date)
-
-      sinon.stub(pathToRegexp, 'match')
-      sinon.stub(pathToRegexp, 'compile').callsFake(() => compileStub)
+      sinon.stub(urlHelpers, 'compileFromRoute').returnsArg(0)
       this.clock = sinon.useFakeTimers(new Date(mockToday).getTime())
       res = {}
       req = {
@@ -39,79 +29,44 @@ describe('Moves middleware', function() {
       this.clock.restore()
     })
 
-    context('with route', function() {
-      let matchStub
-
-      beforeEach(function() {
-        matchStub = sinon.stub().returns(false)
-        pathToRegexp.match.callsFake(() => matchStub)
-
-        middleware(mockRoute)(req, res, nextSpy)
-      })
-
-      it('should call match with route', function() {
-        expect(pathToRegexp.match).to.have.been.calledOnceWithExactly(mockRoute)
-      })
-
-      it('should combine base url and path to find a match', function() {
-        expect(matchStub).to.have.been.calledOnceWithExactly('/base-url/path')
-      })
-    })
-
-    context('when no matching route is found', function() {
-      beforeEach(function() {
-        pathToRegexp.match.callsFake(() => sinon.stub().returns(false))
-
-        middleware()(req, res, nextSpy)
-      })
-
-      it('should not set pagination on req', function() {
-        expect(req).not.to.have.property('pagination')
-      })
-
-      it('should call next', function() {
-        expect(nextSpy).to.have.been.calledOnceWithExactly()
-      })
-    })
-
     context('when matching route is found', function() {
-      beforeEach(function() {
-        pathToRegexp.match.callsFake(() => sinon.stub().returns(mockMatch))
-      })
-
       context('by default', function() {
         beforeEach(function() {
           middleware(mockRoute)(req, res, nextSpy)
         })
-
         it('should contain pagination on req', function() {
           expect(req).to.have.property('pagination')
         })
-
         it('should set today link', function() {
-          expect(compileStub).to.be.calledWithExactly({
-            ...mockMatch.params,
-            date: '2020-10-10',
-          })
-          expect(req.pagination.todayUrl).to.equal('2020-10-10')
+          expect(req.pagination.todayUrl).to.equal(mockRoute)
+          expect(urlHelpers.compileFromRoute).to.be.calledWithExactly(
+            mockRoute,
+            req,
+            {
+              date: '2020-10-10',
+            }
+          )
         })
-
         it('should set next link', function() {
-          expect(compileStub).to.be.calledWithExactly({
-            ...mockMatch.params,
-            date: '2019-10-11',
-          })
-          expect(req.pagination.nextUrl).to.equal('2019-10-11')
+          expect(req.pagination.nextUrl).to.equal(mockRoute)
+          expect(urlHelpers.compileFromRoute).to.be.calledWithExactly(
+            mockRoute,
+            req,
+            {
+              date: '2019-10-11',
+            }
+          )
         })
-
         it('should set previous link', function() {
-          expect(compileStub).to.be.calledWithExactly({
-            ...mockMatch.params,
-            date: '2019-10-09',
-          })
-          expect(req.pagination.prevUrl).to.equal('2019-10-09')
+          expect(req.pagination.prevUrl).to.equal(mockRoute)
+          expect(urlHelpers.compileFromRoute).to.be.calledWithExactly(
+            mockRoute,
+            req,
+            {
+              date: '2019-10-09',
+            }
+          )
         })
-
         it('should call next', function() {
           expect(nextSpy).to.be.calledOnceWithExactly()
         })
@@ -122,35 +77,39 @@ describe('Moves middleware', function() {
           req.params.period = 'day'
           middleware(mockRoute)(req, res, nextSpy)
         })
-
         it('should contain pagination on req', function() {
           expect(req).to.have.property('pagination')
         })
-
         it('should set today link', function() {
-          expect(compileStub).to.be.calledWithExactly({
-            ...mockMatch.params,
-            date: '2020-10-10',
-          })
-          expect(req.pagination.todayUrl).to.equal('2020-10-10')
+          expect(req.pagination.todayUrl).to.equal(mockRoute)
+          expect(urlHelpers.compileFromRoute).to.be.calledWithExactly(
+            mockRoute,
+            req,
+            {
+              date: '2020-10-10',
+            }
+          )
         })
-
         it('should set next link', function() {
-          expect(compileStub).to.be.calledWithExactly({
-            ...mockMatch.params,
-            date: '2019-10-11',
-          })
-          expect(req.pagination.nextUrl).to.equal('2019-10-11')
+          expect(req.pagination.nextUrl).to.equal(mockRoute)
+          expect(urlHelpers.compileFromRoute).to.be.calledWithExactly(
+            mockRoute,
+            req,
+            {
+              date: '2019-10-11',
+            }
+          )
         })
-
         it('should set previous link', function() {
-          expect(compileStub).to.be.calledWithExactly({
-            ...mockMatch.params,
-            date: '2019-10-09',
-          })
-          expect(req.pagination.prevUrl).to.equal('2019-10-09')
+          expect(req.pagination.prevUrl).to.equal(mockRoute)
+          expect(urlHelpers.compileFromRoute).to.be.calledWithExactly(
+            mockRoute,
+            req,
+            {
+              date: '2019-10-09',
+            }
+          )
         })
-
         it('should call next', function() {
           expect(nextSpy).to.be.calledOnceWithExactly()
         })
@@ -161,87 +120,42 @@ describe('Moves middleware', function() {
           req.params.period = 'week'
           middleware(mockRoute)(req, res, nextSpy)
         })
-
         it('should contain pagination on req', function() {
           expect(req).to.have.property('pagination')
         })
-
         it('should set today link', function() {
-          expect(req.pagination.todayUrl).to.equal('2020-10-10')
-          expect(compileStub).to.be.calledWithExactly({
-            ...mockMatch.params,
-            date: '2020-10-10',
-          })
+          expect(req.pagination.todayUrl).to.equal(mockRoute)
+          expect(urlHelpers.compileFromRoute).to.be.calledWithExactly(
+            mockRoute,
+            req,
+            {
+              date: '2020-10-10',
+            }
+          )
         })
-
         it('should set next link', function() {
-          expect(req.pagination.nextUrl).to.equal('2019-10-17')
-          expect(compileStub).to.be.calledWithExactly({
-            ...mockMatch.params,
-            date: '2019-10-17',
-          })
+          expect(req.pagination.nextUrl).to.equal(mockRoute)
+          expect(urlHelpers.compileFromRoute).to.be.calledWithExactly(
+            mockRoute,
+            req,
+            {
+              date: '2019-10-17',
+            }
+          )
         })
-
         it('should set previous link', function() {
-          expect(req.pagination.prevUrl).to.equal('2019-10-03')
-          expect(compileStub).to.be.calledWithExactly({
-            ...mockMatch.params,
-            date: '2019-10-03',
-          })
+          expect(req.pagination.prevUrl).to.equal(mockRoute)
+          expect(urlHelpers.compileFromRoute).to.be.calledWithExactly(
+            mockRoute,
+            req,
+            {
+              date: '2019-10-03',
+            }
+          )
         })
-
         it('should call next', function() {
           expect(nextSpy).to.be.calledOnceWithExactly()
         })
-      })
-    })
-
-    context('with query', function() {
-      beforeEach(function() {
-        pathToRegexp.match.callsFake(() => sinon.stub().returns(mockMatch))
-        req.query = {
-          status: 'approved',
-          foo: 'bar',
-        }
-        middleware(mockRoute)(req, res, nextSpy)
-      })
-
-      it('should contain pagination on req', function() {
-        expect(req).to.have.property('pagination')
-      })
-
-      it('should set today link', function() {
-        expect(req.pagination.todayUrl).to.equal(
-          '2020-10-10?status=approved&foo=bar'
-        )
-        expect(compileStub).to.be.calledWithExactly({
-          ...mockMatch.params,
-          date: '2020-10-10',
-        })
-      })
-
-      it('should set next link', function() {
-        expect(req.pagination.nextUrl).to.equal(
-          '2019-10-11?status=approved&foo=bar'
-        )
-        expect(compileStub).to.be.calledWithExactly({
-          ...mockMatch.params,
-          date: '2019-10-11',
-        })
-      })
-
-      it('should set previous link', function() {
-        expect(req.pagination.prevUrl).to.equal(
-          '2019-10-09?status=approved&foo=bar'
-        )
-        expect(compileStub).to.be.calledWithExactly({
-          ...mockMatch.params,
-          date: '2019-10-09',
-        })
-      })
-
-      it('should call next', function() {
-        expect(nextSpy).to.be.calledOnceWithExactly()
       })
     })
   })

--- a/common/helpers/date-utils.js
+++ b/common/helpers/date-utils.js
@@ -13,7 +13,7 @@ const { DATE_FORMATS } = require('../../config/index')
 
 module.exports = {
   dateFormat: DATE_FORMATS.URL_PARAM,
-  getPeriod: (date, interval) => {
+  getRelativeDate: (date, interval) => {
     const method = interval >= 0 ? addDays : subDays
     return format(
       method(parseISO(date), Math.abs(interval)),

--- a/common/helpers/date-utils.test.js
+++ b/common/helpers/date-utils.test.js
@@ -1,6 +1,6 @@
 const {
   dateFormat,
-  getPeriod,
+  getRelativeDate,
   getDateFromParams,
   getDateRange,
 } = require('./date-utils')
@@ -12,12 +12,12 @@ describe('Date helpers', function() {
       expect(dateFormat).to.equal('yyyy-MM-dd')
     })
   })
-  describe('#getPeriod', function() {
+  describe('#getRelativeDate', function() {
     it('invoked with a negative number, returns the date minus the days specified', function() {
-      expect(getPeriod('2010-01-02', -7)).to.equal('2009-12-26')
+      expect(getRelativeDate('2010-01-02', -7)).to.equal('2009-12-26')
     })
     it('invoked with a positive number, returns the date plus the days specified', function() {
-      expect(getPeriod('2010-01-02', 7)).to.equal('2010-01-09')
+      expect(getRelativeDate('2010-01-02', 7)).to.equal('2010-01-09')
     })
   })
   describe('#getDateFromParams', function() {

--- a/common/helpers/index.js
+++ b/common/helpers/index.js
@@ -1,9 +1,11 @@
 const dateUtil = require('./date-utils')
 const field = require('./field')
 const referenceData = require('./reference-data')
+const url = require('./url')
 
 module.exports = {
   dateUtil,
   field,
   referenceData,
+  url,
 }

--- a/common/helpers/url.js
+++ b/common/helpers/url.js
@@ -1,0 +1,21 @@
+const { isEmpty } = require('lodash')
+const pathToRegexp = require('path-to-regexp')
+const querystring = require('qs')
+
+function compileFromRoute(route, req = {}, overrides = {}) {
+  const { baseUrl, path, query } = req
+  const matched = pathToRegexp.match(route)(baseUrl + path)
+
+  if (!matched) {
+    return ''
+  }
+
+  const compileUrl = pathToRegexp.compile(route)
+  const queryInUrl = !isEmpty(query) ? `?${querystring.stringify(query)}` : ''
+
+  return compileUrl({ ...matched.params, ...overrides }) + queryInUrl
+}
+
+module.exports = {
+  compileFromRoute,
+}

--- a/common/helpers/url.test.js
+++ b/common/helpers/url.test.js
@@ -1,0 +1,154 @@
+const pathToRegexp = require('path-to-regexp')
+
+const helpers = require('./url')
+
+describe('URL Helpers', function() {
+  describe('#compileFromRoute()', function() {
+    const mockRoute = '/moves/:date/:locationId?'
+    const mockMatch = {
+      params: {
+        date: '2020-10-10',
+        locationId: '12345',
+        view: 'requested',
+      },
+    }
+    let compileStub, matchStub, req, output
+
+    beforeEach(function() {
+      matchStub = sinon.stub().returns(false)
+      compileStub = sinon.stub().returns('/compiled/url')
+      sinon
+        .stub(pathToRegexp, 'match')
+        .callsFake(() => sinon.stub().returns(false))
+      sinon.stub(pathToRegexp, 'compile').callsFake(() => compileStub)
+
+      req = {
+        baseUrl: '/base-url',
+        path: '/path',
+        query: {},
+        params: {},
+      }
+    })
+
+    context('without args', function() {
+      beforeEach(function() {
+        output = helpers.compileFromRoute()
+      })
+
+      it('should return empty string', function() {
+        expect(output).to.equal('')
+      })
+    })
+
+    context('with args', function() {
+      context('when no matching route is found', function() {
+        beforeEach(function() {
+          pathToRegexp.match.callsFake(() => sinon.stub().returns(false))
+
+          output = helpers.compileFromRoute(mockRoute, req)
+        })
+
+        it('should return empty string', function() {
+          expect(output).to.equal('')
+        })
+      })
+
+      context('when matching route is found', function() {
+        beforeEach(function() {
+          matchStub = sinon.stub().returns(mockMatch)
+          pathToRegexp.match.callsFake(() => matchStub)
+        })
+
+        context('by default', function() {
+          beforeEach(function() {
+            output = helpers.compileFromRoute(mockRoute, req)
+          })
+
+          it('should combine base url and path to find a match', function() {
+            expect(matchStub).to.have.been.calledOnceWithExactly(
+              '/base-url/path'
+            )
+          })
+
+          it('should call match with route', function() {
+            expect(pathToRegexp.match).to.have.been.calledOnceWithExactly(
+              mockRoute
+            )
+          })
+
+          it('should call compile with correct args', function() {
+            expect(compileStub).to.be.calledWithExactly(mockMatch.params)
+          })
+
+          it('should return a url', function() {
+            expect(output).to.equal('/compiled/url')
+          })
+        })
+
+        context('with overrides', function() {
+          beforeEach(function() {
+            output = helpers.compileFromRoute(mockRoute, req, {
+              date: '2018-01-01',
+              foo: 'bar',
+            })
+          })
+
+          it('should combine base url and path to find a match', function() {
+            expect(matchStub).to.have.been.calledOnceWithExactly(
+              '/base-url/path'
+            )
+          })
+
+          it('should call match with route', function() {
+            expect(pathToRegexp.match).to.have.been.calledOnceWithExactly(
+              mockRoute
+            )
+          })
+
+          it('should call compile with overrides', function() {
+            expect(compileStub).to.be.calledWithExactly({
+              ...mockMatch.params,
+              date: '2018-01-01',
+              foo: 'bar',
+            })
+          })
+
+          it('should return a url', function() {
+            expect(output).to.equal('/compiled/url')
+          })
+        })
+
+        context('with query', function() {
+          beforeEach(function() {
+            req.query = {
+              status: 'approved',
+              foo: 'bar',
+            }
+
+            output = helpers.compileFromRoute(mockRoute, req)
+          })
+
+          it('should combine base url and path to find a match', function() {
+            expect(matchStub).to.have.been.calledOnceWithExactly(
+              '/base-url/path'
+            )
+          })
+
+          it('should call match with route', function() {
+            expect(pathToRegexp.match).to.have.been.calledOnceWithExactly(
+              mockRoute
+            )
+          })
+
+          it('should call compile with overrides', function() {
+            expect(compileStub).to.be.calledWithExactly(mockMatch.params)
+          })
+
+          it('should return a url with query', function() {
+            expect(output).to.equal('/compiled/url?status=approved&foo=bar')
+          })
+        })
+      })
+    })
+  })
+})

--- a/common/lib/permissions.js
+++ b/common/lib/permissions.js
@@ -35,7 +35,7 @@ if (FEATURE_FLAGS.EDITABILITY) {
 }
 
 const supplierPermissions = [
-  'moves:view:all',
+  'locations:all',
   'moves:view:outgoing',
   'moves:download',
   'move:view',

--- a/common/lib/permissions.js
+++ b/common/lib/permissions.js
@@ -59,9 +59,10 @@ const ocaPermissions = [
 ]
 const pmuPermissions = [
   'dashboard:view',
-  'allocations:view',
-  'allocation:create',
+  'locations:all',
+  'moves:view:proposed',
   'move:review',
+  'move:view',
 ]
 
 const permissionsByRole = {

--- a/common/lib/user.test.js
+++ b/common/lib/user.test.js
@@ -245,7 +245,7 @@ describe('User class', function() {
 
       it('should contain correct permission', function() {
         expect(permissions).to.deep.equal([
-          'moves:view:all',
+          'locations:all',
           'moves:view:outgoing',
           'moves:download',
           'move:view',
@@ -277,7 +277,7 @@ describe('User class', function() {
           'move:create:court_appearance',
           'move:create:prison_recall',
           'move:cancel',
-          'moves:view:all',
+          'locations:all',
           'dashboard:view',
           'moves:view:proposed',
           'move:create:prison_transfer',

--- a/common/lib/user.test.js
+++ b/common/lib/user.test.js
@@ -231,9 +231,10 @@ describe('User class', function() {
       it('should contain correct permission', function() {
         expect(permissions).to.deep.equal([
           'dashboard:view',
-          'allocations:view',
-          'allocation:create',
+          'locations:all',
+          'moves:view:proposed',
           'move:review',
+          'move:view',
         ])
       })
     })
@@ -281,8 +282,6 @@ describe('User class', function() {
           'dashboard:view',
           'moves:view:proposed',
           'move:create:prison_transfer',
-          'allocations:view',
-          'allocation:create',
         ]
         if (FEATURE_FLAGS.EDITABILITY) {
           allPermissions.push('move:update')

--- a/common/middleware/permissions.js
+++ b/common/middleware/permissions.js
@@ -4,7 +4,7 @@ function check(permissions, userPermissions = []) {
   if (!Array.isArray(permissions)) {
     permissions = [permissions]
   }
-  return permissions.every(permission => userPermissions.includes(permission))
+  return permissions.some(permission => userPermissions.includes(permission))
 }
 
 function protectRoute(permission) {

--- a/common/middleware/permissions.test.js
+++ b/common/middleware/permissions.test.js
@@ -28,31 +28,37 @@ describe('Permissions middleware', function() {
       })
     })
 
-    describe('when multiple permissions are required', function() {
+    describe('when multiple permissions are possible', function() {
       let permit
+
       context('and all required permissions are missing', function() {
         beforeEach(function() {
           permit = middleware.check(['perm1', 'perm2'], ['permZ'])
         })
+
         it('should return false', function() {
           expect(permit).to.be.false
         })
       })
+
       context('and some of the required permissions are missing', function() {
         beforeEach(function() {
           permit = middleware.check(['perm1', 'perm2'], ['perm1', 'permZ'])
         })
-        it('should return false', function() {
-          expect(permit).to.be.false
+
+        it('should return true', function() {
+          expect(permit).to.be.true
         })
       })
-      context('and the required permissions exist', function() {
+
+      context('and all the required permissions exist', function() {
         beforeEach(function() {
           permit = middleware.check(
             ['perm1', 'perm2'],
             ['perm1', 'perm2', 'permZ']
           )
         })
+
         it('should return true', function() {
           expect(permit).to.be.true
         })
@@ -118,14 +124,14 @@ describe('Permissions middleware', function() {
       })
     })
 
-    describe('when there multiple permissions are required', function() {
-      context('and user does not have all required permissions', function() {
+    describe('when multiple permissions are possible', function() {
+      context('and user does not have any required permissions', function() {
         beforeEach(function() {
           req.session.user = {
-            permissions: ['user_permission_1', 'required_permission'],
+            permissions: ['user_permission_1', 'user_permission_2'],
           }
           middleware.protectRoute([
-            'required_permission',
+            'required_permission_1',
             'required_permission_2',
           ])(req, {}, nextSpy)
         })
@@ -135,22 +141,41 @@ describe('Permissions middleware', function() {
           expect(nextSpy).to.be.calledOnce
           expect(error).to.be.an.instanceOf(Error)
           expect(error.message).to.equal(
-            "Forbidden. Missing permission: 'required_permission,required_permission_2'"
+            "Forbidden. Missing permission: 'required_permission_1,required_permission_2'"
           )
           expect(error.statusCode).to.equal(403)
+        })
+      })
+
+      context('and user has some of the required permissions', function() {
+        beforeEach(function() {
+          req.session.user = {
+            permissions: ['user_permission_1', 'required_permission_1'],
+          }
+          middleware.protectRoute([
+            'required_permission_1',
+            'required_permission_2',
+          ])(req, {}, nextSpy)
+        })
+
+        it('should call next without error', function() {
+          expect(nextSpy).to.be.calledOnceWithExactly()
         })
       })
 
       context('and user has all required permissions', function() {
         beforeEach(function() {
           req.session.user = {
-            permissions: ['user_permission_1', 'required_permission'],
+            permissions: [
+              'user_permission_1',
+              'required_permission_1',
+              'required_permission_2',
+            ],
           }
-          middleware.protectRoute(['user_permission_1', 'required_permission'])(
-            req,
-            {},
-            nextSpy
-          )
+          middleware.protectRoute([
+            'required_permission_1',
+            'required_permission_2',
+          ])(req, {}, nextSpy)
         })
 
         it('should call next without error', function() {

--- a/common/templates/layouts/base.njk
+++ b/common/templates/layouts/base.njk
@@ -38,6 +38,8 @@
 {% block head %}
   <link rel="canonical" href="{{ CANONICAL_URL }}">
 
+  <meta name="location" content="{{ CURRENT_LOCATION.id }}">
+
   <!--[if lte IE 8]><link href="{{ getAssetPath('styles-ie8.css') }}" rel="stylesheet" type="text/css" /><![endif]-->
   <!--[if gt IE 8]><!--><link href="{{ getAssetPath('styles.css') }}" media="all" rel="stylesheet" type="text/css" /><!--<![endif]-->
 

--- a/common/templates/layouts/base.njk
+++ b/common/templates/layouts/base.njk
@@ -102,7 +102,7 @@
   {% endblock %}
 
   {% block organisationSwitcher %}
-    {% if CURRENT_LOCATION or canAccess("moves:view:all") %}
+    {% if CURRENT_LOCATION or canAccess("locations:all") %}
       <div class="govuk-width-container">
         {{ mojOrganisationSwitcher({
           text: CURRENT_LOCATION.title or t("locations::all_locations"),

--- a/package-lock.json
+++ b/package-lock.json
@@ -9925,6 +9925,11 @@
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         },
+        "path-to-regexp": {
+          "version": "0.1.7",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+          "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
+        },
         "qs": {
           "version": "6.7.0",
           "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
@@ -19475,9 +19480,9 @@
       "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
     },
     "path-to-regexp": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
-      "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.1.0.tgz",
+      "integrity": "sha512-h9DqehX3zZZDCEm+xbfU0ZmwCGFCAAraPJWMXJ4+v32NjZJilVg3k1TcKsRgIb8IQ/izZSaydDc1OhJCZvs2Dw=="
     },
     "path-type": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "multer": "1.4.2",
     "npm-run-all": "4.1.5",
     "nunjucks": "3.2.1",
+    "path-to-regexp": "6.1.0",
     "pluralize": "8.0.0",
     "qs": "6.9.4",
     "query-string": "6.12.1",

--- a/test/e2e/_move.js
+++ b/test/e2e/_move.js
@@ -38,14 +38,9 @@ export async function createMove(options = {}) {
   ) {
     await t.navigateTo(home)
 
-    const currentUrl = await page.getCurrentUrl()
-    const matched = currentUrl.match(
-      /([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})/
+    const currentLocation = await page.nodes.locationMeta.getAttribute(
+      'content'
     )
-    if (!matched) {
-      throw new Error('Could not determine current location')
-    }
-    const currentLocation = matched[0]
     t.ctx.from_location = currentLocation
 
     options.moveOverrides = {

--- a/test/e2e/pages/page.js
+++ b/test/e2e/pages/page.js
@@ -6,6 +6,7 @@ export default class Page {
   constructor() {
     this.baseUrl = E2E.BASE_URL
     this.nodes = {
+      locationMeta: Selector('meta').withAttribute('name', 'location'),
       appHeader: Selector('.app-header__logo').withExactText(
         'HMPPS Book a secure move'
       ),


### PR DESCRIPTION
## Proposed changes

This set of changes refactors and updates the permissions and routing for moves.

It allows OCA users to see single requests and makes the middleware more re-usable by other
parts of the application but using a configuration approach.

It also adds the correct permissions for Population Management Unit (PMU) users to see all
single requests for this MVP release.