### PR TITLE
fix(allocations): Pass status filter in api service

### DIFF
--- a/app/allocations/middleware/set-filter.allocations.js
+++ b/app/allocations/middleware/set-filter.allocations.js
@@ -8,7 +8,7 @@ function setfilterAllocations(items = []) {
   return async function buildFilter(req, res, next) {
     const promises = items.map(item =>
       allocationService
-        .getByDateAndLocation({
+        .getByDateLocationAndStatus({
           ...req.body.allocations,
           isAggregation: true,
           status: item.status,

--- a/app/allocations/middleware/set-filter.allocations.test.js
+++ b/app/allocations/middleware/set-filter.allocations.test.js
@@ -30,7 +30,7 @@ describe('Allocations middleware', function() {
 
       beforeEach(function() {
         sinon.stub(i18n, 't').returnsArg(0)
-        sinon.stub(allocationService, 'getByDateAndLocation').resolves(4)
+        sinon.stub(allocationService, 'getByDateLocationAndStatus').resolves(4)
         next = sinon.spy()
         req = {
           baseUrl: '/moves',
@@ -76,7 +76,7 @@ describe('Allocations middleware', function() {
 
         it('calls the servive with correct arguments', async function() {
           expect(
-            allocationService.getByDateAndLocation
+            allocationService.getByDateLocationAndStatus
           ).to.have.been.calledWithExactly({
             isAggregation: true,
             status: 'pending',
@@ -84,7 +84,7 @@ describe('Allocations middleware', function() {
             fromLocationId: mockLocationId,
           })
           expect(
-            allocationService.getByDateAndLocation
+            allocationService.getByDateLocationAndStatus
           ).to.have.been.calledWithExactly({
             isAggregation: true,
             status: 'approved',
@@ -92,7 +92,7 @@ describe('Allocations middleware', function() {
             fromLocationId: mockLocationId,
           })
           expect(
-            allocationService.getByDateAndLocation
+            allocationService.getByDateLocationAndStatus
           ).to.have.been.calledWithExactly({
             isAggregation: true,
             status: 'rejected',
@@ -102,7 +102,9 @@ describe('Allocations middleware', function() {
         })
 
         it('calls the service on each item', async function() {
-          expect(allocationService.getByDateAndLocation.callCount).to.equal(3)
+          expect(
+            allocationService.getByDateLocationAndStatus.callCount
+          ).to.equal(3)
         })
 
         it('calls next', function() {
@@ -200,7 +202,9 @@ describe('Allocations middleware', function() {
       const mockError = new Error('Error!')
 
       beforeEach(async function() {
-        sinon.stub(allocationService, 'getByDateAndLocation').rejects(mockError)
+        sinon
+          .stub(allocationService, 'getByDateLocationAndStatus')
+          .rejects(mockError)
         next = sinon.spy()
         req = {
           body: {},

--- a/app/allocations/middleware/set-results.allocations.js
+++ b/app/allocations/middleware/set-results.allocations.js
@@ -3,7 +3,7 @@ const allocationService = require('../../../common/services/allocation')
 
 async function setResultsAllocations(req, res, next) {
   try {
-    const allocations = await allocationService.getByDateAndLocation(
+    const allocations = await allocationService.getByDateLocationAndStatus(
       req.body.allocations
     )
 

--- a/app/allocations/middleware/set-results.allocations.test.js
+++ b/app/allocations/middleware/set-results.allocations.test.js
@@ -17,7 +17,7 @@ describe('Allocations middleware', function() {
     let next
 
     beforeEach(function() {
-      sinon.stub(allocationService, 'getByDateAndLocation')
+      sinon.stub(allocationService, 'getByDateLocationAndStatus')
       sinon.stub(presenters, 'allocationsToTable').returnsArg(0)
       next = sinon.stub()
       res = {}
@@ -34,13 +34,13 @@ describe('Allocations middleware', function() {
 
     context('when service resolves', function() {
       beforeEach(async function() {
-        allocationService.getByDateAndLocation.resolves(mockActiveMoves)
+        allocationService.getByDateLocationAndStatus.resolves(mockActiveMoves)
         await middleware(req, res, next)
       })
 
       it('should call the data service with request body', function() {
         expect(
-          allocationService.getByDateAndLocation
+          allocationService.getByDateLocationAndStatus
         ).to.have.been.calledOnceWithExactly({
           status: 'proposed',
           moveDate: ['2019-01-01', '2019-01-07'],
@@ -79,7 +79,7 @@ describe('Allocations middleware', function() {
       const mockError = new Error('Error!')
 
       beforeEach(async function() {
-        allocationService.getByDateAndLocation.rejects(mockError)
+        allocationService.getByDateLocationAndStatus.rejects(mockError)
         await middleware(req, res, next)
       })
 

--- a/common/services/allocation.js
+++ b/common/services/allocation.js
@@ -41,12 +41,14 @@ const allocationService = {
     fromLocationId,
     toLocationId,
     isAggregation = false,
+    status,
   } = {}) {
     const [moveDateFrom, moveDateTo] = moveDate
 
     return allocationService.getAll({
       isAggregation,
       filter: pickBy({
+        'filter[status]': status,
         'filter[from_locations]': fromLocationId,
         'filter[to_locations]': toLocationId,
         'filter[date_from]': moveDateFrom,

--- a/common/services/allocation.js
+++ b/common/services/allocation.js
@@ -36,7 +36,7 @@ const allocationService = {
       .create('allocation', allocationService.format(data))
       .then(response => response.data)
   },
-  getByDateAndLocation({
+  getByDateLocationAndStatus({
     moveDate = [],
     fromLocationId,
     toLocationId,

--- a/common/services/allocation.test.js
+++ b/common/services/allocation.test.js
@@ -312,10 +312,12 @@ describe('Allocation service', function() {
       const mockMoveDateRange = ['2019-10-10', '2019-10-11']
       const mockFromLocationId = 'b695d0f0-af8e-4b97-891e-92020d6820b9'
       const mockToLocationId = 'b195d0f0-df8e-4b97-891e-92020d6820b9'
+      const mockStatus = 'cancelled'
 
       context('with all arguments', function() {
         beforeEach(async function() {
           results = await allocationService.getByDateAndLocation({
+            status: mockStatus,
             moveDate: mockMoveDateRange,
             fromLocationId: mockFromLocationId,
             toLocationId: mockToLocationId,
@@ -328,6 +330,7 @@ describe('Allocation service', function() {
             filter: {
               'filter[date_from]': mockMoveDateRange[0],
               'filter[date_to]': mockMoveDateRange[1],
+              'filter[status]': mockStatus,
               'filter[from_locations]': mockFromLocationId,
               'filter[to_locations]': mockToLocationId,
             },

--- a/common/services/allocation.test.js
+++ b/common/services/allocation.test.js
@@ -284,7 +284,7 @@ describe('Allocation service', function() {
     })
   })
 
-  describe('#getByDateAndLocation()', function() {
+  describe('#getByDateLocationAndStatus()', function() {
     let results
 
     beforeEach(async function() {
@@ -293,7 +293,7 @@ describe('Allocation service', function() {
 
     context('without arguments', function() {
       beforeEach(async function() {
-        results = await allocationService.getByDateAndLocation()
+        results = await allocationService.getByDateLocationAndStatus()
       })
 
       it('should call getAll with default filter', function() {
@@ -316,7 +316,7 @@ describe('Allocation service', function() {
 
       context('with all arguments', function() {
         beforeEach(async function() {
-          results = await allocationService.getByDateAndLocation({
+          results = await allocationService.getByDateLocationAndStatus({
             status: mockStatus,
             moveDate: mockMoveDateRange,
             fromLocationId: mockFromLocationId,
@@ -344,7 +344,7 @@ describe('Allocation service', function() {
 
       context('with some arguments', function() {
         beforeEach(async function() {
-          results = await allocationService.getByDateAndLocation({
+          results = await allocationService.getByDateLocationAndStatus({
             fromLocationId: mockFromLocationId,
           })
         })
@@ -365,7 +365,7 @@ describe('Allocation service', function() {
 
       context('with aggregation', function() {
         beforeEach(async function() {
-          results = await allocationService.getByDateAndLocation({
+          results = await allocationService.getByDateLocationAndStatus({
             isAggregation: true,
             fromLocationId: mockFromLocationId,
           })


### PR DESCRIPTION
Currently we don't pass the status for the allocations in the filter that builds the dashboard, so even the cancelled allocations are displayed, which makes for an unsatisfying user experience upon cancelling.

It seems however that the api doesn't support yet this filter, so this fix will have to be accompanied by a corresponding one in the api.



### Checklist

- [x] If adding new environment variables, they have been documented in the [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md)
- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
