### PR TITLE
fix: Ensure card without image doesn't have left margin

### DIFF
--- a/common/components/card/_card.scss
+++ b/common/components/card/_card.scss
@@ -66,7 +66,9 @@ $_image-width: 80px;
 }
 
 .app-card__content {
-  margin-left: $_image-width + govuk-spacing(3);
+  .app-card--with-aside & {
+    margin-left: $_image-width + govuk-spacing(3);
+  }
 
   .app-card--placeholder & {
     background: govuk-colour("light-grey");

--- a/common/components/card/template.njk
+++ b/common/components/card/template.njk
@@ -3,7 +3,7 @@
 
 {% set headingLevel = params.headingLevel if params.headingLevel else 2 %}
 
-<div class="app-card{%- if params.classes %} {{ params.classes }}{% endif %}">
+<div class="app-card{%- if params.image_path %} app-card--with-aside{% endif %}{%- if params.classes %} {{ params.classes }}{% endif %}">
   {% if params.image_path %}
     <aside class="app-card__aside">
       <img class="app-card__image" src="{{ params.image_path }}" alt="{{ params.image_alt }}">


### PR DESCRIPTION
## Proposed changes

A previous update to the card component fixed the float issue with
images. This meant introducing a fixed width margin on the left.

However, this caused a problem when a card didn't include an image
as the margin was still being applied.

This fix uses a modifier class on the card for when an image is present
to handle applying the extra style required for the image.

## Screenshots

| Before | After |
| ------ | ----- |
| <kbd><img src="https://user-images.githubusercontent.com/3327997/83125554-9a8fa100-a0cf-11ea-837a-1271213eedc9.png"></kbd> | <kbd><img src="https://user-images.githubusercontent.com/3327997/83125497-83e94a00-a0cf-11ea-94ab-1fe5d2f9eee7.png"></kbd> |
