### PR TITLE
P4 1336 confirm person added to allocation

### DIFF
--- a/app/move/controllers/assign/confirmation.js
+++ b/app/move/controllers/assign/confirmation.js
@@ -13,12 +13,13 @@ class ConfirmationController extends PersonAssignBase {
       const allocationId = res.locals.move.allocation.id
 
       const allocation = await allocationService.getById(allocationId)
-      const unassignedMove =
-        allocation.moves.filter(
-          move => !move.person || move.person === null
-        )[0] || {}
 
-      res.locals.unassignedMoveId = unassignedMove.id
+      const unassignedMoves = allocation.moves.filter(move => !move.person)
+      const unassignedMoveId = unassignedMoves.length
+        ? unassignedMoves[0].id
+        : undefined
+
+      res.locals.unassignedMoveId = unassignedMoveId
       next()
     } catch (err) {
       next(err)

--- a/app/move/controllers/assign/confirmation.js
+++ b/app/move/controllers/assign/confirmation.js
@@ -1,0 +1,25 @@
+const allocationService = require('../../../../common/services/allocation')
+
+const PersonAssignBase = require('./base')
+
+class ConfirmationController extends PersonAssignBase {
+  middlewareLocals() {
+    super.middlewareLocals()
+    this.use(this.setAssignNext)
+  }
+
+  async setAssignNext(req, res, next) {
+    const allocationId = res.locals.move.allocation.id
+
+    const allocation = await allocationService.getById(allocationId)
+    const unfilledMove =
+      allocation.moves.filter(
+        move => !move.person || move.person === null
+      )[0] || {}
+
+    res.locals.assignNext = unfilledMove.id
+    next()
+  }
+}
+
+module.exports = ConfirmationController

--- a/app/move/controllers/assign/confirmation.js
+++ b/app/move/controllers/assign/confirmation.js
@@ -5,20 +5,20 @@ const PersonAssignBase = require('./base')
 class ConfirmationController extends PersonAssignBase {
   middlewareLocals() {
     super.middlewareLocals()
-    this.use(this.setAssignNext)
+    this.use(this.setUnassignedMove)
   }
 
-  async setAssignNext(req, res, next) {
+  async setUnassignedMove(req, res, next) {
     try {
       const allocationId = res.locals.move.allocation.id
 
       const allocation = await allocationService.getById(allocationId)
-      const unfilledMove =
+      const unassignedMove =
         allocation.moves.filter(
           move => !move.person || move.person === null
         )[0] || {}
 
-      res.locals.assignNext = unfilledMove.id
+      res.locals.unassignedMoveId = unassignedMove.id
       next()
     } catch (err) {
       next(err)

--- a/app/move/controllers/assign/confirmation.js
+++ b/app/move/controllers/assign/confirmation.js
@@ -9,16 +9,20 @@ class ConfirmationController extends PersonAssignBase {
   }
 
   async setAssignNext(req, res, next) {
-    const allocationId = res.locals.move.allocation.id
+    try {
+      const allocationId = res.locals.move.allocation.id
 
-    const allocation = await allocationService.getById(allocationId)
-    const unfilledMove =
-      allocation.moves.filter(
-        move => !move.person || move.person === null
-      )[0] || {}
+      const allocation = await allocationService.getById(allocationId)
+      const unfilledMove =
+        allocation.moves.filter(
+          move => !move.person || move.person === null
+        )[0] || {}
 
-    res.locals.assignNext = unfilledMove.id
-    next()
+      res.locals.assignNext = unfilledMove.id
+      next()
+    } catch (err) {
+      next(err)
+    }
   }
 }
 

--- a/app/move/controllers/assign/confirmation.test.js
+++ b/app/move/controllers/assign/confirmation.test.js
@@ -34,7 +34,7 @@ describe('Assign controllers', function() {
 
       it('should call set assign next method', function() {
         expect(controller.use.getCall(0)).to.have.been.calledWithExactly(
-          controller.setAssignNext
+          controller.setUnassignedMove
         )
       })
 
@@ -43,7 +43,7 @@ describe('Assign controllers', function() {
       })
     })
 
-    describe('#setAssignNext()', function() {
+    describe('#setUnassignedMove()', function() {
       const move = { id: '__move__', allocation: { id: '__allocation__' } }
       const req = {}
       const res = {
@@ -59,7 +59,7 @@ describe('Assign controllers', function() {
 
       describe('When setting the next move to assign', function() {
         beforeEach(async function() {
-          await controller.setAssignNext(req, res, next)
+          await controller.setUnassignedMove(req, res, next)
         })
 
         it('should fetch the allocation the move is in', function() {
@@ -75,11 +75,11 @@ describe('Assign controllers', function() {
 
       describe('When no unfilled moves remain', function() {
         beforeEach(async function() {
-          await controller.setAssignNext(req, res, next)
+          await controller.setUnassignedMove(req, res, next)
         })
 
         it('should not set a move to assign next', function() {
-          expect(res.locals.assignNext).to.be.undefined
+          expect(res.locals.unassignedMoveId).to.be.undefined
         })
       })
 
@@ -99,11 +99,11 @@ describe('Assign controllers', function() {
               },
             ],
           })
-          await controller.setAssignNext(req, res, next)
+          await controller.setUnassignedMove(req, res, next)
         })
 
         it('should set a move to assign next', function() {
-          expect(res.locals.assignNext).to.equal('5678')
+          expect(res.locals.unassignedMoveId).to.equal('5678')
         })
       })
 
@@ -111,7 +111,7 @@ describe('Assign controllers', function() {
         const error = new Error()
         beforeEach(async function() {
           allocationGetByIdStub.throws(error)
-          await controller.setAssignNext(req, res, next)
+          await controller.setUnassignedMove(req, res, next)
         })
 
         it('should call next with the error', function() {

--- a/app/move/controllers/assign/confirmation.test.js
+++ b/app/move/controllers/assign/confirmation.test.js
@@ -1,14 +1,7 @@
-const proxyquire = require('proxyquire')
+const allocationService = require('../../../../common/services/allocation')
 
 const AssignBaseController = require('./base')
-
-const allocationGetByIdStub = sinon.stub().resolves({ moves: [] })
-
-const ConfirmationController = proxyquire('./confirmation', {
-  '../../../../common/services/allocation': {
-    getById: allocationGetByIdStub,
-  },
-})
+const ConfirmationController = require('./confirmation')
 
 const controller = new ConfirmationController({ route: '/' })
 const ownProto = Object.getPrototypeOf(controller)
@@ -54,7 +47,8 @@ describe('Assign controllers', function() {
       let next
       beforeEach(function() {
         next = sinon.stub()
-        allocationGetByIdStub.resetHistory()
+        sinon.stub(allocationService, 'getById')
+        allocationService.getById.resolves({ moves: [] })
       })
 
       describe('When setting the next move to assign', function() {
@@ -63,7 +57,7 @@ describe('Assign controllers', function() {
         })
 
         it('should fetch the allocation the move is in', function() {
-          expect(allocationGetByIdStub).to.be.calledOnceWithExactly(
+          expect(allocationService.getById).to.be.calledOnceWithExactly(
             '__allocation__'
           )
         })
@@ -85,7 +79,7 @@ describe('Assign controllers', function() {
 
       describe('When unfilled moves remain', function() {
         beforeEach(async function() {
-          allocationGetByIdStub.resolves({
+          allocationService.getById.resolves({
             moves: [
               {
                 id: '1234',
@@ -110,7 +104,7 @@ describe('Assign controllers', function() {
       describe('When allocation service returns an error', function() {
         const error = new Error()
         beforeEach(async function() {
-          allocationGetByIdStub.throws(error)
+          allocationService.getById.throws(error)
           await controller.setUnassignedMove(req, res, next)
         })
 

--- a/app/move/controllers/assign/confirmation.test.js
+++ b/app/move/controllers/assign/confirmation.test.js
@@ -1,0 +1,111 @@
+const proxyquire = require('proxyquire')
+
+const AssignBaseController = require('./base')
+
+const allocationGetByIdStub = sinon.stub().resolves({ moves: [] })
+
+const ConfirmationController = proxyquire('./confirmation', {
+  '../../../../common/services/allocation': {
+    getById: allocationGetByIdStub,
+  },
+})
+
+const controller = new ConfirmationController({ route: '/' })
+const ownProto = Object.getPrototypeOf(controller)
+const BaseProto = AssignBaseController.prototype
+
+describe('Assign controllers', function() {
+  describe('Assign confirmation status controller', function() {
+    it('should extend AssignBaseController', function() {
+      expect(Object.getPrototypeOf(ownProto)).to.equal(BaseProto)
+    })
+
+    describe('#middlewareLocals()', function() {
+      beforeEach(function() {
+        sinon.stub(BaseProto, 'middlewareLocals')
+        sinon.stub(controller, 'use')
+
+        controller.middlewareLocals()
+      })
+
+      it('should call parent method', function() {
+        expect(BaseProto.middlewareLocals).to.have.been.calledOnce
+      })
+
+      it('should call set assign next method', function() {
+        expect(controller.use.getCall(0)).to.have.been.calledWithExactly(
+          controller.setAssignNext
+        )
+      })
+
+      it('should call correct number of additional middleware', function() {
+        expect(controller.use).to.be.callCount(1)
+      })
+    })
+
+    describe('#setAssignNext()', function() {
+      const move = { id: '__move__', allocation: { id: '__allocation__' } }
+      const req = {}
+      const res = {
+        locals: {
+          move,
+        },
+      }
+      let next
+      beforeEach(function() {
+        next = sinon.stub()
+        allocationGetByIdStub.resetHistory()
+      })
+
+      describe('When setting the next move to assign', function() {
+        beforeEach(async function() {
+          await controller.setAssignNext(req, res, next)
+        })
+
+        it('should fetch the allocation the move is in', function() {
+          expect(allocationGetByIdStub).to.be.calledOnceWithExactly(
+            '__allocation__'
+          )
+        })
+
+        it('should call next', function() {
+          expect(next).to.be.calledOnceWithExactly()
+        })
+      })
+
+      describe('When no unfilled moves remain', function() {
+        beforeEach(async function() {
+          await controller.setAssignNext(req, res, next)
+        })
+
+        it('should not set a move to assign next', function() {
+          expect(res.locals.assignNext).to.be.undefined
+        })
+      })
+
+      describe('When unfilled moves remain', function() {
+        beforeEach(async function() {
+          allocationGetByIdStub.resolves({
+            moves: [
+              {
+                id: '1234',
+                person: {
+                  id: '__person__',
+                },
+              },
+              {
+                id: '5678',
+                person: null,
+              },
+            ],
+          })
+          await controller.setAssignNext(req, res, next)
+        })
+
+        it('should set a move to assign next', function() {
+          expect(res.locals.assignNext).to.equal('5678')
+        })
+      })
+    })
+  })
+})

--- a/app/move/controllers/assign/confirmation.test.js
+++ b/app/move/controllers/assign/confirmation.test.js
@@ -106,6 +106,18 @@ describe('Assign controllers', function() {
           expect(res.locals.assignNext).to.equal('5678')
         })
       })
+
+      describe('When allocation service returns an error', function() {
+        const error = new Error()
+        beforeEach(async function() {
+          allocationGetByIdStub.throws(error)
+          await controller.setAssignNext(req, res, next)
+        })
+
+        it('should call next with the error', function() {
+          expect(next).to.be.calledOnceWithExactly(error)
+        })
+      })
     })
   })
 })

--- a/app/move/controllers/assign/index.js
+++ b/app/move/controllers/assign/index.js
@@ -1,6 +1,7 @@
 const AgreementStatus = require('./agreement-status')
 const Assessment = require('./assessment')
 const Base = require('./base')
+const Confirmation = require('./confirmation')
 const PersonSearch = require('./person-search')
 const PersonSearchResults = require('./person-search-results')
 const Save = require('./save')
@@ -9,6 +10,7 @@ module.exports = {
   AgreementStatus,
   Assessment,
   Base,
+  Confirmation,
   PersonSearch,
   PersonSearchResults,
   Save,

--- a/app/move/steps/assign.js
+++ b/app/move/steps/assign.js
@@ -58,6 +58,7 @@ const assignSteps = {
   '/confirmation': {
     checkJourney: false,
     checkSession: false,
+    controller: controllers.Confirmation,
     templatePath: 'move/views/assign/',
     template: 'confirmation',
   },

--- a/app/move/views/assign/confirmation.njk
+++ b/app/move/views/assign/confirmation.njk
@@ -33,6 +33,10 @@
         }) | safe }}
       </p>
 
+      {{ govukWarningText({
+        text: t("allocation::confirmation.saved_to_nomis")
+      }) }}
+
       <p>
         {{ t("allocation::confirmation.return_dashboard", {
               context: "with_assign_next" if assignNext,

--- a/app/move/views/assign/confirmation.njk
+++ b/app/move/views/assign/confirmation.njk
@@ -39,8 +39,8 @@
 
       <p>
         {{ t("allocation::confirmation.return_dashboard", {
-              context: "with_assign_next" if assignNext,
-              assignHref: '/move/' + assignNext + '/assign',
+              context: "with_assign_next" if unassignedMoveId,
+              assignHref: '/move/' + unassignedMoveId + '/assign',
               dashboardHref: '/allocations'
             }) | safe
         }}

--- a/app/move/views/assign/confirmation.njk
+++ b/app/move/views/assign/confirmation.njk
@@ -34,9 +34,9 @@
       </p>
 
       <p>
-      {% if addAnother %}
+      {% if assignNext %}
         {# TODO: Find way to get next empty move #}
-        <a href="{{ cancelUrl }}/assign">Add another person to this allocation</a> or
+        <a href="/move/{{ assignNext }}/assign">Add another person to this allocation</a> or
         <a href="/allocations">
         return to dashboard
         </a>

--- a/app/move/views/assign/confirmation.njk
+++ b/app/move/views/assign/confirmation.njk
@@ -34,17 +34,12 @@
       </p>
 
       <p>
-      {% if assignNext %}
-        {# TODO: Find way to get next empty move #}
-        <a href="/move/{{ assignNext }}/assign">Add another person to this allocation</a> or
-        <a href="/allocations">
-        return to dashboard
-        </a>
-      {% else %}
-        <a href="/allocations">
-          Return to dashboard
-        </a>
-      {% endif %}
+        {{ t("allocation::confirmation.return_dashboard", {
+              context: "with_assign_next" if assignNext,
+              assignHref: '/move/' + assignNext + '/assign',
+              dashboardHref: '/allocations'
+            }) | safe
+        }}
       </p>
     </div>
   </div>

--- a/locales/en/allocation.json
+++ b/locales/en/allocation.json
@@ -2,6 +2,7 @@
   "confirmation": {
     "page_title": "Person assigned",
     "detail": "The move for <a href=\"/move/{{move.id}}\">{{person.fullname}}</a> has been added to allocation for <a href=\"{{href}}\">{{moves_count}} {{people}}</a> from {{from_location}} to {{to_location}} on {{date}}",
+    "saved_to_nomis": "You need to add this move to NOMIS",
     "view_all": "View all allocations",
     "view_by_from_location": "View {{from_location}} overview",
     "return_dashboard": "<a href=\"{{dashboardHref}}\">Return to dashboard</a>",

--- a/locales/en/allocation.json
+++ b/locales/en/allocation.json
@@ -3,7 +3,9 @@
     "page_title": "Person assigned",
     "detail": "The move for <a href=\"/move/{{move.id}}\">{{person.fullname}}</a> has been added to allocation for <a href=\"{{href}}\">{{moves_count}} {{people}}</a> from {{from_location}} to {{to_location}} on {{date}}",
     "view_all": "View all allocations",
-    "view_by_from_location": "View {{from_location}} overview"
+    "view_by_from_location": "View {{from_location}} overview",
+    "return_dashboard": "<a href=\"{{dashboardHref}}\">Return to dashboard</a>",
+    "return_dashboard_with_assign_next": "<a href=\"{{assignHref}}\">Add another person to this allocation</a> or <a href=\"{{dashboardHref}}\">return to dashboard</a>"
   },
   "no_special_vehicle": {
     "page_title": "You can’t add this person to an allocation",


### PR DESCRIPTION
Adds a warning to confirmation page that user should add the move to NOMIS

![Person_assigned](https://user-images.githubusercontent.com/4856/83151941-1e0fb900-a0f5-11ea-8bac-83d8fcab3b8f.png)


Also reinstates the link to assign another person if allocation still has unfilled moves


### Checklist

- [x] If adding new environment variables, they have been documented in the [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md)
- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
