### PR TITLE
test: Increase the speed of the editability tests

### DIFF
--- a/test/e2e/move.update.forbidden.test.js
+++ b/test/e2e/move.update.forbidden.test.js
@@ -1,15 +1,35 @@
 import { FEATURE_FLAGS } from '../../config'
 
 import {
-  createPrisonMove,
-  createOcaMove,
-  createSupplierMove,
+  createCourtMove,
   checkNoUpdateLinks,
   checkUpdatePagesForbidden,
 } from './_move'
+import { prisonUser, ocaUser, supplierUser } from './_roles'
+import { home } from './_routes'
+
+const users = [
+  {
+    name: 'prison user',
+    role: prisonUser,
+  },
+  {
+    name: 'OCA user',
+    role: ocaUser,
+  },
+  {
+    name: 'supplier user',
+    role: supplierUser,
+  },
+]
 
 if (FEATURE_FLAGS.EDITABILITY) {
-  const checkUserCannotUpdate = () => {
+  users.forEach(user => {
+    fixture(`Existing move (As ${user.name})`).beforeEach(async t => {
+      await t.useRole(user.role).navigateTo(home)
+      await createCourtMove()
+    })
+
     test('User should not see any update links on move page', async () => {
       await checkNoUpdateLinks()
     })
@@ -17,20 +37,5 @@ if (FEATURE_FLAGS.EDITABILITY) {
     test('User should not be able to access move update pages', async () => {
       await checkUpdatePagesForbidden()
     })
-  }
-
-  fixture('Existing move - Prison user').beforeEach(async () => {
-    await createPrisonMove()
   })
-  checkUserCannotUpdate()
-
-  fixture('Existing move - OCA user').beforeEach(async () => {
-    await createOcaMove()
-  })
-  checkUserCannotUpdate()
-
-  fixture('Existing move - Supplier user').beforeEach(async () => {
-    await createSupplierMove()
-  })
-  checkUserCannotUpdate()
 }

--- a/test/e2e/move.update.police.test.js
+++ b/test/e2e/move.update.police.test.js
@@ -3,7 +3,7 @@ import { addDays, format } from 'date-fns'
 import { FEATURE_FLAGS } from '../../config'
 
 import {
-  createPoliceMove,
+  createCourtMove,
   checkUpdateLinks,
   checkUpdatePagesAccessible,
   checkPoliceNationalComputerReadOnly,
@@ -14,13 +14,16 @@ import {
   checkUpdateMoveDetails,
   checkUpdateMoveDate,
 } from './_move'
+import { policeUser } from './_roles'
+import { home, getMove } from './_routes'
 
 if (FEATURE_FLAGS.EDITABILITY) {
-  fixture('Existing move - Police user').beforeEach(async () => {
-    await createPoliceMove()
+  fixture('Existing move from Police Custody to Court').beforeEach(async t => {
+    await t.useRole(policeUser).navigateTo(home)
+    await createCourtMove()
   })
 
-  test('User should see expected update links on move page', async () => {
+  test('With existing PNC number', async t => {
     await checkUpdateLinks([
       'personal_details',
       'risk',
@@ -29,9 +32,23 @@ if (FEATURE_FLAGS.EDITABILITY) {
       'move',
       'date',
     ])
-  })
 
-  test('User should see be able to access update pages', async () => {
+    await checkPoliceNationalComputerReadOnly()
+
+    await t.navigateTo(getMove(t.ctx.move.id))
+    await checkUpdatePersonalDetails({
+      exclude: ['policeNationalComputer'],
+    })
+
+    await checkUpdateRiskInformation()
+    await checkUpdateHealthInformation()
+    await checkUpdateCourtInformation()
+    await checkUpdateMoveDetails()
+    await checkUpdateMoveDate()
+
+    const anotherDate = format(addDays(new Date(), 3), 'iiii d MMM yyyy')
+    await checkUpdateMoveDate(anotherDate)
+
     await checkUpdatePagesAccessible([
       'personal_details',
       'risk',
@@ -42,66 +59,29 @@ if (FEATURE_FLAGS.EDITABILITY) {
     ])
   })
 
-  test('User should not be able to edit PNC if it already exists', async t => {
-    await checkPoliceNationalComputerReadOnly()
-  })
-
-  test('User should be able to update other personal details', async () => {
-    await checkUpdatePersonalDetails({
-      exclude: ['policeNationalComputer'],
-    })
-  })
-
-  test.before(async () => {
-    await createPoliceMove({
+  test.before(async t => {
+    await t.useRole(policeUser).navigateTo(home)
+    await createCourtMove({
       personOverrides: {
         policeNationalComputer: undefined,
       },
     })
-  })(
-    'User should be able to update PNC if it does not already exist',
-    async t => {
-      await checkUpdatePersonalDetails({
-        include: ['policeNationalComputer'],
-      })
-    }
-  )
-
-  test('User should be able to update risk information', async () => {
-    await checkUpdateRiskInformation()
+  })('Without existing PNC number', async t => {
+    await checkUpdatePersonalDetails({
+      include: ['policeNationalComputer'],
+    })
   })
 
-  test('User should be able to update health information', async () => {
-    await checkUpdateHealthInformation()
-  })
-
-  test('User should be able to update court information', async () => {
-    await checkUpdateCourtInformation()
-  })
-
-  test('User should be able to update move details for a court appearance', async () => {
-    await checkUpdateMoveDetails()
-  })
-
-  test.before(async () => {
-    await createPoliceMove({
+  fixture.beforeEach(async t => {
+    await t.useRole(policeUser).navigateTo(home)
+    await createCourtMove({
       moveOverrides: {
         move_type: 'prison_recall',
       },
     })
-  })(
-    'User should be able to update move details for a prison recall',
-    async t => {
-      await checkUpdateMoveDetails()
-    }
-  )
+  })('Existing move from Police Custody to Prison (recall)')
 
-  test('User should be able to change move date to tomorrow', async () => {
-    await checkUpdateMoveDate()
-  })
-
-  test('User should be able to change move date to another date', async () => {
-    const anotherDate = format(addDays(new Date(), 3), 'iiii d MMM yyyy')
-    await checkUpdateMoveDate(anotherDate)
+  test('User should be able to update move details', async t => {
+    await checkUpdateMoveDetails()
   })
 }

--- a/test/e2e/move.update.stc.test.js
+++ b/test/e2e/move.update.stc.test.js
@@ -1,18 +1,23 @@
 import { FEATURE_FLAGS } from '../../config'
 
 import {
-  createStcMove,
+  createCourtMove,
   checkUpdateLinks,
   checkUpdatePagesAccessible,
   checkUpdateDocuments,
 } from './_move'
+import { stcUser } from './_roles'
+import { home } from './_routes'
 
 if (FEATURE_FLAGS.EDITABILITY) {
-  fixture('Existing move - STC User').beforeEach(async () => {
-    await createStcMove()
+  fixture(
+    'Existing move from Secure Training Centre (STC) to Court'
+  ).beforeEach(async t => {
+    await t.useRole(stcUser).navigateTo(home)
+    await createCourtMove()
   })
 
-  test('User should see expected update links on move page', async () => {
+  test('User should be able to update move', async () => {
     await checkUpdateLinks([
       'personal_details',
       'risk',
@@ -22,9 +27,9 @@ if (FEATURE_FLAGS.EDITABILITY) {
       'date',
       'document',
     ])
-  })
 
-  test('User should see be able to access update pages', async () => {
+    await checkUpdateDocuments()
+
     await checkUpdatePagesAccessible([
       'personal_details',
       'risk',
@@ -34,9 +39,5 @@ if (FEATURE_FLAGS.EDITABILITY) {
       'date',
       'document',
     ])
-  })
-
-  test('User should be able to update documents', async t => {
-    await checkUpdateDocuments()
   })
 }

--- a/test/e2e/pages/update-move.js
+++ b/test/e2e/pages/update-move.js
@@ -31,7 +31,7 @@ UpdateMovePage.gotoPersonalDetails = async () => {
 }
 
 UpdateMovePage.updatePersonalDetails = async options => {
-  const { person } = t.ctx
+  const { person } = t.ctx.move
   const updateMovePage = await UpdateMovePage.gotoPersonalDetails()
   const updatedFields = await updateMovePage.fillInPersonalDetails({}, options)
   const updatedDetails = { ...person, ...updatedFields }


### PR DESCRIPTION
This tries to reduce the need to create a new move for each editability
test in order to speed them up.

It also moves away from moves being created based on a user and their role
as this is a concept we have tried to stay away from. We can keep some
checks linked to roles based around permissions but when creating those
fixtures they shouldn't be tied to a person's role.