### PR TITLE
fix(allocations): Ensure cancelled moves are returned correctly

### DIFF
--- a/app/allocations/middleware/set-filter.allocations.js
+++ b/app/allocations/middleware/set-filter.allocations.js
@@ -8,7 +8,7 @@ function setfilterAllocations(items = []) {
   return async function buildFilter(req, res, next) {
     const promises = items.map(item =>
       allocationService
-        .getByDateAndLocation({
+        .getActiveAllocations({
           ...req.body.allocations,
           isAggregation: true,
           status: item.status,

--- a/app/allocations/middleware/set-filter.allocations.test.js
+++ b/app/allocations/middleware/set-filter.allocations.test.js
@@ -30,7 +30,7 @@ describe('Allocations middleware', function() {
 
       beforeEach(function() {
         sinon.stub(i18n, 't').returnsArg(0)
-        sinon.stub(allocationService, 'getByDateAndLocation').resolves(4)
+        sinon.stub(allocationService, 'getActiveAllocations').resolves(4)
         next = sinon.spy()
         req = {
           baseUrl: '/moves',
@@ -76,7 +76,7 @@ describe('Allocations middleware', function() {
 
         it('calls the servive with correct arguments', async function() {
           expect(
-            allocationService.getByDateAndLocation
+            allocationService.getActiveAllocations
           ).to.have.been.calledWithExactly({
             isAggregation: true,
             status: 'pending',
@@ -84,7 +84,7 @@ describe('Allocations middleware', function() {
             fromLocationId: mockLocationId,
           })
           expect(
-            allocationService.getByDateAndLocation
+            allocationService.getActiveAllocations
           ).to.have.been.calledWithExactly({
             isAggregation: true,
             status: 'approved',
@@ -92,7 +92,7 @@ describe('Allocations middleware', function() {
             fromLocationId: mockLocationId,
           })
           expect(
-            allocationService.getByDateAndLocation
+            allocationService.getActiveAllocations
           ).to.have.been.calledWithExactly({
             isAggregation: true,
             status: 'rejected',
@@ -102,7 +102,7 @@ describe('Allocations middleware', function() {
         })
 
         it('calls the service on each item', async function() {
-          expect(allocationService.getByDateAndLocation.callCount).to.equal(3)
+          expect(allocationService.getActiveAllocations.callCount).to.equal(3)
         })
 
         it('calls next', function() {
@@ -200,7 +200,7 @@ describe('Allocations middleware', function() {
       const mockError = new Error('Error!')
 
       beforeEach(async function() {
-        sinon.stub(allocationService, 'getByDateAndLocation').rejects(mockError)
+        sinon.stub(allocationService, 'getActiveAllocations').rejects(mockError)
         next = sinon.spy()
         req = {
           body: {},

--- a/common/services/allocation.js
+++ b/common/services/allocation.js
@@ -57,6 +57,7 @@ const allocationService = {
     moveDate = [],
     fromLocationId,
     toLocationId,
+    includeCancelled = false,
     isAggregation = false,
     status,
   } = {}) {
@@ -64,6 +65,7 @@ const allocationService = {
 
     return allocationService.getAll({
       isAggregation,
+      includeCancelled,
       filter: pickBy({
         'filter[status]': status,
         'filter[from_locations]': fromLocationId,
@@ -73,15 +75,16 @@ const allocationService = {
       }),
     })
   },
-  getActiveAllocations(allocationsParams) {
+  getActiveAllocations(args) {
     return allocationService.getByDateAndLocation({
-      ...allocationsParams,
-      status: ['filled', 'unfilled'],
+      ...args,
+      status: 'filled,unfilled',
     })
   },
-  getCancelledAllocations(allocationsParams) {
+  getCancelledAllocations(args) {
     return allocationService.getByDateAndLocation({
-      ...allocationsParams,
+      ...args,
+      includeCancelled: true,
       status: 'cancelled',
     })
   },
@@ -89,6 +92,7 @@ const allocationService = {
     filter = {},
     combinedData = [],
     page = 1,
+    includeCancelled = false,
     isAggregation = false,
   } = {}) {
     return apiClient
@@ -106,7 +110,7 @@ const allocationService = {
         }
 
         if (!links.next) {
-          return results.map(allocationService.transform())
+          return results.map(allocationService.transform({ includeCancelled }))
         }
 
         return allocationService.getAll({

--- a/common/services/allocation.test.js
+++ b/common/services/allocation.test.js
@@ -309,6 +309,12 @@ describe('Allocation service', function() {
           expect(transformStub.callCount).to.equal(mockAllocations.length)
         })
 
+        it('should transform each person object not including cancelled', function() {
+          expect(allocationService.transform).to.be.calledOnceWithExactly({
+            includeCancelled: false,
+          })
+        })
+
         it('should return moves', function() {
           expect(moves).to.deep.equal(mockAllocations)
         })
@@ -355,6 +361,38 @@ describe('Allocation service', function() {
 
         it('should return a count', function() {
           expect(moves).to.equal(10)
+        })
+      })
+
+      context('with including cancelled moves', function() {
+        beforeEach(async function() {
+          moves = await allocationService.getAll({
+            includeCancelled: true,
+          })
+        })
+
+        it('should call the API client with default options', function() {
+          expect(apiClient.findAll.firstCall).to.be.calledWithExactly(
+            'allocation',
+            {
+              page: 1,
+              per_page: 100,
+            }
+          )
+        })
+
+        it('should transform each person object', function() {
+          expect(transformStub.callCount).to.equal(mockAllocations.length)
+        })
+
+        it('should transform each person object and include cancelled', function() {
+          expect(allocationService.transform).to.be.calledOnceWithExactly({
+            includeCancelled: true,
+          })
+        })
+
+        it('should return moves', function() {
+          expect(moves).to.deep.equal(mockAllocations)
         })
       })
     })
@@ -474,6 +512,7 @@ describe('Allocation service', function() {
       it('should call getAll with default filter', function() {
         expect(allocationService.getAll).to.be.calledOnceWithExactly({
           isAggregation: false,
+          includeCancelled: false,
           filter: {},
         })
       })
@@ -500,6 +539,7 @@ describe('Allocation service', function() {
         it('should call moves.getAll with correct args', function() {
           expect(allocationService.getAll).to.be.calledOnceWithExactly({
             isAggregation: false,
+            includeCancelled: false,
             filter: {
               'filter[date_from]': mockMoveDateRange[0],
               'filter[date_to]': mockMoveDateRange[1],
@@ -524,6 +564,7 @@ describe('Allocation service', function() {
         it('should call moves.getAll with correct args', function() {
           expect(allocationService.getAll).to.be.calledOnceWithExactly({
             isAggregation: false,
+            includeCancelled: false,
             filter: {
               'filter[from_locations]': mockFromLocationId,
             },
@@ -546,6 +587,30 @@ describe('Allocation service', function() {
         it('should call moves.getAll with correct args', function() {
           expect(allocationService.getAll).to.be.calledOnceWithExactly({
             isAggregation: true,
+            includeCancelled: false,
+            filter: {
+              'filter[from_locations]': mockFromLocationId,
+            },
+          })
+        })
+
+        it('should return results', function() {
+          expect(results).to.deep.equal(mockAllocations)
+        })
+      })
+
+      context('with including cancelled moves', function() {
+        beforeEach(async function() {
+          results = await allocationService.getByDateAndLocation({
+            includeCancelled: true,
+            fromLocationId: mockFromLocationId,
+          })
+        })
+
+        it('should call moves.getAll with correct args', function() {
+          expect(allocationService.getAll).to.be.calledOnceWithExactly({
+            isAggregation: false,
+            includeCancelled: true,
             filter: {
               'filter[from_locations]': mockFromLocationId,
             },
@@ -566,18 +631,17 @@ describe('Allocation service', function() {
         additionalParams: {},
       })
     })
-    afterEach(function() {
-      allocationService.getByDateAndLocation.restore()
-    })
+
     it('invokes getByDateAndLocation passing a proposed status', function() {
       expect(
         allocationService.getByDateAndLocation
       ).to.have.been.calledWithExactly({
         additionalParams: {},
-        status: ['filled', 'unfilled'],
+        status: 'filled,unfilled',
       })
     })
   })
+
   describe('#getCancelledAllocations', function() {
     beforeEach(function() {
       sinon.stub(allocationService, 'getByDateAndLocation')
@@ -585,14 +649,13 @@ describe('Allocation service', function() {
         additionalParams: {},
       })
     })
-    afterEach(function() {
-      allocationService.getByDateAndLocation.restore()
-    })
+
     it('invokes getByDateAndLocation passing a cancelled status', function() {
       expect(
         allocationService.getByDateAndLocation
       ).to.have.been.calledWithExactly({
         additionalParams: {},
+        includeCancelled: true,
         status: 'cancelled',
       })
     })


### PR DESCRIPTION
## Proposed changes

This update ensures that the correct filter to show non-cancelled
moves is sent to the API.

It also ensures that the correct method is called in the filter so that
the numbers reflect the correct results.

**Depends on** [#494](https://github.com/ministryofjustice/hmpps-book-secure-move-api/pull/494) in API project