### PR TITLE
fix(allocations): Allow the user to call off the cancellation

### DIFF
--- a/app/allocation/steps/cancel.js
+++ b/app/allocation/steps/cancel.js
@@ -9,7 +9,10 @@ module.exports = {
     next: 'reason',
   },
   '/reason': {
+    template: 'cancel-reason',
     controller: cancelControllers.CancelController,
     pageTitle: 'allocations::allocation_cancel_reasons.page_title',
+    buttonText: 'actions::cancel_move_confirmation',
+    buttonClasses: 'govuk-button--warning',
   },
 }

--- a/app/allocation/views/cancel/cancel-reason.njk
+++ b/app/allocation/views/cancel/cancel-reason.njk
@@ -1,0 +1,10 @@
+{% extends "form-wizard.njk" %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+    text: t("actions::back_to_allocation"),
+    href: "/allocation/" + allocation.id
+  }) }}
+
+  {{ super() }}
+{% endblock %}

--- a/locales/en/actions.json
+++ b/locales/en/actions.json
@@ -9,6 +9,7 @@
   "back": "Back",
   "back_to_dashboard": "$t(actions::back) to dashboard",
   "back_to_move": "$t(actions::back) to move",
+  "back_to_allocation": "$t(actions::back) to allocation",
   "request_move": "Request move",
   "send_for_review": "Send for review",
   "search": "Search",


### PR DESCRIPTION
<img width="720" alt="Screenshot 2020-05-19 at 17 56 53" src="https://user-images.githubusercontent.com/853989/82355624-609d0b80-99fa-11ea-8bc6-dd620bb327bc.png">

This change adds the red colour to the button and the "back to allocation" link to the cancel reasons page.

### Checklist

- [x] If adding new environment variables, they have been documented in the [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md)
- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
