### PR TITLE
Update move detail page with moves that don't have a person

### DIFF
--- a/app/move/controllers/cancel.js
+++ b/app/move/controllers/cancel.js
@@ -4,6 +4,21 @@ const FormWizardController = require('../../../common/controllers/form-wizard')
 const moveService = require('../../../common/services/move')
 
 class CancelController extends FormWizardController {
+  middlewareChecks() {
+    super.middlewareChecks()
+    this.use(this.checkAllocation)
+  }
+
+  checkAllocation(req, res, next) {
+    const { allocation, id } = res.locals.move
+
+    if (allocation) {
+      return res.redirect(`/move/${id}`)
+    }
+
+    next()
+  }
+
   async successHandler(req, res, next) {
     const { id: moveId } = res.locals.move
 

--- a/app/move/controllers/cancel.test.js
+++ b/app/move/controllers/cancel.test.js
@@ -1,3 +1,4 @@
+const FormWizardController = require('../../../common/controllers/form-wizard')
 const moveService = require('../../../common/services/move')
 
 const CancelController = require('./cancel')
@@ -16,6 +17,78 @@ const mockValues = {
 
 describe('Move controllers', function() {
   describe('Cancel controller', function() {
+    describe('#middlewareChecks()', function() {
+      beforeEach(function() {
+        sinon.stub(FormWizardController.prototype, 'middlewareChecks')
+        sinon.stub(controller, 'use')
+        sinon.stub(controller, 'checkAllocation')
+
+        controller.middlewareChecks()
+      })
+
+      it('should call parent method', function() {
+        expect(FormWizardController.prototype.middlewareChecks).to.have.been
+          .calledOnce
+      })
+
+      it('should call checkAllocation middleware', function() {
+        expect(controller.use.firstCall).to.have.been.calledWith(
+          controller.checkAllocation
+        )
+      })
+
+      it('should call correct number of middleware', function() {
+        expect(controller.use.callCount).to.equal(1)
+      })
+    })
+
+    describe('#checkAllocation()', function() {
+      let mockRes, nextSpy
+
+      beforeEach(function() {
+        nextSpy = sinon.spy()
+        mockRes = {
+          locals: {
+            move: {
+              id: '12345',
+            },
+          },
+          redirect: sinon.spy(),
+        }
+      })
+
+      context('with non allocation move', function() {
+        beforeEach(function() {
+          controller.checkAllocation({}, mockRes, nextSpy)
+        })
+
+        it('should not redirect', function() {
+          expect(mockRes.redirect).not.to.be.called
+        })
+
+        it('should call next', function() {
+          expect(nextSpy).to.be.calledOnceWithExactly()
+        })
+      })
+
+      context('with allocation move', function() {
+        beforeEach(function() {
+          mockRes.locals.move.allocation = {
+            id: '123',
+          }
+          controller.checkAllocation({}, mockRes, nextSpy)
+        })
+
+        it('should redirect to move', function() {
+          expect(mockRes.redirect).to.be.calledOnceWithExactly('/move/12345')
+        })
+
+        it('should not call next', function() {
+          expect(nextSpy).not.to.be.called
+        })
+      })
+    })
+
     describe('#successHandler()', function() {
       let req, res, nextSpy
 

--- a/app/move/views/view.njk
+++ b/app/move/views/view.njk
@@ -62,6 +62,37 @@
       }
     }) }}
   {% endif %}
+
+  {% if not move.person %}
+    {% set html %}
+      <p>
+        {# TODO: Get moves returned as part of an allocation so that we can determine the number #}
+        {{ t("messages::pending_assign.content", {
+          context: "with_link" if canAccess("allocations:view"),
+          count: move.allocation.moves.length or move.allocation.moves_count,
+          href: "/allocation/" + move.allocation.id
+        }) | safe }}
+      </p>
+
+      {% if canAccess("allocation:person:assign") %}
+        {{ govukButton({
+          href: move.id + "/assign",
+          text: t("actions::add_person_to_move")
+        }) }}
+      {% endif %}
+    {% endset %}
+
+    {{ appMessage({
+      allowDismiss: false,
+      classes: "app-message--instruction",
+      title: {
+        text: t("messages::pending_assign.heading")
+      },
+      content: {
+        html: html
+      }
+    }) }}
+  {% endif %}
 {% endblock %}
 
 {% block contentHeader %}

--- a/app/move/views/view.njk
+++ b/app/move/views/view.njk
@@ -135,61 +135,77 @@
 {% endmacro %}
 
 {% block contentMain %}
-  <section class="app-!-position-relative">
-    <h2 class="govuk-heading-m">
-      {{ t("moves::steps.personal_details.heading") }}
-    </h2>
+  {% if move.person %}
+    <div class="govuk-!-margin-bottom-9">
+      <section class="app-!-position-relative">
+        <h2 class="govuk-heading-m">
+          {{ t("moves::steps.personal_details.heading") }}
+        </h2>
 
-    {{ govukSummaryList(personalDetailsSummary) }}
+        {{ govukSummaryList(personalDetailsSummary) }}
 
-    {{ updateLink(updateLinks.personal_details) }}
-  </section>
+        {{ updateLink(updateLinks.personal_details) }}
+      </section>
 
-  {% include "move/views/_includes/assessment.njk" %}
+      {% include "move/views/_includes/assessment.njk" %}
 
-  {% if move.from_location.can_upload_documents %}
-    <section class="app-!-position-relative">
-      <h2 class="govuk-heading-m govuk-!-margin-top-7">
-        {{ t("moves::detail.documents.heading", {
-          count: move.documents.length if move.documents.length > 1
-        }) }}
-      </h2>
+      {% if move.from_location.can_upload_documents %}
+        <section class="app-!-position-relative">
+          <h2 class="govuk-heading-m govuk-!-margin-top-7">
+            {{ t("moves::detail.documents.heading", {
+              count: move.documents.length if move.documents.length > 1
+            }) }}
+          </h2>
 
-      {% if move.documents | length %}
-        <ul class="govuk-list">
-          {% for document in move.documents %}
-            <li class="govuk-!-margin-bottom-3">
-              <a href="{{ document.url }}"
-                class="govuk-link"
-                target="_blank"
-                aria-labelledby="document-{{ loop.index }}">
-                {{- document.filename -}}
-              </a>
-              <span class="govuk-body-s">
-                ({{ document.filesize | filesize }})
-              </span>
-              <div class="govuk-hint govuk-!-font-size-16 govuk-!-margin-bottom-0" id="document-{{ loop.index }}">
-                ({{ t("opens_new_window") }})
-              </div>
-            </li>
-          {% endfor %}
-        </ul>
-      {% else %}
-        {{ appMessage({
-          classes: "app-message--muted",
-          allowDismiss: false,
-          content: {
-            html: t("moves::detail.documents.empty")
-          }
-        }) }}
+          {% if move.documents | length %}
+            <ul class="govuk-list">
+              {% for document in move.documents %}
+                <li class="govuk-!-margin-bottom-3">
+                  <a href="{{ document.url }}"
+                    class="govuk-link"
+                    target="_blank"
+                    aria-labelledby="document-{{ loop.index }}">
+                    {{- document.filename -}}
+                  </a>
+                  <span class="govuk-body-s">
+                    ({{ document.filesize | filesize }})
+                  </span>
+                  <div class="govuk-hint govuk-!-font-size-16 govuk-!-margin-bottom-0" id="document-{{ loop.index }}">
+                    ({{ t("opens_new_window") }})
+                  </div>
+                </li>
+              {% endfor %}
+            </ul>
+          {% else %}
+            {{ appMessage({
+              classes: "app-message--muted",
+              allowDismiss: false,
+              content: {
+                html: t("moves::detail.documents.empty")
+              }
+            }) }}
+          {% endif %}
+
+          {{ updateLink(updateLinks.document) }}
+        </section>
       {% endif %}
-
-      {{ updateLink(updateLinks.document) }}
-    </section>
+    </div>
   {% endif %}
 
-  {% if canAccess("move:cancel") and move.status == "requested" %}
-    <p class="govuk-!-margin-top-9 govuk-!-margin-bottom-0">
+  {% if move.allocation %}
+    {# TODO: Get moves returned as part of an allocation so that we can determine the number #}
+    {{ govukInsetText({
+      html: t("messages::cancel_allocation_move.content", {
+        context: "with_link" if canAccess("allocations:view"),
+        count: move.allocation.moves.length or move.allocation.moves_count,
+        href: "/allocation/" + move.allocation.id
+      }),
+      classes: "govuk-!-margin-bottom-0"
+    }) }}
+  {% endif %}
+
+  {% if canAccess("move:cancel") and move.status == "requested" and not move.allocation %}
+    <p class="govuk-!-margin-bottom-0">
       <a href="{{ move.id }}/cancel" class="app-link--destructive">
         {{ t("actions::cancel_move") }}
       </a>

--- a/locales/en/actions.json
+++ b/locales/en/actions.json
@@ -21,6 +21,7 @@
   "cancel_allocation": "Cancel allocation",
   "cancel_move": "Cancel this move",
   "cancel_move_confirmation": "Cancel move",
+  "add_person_to_move": "Add person to this move",
   "download": "Download",
   "download_csv": "Download (.csv)",
   "download_csv_allocations": "Download allocations (.csv)",

--- a/locales/en/default.json
+++ b/locales/en/default.json
@@ -11,6 +11,8 @@
   "location": "Location",
   "person": "person",
   "person_plural": "people",
+  "n_person": "{{count}} person",
+  "n_person_plural": "{{count}} people",
   "age_with_date_of_birth": "{{date_of_birth}} (Age {{age}})",
   "supplier_fallback": "the supplier",
   "opens_new_window": "Opens in a new window",

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -17,6 +17,9 @@
     "heading": "Awaiting a person to be added",
     "content": "$t(moves::allocation_relationship) and is waiting for a person to be added."
   },
+  "cancel_allocation_move": {
+    "content": "$t(moves::allocation_relationship). It can only be cancelled from the allocations page by a member of the Population Management Unit (PMU)."
+  },
   "assign_allocation": {
     "success": {
       "heading": "Move requested",

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -13,6 +13,10 @@
     "heading": "Pending review",
     "content": "This request needs to be reviewed by a member of the Population Management Unit (PMU) before it can be requested with the supplier."
   },
+  "pending_assign": {
+    "heading": "Awaiting a person to be added",
+    "content": "$t(moves::allocation_relationship) and is waiting for a person to be added."
+  },
   "assign_allocation": {
     "success": {
       "heading": "Move requested",

--- a/locales/en/moves.json
+++ b/locales/en/moves.json
@@ -213,5 +213,7 @@
       }
     }
   },
-  "redirect_notes": "Requested by {{fullname}} (user_name:{{username}} / user_id:{{userId}})"
+  "redirect_notes": "Requested by {{fullname}} (user_name:{{username}} / user_id:{{userId}})",
+  "allocation_relationship": "This move is part of an allocation for $t(n_person)",
+  "allocation_relationship_with_link": "This move is part of <a href=\"{{href}}\">an allocation for $t(n_person)</a>"
 }


### PR DESCRIPTION
## Proposed changes

This change improves the way a move that doesn't have a person is handled. Because the detail page relies heavily on the person details this page looked a little patchy, this change removes the details that we don't have and replaces them with a message.

It also includes the banner that shows there are actions awaiting on this item, with an action if the user has that permission level.

## Screenshots

| Before | After |
| ------ | ----- |
| <kbd><img src="https://user-images.githubusercontent.com/3327997/82954175-1c82ab80-9fa4-11ea-9649-40afc5900145.png"></kbd> | <kbd><img src="https://user-images.githubusercontent.com/3327997/82954079-e47b6880-9fa3-11ea-8cb2-46da9318bebb.png"></kbd> |
