### PR TITLE
fix(allocations): Display correct links in the confirmation page

### DIFF
--- a/app/allocation/views/confirmation.njk
+++ b/app/allocation/views/confirmation.njk
@@ -19,6 +19,7 @@
 
       <p>
         {{ t("allocations::confirmation.detail", {
+          href: '/allocation/' + allocation.id,
           moves_count: allocation.moves_count,
           from_location: allocation.from_location.title,
           to_location: allocation.to_location.title,
@@ -28,14 +29,8 @@
       </p>
 
       <p>
-        <a href="{{ ALLOCATIONS_URL }}">
+        <a href="/allocations">
           {{ t("allocations::confirmation.view_all") }}
-        </a>
-        <span> {{t("or")}} </span>
-        <a href="{{ ALLOCATIONS_URL }}">
-          {{ t("allocations::confirmation.view_by_from_location", {
-            from_location: allocation.from_location.title
-          }) }}
         </a>
       </p>
     </div>

--- a/locales/en/allocations.json
+++ b/locales/en/allocations.json
@@ -18,7 +18,7 @@
   "progress": "Progress",
   "confirmation": {
     "page_title": "Allocation requested",
-    "detail": "The request for {{moves_count}} {{people}} from {{from_location}} to {{to_location}} on {{date}} has been sent",
+    "detail": "The request for <a href=\"{{href}}\">{{moves_count}} {{people}}</a> from {{from_location}} to {{to_location}} on {{date}} has been sent",
     "view_all": "View all allocations",
     "view_by_from_location": "View {{from_location}} overview"
   },


### PR DESCRIPTION
As mentioned by @Andy-Millar :

- removed the link to the dashboard by region, since we don't have it yet
- fixed the link to the dashboard (might possibly need to be revisited after https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/pull/523 is merged)
- added the link to the single allocation
- as for the locations, there is no link because we don't have that view yet

<img width="699" alt="Screenshot 2020-05-19 at 10 21 40" src="https://user-images.githubusercontent.com/853989/82309251-d2edfb80-99ba-11ea-8213-dad5baa877a7.png">



### Checklist

- [x] If adding new environment variables, they have been documented in the [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md)
- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
