### PR TITLE
P4 1349 remove person from allocation

### DIFF
--- a/app/allocation/controllers/index.js
+++ b/app/allocation/controllers/index.js
@@ -11,6 +11,7 @@ const createControllers = {
 const cancelControllers = {
   CancelController,
 }
+
 module.exports = {
   cancelControllers,
   createControllers,

--- a/app/allocation/controllers/view.js
+++ b/app/allocation/controllers/view.js
@@ -4,7 +4,12 @@ module.exports = function view(req, res) {
   const { allocation } = res.locals
   const { moves } = allocation
   const bannerStatuses = ['cancelled']
+
   const movesWithoutPerson = moves.filter(move => !move.person)
+  const moveToCardComponent = presenters.moveToCardComponent({
+    showStatus: false,
+  })
+
   const locals = {
     dashboardUrl: '/allocations',
     /* eslint-disable indent */
@@ -22,7 +27,7 @@ module.exports = function view(req, res) {
       emptySlots: movesWithoutPerson.length,
       filledSlots: moves
         .filter(move => move.person)
-        .map(presenters.moveToCardComponent()),
+        .map(move => ({ ...move, ...moveToCardComponent(move) })),
     },
   }
   res.render('allocation/views/view', locals)

--- a/app/allocation/controllers/view.js
+++ b/app/allocation/controllers/view.js
@@ -27,7 +27,11 @@ module.exports = function view(req, res) {
       emptySlots: movesWithoutPerson.length,
       filledSlots: moves
         .filter(move => move.person)
-        .map(move => ({ ...move, ...moveToCardComponent(move) })),
+        .map(move => ({
+          id: move.id,
+          fullname: move.person.fullname,
+          card: moveToCardComponent(move),
+        })),
     },
   }
   res.render('allocation/views/view', locals)

--- a/app/allocation/controllers/view.test.js
+++ b/app/allocation/controllers/view.test.js
@@ -1,3 +1,5 @@
+const { expect } = require('chai')
+
 const presenters = require('../../../common/presenters')
 
 const handler = require('./view')
@@ -118,9 +120,14 @@ describe('view allocation', function() {
     })
 
     it('calls render with the template', function() {
-      expect(mockRes.render).to.have.been.calledWithExactly(
+      expect(
+        JSON.parse(JSON.stringify(mockRes.render.getCall(0).args))
+      ).to.deep.equal([
         'allocation/views/view',
         {
+          dashboardUrl: '/allocations',
+          messageContent: 'allocations::statuses.description',
+          unassignedMoveId: '123',
           allocationDetails: {},
           allocationSummary: {},
           allocationPeople: {
@@ -128,26 +135,16 @@ describe('view allocation', function() {
             filledSlots: [
               {
                 id: '456',
-                person: {
-                  first_names: 'John',
-                  last_name: 'Doe',
-                },
+                person: { first_names: 'John', last_name: 'Doe' },
               },
               {
                 id: '011',
-                person: {
-                  first_names: 'Phil',
-                  last_name: 'Jones',
-                },
+                person: { first_names: 'Phil', last_name: 'Jones' },
               },
             ],
           },
-          unassignedMoveId: '123',
-          messageContent: 'allocations::statuses.description',
-          messageTitle: undefined,
-          dashboardUrl: '/allocations',
-        }
-      )
+        },
+      ])
     })
   })
 
@@ -169,6 +166,33 @@ describe('view allocation', function() {
     it('does create a message banner content', function() {
       expect(locals.messageContent).to.equal(
         'allocations::statuses.description'
+      )
+    })
+
+    it('calls render with the template', function() {
+      expect(mockRes.render).to.be.calledOnceWithExactly(
+        'allocation/views/view',
+        {
+          dashboardUrl: '/allocations',
+          messageTitle: 'allocations::statuses.cancelled',
+          messageContent: 'allocations::statuses.description',
+          unassignedMoveId: '123',
+          allocationDetails: {},
+          allocationSummary: {},
+          allocationPeople: {
+            emptySlots: 2,
+            filledSlots: [
+              {
+                id: '456',
+                person: { first_names: 'John', last_name: 'Doe' },
+              },
+              {
+                id: '011',
+                person: { first_names: 'Phil', last_name: 'Jones' },
+              },
+            ],
+          },
+        }
       )
     })
   })

--- a/app/allocation/controllers/view.test.js
+++ b/app/allocation/controllers/view.test.js
@@ -1,5 +1,3 @@
-const { expect } = require('chai')
-
 const presenters = require('../../../common/presenters')
 
 const handler = require('./view')

--- a/app/allocation/controllers/view.test.js
+++ b/app/allocation/controllers/view.test.js
@@ -49,6 +49,7 @@ describe('view allocation', function() {
         person: {
           first_names: 'John',
           last_name: 'Doe',
+          fullname: 'John Doe',
         },
       },
       { id: '789' },
@@ -57,6 +58,7 @@ describe('view allocation', function() {
         person: {
           first_names: 'Phil',
           last_name: 'Jones',
+          fullname: 'Phil Jones',
         },
       },
     ],
@@ -135,11 +137,27 @@ describe('view allocation', function() {
             filledSlots: [
               {
                 id: '456',
-                person: { first_names: 'John', last_name: 'Doe' },
+                fullname: 'John Doe',
+                card: {
+                  id: '456',
+                  person: {
+                    first_names: 'John',
+                    last_name: 'Doe',
+                    fullname: 'John Doe',
+                  },
+                },
               },
               {
                 id: '011',
-                person: { first_names: 'Phil', last_name: 'Jones' },
+                fullname: 'Phil Jones',
+                card: {
+                  id: '011',
+                  person: {
+                    first_names: 'Phil',
+                    last_name: 'Jones',
+                    fullname: 'Phil Jones',
+                  },
+                },
               },
             ],
           },
@@ -184,11 +202,27 @@ describe('view allocation', function() {
             filledSlots: [
               {
                 id: '456',
-                person: { first_names: 'John', last_name: 'Doe' },
+                fullname: 'John Doe',
+                card: {
+                  id: '456',
+                  person: {
+                    first_names: 'John',
+                    last_name: 'Doe',
+                    fullname: 'John Doe',
+                  },
+                },
               },
               {
                 id: '011',
-                person: { first_names: 'Phil', last_name: 'Jones' },
+                fullname: 'Phil Jones',
+                card: {
+                  id: '011',
+                  person: {
+                    first_names: 'Phil',
+                    last_name: 'Jones',
+                    fullname: 'Phil Jones',
+                  },
+                },
               },
             ],
           },

--- a/app/allocation/views/view.njk
+++ b/app/allocation/views/view.njk
@@ -119,18 +119,20 @@
   {% endif %}
 
   {% for slot in allocationPeople.filledSlots %}
-  <section class="app-!-position-relative">
-    {{ appCard(slot) }}
-    {% if canAccess('allocation:person:assign') %}
-      <p class="app-!-position-top-right govuk-!-margin-top-3">
-        {{ govukButton({
-          href: '/move/' + slot.id + "/unassign",
-          html: t("allocations::view.person_unassign", {name: slot.person.fullname}),
-          classes: "govuk-button--secondary"
-        })}}
-      </p>
-    {% endif %}
-  </section>
+    <section class="app-!-position-relative">
+      {{ appCard(slot.card) }}
+      {# TODO: consider handling actions within card component #}
+      {# TODO: consider whether long names may cause overlap problems #}
+      {% if canAccess('allocation:person:assign') %}
+        <p class="app-!-position-top-right govuk-!-margin-top-3">
+          {{ govukButton({
+            href: '/move/' + slot.id + "/unassign",
+            html: t("allocations::view.person_unassign", {name: slot.fullname}),
+            classes: "govuk-button--secondary"
+          })}}
+        </p>
+      {% endif %}
+    </section>
   {% endfor %}
 
 

--- a/app/allocation/views/view.njk
+++ b/app/allocation/views/view.njk
@@ -84,7 +84,7 @@
     <section class="govuk-!-margin-top-8">
     <h2 class="govuk-heading-m govuk-!-margin-bottom-1">{{ t("allocations::view.people_assign.heading") }}</h2>
     {% if allocationPeople.emptySlots %}
-    <p>You can’t add people who require a special vehicle to an allocation - you need to <a href="/move/new">create a single request</a> instead</p>
+    <p>{{ t("allocations::view.people_assign.special_vehicle_instruction", {href:"/move/new"}) | safe }}</p>
 
     <h3 class="govuk-heading-s">{{ t("allocations::view.people_assign.slots_empty", {
       slots_empty: allocationPeople.emptySlots,
@@ -98,7 +98,7 @@
       }) }}</p>
     {% endif %}
     {% if allocationPeople.filledSlots.length === 0 %}
-      {{ emptySlot('No prisoners added to allocation') }}
+      {{ emptySlot(t("allocations::view.people_assign.no_slots_filled")) }}
     {% endif %}
   </section>
   {% else %}
@@ -119,7 +119,18 @@
   {% endif %}
 
   {% for slot in allocationPeople.filledSlots %}
+  <section class="app-!-position-relative">
     {{ appCard(slot) }}
+    {% if canAccess('allocation:person:assign') %}
+      <p class="app-!-position-top-right govuk-!-margin-top-3">
+        {{ govukButton({
+          href: '/move/' + slot.id + "/unassign",
+          html: t("allocations::view.person_unassign", {name: slot.person.fullname}),
+          classes: "govuk-button--secondary"
+        })}}
+      </p>
+    {% endif %}
+  </section>
   {% endfor %}
 
 

--- a/app/move/controllers/index.js
+++ b/app/move/controllers/index.js
@@ -3,6 +3,7 @@ const Cancel = require('./cancel')
 const confirmation = require('./confirmation')
 const create = require('./create')
 const Review = require('./review')
+const Unassign = require('./unassign')
 const update = require('./update')
 const view = require('./view')
 
@@ -12,6 +13,7 @@ module.exports = {
   confirmation,
   create,
   Review,
+  Unassign,
   update,
   view,
 }

--- a/app/move/controllers/unassign.js
+++ b/app/move/controllers/unassign.js
@@ -40,18 +40,11 @@ class UnassignController extends FormWizardController {
   async saveValues(req, res, next) {
     try {
       const { id } = res.locals.move
-      await moveService.update({
-        id,
-        person: {
-          id: null,
-        },
-        move_agreed: false,
-        move_agreed_by: '',
-      })
+      await moveService.unassign(id)
+      super.saveValues(req, res, next)
     } catch (err) {
-      return next(err)
+      next(err)
     }
-    super.saveValues(req, res, next)
   }
 
   async successHandler(req, res, next) {

--- a/app/move/controllers/unassign.js
+++ b/app/move/controllers/unassign.js
@@ -3,9 +3,9 @@ const allocationService = require('../../../common/services/allocation')
 const moveService = require('../../../common/services/move')
 
 class UnassignController extends FormWizardController {
-  middlewareLocals() {
+  middlewareChecks() {
     this.use(this.checkAllocation)
-    super.middlewareLocals()
+    super.middlewareChecks()
   }
 
   async checkAllocation(req, res, next) {
@@ -17,6 +17,17 @@ class UnassignController extends FormWizardController {
     if (!move.person) {
       return res.redirect(`/allocation/${move.allocation.id}`)
     }
+
+    next()
+  }
+
+  middlewareLocals() {
+    super.middlewareLocals()
+    this.use(this.setMoveRelationships)
+  }
+
+  async setMoveRelationships(req, res, next) {
+    const { move } = res.locals
 
     const allocation = await allocationService.getById(move.allocation.id)
     res.locals.allocation = allocation

--- a/app/move/controllers/unassign.js
+++ b/app/move/controllers/unassign.js
@@ -7,7 +7,7 @@ class UnassignController extends FormWizardController {
     super.middlewareChecks()
   }
 
-  async checkAllocation(req, res, next) {
+  checkAllocation(req, res, next) {
     const { move } = res.locals
 
     if (!move.allocation) {

--- a/app/move/controllers/unassign.js
+++ b/app/move/controllers/unassign.js
@@ -47,7 +47,7 @@ class UnassignController extends FormWizardController {
     }
   }
 
-  async successHandler(req, res, next) {
+  successHandler(req, res) {
     const { id: allocationId } = res.locals.allocation
 
     req.journeyModel.reset()

--- a/app/move/controllers/unassign.js
+++ b/app/move/controllers/unassign.js
@@ -1,5 +1,4 @@
 const FormWizardController = require('../../../common/controllers/form-wizard')
-const allocationService = require('../../../common/services/allocation')
 const moveService = require('../../../common/services/move')
 
 class UnassignController extends FormWizardController {
@@ -26,19 +25,12 @@ class UnassignController extends FormWizardController {
     this.use(this.setMoveRelationships)
   }
 
-  async setMoveRelationships(req, res, next) {
-    try {
-      const { move } = res.locals
+  setMoveRelationships(req, res, next) {
+    const { move } = res.locals
+    res.locals.person = move.person
+    res.locals.allocation = move.allocation
 
-      const allocation = await allocationService.getById(move.allocation.id)
-      res.locals.allocation = allocation
-
-      res.locals.person = move.person
-
-      next()
-    } catch (err) {
-      next(err)
-    }
+    next()
   }
 
   async saveValues(req, res, next) {

--- a/app/move/controllers/unassign.js
+++ b/app/move/controllers/unassign.js
@@ -27,14 +27,18 @@ class UnassignController extends FormWizardController {
   }
 
   async setMoveRelationships(req, res, next) {
-    const { move } = res.locals
+    try {
+      const { move } = res.locals
 
-    const allocation = await allocationService.getById(move.allocation.id)
-    res.locals.allocation = allocation
+      const allocation = await allocationService.getById(move.allocation.id)
+      res.locals.allocation = allocation
 
-    res.locals.person = move.person
+      res.locals.person = move.person
 
-    next()
+      next()
+    } catch (err) {
+      next(err)
+    }
   }
 
   async saveValues(req, res, next) {
@@ -48,7 +52,7 @@ class UnassignController extends FormWizardController {
   }
 
   successHandler(req, res) {
-    const { id: allocationId } = res.locals.allocation
+    const { id: allocationId } = res.locals.move.allocation
 
     req.journeyModel.reset()
     req.sessionModel.reset()

--- a/app/move/controllers/unassign.js
+++ b/app/move/controllers/unassign.js
@@ -1,0 +1,56 @@
+const FormWizardController = require('../../../common/controllers/form-wizard')
+const allocationService = require('../../../common/services/allocation')
+const moveService = require('../../../common/services/move')
+
+class UnassignController extends FormWizardController {
+  middlewareLocals() {
+    this.use(this.checkAllocation)
+    super.middlewareLocals()
+  }
+
+  async checkAllocation(req, res, next) {
+    const { move } = res.locals
+
+    if (!move.allocation) {
+      return res.redirect(`/move/${move.id}`)
+    }
+    if (!move.person) {
+      return res.redirect(`/allocation/${move.allocation.id}`)
+    }
+
+    const allocation = await allocationService.getById(move.allocation.id)
+    res.locals.allocation = allocation
+
+    res.locals.person = move.person
+
+    next()
+  }
+
+  async saveValues(req, res, next) {
+    try {
+      const { id } = res.locals.move
+      await moveService.update({
+        id,
+        person: {
+          id: null,
+        },
+        move_agreed: false,
+        move_agreed_by: '',
+      })
+    } catch (err) {
+      return next(err)
+    }
+    super.saveValues(req, res, next)
+  }
+
+  async successHandler(req, res, next) {
+    const { id: allocationId } = res.locals.allocation
+
+    req.journeyModel.reset()
+    req.sessionModel.reset()
+
+    res.redirect(`/allocation/${allocationId}`)
+  }
+}
+
+module.exports = UnassignController

--- a/app/move/controllers/unassign.test.js
+++ b/app/move/controllers/unassign.test.js
@@ -1,0 +1,235 @@
+const proxyquire = require('proxyquire')
+
+const FormWizardController = require('../../../common/controllers/form-wizard')
+
+const allocationGetByIdStub = sinon.stub()
+allocationGetByIdStub.resolves({ id: '__allocation__' })
+const moveUpdateStub = sinon.stub()
+moveUpdateStub.resolves({})
+
+const UnassignController = proxyquire('./unassign', {
+  '../../../common/services/allocation': {
+    getById: allocationGetByIdStub,
+  },
+  '../../../common/services/move': {
+    update: moveUpdateStub,
+  },
+})
+
+const controller = new UnassignController({ route: '/' })
+
+describe('Move controllers', function() {
+  describe('Unassign controller', function() {
+    describe('#middlewareLocals()', function() {
+      beforeEach(function() {
+        sinon.stub(FormWizardController.prototype, 'middlewareLocals')
+        sinon.stub(controller, 'use')
+
+        controller.middlewareLocals()
+      })
+
+      it('should call parent method', function() {
+        expect(FormWizardController.prototype.middlewareLocals).to.have.been
+          .calledOnce
+      })
+
+      it('should call checkAllocation middleware', function() {
+        expect(controller.use.firstCall).to.have.been.calledWith(
+          controller.checkAllocation
+        )
+      })
+
+      it('should call correct number of middleware', function() {
+        expect(controller.use.callCount).to.equal(1)
+      })
+    })
+
+    describe('#checkAllocation()', function() {
+      let res, next
+
+      beforeEach(function() {
+        next = sinon.stub()
+      })
+
+      context('with no allocation', function() {
+        beforeEach(function() {
+          res = {
+            locals: {
+              move: {
+                id: '12345',
+              },
+            },
+            redirect: sinon.stub(),
+          }
+          controller.checkAllocation({}, res, next)
+        })
+
+        it('should redirect to allocation', function() {
+          expect(res.redirect).to.be.calledOnceWithExactly('/move/12345')
+        })
+
+        it('should not call next', function() {
+          expect(next).to.not.be.called
+        })
+      })
+
+      context('with allocation but not person', function() {
+        beforeEach(function() {
+          res = {
+            locals: {
+              move: {
+                id: '12345',
+                allocation: { id: '6789' },
+              },
+            },
+            redirect: sinon.stub(),
+          }
+          controller.checkAllocation({}, res, next)
+        })
+
+        it('should redirect to allocation', function() {
+          expect(res.redirect).to.be.calledOnceWithExactly('/allocation/6789')
+        })
+
+        it('should not call next', function() {
+          expect(next).to.not.be.called
+        })
+      })
+
+      context('with allocation and person', async function() {
+        beforeEach(function() {
+          allocationGetByIdStub.resetHistory()
+
+          res = {
+            locals: {
+              move: {
+                id: '12345',
+                allocation: { id: '6789' },
+                person: { id: '__person__' },
+              },
+            },
+            redirect: sinon.stub(),
+          }
+
+          controller.checkAllocation({}, res, next)
+        })
+
+        it('should not redirect', function() {
+          expect(res.redirect).to.not.be.called
+        })
+
+        it('should fetch allocation', function() {
+          expect(allocationGetByIdStub).to.be.calledOnceWithExactly('6789')
+        })
+
+        it('should call next', function() {
+          expect(next).to.not.be.calledOnceWithExactly()
+        })
+      })
+    })
+
+    describe('#saveValues()', function() {
+      const move = { id: '__move__' }
+      const req = {}
+      const res = {
+        locals: {
+          move,
+        },
+      }
+      let next
+
+      beforeEach(function() {
+        moveUpdateStub.resetHistory()
+        sinon.stub(FormWizardController.prototype, 'saveValues')
+        next = sinon.stub()
+      })
+
+      context('when person is unassigned', function() {
+        beforeEach(async function() {
+          await controller.saveValues(req, res, next)
+        })
+
+        it('should remove person from move', function() {
+          expect(moveUpdateStub).to.be.calledOnceWithExactly({
+            id: '__move__',
+            person: {
+              id: null,
+            },
+            move_agreed: false,
+            move_agreed_by: '',
+          })
+        })
+
+        it('should call the super method', function() {
+          expect(
+            FormWizardController.prototype.saveValues
+          ).to.be.calledOnceWithExactly(req, res, next)
+        })
+
+        it('should not call next', function() {
+          expect(next).to.not.be.called
+        })
+      })
+
+      context('when the api returns an error', function() {
+        const error = new Error()
+        beforeEach(async function() {
+          moveUpdateStub.throws(error)
+          await controller.saveValues(req, res, next)
+        })
+
+        it('should not call the super method', function() {
+          expect(FormWizardController.prototype.saveValues).to.not.be.called
+        })
+
+        it('should call next with the error', function() {
+          expect(next).to.be.calledOnceWithExactly(error)
+        })
+      })
+    })
+
+    describe('#successHandler()', function() {
+      let req, res, nextSpy
+
+      beforeEach(function() {
+        nextSpy = sinon.spy()
+        req = {
+          sessionModel: {
+            reset: sinon.stub(),
+          },
+          journeyModel: {
+            reset: sinon.stub(),
+          },
+        }
+        res = {
+          redirect: sinon.stub(),
+          locals: {
+            allocation: {
+              id: '__allocation__',
+            },
+          },
+        }
+      })
+
+      context('when person unassign is successful', function() {
+        beforeEach(async function() {
+          await controller.successHandler(req, res, nextSpy)
+        })
+
+        it('should reset the journey', function() {
+          expect(req.journeyModel.reset).to.have.been.calledOnce
+        })
+
+        it('should reset the session', function() {
+          expect(req.sessionModel.reset).to.have.been.calledOnce
+        })
+
+        it('should redirect to allocation correctly', function() {
+          expect(res.redirect).to.have.been.calledOnceWithExactly(
+            '/allocation/__allocation__'
+          )
+        })
+      })
+    })
+  })
+})

--- a/app/move/controllers/unassign.test.js
+++ b/app/move/controllers/unassign.test.js
@@ -1,5 +1,4 @@
 const FormWizardController = require('../../../common/controllers/form-wizard')
-const allocationService = require('../../../common/services/allocation')
 const moveService = require('../../../common/services/move')
 
 const UnassignController = require('./unassign')
@@ -135,40 +134,29 @@ describe('Move controllers', function() {
 
       beforeEach(function() {
         next = sinon.stub()
-        sinon.stub(allocationService, 'getById')
-        allocationService.getById.resolves({ id: '__allocation__' })
         res = {
           locals: {
             move: {
               id: '12345',
-              allocation: { id: '6789' },
+              allocation: { id: '__allocation__' },
               person: { id: '__person__' },
             },
           },
           redirect: sinon.stub(),
         }
+        controller.setMoveRelationships({}, res, next)
       })
 
-      context('When setting the move relationships', async function() {
-        beforeEach(function() {
-          controller.setMoveRelationships({}, res, next)
-        })
-
-        it('should fetch allocation', function() {
-          expect(allocationService.getById).to.be.calledOnceWithExactly('6789')
-        })
+      it('should set allocation on locals', function() {
+        expect(res.locals.allocation).to.deep.equal({ id: '__allocation__' })
       })
 
-      context('When allocation service returns an error', async function() {
-        const error = new Error()
-        beforeEach(function() {
-          allocationService.getById.throws(error)
-          controller.setMoveRelationships({}, res, next)
-        })
+      it('should set person on locals', function() {
+        expect(res.locals.person).to.deep.equal({ id: '__person__' })
+      })
 
-        it('should call next with the error', function() {
-          expect(next).to.be.calledOnceWithExactly(error)
-        })
+      it('should call next', function() {
+        expect(next).to.be.calledOnceWithExactly()
       })
     })
 

--- a/app/move/controllers/unassign.test.js
+++ b/app/move/controllers/unassign.test.js
@@ -4,15 +4,15 @@ const FormWizardController = require('../../../common/controllers/form-wizard')
 
 const allocationGetByIdStub = sinon.stub()
 allocationGetByIdStub.resolves({ id: '__allocation__' })
-const moveUpdateStub = sinon.stub()
-moveUpdateStub.resolves({})
+const moveUnassignStub = sinon.stub()
+moveUnassignStub.resolves({})
 
 const UnassignController = proxyquire('./unassign', {
   '../../../common/services/allocation': {
     getById: allocationGetByIdStub,
   },
   '../../../common/services/move': {
-    update: moveUpdateStub,
+    unassign: moveUnassignStub,
   },
 })
 
@@ -188,7 +188,7 @@ describe('Move controllers', function() {
       let next
 
       beforeEach(function() {
-        moveUpdateStub.resetHistory()
+        moveUnassignStub.resetHistory()
         sinon.stub(FormWizardController.prototype, 'saveValues')
         next = sinon.stub()
       })
@@ -199,14 +199,7 @@ describe('Move controllers', function() {
         })
 
         it('should remove person from move', function() {
-          expect(moveUpdateStub).to.be.calledOnceWithExactly({
-            id: '__move__',
-            person: {
-              id: null,
-            },
-            move_agreed: false,
-            move_agreed_by: '',
-          })
+          expect(moveUnassignStub).to.be.calledOnceWithExactly('__move__')
         })
 
         it('should call the super method', function() {
@@ -223,7 +216,7 @@ describe('Move controllers', function() {
       context('when the api returns an error', function() {
         const error = new Error()
         beforeEach(async function() {
-          moveUpdateStub.throws(error)
+          moveUnassignStub.throws(error)
           await controller.saveValues(req, res, next)
         })
 

--- a/app/move/controllers/unassign.test.js
+++ b/app/move/controllers/unassign.test.js
@@ -103,7 +103,7 @@ describe('Move controllers', function() {
         })
       })
 
-      context('with allocation and person', async function() {
+      context('with allocation and person', function() {
         beforeEach(function() {
           res = {
             locals: {

--- a/app/move/index.js
+++ b/app/move/index.js
@@ -21,6 +21,7 @@ const {
   cancel: cancelSteps,
   create: createSteps,
   review: reviewSteps,
+  unassign: unassignSteps,
   update: updateSteps,
 } = require('./steps')
 
@@ -106,6 +107,28 @@ if (FEATURE_FLAGS.EDITABILITY) {
     )
   })
 }
+
+// RESOLVE THESE PATHS PROPERLY
+const unassignConfig = {
+  ...wizardConfig,
+  controller: FormWizardController,
+  name: 'unassign-an-allocation',
+  templatePath: 'move/views/',
+  template: '../../../form-wizard',
+  journeyName: 'unassign-an-allocation',
+  journeyPageTitle: 'actions::cancel_allocation',
+}
+router.use(
+  '/:moveId/unassign',
+  protectRoute('allocation:person:assign'),
+  (req, res, next) => {
+    req.allocationId = req.params.allocationId
+    req.moveId = req.params.moveId
+    req.personId = req.params.personId
+    next()
+  },
+  wizard(unassignSteps, cancelFields, unassignConfig)
+)
 
 // Export
 module.exports = {

--- a/app/move/index.js
+++ b/app/move/index.js
@@ -108,7 +108,6 @@ if (FEATURE_FLAGS.EDITABILITY) {
   })
 }
 
-// RESOLVE THESE PATHS PROPERLY
 const unassignConfig = {
   ...wizardConfig,
   controller: FormWizardController,
@@ -121,12 +120,6 @@ const unassignConfig = {
 router.use(
   '/:moveId/unassign',
   protectRoute('allocation:person:assign'),
-  (req, res, next) => {
-    req.allocationId = req.params.allocationId
-    req.moveId = req.params.moveId
-    req.personId = req.params.personId
-    next()
-  },
   wizard(unassignSteps, cancelFields, unassignConfig)
 )
 

--- a/app/move/steps/index.js
+++ b/app/move/steps/index.js
@@ -2,6 +2,7 @@ const assign = require('./assign')
 const cancel = require('./cancel')
 const create = require('./create')
 const review = require('./review')
+const unassign = require('./unassign')
 const update = require('./update')
 
 module.exports = {
@@ -9,5 +10,6 @@ module.exports = {
   cancel,
   create,
   review,
+  unassign,
   update,
 }

--- a/app/move/steps/unassign.js
+++ b/app/move/steps/unassign.js
@@ -1,0 +1,20 @@
+const { Unassign } = require('../controllers')
+
+const unassignSteps = {
+  '/': {
+    entryPoint: true,
+    reset: true,
+    resetJourney: true,
+    skip: true,
+    next: 'remove',
+  },
+  '/remove': {
+    template: 'unassign',
+    controller: Unassign,
+    pageTitle: 'allocation::unassign.page_title',
+    buttonText: 'actions::person_unassign_confirmation',
+    buttonClasses: 'govuk-button--warning',
+  },
+}
+
+module.exports = unassignSteps

--- a/app/move/views/unassign.njk
+++ b/app/move/views/unassign.njk
@@ -13,7 +13,6 @@
   <p class="govuk-lede">
     {{ t("allocation::unassign.detail", {
       name: person.fullname,
-      move: move,
       href: '/allocation/' + allocation.id,
       count: allocation.moves_count,
       from_location: move.from_location.title,

--- a/app/move/views/unassign.njk
+++ b/app/move/views/unassign.njk
@@ -1,0 +1,26 @@
+{% extends "form-wizard.njk" %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+    text: t("actions::back_to_allocation"),
+    href: "/allocation/" + allocation.id
+  }) }}
+
+  {{ super() }}
+{% endblock %}
+
+{% block contentMain %}
+  <p class="govuk-lede">
+    {{ t("allocation::unassign.detail", {
+      person: person,
+      move: move,
+      href: '/allocation/' + allocation.id,
+      moves_count: allocation.moves_count,
+      from_location: move.from_location.title,
+      to_location: move.to_location.title,
+      date: move.date | formatDateWithDay,
+      people: "person" | pluralize(allocation.moves_count)
+    }) | safe }}
+  </p>
+  {{ super() }}
+{% endblock %}

--- a/app/move/views/unassign.njk
+++ b/app/move/views/unassign.njk
@@ -12,14 +12,13 @@
 {% block contentMain %}
   <p class="govuk-lede">
     {{ t("allocation::unassign.detail", {
-      person: person,
+      name: person.fullname,
       move: move,
       href: '/allocation/' + allocation.id,
-      moves_count: allocation.moves_count,
+      count: allocation.moves_count,
       from_location: move.from_location.title,
       to_location: move.to_location.title,
-      date: move.date | formatDateWithDay,
-      people: "person" | pluralize(allocation.moves_count)
+      date: move.date | formatDateWithDay
     }) | safe }}
   </p>
   {{ super() }}

--- a/common/presenters/move-to-card-component.js
+++ b/common/presenters/move-to-card-component.js
@@ -7,15 +7,18 @@ function moveToCardComponent({
   showImage = true,
   showMeta = true,
   showTags = true,
+  showStatus = true,
   hrefSuffix = '',
 } = {}) {
   return function item({ id, reference, person = {}, status }) {
     const href = `/move/${id}${hrefSuffix}`
     const excludedBadgeStatuses = ['cancelled']
-    const statusBadge =
-      excludedBadgeStatuses.includes(status) || isCompact
-        ? undefined
-        : { text: i18n.t(`statuses::${status}`) }
+
+    const showStatusBadge =
+      showStatus && !excludedBadgeStatuses.includes(status) && !isCompact
+    const statusBadge = showStatusBadge
+      ? { text: i18n.t(`statuses::${status}`) }
+      : undefined
     const personCardComponent = personToCardComponent({
       showImage: isCompact ? false : showImage,
       showMeta: isCompact ? false : showMeta,

--- a/common/presenters/move-to-card-component.test.js
+++ b/common/presenters/move-to-card-component.test.js
@@ -167,6 +167,30 @@ describe('Presenters', function() {
       })
     })
 
+    context('with status disabled', function() {
+      beforeEach(function() {
+        transformedResponse = moveToCardComponent({
+          showStatus: false,
+        })(mockMove)
+      })
+
+      it('should call person to card component correctly', function() {
+        expect(personToCardComponentItemStub).to.be.calledWithExactly({
+          ...mockMove.person,
+          href: '/move/12345',
+        })
+        expect(personToCardComponentStub).to.be.calledWithExactly({
+          showImage: true,
+          showMeta: true,
+          showTags: true,
+        })
+      })
+
+      it('should not set status on move card object', function() {
+        expect(transformedResponse.status).to.be.undefined
+      })
+    })
+
     context('with compact design', function() {
       beforeEach(function() {
         transformedResponse = moveToCardComponent({

--- a/common/services/move.js
+++ b/common/services/move.js
@@ -190,6 +190,17 @@ const moveService = {
       })
   },
 
+  unassign(id) {
+    return moveService.update({
+      id,
+      person: {
+        id: null,
+      },
+      move_agreed: false,
+      move_agreed_by: '',
+    })
+  },
+
   cancel(id, { reason, comment } = {}) {
     if (!id) {
       return Promise.reject(new Error(noMoveIdMessage))

--- a/common/services/move.test.js
+++ b/common/services/move.test.js
@@ -892,6 +892,47 @@ describe('Move Service', function() {
     })
   })
 
+  describe('#unassign()', function() {
+    context('without move ID', function() {
+      it('should reject with error', function() {
+        return expect(moveService.unassign()).to.be.rejectedWith(
+          'No move ID supplied'
+        )
+      })
+    })
+
+    context('with move ID', function() {
+      const mockId = 'b695d0f0-af8e-4b97-891e-92020d6820b9'
+      const mockResponse = {
+        data: {
+          ...mockMove,
+          person: null,
+        },
+      }
+
+      beforeEach(async function() {
+        sinon.stub(moveService, 'update').resolves(mockResponse)
+      })
+
+      context('without data args', function() {
+        beforeEach(async function() {
+          await moveService.unassign(mockId)
+        })
+
+        it('should call update method with data', function() {
+          expect(moveService.update).to.be.calledOnceWithExactly({
+            id: mockId,
+            person: {
+              id: null,
+            },
+            move_agreed: false,
+            move_agreed_by: '',
+          })
+        })
+      })
+    })
+  })
+
   describe('#redirect()', function() {
     const mockRedirect = {
       id: '#moveId',

--- a/locales/en/actions.json
+++ b/locales/en/actions.json
@@ -22,6 +22,7 @@
   "cancel_move": "Cancel this move",
   "cancel_move_confirmation": "Cancel move",
   "add_person_to_move": "Add person to this move",
+  "person_unassign_confirmation": "Remove from allocation",
   "download": "Download",
   "download_csv": "Download (.csv)",
   "download_csv_allocations": "Download allocations (.csv)",

--- a/locales/en/allocation.json
+++ b/locales/en/allocation.json
@@ -10,5 +10,9 @@
     "heading": "You can’t add this person to an allocation",
     "content": "<p>As this person needs a special vehicle they cannot be part of this allocation.</p>\n<p>If you would still like to move this person you can create a single request for them to move to another prison.",
     "return_link_text": "Return to allocation"
+  },
+  "unassign": {
+    "page_title": "Remove person from allocation",
+    "detail": "Remove {{person.fullname}} from the allocation for <a href=\"{{href}}\">{{moves_count}} {{people}}</a> from {{from_location}} to {{to_location}} on {{date}}"
   }
 }

--- a/locales/en/allocation.json
+++ b/locales/en/allocation.json
@@ -13,6 +13,6 @@
   },
   "unassign": {
     "page_title": "Remove person from allocation",
-    "detail": "Remove {{person.fullname}} from the allocation for <a href=\"{{href}}\">{{moves_count}} {{people}}</a> from {{from_location}} to {{to_location}} on {{date}}"
+    "detail": "Remove {{name}} from the allocation for <a href=\"{{href}}\">$t(n_person)</a> from {{from_location}} to {{to_location}} on {{date}}"
   }
 }

--- a/locales/en/allocations.json
+++ b/locales/en/allocations.json
@@ -37,10 +37,13 @@
       "empty_slot": "Person to be allocated"
     },
     "people_assign": {
+      "special_vehicle_instruction": "You can’t add people who require a special vehicle to an allocation - you need to <a href=\"{{href}}\">create a single request</a> instead",
+      "no_slots_filled": "No prisoners added to allocation",
       "slots_empty": "{{slots_empty}} {{person_or_people}} to add",
       "heading": "People for allocation",
       "empty_slot": "Person to be allocated"
     },
+    "person_unassign": "Remove <span class=\"govuk-visually-hidden\">{{ name }}</span>",
     "cancel_allocation": "Cancel allocation",
     "allocation_details": "Allocation details",
     "sidebar": {


### PR DESCRIPTION
Adds unassign route to move

![Remove_person_from_allocation_-_Cancel_allocation](https://user-images.githubusercontent.com/4856/83120365-decb7300-a0c8-11ea-9fbb-28786141407b.png)

Adds unassign link to allocation view and suppresses status badge

| Before | After |
| ------ | ----- |
|![View_allocation](https://user-images.githubusercontent.com/4856/83120580-23efa500-a0c9-11ea-9a18-8bbc0190fb95.png)|![View_allocation](https://user-images.githubusercontent.com/4856/83120478-07536d00-a0c9-11ea-80c5-4add92bd142b.png)|


### Checklist

- [x] If adding new environment variables, they have been documented in the [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md)
- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
