### PR TITLE
fix(e2e): Update the tests for dashboards

### DIFF
--- a/app/moves/middleware/redirect-base-url.js
+++ b/app/moves/middleware/redirect-base-url.js
@@ -16,7 +16,7 @@ function redirectBaseUrl(req, res) {
     )
     const url =
       canViewProposedMoves && currentLocation.location_type === 'prison'
-        ? `${req.baseUrl}/week/${today}/${currentLocation.id}/`
+        ? `${req.baseUrl}/week/${today}/${currentLocation.id}/requested`
         : `${req.baseUrl}/day/${today}/${currentLocation.id}/outgoing`
     return res.redirect(url)
   }

--- a/app/moves/middleware/redirect-base-url.test.js
+++ b/app/moves/middleware/redirect-base-url.test.js
@@ -91,7 +91,7 @@ describe('Moves middleware', function() {
           })
           it('should redirect to the dashboard if the user can see them', function() {
             expect(res.redirect).to.have.been.calledOnceWithExactly(
-              `/moves/week/${mockMoveDate}/${mockLocation.id}/`
+              `/moves/week/${mockMoveDate}/${mockLocation.id}/requested`
             )
           })
         })

--- a/test/e2e/pages/dashboard.js
+++ b/test/e2e/pages/dashboard.js
@@ -8,9 +8,9 @@ class DashboardPage extends Page {
 
     this.nodes = {
       singleRequestsSection: Selector('h2')
-        .withText('Single requests this week')
+        .withText('Single requests sent this week')
         .parent('section'),
-      singleRequestsLink: Selector('a').withText('sent for review'),
+      singleRequestsLink: Selector('a').withText('pending review'),
     }
   }
 }

--- a/test/e2e/smoke.test.js
+++ b/test/e2e/smoke.test.js
@@ -5,7 +5,7 @@ import {
   supplierUser,
   ocaUser,
 } from './_roles'
-import { movesByDay } from './_routes'
+import { home, movesByDay } from './_routes'
 import { dashboardPage, page, movesDashboardPage } from './pages'
 
 const users = [
@@ -80,7 +80,7 @@ users.forEach(user => {
 
 usersWhoHaveADashboard.forEach(user => {
   test.before(async t => {
-    await t.useRole(user.role).navigateTo(movesByDay)
+    await t.useRole(user.role).navigateTo(home)
   })(`As ${user.name}`, async t => {
     await t
       .expect(page.nodes.appHeader.exists)


### PR DESCRIPTION
## Proposed changes

This fixes the issue with failing tests around users who have a
dashboard.

Previously the dashboard was nested within moves and expected some
redirects to take place. This udpates the tests to match the new
behaviour.