### PR TITLE
Handle moves without a person

### DIFF
--- a/app/allocation/controllers/view.js
+++ b/app/allocation/controllers/view.js
@@ -18,14 +18,7 @@ module.exports = function view(req, res) {
       emptySlots: moves.filter(move => !move.person).length,
       filledSlots: moves
         .filter(move => move.person)
-        .map(move => {
-          const { person } = move
-          if (!person.fullname) {
-            person.fullname = `${person.first_names} ${person.last_name}`
-          }
-          return person
-        })
-        .map(presenters.personToCardComponent()),
+        .map(presenters.moveToCardComponent()),
     },
   }
   res.render('allocation/views/view', locals)

--- a/app/allocation/controllers/view.test.js
+++ b/app/allocation/controllers/view.test.js
@@ -56,9 +56,14 @@ describe('view allocation', function() {
     let locals
     let render
     let output
+    let moveToCardComponentStub
     beforeEach(function() {
+      moveToCardComponentStub = sinon.stub().returnsArg(0)
       sinon.stub(presenters, 'allocationToMetaListComponent').returns({})
       sinon.stub(presenters, 'allocationToSummaryListComponent').returns({})
+      sinon
+        .stub(presenters, 'moveToCardComponent')
+        .callsFake(() => moveToCardComponentStub)
       render = sinon.stub()
       locals = { allocation: { ...allocationExample } }
       handler(
@@ -72,21 +77,25 @@ describe('view allocation', function() {
       )
       output = render.firstCall.lastArg
     })
+
     it('creates allocationDetails on locals with the result of the correct presenter', function() {
       expect(output.allocationDetails).to.exist
       expect(
         presenters.allocationToMetaListComponent
       ).to.have.been.calledOnceWithExactly(locals.allocation)
     })
+
     it('creates allocationSummary on locals with the result of the correct presenter', function() {
       expect(output.allocationSummary).to.exist
       expect(
         presenters.allocationToSummaryListComponent
       ).to.have.been.calledOnceWithExactly(locals.allocation)
     })
+
     it('does not create a message banner if the status is not cancelled', function() {
       expect(output.messageTitle).to.be.undefined
     })
+
     it('calls render with the template', function() {
       expect(render).to.have.been.calledWithExactly('allocation/views/view', {
         allocationDetails: {},
@@ -95,12 +104,10 @@ describe('view allocation', function() {
           emptySlots: 2,
           filledSlots: [
             {
-              href: undefined,
-              image_alt: 'JOHN DOE',
-              image_path: undefined,
-              meta: { items: [] },
-              tags: { items: [] },
-              title: { text: 'JOHN DOE' },
+              person: {
+                first_names: 'John',
+                last_name: 'Doe',
+              },
             },
           ],
         },
@@ -110,6 +117,7 @@ describe('view allocation', function() {
       })
     })
   })
+
   context('Cancelled allocation', function() {
     let locals
     let render

--- a/app/move/controllers/view.js
+++ b/app/move/controllers/view.js
@@ -18,6 +18,7 @@ module.exports = function view(req, res) {
   const userPermissions = get(req.session, 'user.permissions')
   const updateUrls = getUpdateUrls(updateSteps, move.id, userPermissions)
   const updateActions = getUpdateLinks(updateSteps, updateUrls)
+  const assessmentAnswers = get(person, 'assessment_answers', [])
 
   const urls = {
     update: updateUrls,
@@ -26,9 +27,9 @@ module.exports = function view(req, res) {
   const locals = {
     moveSummary: presenters.moveToMetaListComponent(move, updateActions),
     personalDetailsSummary: presenters.personToSummaryListComponent(person),
-    tagList: presenters.assessmentToTagList(person.assessment_answers),
+    tagList: presenters.assessmentToTagList(assessmentAnswers),
     assessment: presenters
-      .assessmentAnswersByCategory(person.assessment_answers)
+      .assessmentAnswersByCategory(assessmentAnswers)
       .map(presenters.assessmentCategoryToPanelComponent),
     courtHearings: sortBy(move.court_hearings, 'start_time').map(
       courtHearing => {
@@ -41,7 +42,7 @@ module.exports = function view(req, res) {
       }
     ),
     courtSummary: presenters.assessmentToSummaryListComponent(
-      person.assessment_answers,
+      assessmentAnswers,
       'court'
     ),
     messageTitle: bannerStatuses.includes(status)

--- a/app/move/controllers/view.test.js
+++ b/app/move/controllers/view.test.js
@@ -294,5 +294,56 @@ describe('Move controllers', function() {
         expect(params.messageContent).to.equal('statuses::description')
       })
     })
+
+    context('when move doesn’t have a person', function() {
+      let params
+
+      beforeEach(function() {
+        res.locals.move = {
+          ...mockMove,
+          person: undefined,
+        }
+
+        controller(req, res)
+        params = res.render.args[0][1]
+      })
+
+      it('should call personToSummaryListComponent presenter with undefined', function() {
+        expect(
+          presenters.personToSummaryListComponent
+        ).to.be.calledOnceWithExactly(undefined)
+      })
+
+      it('should contain undefined personal details summary param', function() {
+        expect(params).to.have.property('personalDetailsSummary')
+        expect(params.personalDetailsSummary).to.equal(undefined)
+      })
+
+      it('should call assessmentToTagList presenter with empty array', function() {
+        expect(presenters.assessmentToTagList).to.be.calledOnceWithExactly([])
+      })
+
+      it('should contain tag list param', function() {
+        expect(params).to.have.property('tagList')
+        expect(params.tagList).to.deep.equal([])
+      })
+
+      it('should call assessmentAnswersByCategory presenter with empty array', function() {
+        expect(
+          presenters.assessmentAnswersByCategory
+        ).to.be.calledOnceWithExactly([])
+      })
+
+      it('should contain assessment param as empty array', function() {
+        expect(params).to.have.property('assessment')
+        expect(params.assessment).to.deep.equal([])
+      })
+
+      it('should call assessmentToSummaryListComponent presenter with empty array', function() {
+        expect(
+          presenters.assessmentToSummaryListComponent
+        ).to.be.calledOnceWithExactly([], 'court')
+      })
+    })
   })
 })

--- a/app/move/views/view.njk
+++ b/app/move/views/view.njk
@@ -1,6 +1,7 @@
 {% extends "layouts/two-column.njk" %}
 
 {% set additionalContainerClass = "sticky-sidebar-container" %}
+{% set name = (move.person.fullname or t("awaiting_person")) | upper %}
 
 {% block customGtagConfig %}
   gtag('set', {'page_title': 'Move details'});
@@ -8,7 +9,7 @@
 
 {% block pageTitle %}
   {{ t("moves::detail.page_title", {
-    name: move.person.fullname | upper
+    name: name
   }) }}
 {% endblock %}
 
@@ -74,7 +75,7 @@
     {% endif %}
 
     <h1 class="govuk-heading-xl govuk-!-margin-bottom-1">
-      {{ move.person.fullname | upper }}
+      {{ name }}
     </h1>
     <span class="govuk-caption-xl">
       {{ t("moves::move_reference", {
@@ -170,12 +171,12 @@
     <div class="sticky-sidebar">
       <div class="sticky-sidebar__inner">
         <h3 class="govuk-heading-m app-border-top-2 app-border--blue govuk-!-padding-top-4 govuk-!-margin-bottom-3">
-          {{ move.person.fullname | upper }}
+          {{ name }}
         </h3>
 
         {% if move.person.image_url %}
           <div class="govuk-!-width-one-half govuk-!-margin-bottom-3">
-            <img src="{{ move.person.image_url }}" alt="{{ move.person.fullname | upper }}">
+            <img src="{{ move.person.image_url }}" alt="{{ name }}">
           </div>
         {% endif %}
 

--- a/common/assets/scss/overrides/_all.scss
+++ b/common/assets/scss/overrides/_all.scss
@@ -1,5 +1,6 @@
 @import "buttons";
 @import "font-corrections";
 @import "govuk-frontend";
+@import "moj-frontend";
 @import "positioning";
 @import "visibility";

--- a/common/assets/scss/overrides/_moj-frontend.scss
+++ b/common/assets/scss/overrides/_moj-frontend.scss
@@ -1,0 +1,3 @@
+.moj-badge {
+  background-color: govuk-colour("white");
+}

--- a/common/components/card/_card.scss
+++ b/common/components/card/_card.scss
@@ -20,8 +20,17 @@ $_image-width: 80px;
   padding: 0;
 }
 
+.app-card--placeholder {
+  padding-top: govuk-spacing(2);
+  padding-bottom: govuk-spacing(2);
+}
+
 .app-card__aside {
   float: left;
+
+  .app-card--placeholder & {
+    display: none;
+  }
 }
 
 .app-card__image {
@@ -37,6 +46,7 @@ $_image-width: 80px;
     float: right;
     margin-bottom: 0;
     margin-left: govuk-spacing(3);
+    margin-right: govuk-spacing(3);
   }
 }
 
@@ -49,6 +59,10 @@ $_image-width: 80px;
   @include govuk-font($size: 19, $weight: bold);
   margin: 0;
 
+  .app-card--placeholder & {
+    font-weight: normal;
+  }
+
   .govuk-checkboxes &,
   .govuk-radios & {
     margin-top: 8px;
@@ -57,6 +71,15 @@ $_image-width: 80px;
 
 .app-card__content {
   margin-left: $_image-width + govuk-spacing(3);
+
+  .app-card--placeholder & {
+    background: govuk-colour("light-grey");
+    border-left: 5px solid govuk-colour("dark-grey");
+    padding-bottom: govuk-spacing(3);
+    padding-left: govuk-spacing(3);
+    padding-top: govuk-spacing(3);
+    margin-left: 0;
+  }
 }
 
 .app-card__meta-list {

--- a/common/components/card/_card.scss
+++ b/common/components/card/_card.scss
@@ -1,7 +1,7 @@
+$_image-width: 80px;
+
 .app-card {
   @include govuk-clearfix;
-  display: flex;
-  align-items: flex-start;
   border-top: 1px solid $govuk-border-colour;
   padding-top: govuk-spacing(3);
   padding-bottom: govuk-spacing(3);
@@ -21,12 +21,12 @@
 }
 
 .app-card__aside {
-  margin-right: govuk-spacing(4);
+  float: left;
 }
 
 .app-card__image {
   display: block;
-  width: 80px;
+  width: $_image-width;
 }
 
 .app-card__badge {
@@ -41,7 +41,6 @@
 }
 
 .app-card__caption {
-  @include govuk-clearfix;
   @include govuk-font($size: 16);
   color: govuk-colour("dark-grey");
 }
@@ -57,7 +56,7 @@
 }
 
 .app-card__content {
-  flex-grow: 1;
+  margin-left: $_image-width + govuk-spacing(3);
 }
 
 .app-card__meta-list {

--- a/common/presenters/assessment-answers-by-category.js
+++ b/common/presenters/assessment-answers-by-category.js
@@ -3,7 +3,7 @@ const { sortBy, mapValues } = require('lodash')
 const { TAG_CATEGORY_WHITELIST } = require('../../config')
 const { filterExpired } = require('../helpers/reference-data')
 
-module.exports = function assessmentAnswersByCategory(assessmentAnswers) {
+module.exports = function assessmentAnswersByCategory(assessmentAnswers = []) {
   const mapped = mapValues(TAG_CATEGORY_WHITELIST, (params, category) => {
     const answers = assessmentAnswers
       .filter(answer => answer.category === category)

--- a/common/presenters/assessment-answers-by-category.test.js
+++ b/common/presenters/assessment-answers-by-category.test.js
@@ -141,5 +141,30 @@ describe('Presenters', function() {
         expect(Object.keys(transformedResponse[1].answers)).to.have.length(0)
       })
     })
+
+    context('when called with no arguments', function() {
+      let transformedResponse
+
+      beforeEach(function() {
+        transformedResponse = assessmentAnswersByCategory()
+      })
+
+      it('should return the correct number of categories', function() {
+        expect(transformedResponse.length).to.equal(2)
+      })
+
+      it('should correctly order categories', function() {
+        expect(transformedResponse[0].key).to.equal('risk')
+      })
+
+      it('should correctly order categories', function() {
+        expect(transformedResponse[1].key).to.equal('health')
+      })
+
+      it('should contain correct number of types', function() {
+        expect(Object.keys(transformedResponse[0].answers)).to.have.length(0)
+        expect(Object.keys(transformedResponse[1].answers)).to.have.length(0)
+      })
+    })
   })
 })

--- a/common/presenters/assessment-to-summary-list-component.js
+++ b/common/presenters/assessment-to-summary-list-component.js
@@ -19,7 +19,7 @@ function _filterAnswer(category) {
 }
 
 module.exports = function assessmentToSummaryListComponent(
-  answers,
+  answers = [],
   filterCategory
 ) {
   const rows = answers.filter(_filterAnswer(filterCategory)).map(_mapAnswer)

--- a/common/presenters/assessment-to-summary-list-component.test.js
+++ b/common/presenters/assessment-to-summary-list-component.test.js
@@ -92,5 +92,26 @@ describe('Presenters', function() {
         })
       })
     })
+
+    context('when called with empty arguments', function() {
+      let transformedResponse
+
+      beforeEach(function() {
+        transformedResponse = assessmentToSummaryListComponent()
+      })
+
+      describe('response', function() {
+        describe('response', function() {
+          it('should return empty rows', function() {
+            expect(transformedResponse).to.have.property('rows')
+            expect(transformedResponse.rows.length).to.equal(0)
+          })
+
+          it('should return empty array', function() {
+            expect(transformedResponse.rows).to.deep.equal([])
+          })
+        })
+      })
+    })
   })
 })

--- a/common/presenters/move-to-card-component.js
+++ b/common/presenters/move-to-card-component.js
@@ -28,7 +28,9 @@ function moveToCardComponent({
     return {
       ...personCardComponent,
       status: statusBadge,
-      classes: isCompact ? 'app-card--compact' : '',
+      classes: isCompact
+        ? `app-card--compact ${personCardComponent.classes || ''}`
+        : personCardComponent.classes || '',
       caption: {
         text: i18n.t('moves::move_reference', {
           reference,

--- a/common/presenters/move-to-card-component.test.js
+++ b/common/presenters/move-to-card-component.test.js
@@ -22,16 +22,16 @@ const personToCardComponentStub = sinon
   .stub()
   .callsFake(() => personToCardComponentItemStub)
 
-const moveToCardComponent = proxyquire('./move-to-card-component', {
-  './person-to-card-component': personToCardComponentStub,
-})
-
 describe('Presenters', function() {
   describe('#moveToCardComponent()', function() {
     let transformedResponse
+    let moveToCardComponent
 
     beforeEach(function() {
       sinon.stub(i18n, 't').returns('__translated__')
+      moveToCardComponent = proxyquire('./move-to-card-component', {
+        './person-to-card-component': personToCardComponentStub,
+      })
     })
 
     context('with default options', function() {
@@ -189,7 +189,7 @@ describe('Presenters', function() {
       it('should contain correct output', function() {
         expect(transformedResponse).to.deep.equal({
           ...mockPersonCardComponent,
-          classes: 'app-card--compact',
+          classes: 'app-card--compact ',
           status: undefined,
           caption: {
             text: '__translated__',
@@ -223,7 +223,7 @@ describe('Presenters', function() {
       it('should contain correct output', function() {
         expect(transformedResponse).to.deep.equal({
           ...mockPersonCardComponent,
-          classes: 'app-card--compact',
+          classes: 'app-card--compact ',
           status: undefined,
           caption: {
             text: '__translated__',
@@ -260,6 +260,59 @@ describe('Presenters', function() {
           })
         })
       }
+    })
+
+    context('with card component classes', function() {
+      const mockClasses = 'mock classes'
+
+      beforeEach(function() {
+        moveToCardComponent = proxyquire('./move-to-card-component', {
+          './person-to-card-component': sinon.stub().callsFake(() =>
+            sinon.stub().returns({
+              ...mockPersonCardComponent,
+              classes: mockClasses,
+            })
+          ),
+        })
+      })
+
+      context('with compact design', function() {
+        beforeEach(function() {
+          transformedResponse = moveToCardComponent({ isCompact: true })(
+            mockMove
+          )
+        })
+
+        it('should combine with card classes', function() {
+          expect(transformedResponse).to.deep.equal({
+            ...mockPersonCardComponent,
+            classes: `app-card--compact ${mockClasses}`,
+            status: undefined,
+            caption: {
+              text: '__translated__',
+            },
+          })
+        })
+      })
+
+      context('without compact design', function() {
+        beforeEach(function() {
+          transformedResponse = moveToCardComponent()(mockMove)
+        })
+
+        it('should return card classes', function() {
+          expect(transformedResponse).to.deep.equal({
+            ...mockPersonCardComponent,
+            classes: mockClasses,
+            status: {
+              text: '__translated__',
+            },
+            caption: {
+              text: '__translated__',
+            },
+          })
+        })
+      })
     })
   })
 })

--- a/common/presenters/moves-to-csv.js
+++ b/common/presenters/moves-to-csv.js
@@ -7,7 +7,7 @@ const referenceDataService = require('../services/reference-data')
 
 function getIdentifier(identifier) {
   return function(row) {
-    const item = find(row.person.identifiers, {
+    const item = find(get(row, 'person.identifiers'), {
       identifier_type: identifier,
     })
     return item ? item.value : null
@@ -18,7 +18,13 @@ function mapAnswer({ title, key } = {}) {
   return [
     {
       label: title,
-      value: row => some(row.person.assessment_answers, { key }),
+      value: row => {
+        if (!row.person) {
+          return null
+        }
+
+        return some(get(row, 'person.assessment_answers'), { key })
+      },
     },
     {
       label: [

--- a/common/presenters/person-to-card-component.js
+++ b/common/presenters/person-to-card-component.js
@@ -13,11 +13,11 @@ function personToCardComponent({
   return function item({
     href,
     gender,
-    fullname = '',
+    fullname = i18n.t('awaiting_person'),
     image_url: imageUrl,
     date_of_birth: dateOfBirth,
     assessment_answers: assessmentAnswers,
-  }) {
+  } = {}) {
     const card = {
       href,
       title: {

--- a/common/presenters/person-to-card-component.js
+++ b/common/presenters/person-to-card-component.js
@@ -11,6 +11,7 @@ function personToCardComponent({
   showTags = true,
 } = {}) {
   return function item({
+    id,
     href,
     gender,
     fullname = i18n.t('awaiting_person'),
@@ -23,6 +24,10 @@ function personToCardComponent({
       title: {
         text: fullname.toUpperCase(),
       },
+    }
+
+    if (!id) {
+      card.classes = 'app-card--placeholder'
     }
 
     if (showMeta) {

--- a/common/presenters/person-to-card-component.test.js
+++ b/common/presenters/person-to-card-component.test.js
@@ -4,6 +4,7 @@ const filters = require('../../config/nunjucks/filters')
 const personToCardComponent = require('./person-to-card-component')
 
 const mockPerson = {
+  id: '12345',
   href: '/move/12345',
   fullname: 'Name, Full',
   image_url: '/path/to/image.jpg',
@@ -64,6 +65,10 @@ describe('Presenters', function() {
             })
           })
 
+          it('should not contain classes', function() {
+            expect(transformedResponse).not.to.have.property('classes')
+          })
+
           it('should contain an image path', function() {
             expect(transformedResponse).to.have.property('image_path')
             expect(transformedResponse.image_path).to.equal(
@@ -118,6 +123,10 @@ describe('Presenters', function() {
                 },
               ],
             })
+          })
+
+          it('should contain correct amount of properties', function() {
+            expect(Object.keys(transformedResponse)).to.have.length(6)
           })
         })
 
@@ -393,6 +402,10 @@ describe('Presenters', function() {
         expect(transformedResponse).not.to.have.property('image_path')
       })
 
+      it('should not contain an image path', function() {
+        expect(transformedResponse).not.to.have.property('image_path')
+      })
+
       it('should not contain image alt', function() {
         expect(transformedResponse).not.to.have.property('image_alt')
       })
@@ -419,6 +432,7 @@ describe('Presenters', function() {
       it('should use fallback values', function() {
         expect(transformedResponse).to.deep.equal({
           href: undefined,
+          classes: 'app-card--placeholder',
           title: { text: '__TRANSLATED__' },
           meta: { items: [] },
           tags: { items: [] },

--- a/common/presenters/person-to-card-component.test.js
+++ b/common/presenters/person-to-card-component.test.js
@@ -410,5 +410,22 @@ describe('Presenters', function() {
         expect(transformedResponse.meta.items.length).to.equal(2)
       })
     })
+
+    context('with no arguments', function() {
+      beforeEach(function() {
+        transformedResponse = personToCardComponent()()
+      })
+
+      it('should use fallback values', function() {
+        expect(transformedResponse).to.deep.equal({
+          href: undefined,
+          title: { text: '__TRANSLATED__' },
+          meta: { items: [] },
+          tags: { items: [] },
+          image_path: undefined,
+          image_alt: '__TRANSLATED__',
+        })
+      })
+    })
   })
 })

--- a/common/presenters/person-to-summary-list-component.js
+++ b/common/presenters/person-to-summary-list-component.js
@@ -12,13 +12,18 @@ function mapIdentifier({ value, identifier_type: type }) {
   }
 }
 
-module.exports = function personToSummaryListComponent({
-  gender,
-  ethnicity,
-  identifiers = [],
-  date_of_birth: dateOfBirth,
-  gender_additional_information: genderAdditionalInformation,
-}) {
+module.exports = function personToSummaryListComponent(props) {
+  if (!props) {
+    return undefined
+  }
+
+  const {
+    gender,
+    ethnicity,
+    identifiers = [],
+    date_of_birth: dateOfBirth,
+    gender_additional_information: genderAdditionalInformation,
+  } = props
   const age = `(${i18n.t('age')} ${filters.calculateAge(dateOfBirth)})`
   const genderExtra = genderAdditionalInformation
     ? ` — ${genderAdditionalInformation}`

--- a/common/presenters/person-to-summary-list-component.test.js
+++ b/common/presenters/person-to-summary-list-component.test.js
@@ -4,6 +4,7 @@ const filters = require('../../config/nunjucks/filters')
 const personToSummaryListComponent = require('./person-to-summary-list-component')
 
 const mockPerson = {
+  id: '12345',
   date_of_birth: '1948-04-24',
   gender_additional_information: 'Additional gender information',
   identifiers: [
@@ -143,7 +144,9 @@ describe('Presenters', function() {
       let transformedResponse
 
       beforeEach(function() {
-        transformedResponse = personToSummaryListComponent({})
+        transformedResponse = personToSummaryListComponent({
+          id: '12345',
+        })
       })
 
       describe('response', function() {
@@ -181,6 +184,7 @@ describe('Presenters', function() {
 
       beforeEach(function() {
         transformedResponse = personToSummaryListComponent({
+          id: '12345',
           gender: {
             title: 'Male',
           },
@@ -195,6 +199,20 @@ describe('Presenters', function() {
             key: { text: '__translated__' },
             value: { text: 'Male' },
           })
+        })
+      })
+    })
+
+    context('when provided with no arguments', function() {
+      let transformedResponse
+
+      beforeEach(function() {
+        transformedResponse = personToSummaryListComponent()
+      })
+
+      describe('response', function() {
+        it('should return undefined', function() {
+          expect(transformedResponse).to.be.undefined
         })
       })
     })

--- a/common/services/person.js
+++ b/common/services/person.js
@@ -39,8 +39,9 @@ const explicitAssessmentKeys = ['special_vehicle', 'not_to_be_released']
 const personService = {
   transform(person) {
     if (!person) {
-      return {}
+      return undefined
     }
+
     return {
       ...person,
       image_url: `/person/${person.id}/image`,

--- a/common/services/person.test.js
+++ b/common/services/person.test.js
@@ -82,6 +82,16 @@ describe('Person Service', function() {
         expect(transformed.fullname).to.equal('')
       })
     })
+
+    context('with no arguments', function() {
+      beforeEach(async function() {
+        transformed = await personService.transform()
+      })
+
+      it('should return only last name for full name', function() {
+        expect(transformed).to.be.undefined
+      })
+    })
   })
 
   describe('#format()', function() {

--- a/locales/en/default.json
+++ b/locales/en/default.json
@@ -15,6 +15,7 @@
   "supplier_fallback": "the supplier",
   "opens_new_window": "Opens in a new window",
   "created_on": "Created on",
+  "awaiting_person": "Awaiting person",
   "primary_navigation": {
     "home": "Home",
     "outgoing": "Outgoing",


### PR DESCRIPTION
## Proposed changes

This set of changes address handling moves that do not yet have a person attached to them.

These types of moves are ones that have been created as a placeholder as part of an "allocation" (or a collection of moves). The journey is for another user to come back and add a person to each of these moves.

Previously the application had an expectation that all moves always had a person associated with them so a lot of display and logic relied on that concept. This concept now needs to be adapted with these extra journeys and that's what this PR attempts to address.

It fixes the logic within the person transform method as well as other parts of the application that display a person.

## Screenshots

| Before | After |
| ------ | ----- |
| <kbd><img src="https://user-images.githubusercontent.com/3327997/82664924-a50eee00-9c2a-11ea-8b7e-a6e6791c3284.png"></kbd> | <kbd><img src="https://user-images.githubusercontent.com/3327997/82665032-d7205000-9c2a-11ea-9d81-4900ce424387.png"></kbd> |