### PR TITLE
test(e2e): Add additional assertions to aid end-to-end tests

### DIFF
--- a/test/e2e/_roles.js
+++ b/test/e2e/_roles.js
@@ -6,38 +6,23 @@ import { home } from './_routes'
 import { page } from './pages'
 
 export const policeUser = Role(home, async t => {
-  await t
-    .typeText('#username', E2E.ROLES.POLICE.username)
-    .typeText('#password', E2E.ROLES.POLICE.password)
-    .pressKey('enter')
+  await page.signIn(E2E.ROLES.POLICE)
   await page.chooseLocation()
 })
 
 export const supplierUser = Role(home, async t => {
-  await t
-    .typeText('#username', E2E.ROLES.SUPPLIER.username)
-    .typeText('#password', E2E.ROLES.SUPPLIER.password)
-    .pressKey('enter')
+  await page.signIn(E2E.ROLES.SUPPLIER)
   await page.chooseLocation()
 })
 
 export const stcUser = Role(home, async t => {
-  await t
-    .typeText('#username', E2E.ROLES.STC.username)
-    .typeText('#password', E2E.ROLES.STC.password)
-    .pressKey('enter')
+  await page.signIn(E2E.ROLES.STC)
 })
 
 export const prisonUser = Role(home, async t => {
-  await t
-    .typeText('#username', E2E.ROLES.PRISON.username)
-    .typeText('#password', E2E.ROLES.PRISON.password)
-    .pressKey('enter')
+  await page.signIn(E2E.ROLES.PRISON)
 })
 
 export const ocaUser = Role(home, async t => {
-  await t
-    .typeText('#username', E2E.ROLES.OCA.username)
-    .typeText('#password', E2E.ROLES.OCA.password)
-    .pressKey('enter')
+  await page.signIn(E2E.ROLES.OCA)
 })

--- a/test/e2e/pages/create-move.js
+++ b/test/e2e/pages/create-move.js
@@ -1,3 +1,4 @@
+import { format } from 'date-fns'
 import faker from 'faker'
 import { omit, pick } from 'lodash'
 import pluralize from 'pluralize'
@@ -291,7 +292,7 @@ class CreateMovePage extends Page {
     return fillInForm({
       dateFrom: {
         selector: this.fields.dateFrom,
-        value: faker.date.future().toLocaleDateString(),
+        value: format(faker.date.future(), 'd/M/yyyy'),
       },
       hasDateTo: {
         selector: this.fields.hasDateTo,

--- a/test/e2e/pages/page.js
+++ b/test/e2e/pages/page.js
@@ -48,9 +48,35 @@ export default class Page {
    * @returns {Promise}
    */
   async chooseLocation() {
+    await t
+      .expect(this.getCurrentUrl())
+      .contains('/locations')
+      .expect(this.nodes.locationsList.count)
+      .notEql(0)
+
     const count = await this.nodes.locationsList.count
     const randomItem = Math.floor(Math.random() * count)
-    return t.click(this.nodes.locationsList.nth(randomItem))
+
+    return t
+      .click(this.nodes.locationsList.nth(randomItem))
+      .expect(this.getCurrentUrl())
+      .notContains('/locations')
+  }
+
+  /**
+   * Sign in using the auth service
+   *
+   * @returns {Promise}
+   */
+  signIn(role) {
+    return t
+      .expect(this.getCurrentUrl())
+      .contains('/auth/login')
+      .typeText('#username', role.username)
+      .typeText('#password', role.password)
+      .click(Selector('#submit'))
+      .expect(this.getCurrentUrl())
+      .notContains('/auth/login')
   }
 
   /**

--- a/test/e2e/pages/page.js
+++ b/test/e2e/pages/page.js
@@ -22,15 +22,7 @@ export default class Page {
         /\/locations\/.+/
       ),
     }
-  }
-
-  /**
-   * Return the current URL
-   *
-   * @returns {Promise<String>}
-   */
-  getCurrentUrl() {
-    return ClientFunction(() => window.location.href)()
+    this.getCurrentUrl = ClientFunction(() => window.location.href)
   }
 
   /**
@@ -52,15 +44,14 @@ export default class Page {
       .expect(this.getCurrentUrl())
       .contains('/locations')
       .expect(this.nodes.locationsList.count)
-      .notEql(0)
+      .notEql(0, { timeout: 15000 })
 
     const count = await this.nodes.locationsList.count
     const randomItem = Math.floor(Math.random() * count)
 
-    return t
-      .click(this.nodes.locationsList.nth(randomItem))
-      .expect(this.getCurrentUrl())
-      .notContains('/locations')
+    await t.click(this.nodes.locationsList.nth(randomItem))
+
+    await t.expect(this.getCurrentUrl()).notContains('/locations')
   }
 
   /**


### PR DESCRIPTION
## Proposed changes

The current suite of end-to-end tests can sometimes fail unexpectedly.

This change attempts to wrap the logic around signing in and choosing
a location with more assertions to see where things are consistently
going wrong.

Code suggestion from @solidgoldpig