### PR TITLE
fix(allocations): Avoid formatting a person if  move has none associated

### DIFF
--- a/common/services/move.js
+++ b/common/services/move.js
@@ -51,7 +51,7 @@ const moveService = {
         if (!links.next) {
           return moves.map(move => ({
             ...move,
-            person: personService.transform(move.person),
+            person: move.person ? personService.transform(move.person) : {},
           }))
         }
 

--- a/common/services/move.test.js
+++ b/common/services/move.test.js
@@ -382,6 +382,34 @@ describe('Move Service', function() {
         })
       })
     })
+
+    context('with moves without associated person', function() {
+      const mockMoves = [
+        {
+          id: '12345',
+          status: 'requested',
+        },
+        {
+          id: '67890',
+          status: 'cancelled',
+        },
+      ]
+      let moves
+      beforeEach(async function() {
+        apiClient.findAll.resolves({
+          data: mockMoves,
+          links: {},
+        })
+        moves = await moveService.getAll()
+      })
+      it('does not call format', function() {
+        expect(personService.transform).to.not.have.been.called
+      })
+      it('returns an empty object instead of person', function() {
+        expect(moves[0].person).to.deep.equal({})
+        expect(moves[1].person).to.deep.equal({})
+      })
+    })
   })
 
   describe('#getRequested()', function() {


### PR DESCRIPTION
Currently, for every move listed, we format the person associated to it. However, we are moving towards supporting moves without people associated, for the allocations.
This causes in some cases the app to fail, as it's looking to extract properties from a null object.

### Checklist

- [x] If adding new environment variables, they have been documented in the [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md)
- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
