### PR TITLE
[P4 1310] Display cancelled allocations

### DIFF
--- a/app/allocations/middleware/set-results.allocations.js
+++ b/app/allocations/middleware/set-results.allocations.js
@@ -3,17 +3,20 @@ const allocationService = require('../../../common/services/allocation')
 
 async function setResultsAllocations(req, res, next) {
   try {
-    const allocations = await allocationService.getByDateAndLocation(
-      req.body.allocations
-    )
+    const [activeAllocations, cancelledAllocations] = (
+      await Promise.all([
+        allocationService.getActiveAllocations(req.body.allocations),
+        allocationService.getCancelledAllocations(req.body.allocations),
+      ])
+    ).map(response => response.flat())
 
     req.results = {
-      active: allocations,
-      cancelled: [],
+      active: activeAllocations,
+      cancelled: cancelledAllocations,
     }
     req.resultsAsTable = {
-      active: presenters.allocationsToTable(allocations),
-      cancelled: [],
+      active: presenters.allocationsToTable(activeAllocations),
+      cancelled: presenters.allocationsToTable(cancelledAllocations),
     }
 
     next()

--- a/common/assets/scss/utilities/_all.scss
+++ b/common/assets/scss/utilities/_all.scss
@@ -1,3 +1,4 @@
 @import "border";
 @import "links";
 @import "print";
+@import "typography";

--- a/common/assets/scss/utilities/_typography.scss
+++ b/common/assets/scss/utilities/_typography.scss
@@ -1,0 +1,3 @@
+.app-secondary-text-colour {
+  color: $govuk-secondary-text-colour
+}

--- a/common/presenters/allocations-to-table.js
+++ b/common/presenters/allocations-to-table.js
@@ -4,7 +4,12 @@ const tablePresenters = require('./table')
 
 const tableConfig = [
   {
-    head: 'collections::labels.move_size',
+    head: {
+      text: 'collections::labels.move_size',
+      attributes: {
+        width: '120',
+      },
+    },
     row: {
       attributes: {
         scope: 'row',
@@ -19,25 +24,39 @@ const tableConfig = [
     },
   },
   {
-    head: 'collections::labels.requested',
+    head: {
+      text: 'collections::labels.requested',
+      attributes: {
+        width: '160',
+      },
+    },
     row: {
       text: data => filters.formatDate(data.created_at),
     },
   },
   {
-    head: 'collections::labels.move_from',
+    head: {
+      text: 'collections::labels.move_from',
+    },
     row: {
       text: 'from_location.title',
     },
   },
   {
-    head: 'collections::labels.move_to',
+    head: {
+      text: 'collections::labels.move_to',
+    },
     row: {
       text: 'to_location.title',
     },
   },
   {
-    head: 'date',
+    head: {
+      text: 'date',
+      attributes: {
+        width: '120',
+      },
+    },
     row: {
       text: data => filters.formatDate(data.date),
     },

--- a/common/presenters/allocations-to-table.test.js
+++ b/common/presenters/allocations-to-table.test.js
@@ -122,19 +122,38 @@ describe('#allocationsToTable', function() {
     it('returns one head row with all the cells', function() {
       expect(output.head).to.deep.equal([
         {
-          text: 'collections::labels.move_size',
+          text: {
+            text: 'collections::labels.move_size',
+            attributes: {
+              width: '120',
+            },
+          },
         },
         {
-          text: 'collections::labels.requested',
+          text: {
+            text: 'collections::labels.requested',
+            attributes: {
+              width: '160',
+            },
+          },
         },
         {
-          text: 'collections::labels.move_from',
+          text: {
+            text: 'collections::labels.move_from',
+          },
         },
         {
-          text: 'collections::labels.move_to',
+          text: {
+            text: 'collections::labels.move_to',
+          },
         },
         {
-          text: 'date',
+          text: {
+            text: 'date',
+            attributes: {
+              width: '120',
+            },
+          },
         },
       ])
     })

--- a/common/presenters/table/object-to-table-head.js
+++ b/common/presenters/table/object-to-table-head.js
@@ -1,8 +1,13 @@
+const { pickBy } = require('lodash')
+
 const i18n = require('../../../config/i18n')
 
 function objectToTableHead(schemaEl) {
-  return {
-    html: i18n.t(schemaEl.head),
-  }
+  const { head } = schemaEl
+  const prop = head.html ? 'html' : 'text'
+  return pickBy({
+    ...head,
+    [prop]: i18n.t(schemaEl.head[prop]),
+  })
 }
 module.exports = objectToTableHead

--- a/common/presenters/table/object-to-table-head.test.js
+++ b/common/presenters/table/object-to-table-head.test.js
@@ -1,28 +1,127 @@
 const i18n = require('../../../config/i18n')
 
-const schemaExample = [
-  {
-    head: 'move_type::label',
-    row: 'prison_transfer_reason',
-  },
-  {
-    head: 'fields::age',
-    row: 'age',
-  },
-]
 const objectToTableHead = require('./object-to-table-head')
 
 describe('table head presenter', function() {
-  it('returns the heading specified', function() {
+  beforeEach(function() {
     sinon.stub(i18n, 't').returnsArg(0)
-    const output = schemaExample.map(objectToTableHead)
-    expect(output).to.deep.equal([
+  })
+  context('with html', function() {
+    const schema = [
       {
-        html: 'move_type::label',
+        head: {
+          html: 'move_type::label',
+        },
       },
       {
-        html: 'fields::age',
+        head: { html: 'fields::age' },
       },
-    ])
+    ]
+    it('returns the correct header', function() {
+      const output = schema.map(objectToTableHead)
+      expect(output).to.deep.equal([
+        {
+          html: 'move_type::label',
+        },
+        {
+          html: 'fields::age',
+        },
+      ])
+    })
+  })
+  context('with text', function() {
+    const schema = [
+      {
+        head: {
+          text: 'move_type::label',
+        },
+      },
+      {
+        head: { text: 'fields::age' },
+      },
+    ]
+    it('returns the correct header', function() {
+      const output = schema.map(objectToTableHead)
+      expect(output).to.deep.equal([
+        {
+          text: 'move_type::label',
+        },
+        {
+          text: 'fields::age',
+        },
+      ])
+    })
+  })
+  context('with attributes', function() {
+    const schema = [
+      {
+        head: {
+          html: 'move_type::label',
+          attributes: {
+            width: 1,
+          },
+        },
+      },
+      {
+        head: { html: 'fields::age' },
+      },
+    ]
+    it('returns the correct header', function() {
+      const output = schema.map(objectToTableHead)
+      expect(output).to.deep.equal([
+        {
+          attributes: {
+            width: 1,
+          },
+          html: 'move_type::label',
+        },
+        {
+          html: 'fields::age',
+        },
+      ])
+    })
+  })
+  context('with neither html nor test', function() {
+    const schema = [
+      {
+        head: {},
+      },
+      {
+        head: {},
+      },
+    ]
+    it('returns the correct header', function() {
+      const output = schema.map(objectToTableHead)
+      expect(output).to.deep.equal([{}, {}])
+    })
+  })
+  context('with both html and text', function() {
+    const schema = [
+      {
+        head: {
+          html: 'move_type::label-html',
+          text: 'move_type::label-text',
+        },
+      },
+      {
+        head: {
+          html: 'fields::age-html',
+          text: 'fields::age-text',
+        },
+      },
+    ]
+    it('returns the correct headers', function() {
+      const output = schema.map(objectToTableHead)
+      expect(output).to.deep.equal([
+        {
+          html: 'move_type::label-html',
+          text: 'move_type::label-text',
+        },
+        {
+          html: 'fields::age-html',
+          text: 'fields::age-text',
+        },
+      ])
+    })
   })
 })

--- a/common/services/allocation.js
+++ b/common/services/allocation.js
@@ -58,17 +58,31 @@ const allocationService = {
     fromLocationId,
     toLocationId,
     isAggregation = false,
+    status,
   } = {}) {
     const [moveDateFrom, moveDateTo] = moveDate
 
     return allocationService.getAll({
       isAggregation,
       filter: pickBy({
+        'filter[status]': status,
         'filter[from_locations]': fromLocationId,
         'filter[to_locations]': toLocationId,
         'filter[date_from]': moveDateFrom,
         'filter[date_to]': moveDateTo,
       }),
+    })
+  },
+  getActiveAllocations(allocationsParams) {
+    return allocationService.getByDateAndLocation({
+      ...allocationsParams,
+      status: ['filled', 'unfilled'],
+    })
+  },
+  getCancelledAllocations(allocationsParams) {
+    return allocationService.getByDateAndLocation({
+      ...allocationsParams,
+      status: 'cancelled',
     })
   },
   getAll({

--- a/common/services/allocation.test.js
+++ b/common/services/allocation.test.js
@@ -559,6 +559,45 @@ describe('Allocation service', function() {
     })
   })
 
+  describe('#getActiveAllocations', function() {
+    beforeEach(function() {
+      sinon.stub(allocationService, 'getByDateAndLocation')
+      allocationService.getActiveAllocations({
+        additionalParams: {},
+      })
+    })
+    afterEach(function() {
+      allocationService.getByDateAndLocation.restore()
+    })
+    it('invokes getByDateAndLocation passing a proposed status', function() {
+      expect(
+        allocationService.getByDateAndLocation
+      ).to.have.been.calledWithExactly({
+        additionalParams: {},
+        status: ['filled', 'unfilled'],
+      })
+    })
+  })
+  describe('#getCancelledAllocations', function() {
+    beforeEach(function() {
+      sinon.stub(allocationService, 'getByDateAndLocation')
+      allocationService.getCancelledAllocations({
+        additionalParams: {},
+      })
+    })
+    afterEach(function() {
+      allocationService.getByDateAndLocation.restore()
+    })
+    it('invokes getByDateAndLocation passing a cancelled status', function() {
+      expect(
+        allocationService.getByDateAndLocation
+      ).to.have.been.calledWithExactly({
+        additionalParams: {},
+        status: 'cancelled',
+      })
+    })
+  })
+
   describe('#getById', function() {
     let output, transformStub
 

--- a/common/templates/collection-as-table.njk
+++ b/common/templates/collection-as-table.njk
@@ -30,4 +30,23 @@
       }
     }) }}
   {% endif %}
+
+  {% if resultsAsTable.cancelled.rows.length %}
+    {% set html %}
+        {{ govukTable({
+          rows: resultsAsTable.cancelled.rows,
+          head: resultsAsTable.cancelled.head,
+          classes: "app-secondary-text-colour"
+        }) }}
+    {% endset %}
+
+    {{ govukDetails({
+      html: html,
+      summaryText: t("collections::cancelled", {
+        context: context,
+        count: resultsAsTable.cancelled.rows.length
+      })
+    }) }}
+  {% endif %}
+
 {% endblock %}


### PR DESCRIPTION
<img width="420" alt="Screenshot 2020-05-21 at 11 06 43" src="https://user-images.githubusercontent.com/853989/82548726-ad482a00-9b53-11ea-8212-686421bb020e.png">

This change aims to display the cancelled allocations in the dashboard. Currently not supported by the api service -- the implementation should be merged soon.

### Checklist

- [x] If adding new environment variables, they have been documented in the [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md)
- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
