### PR TITLE
fix(allocations): Unescape the heading of allocation view

### DIFF
--- a/app/allocation/views/view.njk
+++ b/app/allocation/views/view.njk
@@ -42,7 +42,7 @@
         from_location: allocation.from_location.title,
         to_location: allocation.to_location.title,
         date: allocation.date | formatDate
-      })}}
+      }) | safe }}
     </h1>
   </header>
 {% endblock %}


### PR DESCRIPTION
Currently the heading of the allocation view is not unescaped, which means that strange characters appears on the screen:
<img width="731" alt="Screenshot 2020-05-26 at 14 05 30" src="https://user-images.githubusercontent.com/853989/82906276-e66e0900-9f5c-11ea-964b-1ff0d429146e.png">

Adding `safe` to the template allows the characters to be correctly displayed.

<img width="721" alt="Screenshot 2020-05-26 at 14 26 44" src="https://user-images.githubusercontent.com/853989/82906353-069dc800-9f5d-11ea-9e05-da3b6c743c77.png">


### Checklist

- [x] If adding new environment variables, they have been documented in the [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md)
- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
