### PR TITLE
chore(single requests): Add from location to table

### DIFF
--- a/common/presenters/single-requests-to-table-component.js
+++ b/common/presenters/single-requests-to-table-component.js
@@ -40,6 +40,14 @@ function singleRequestsToTable(moves) {
     },
     {
       head: {
+        text: i18n.t('moves::dashboard.move_from'),
+      },
+      row: {
+        text: 'from_location.title',
+      },
+    },
+    {
+      head: {
         text: i18n.t('moves::dashboard.move_to'),
       },
       row: {

--- a/common/presenters/single-requests-to-table-component.test.js
+++ b/common/presenters/single-requests-to-table-component.test.js
@@ -139,6 +139,7 @@ describe('#singleRequestsToTableComponent()', function() {
         },
       })
     })
+
     it('should call card component with correct arguments', function() {
       expect(moveToCardComponentOptsStub).to.be.calledWithExactly({
         isCompact: true,
@@ -146,32 +147,45 @@ describe('#singleRequestsToTableComponent()', function() {
       })
       expect(moveToCardComponentStub).to.be.calledWithExactly(mockMoves[0])
     })
+
     it('returns html with createdAt on the second cell', function() {
       expect(output.rows[0][1]).to.deep.equal({
         text: mockMoves[0].created_at,
       })
     })
-    it('returns toLocation on the third cell', function() {
+
+    it('returns fromLocation on the third cell', function() {
       expect(output.rows[0][2]).to.deep.equal({
+        text: mockMoves[0].from_location.title,
+      })
+    })
+
+    it('returns toLocation on the forth cell', function() {
+      expect(output.rows[0][3]).to.deep.equal({
         text: mockMoves[0].to_location.title,
       })
     })
-    it('returns the date range on the fourth cell', function() {
-      expect(output.rows[0][3]).to.deep.equal({
+
+    it('returns the date range on the fifth cell', function() {
+      expect(output.rows[0][4]).to.deep.equal({
         text: mockMoves[0].date_from,
       })
     })
-    it('returns the move type on the fifth cell', function() {
-      expect(output.rows[0][4]).to.deep.equal({
+
+    it('returns the move type on the sixth cell', function() {
+      expect(output.rows[0][5]).to.deep.equal({
         text: mockMoves[0].prison_transfer_reason.title,
       })
     })
+
     it('returns empty object with null prison transfer reason', function() {
-      expect(output.rows[1][4]).to.deep.equal({})
+      expect(output.rows[1][5]).to.deep.equal({})
     })
+
     it('returns a row per record', function() {
       expect(output.rows.length).to.equal(2)
     })
+
     it('returns one head row with all the cells', function() {
       expect(output.head).to.deep.equal([
         {
@@ -185,6 +199,9 @@ describe('#singleRequestsToTableComponent()', function() {
           attributes: {
             width: '120',
           },
+        },
+        {
+          text: 'moves::dashboard.move_from',
         },
         {
           text: 'moves::dashboard.move_to',

--- a/locales/en/moves.json
+++ b/locales/en/moves.json
@@ -109,16 +109,11 @@
     "single_moves_no_results_pending": "No single requests pending review",
     "single_moves_no_results_approved": "No single requests have been approved",
     "single_moves_no_results_rejected": "No single requests have been rejected",
+    "move_from": "Move from",
     "move_to": "Move to",
     "earliest_move_date": "Earliest date of travel",
     "created_at": "Sent on",
-    "move_type": "Move type",
-    "filter": {
-      "proposed": "pending review",
-      "approved": "approved",
-      "rejected": "rejected",
-      "total": "sent for review"
-    }
+    "move_type": "Move type"
   },
   "detail": {
     "page_title": "Move details for {{name}}",


### PR DESCRIPTION
## Proposed changes

Currently some users so a table with all locations. In the table view, it's hard to see where the different moves are coming from.

This change adds a column to display the location of the sending location.