### PR TITLE
chore(permissions): Update permission for OCA and PMU users

### DIFF
--- a/app/allocation/index.js
+++ b/app/allocation/index.js
@@ -46,7 +46,7 @@ const cancelConfig = {
 }
 router.use(
   '/:allocationId/cancel',
-  protectRoute('allocation:create'),
+  protectRoute('allocation:cancel'),
   wizard(cancelSteps, cancelFields, cancelConfig)
 )
 

--- a/app/allocation/views/view.njk
+++ b/app/allocation/views/view.njk
@@ -94,7 +94,7 @@
   {% endfor %}
 
 
-  {% if allocation.status != "cancelled" %}
+  {% if canAccess("allocation:cancel") and allocation.status != "cancelled" %}
     <p class="govuk-!-margin-top-9 govuk-!-margin-bottom-0">
       <a href="{{ allocation.id }}/cancel" class="app-link--destructive">
         {{ t("actions::cancel_allocation") }}

--- a/common/lib/permissions.js
+++ b/common/lib/permissions.js
@@ -50,6 +50,7 @@ const prisonPermissions = [
 ]
 const ocaPermissions = [
   'dashboard:view',
+  'allocations:view',
   'moves:view:proposed',
   'moves:download',
   'move:view',
@@ -60,6 +61,7 @@ const ocaPermissions = [
 const pmuPermissions = [
   'allocations:view',
   'allocation:create',
+  'allocation:cancel',
   'dashboard:view',
   'locations:all',
   'moves:view:proposed',

--- a/common/lib/user.test.js
+++ b/common/lib/user.test.js
@@ -213,6 +213,7 @@ describe('User class', function() {
       it('should contain correct permission', function() {
         expect(permissions).to.deep.equal([
           'dashboard:view',
+          'allocations:view',
           'moves:view:proposed',
           'moves:download',
           'move:view',
@@ -232,6 +233,7 @@ describe('User class', function() {
         expect(permissions).to.deep.equal([
           'allocations:view',
           'allocation:create',
+          'allocation:cancel',
           'dashboard:view',
           'locations:all',
           'moves:view:proposed',
@@ -272,8 +274,9 @@ describe('User class', function() {
 
       it('should contain correct permission', function() {
         const allPermissions = [
-          'allocation:create',
           'allocations:view',
+          'allocation:create',
+          'allocation:cancel',
           'moves:view:outgoing',
           'moves:download',
           'move:review',


### PR DESCRIPTION
## Proposed changes

This updates the permissions to allow Operational Capacity Allocation (OCA) users to see allocations and to restrict cancelling an allocation to only Population Management Unit (PMU) users.