### PR TITLE
fix(allocations): Allow the cancellation to be called off

### DIFF
--- a/app/allocation/controllers/cancel.js
+++ b/app/allocation/controllers/cancel.js
@@ -2,6 +2,16 @@ const FormWizardController = require('../../../common/controllers/form-wizard')
 const allocationService = require('../../../common/services/allocation')
 
 class CancelController extends FormWizardController {
+  middlewareLocals() {
+    super.middlewareLocals()
+    this.use(this.setCancelUrl)
+  }
+
+  setCancelUrl(req, res, next) {
+    res.locals.cancelUrl = `/allocation/${res.locals.allocation.id}`
+    next()
+  }
+
   async successHandler(req, res, next) {
     const { id: allocationId } = res.locals.allocation
 

--- a/app/allocation/controllers/cancel.test.js
+++ b/app/allocation/controllers/cancel.test.js
@@ -1,3 +1,4 @@
+const ParentController = require('../../../common/controllers/form-wizard')
 const allocationService = require('../../../common/services/allocation')
 
 const CancelController = require('./cancel')
@@ -7,6 +8,52 @@ const mockAllocation = {
   id: '123',
 }
 describe('Cancel controller', function() {
+  describe('middlewareLocals', function() {
+    const use = sinon.stub()
+    const cancelUrlStub = sinon.stub()
+    beforeEach(function() {
+      sinon.stub(ParentController.prototype, 'middlewareLocals')
+      controller.middlewareLocals.call({
+        use,
+        router: {},
+        setCancelUrl: cancelUrlStub,
+      })
+    })
+    afterEach(function() {
+      use.resetHistory()
+    })
+    it('calls the parent middlewareLocals', function() {
+      expect(ParentController.prototype.middlewareLocals).to.have.been
+        .calledOnce
+    })
+    it('adds setCancelUrl to the middleware stack', function() {
+      expect(use).to.have.been.calledOnceWith(cancelUrlStub)
+    })
+  })
+  describe('setCancelUrl', function() {
+    let locals
+    const next = sinon.stub()
+    beforeEach(function() {
+      locals = {
+        allocation: {
+          id: '123',
+        },
+      }
+      next.resetHistory()
+      controller.setCancelUrl({}, { locals }, next)
+    })
+    it('sets the cancelUrl on locals', function() {
+      expect(locals).to.deep.equal({
+        allocation: {
+          id: '123',
+        },
+        cancelUrl: '/allocation/123',
+      })
+    })
+    it('calls next', function() {
+      expect(next).to.have.been.calledOnce
+    })
+  })
   describe('#successHandler()', function() {
     let req, res, nextSpy
 

--- a/app/allocation/steps/cancel.js
+++ b/app/allocation/steps/cancel.js
@@ -9,6 +9,7 @@ module.exports = {
     next: 'reason',
   },
   '/reason': {
+    template: 'cancel-reason',
     controller: cancelControllers.CancelController,
     pageTitle: 'allocations::allocation_cancel_reasons.page_title',
   },

--- a/app/allocation/views/cancel/cancel-reason.njk
+++ b/app/allocation/views/cancel/cancel-reason.njk
@@ -1,0 +1,10 @@
+{% extends "form-wizard.njk" %}
+
+{% block cancelAction %}
+  {% if cancelUrl %}
+    <a href="{{ cancelUrl }}" class="govuk-button govuk-button--text">
+      {{ t("actions::back_to_allocation") }}
+    </a>
+  {% endif %}
+{% endblock %}
+

--- a/locales/en/actions.json
+++ b/locales/en/actions.json
@@ -9,6 +9,7 @@
   "back": "Back",
   "back_to_dashboard": "$t(actions::back) to dashboard",
   "back_to_move": "$t(actions::back) to move",
+  "back_to_allocation": "$t(actions::back) to allocation",
   "request_move": "Request move",
   "send_for_review": "Send for review",
   "search": "Search",


### PR DESCRIPTION

<img width="691" alt="Screenshot 2020-05-19 at 17 23 16" src="https://user-images.githubusercontent.com/853989/82352215-8e338600-99f5-11ea-8c8c-216f1e9f18de.png">


This PR adds the link to cancel the cancellation, so to speak.



### Checklist

- [x] If adding new environment variables, they have been documented in the [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md)
- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
