### PR TITLE
[P4 1276] e2e tests for cancel and create allocation

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -152,6 +152,10 @@ module.exports = {
         username: process.env.E2E_OCA_USERNAME,
         password: process.env.E2E_OCA_PASSWORD,
       },
+      PMU: {
+        username: process.env.E2E_PMU_USERNAME,
+        password: process.env.E2E_PMU_PASSWORD,
+      },
     },
   },
 }

--- a/locales/en/fields.json
+++ b/locales/en/fields.json
@@ -1,6 +1,7 @@
 {
   "date": {
-    "hint": "For example 28/10/1990 or 28 October 1990"
+    "hint": "For example 28/10/1990 or 28 October 1990",
+    "label_with_error": "Date"
   },
   "filter": {
     "police_national_computer": {

--- a/package.json
+++ b/package.json
@@ -166,7 +166,7 @@
     "standard-version": "7.1.0",
     "style-loader": "1.1.4",
     "terser-webpack-plugin": "2.3.5",
-    "testcafe": "1.8.4",
+    "testcafe": "1.8.5",
     "testcafe-reporter-xunit": "2.1.0",
     "timezone-mock": "1.0.18",
     "webpack": "4.43.0",

--- a/test/e2e/_roles.js
+++ b/test/e2e/_roles.js
@@ -26,3 +26,8 @@ export const prisonUser = Role(home, async t => {
 export const ocaUser = Role(home, async t => {
   await page.signIn(E2E.ROLES.OCA)
 })
+
+export const pmuUser = Role(home, async t => {
+  await page.signIn(E2E.ROLES.PMU)
+  await page.chooseAllLocations()
+})

--- a/test/e2e/_routes.js
+++ b/test/e2e/_routes.js
@@ -19,3 +19,5 @@ export const newMove = `${E2E.BASE_URL}/move/new`
 export const getMove = id => `${E2E.BASE_URL}/move/${id}`
 export const getUpdateMove = (id, page) =>
   `${E2E.BASE_URL}/move/${id}/edit/${getUpdatePageStub(page)}`
+export const newAllocation = `${E2E.BASE_URL}/allocation/new`
+export const allocations = `${E2E.BASE_URL}/allocations`

--- a/test/e2e/allocation.cancel.test.js
+++ b/test/e2e/allocation.cancel.test.js
@@ -1,0 +1,26 @@
+import { pmuUser } from './_roles'
+import { allocations, newAllocation } from './_routes'
+import { allocationJourney } from './pages/'
+
+fixture('Cancel allocation').beforeEach(async t => {
+  await t.useRole(pmuUser).navigateTo(newAllocation)
+  await allocationJourney.createAllocation()
+  await t.navigateTo(allocations)
+})
+test('Cancel allocation', async t => {
+  await t.click(
+    allocationJourney.allocationCancelPage.nodes.linkToFirstAllocation
+  )
+  await allocationJourney.scrollToBottom()
+  await t.click(allocationJourney.allocationCancelPage.nodes.cancelLink)
+  await t
+    .expect(allocationJourney.getCurrentUrl())
+    .match(/\/allocation\/[\w]{8}(-[\w]{4}){3}-[\w]{12}\/cancel\/reason$/)
+  await allocationJourney.allocationCancelPage.submitForm()
+  await t
+    .expect(allocationJourney.getCurrentUrl())
+    .match(/\/allocation\/[\w]{8}(-[\w]{4}){3}-[\w]{12}$/)
+  await t
+    .expect(allocationJourney.allocationCancelPage.nodes.statusHeading.exists)
+    .ok()
+})

--- a/test/e2e/allocation.new.test.js
+++ b/test/e2e/allocation.new.test.js
@@ -1,0 +1,36 @@
+import { pmuUser } from './_roles'
+import { newAllocation } from './_routes'
+import { allocationJourney } from './pages/'
+
+fixture('New PMU allocation').beforeEach(async t => {
+  await t.useRole(pmuUser).navigateTo(newAllocation)
+})
+test('Create allocation and verify the result', async t => {
+  const allocationId = await allocationJourney.createAllocation()
+  await t.navigateTo(`/allocation/${allocationId}`)
+  ;['summary', 'meta'].forEach(async section => {
+    for (const o of allocationJourney.allocationViewPage.nodes[section].keys) {
+      const textExists = allocationJourney.allocationViewPage.getDlDefinitionByKey(
+        allocationJourney.allocationViewPage.nodes[section].selector,
+        o
+      )
+      await t.expect(textExists).ok()
+    }
+  })
+})
+test('Check validation errors on allocation details page', async t => {
+  await allocationJourney.submitForm()
+
+  for (const item of allocationJourney.allocationDetailsPage.errorLinks) {
+    const error = allocationJourney.findErrorInList(item)
+    await t.expect(error).ok()
+  }
+})
+test('Check validation errors on allocation criteria page', async t => {
+  await allocationJourney.triggerValidationOnAllocationCriteriaPage()
+
+  for (const item of allocationJourney.allocationCriteriaPage.errorLinks) {
+    const error = allocationJourney.findErrorInList(item)
+    await t.expect(error).ok()
+  }
+})

--- a/test/e2e/pages/allocation-cancel.js
+++ b/test/e2e/pages/allocation-cancel.js
@@ -1,0 +1,18 @@
+import { Selector } from 'testcafe'
+
+import Page from './page'
+
+class AllocationCancelPage extends Page {
+  constructor() {
+    super()
+    this.nodes = {
+      ...this.nodes,
+      linkToFirstAllocation: Selector('.govuk-table td:first-of-type a'),
+      cancelLink: Selector('a').withText('Cancel allocation'),
+      statusHeading: Selector(
+        '.app-message.app-message--temporary .app-message__heading'
+      ).withText('Allocation cancelled'),
+    }
+  }
+}
+export default AllocationCancelPage

--- a/test/e2e/pages/allocation-criteria.js
+++ b/test/e2e/pages/allocation-criteria.js
@@ -1,0 +1,62 @@
+import faker from 'faker'
+import { Selector } from 'testcafe'
+
+import { fillInForm } from '../_helpers'
+
+import Page from './page'
+
+class AllocationCriteriaPage extends Page {
+  constructor() {
+    super()
+    this.url = '/allocation/new/allocation-criteria'
+    this.fields = {
+      prisonerCategory: Selector('#prisoner_category'),
+      sentenceLength: Selector('[name="sentence_length"]'),
+      complexCases: Selector('#complex_cases'),
+      completeInFull: Selector('#complete_in_full'),
+      hasOtherCriteria: Selector('#has_other_criteria'),
+      otherCriteria: Selector('#other_criteria'),
+      errorSummary: Selector('.govuk-error-summary'),
+    }
+    this.errorSummary = Selector('.govuk-error-summary ul')
+    this.errorLinks = [
+      '#prisoner_category',
+      '#sentence_length',
+      '#complete_in_full',
+      '#has_other_criteria',
+    ]
+  }
+
+  fill() {
+    const fieldsToFill = [
+      {
+        selector: this.fields.prisonerCategory,
+        value: 'C',
+        type: 'radio',
+      },
+      {
+        selector: this.fields.sentenceLength,
+        type: 'radio',
+      },
+      {
+        selector: this.fields.complexCases,
+        type: 'checkbox',
+      },
+      {
+        selector: this.fields.completeInFull,
+        type: 'radio',
+      },
+      {
+        selector: this.fields.hasOtherCriteria,
+        type: 'radio',
+        value: 'Yes',
+      },
+      {
+        selector: this.fields.otherCriteria,
+        value: faker.lorem.sentence(6),
+      },
+    ]
+    return fillInForm(fieldsToFill)
+  }
+}
+export default AllocationCriteriaPage

--- a/test/e2e/pages/allocation-details.js
+++ b/test/e2e/pages/allocation-details.js
@@ -9,7 +9,7 @@ class AllocationDetailsPage extends Page {
   constructor() {
     super()
     this.url = '/allocation/new/allocation-details'
-    this.fields = {
+    this.nodes = {
       movesCount: Selector('#moves_count'),
       fromLocation: Selector('#from_location'),
       toLocation: Selector('#to_location'),
@@ -27,24 +27,24 @@ class AllocationDetailsPage extends Page {
   fill() {
     const fieldsToFill = [
       {
-        selector: this.fields.movesCount,
+        selector: this.nodes.movesCount,
         value: '3',
       },
       // TODO it would be better to let the value blank here, so a random one would be used.
       // However, it currently makes the test fail when the chosen option is not in the visible
       // portion of the list. This clearly needs to be addressed.
       {
-        selector: this.fields.fromLocation,
+        selector: this.nodes.fromLocation,
         type: 'autocomplete',
         value: 0,
       },
       {
-        selector: this.fields.toLocation,
+        selector: this.nodes.toLocation,
         type: 'autocomplete',
         value: 1,
       },
       {
-        selector: this.fields.date,
+        selector: this.nodes.date,
         value: format(endOfWeek(new Date()), 'dd/MM/yyyy'),
       },
     ]

--- a/test/e2e/pages/allocation-details.js
+++ b/test/e2e/pages/allocation-details.js
@@ -1,0 +1,54 @@
+import { endOfWeek, format } from 'date-fns'
+import { Selector } from 'testcafe'
+
+import { fillInForm } from '../_helpers'
+
+import Page from './page'
+
+class AllocationDetailsPage extends Page {
+  constructor() {
+    super()
+    this.url = '/allocation/new/allocation-details'
+    this.fields = {
+      movesCount: Selector('#moves_count'),
+      fromLocation: Selector('#from_location'),
+      toLocation: Selector('#to_location'),
+      date: Selector('#date'),
+    }
+    this.errorSummary = Selector('.govuk-error-summary__list')
+    this.errorLinks = [
+      '#moves_count',
+      '#to_location',
+      '#from_location',
+      '#date',
+    ]
+  }
+
+  fill() {
+    const fieldsToFill = [
+      {
+        selector: this.fields.movesCount,
+        value: '3',
+      },
+      // TODO it would be better to let the value blank here, so a random one would be used.
+      // However, it currently makes the test fail when the chosen option is not in the visible
+      // portion of the list. This clearly needs to be addressed.
+      {
+        selector: this.fields.fromLocation,
+        type: 'autocomplete',
+        value: 0,
+      },
+      {
+        selector: this.fields.toLocation,
+        type: 'autocomplete',
+        value: 1,
+      },
+      {
+        selector: this.fields.date,
+        value: format(endOfWeek(new Date()), 'dd/MM/yyyy'),
+      },
+    ]
+    return fillInForm(fieldsToFill)
+  }
+}
+export default AllocationDetailsPage

--- a/test/e2e/pages/allocation-journey.js
+++ b/test/e2e/pages/allocation-journey.js
@@ -1,0 +1,51 @@
+import { t } from 'testcafe'
+
+import AllocationCancelPage from './allocation-cancel'
+import AllocationCriteriaPage from './allocation-criteria'
+import AllocationDetailsPage from './allocation-details'
+import AllocationViewPage from './allocation-view'
+import Page from './page'
+
+import { allocationJourney } from './index'
+
+const allocationDetailsPage = new AllocationDetailsPage()
+const allocationCriteriaPage = new AllocationCriteriaPage()
+const allocationCancelPage = new AllocationCancelPage()
+const allocationViewPage = new AllocationViewPage()
+
+class AllocationJourney extends Page {
+  constructor() {
+    super()
+    this.allocationCancelPage = allocationCancelPage
+    this.allocationCriteriaPage = allocationCriteriaPage
+    this.allocationDetailsPage = allocationDetailsPage
+    this.allocationViewPage = allocationViewPage
+  }
+
+  async createAllocation() {
+    await allocationDetailsPage.fill()
+    await this.submitForm()
+    await allocationCriteriaPage.fill()
+    await this.submitForm()
+    const currentUrl = await allocationJourney.getCurrentUrl()
+    await t
+      .expect(currentUrl)
+      .match(
+        new RegExp('/allocation/' + this.uuidRegex.source + '/confirmation')
+      )
+    return currentUrl.match(new RegExp(allocationJourney.uuidRegex))[0]
+  }
+
+  async triggerValidationOnAllocationCriteriaPage() {
+    await allocationDetailsPage.fill()
+    await this.submitForm()
+    await this.submitForm()
+  }
+
+  findErrorInList(hrefAttribute) {
+    return allocationDetailsPage.errorSummary
+      .child('a')
+      .withAttribute('href', hrefAttribute)
+  }
+}
+export default AllocationJourney

--- a/test/e2e/pages/allocation-view.js
+++ b/test/e2e/pages/allocation-view.js
@@ -1,0 +1,28 @@
+import { Selector } from 'testcafe'
+
+import Page from './page'
+
+class AllocationViewPage extends Page {
+  constructor() {
+    super()
+    this.nodes = {
+      heading: Selector('h1.govuk-heading-l'),
+      listElements: {
+        category: 'Category',
+      },
+      summary: {
+        selector: Selector('.govuk-summary-list'),
+        keys: [
+          'Time left to serve',
+          'Complex cases for prisons to agree',
+          'Other criteria',
+        ],
+      },
+      meta: {
+        selector: Selector('.app-meta-list'),
+        keys: ['Number of people', 'Move from', 'Move to', 'Date'],
+      },
+    }
+  }
+}
+export default AllocationViewPage

--- a/test/e2e/pages/index.js
+++ b/test/e2e/pages/index.js
@@ -1,3 +1,4 @@
+import AllocationJourney from './allocation-journey'
 import CancelMovePage from './cancel-move'
 import CreateMovePage from './create-move'
 import DashboardPage from './dashboard'
@@ -7,6 +8,7 @@ import Page from './page'
 import UpdateMovePage from './update-move'
 
 const page = new Page()
+const allocationJourney = new AllocationJourney()
 const moveDetailPage = new MoveDetailPage()
 const movesDashboardPage = new MovesDashboardPage()
 const createMovePage = new CreateMovePage()
@@ -15,6 +17,7 @@ const dashboardPage = new DashboardPage()
 
 export {
   page,
+  allocationJourney,
   moveDetailPage,
   movesDashboardPage,
   createMovePage,

--- a/test/e2e/pages/page.js
+++ b/test/e2e/pages/page.js
@@ -5,6 +5,7 @@ import { E2E } from '../../../config'
 export default class Page {
   constructor() {
     this.baseUrl = E2E.BASE_URL
+    this.uuidRegex = /[\w]{8}(-[\w]{4}){3}-[\w]{12}/
     this.nodes = {
       locationMeta: Selector('meta').withAttribute('name', 'location'),
       appHeader: Selector('.app-header__logo').withExactText(
@@ -95,5 +96,11 @@ export default class Page {
       .find('dt')
       .withText(key)
       .sibling('dd').innerText
+  }
+
+  scrollToBottom() {
+    return ClientFunction(function() {
+      window.scrollBy(0, 1000)
+    })
   }
 }

--- a/test/e2e/pages/page.js
+++ b/test/e2e/pages/page.js
@@ -71,6 +71,19 @@ export default class Page {
   }
 
   /**
+   * Select "all locations"
+   *
+   * @returns {Promise}
+   */
+  async chooseAllLocations() {
+    const allLocationsLink = Selector('a').withAttribute(
+      'href',
+      '/locations/all'
+    )
+    return t.click(allLocationsLink)
+  }
+
+  /**
    * Get definition list item value by key text
    *
    * @param {Selector} dl - definition list selector


### PR DESCRIPTION
These are the tests for cancel and create allocation. They pass locally (most of the time), but need a test user to be added to this PR for it to run.



### Checklist

- [ ] If adding new environment variables, they have been documented in the [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md)
- [ ] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
