### PR TITLE
[P4 1445] Display additional info when no allocation move agreement

### DIFF
--- a/app/move/controllers/assign/base.js
+++ b/app/move/controllers/assign/base.js
@@ -14,16 +14,14 @@ class CreateAllocationBaseController extends CreateBaseController {
   }
 
   setMove(req, res, next) {
-    const { move } = res.locals
     const person = req.sessionModel.get('person')
-
-    if (!req.sessionModel.get('move')) {
-      req.sessionModel.set('move', move)
-    }
-
     res.locals.person = person
 
+    const move = req.sessionModel.get('move') || res.locals.move
+    req.sessionModel.set('move', move)
+
     // TODO: when req.getMove et al are removed these can be zapped
+    res.locals.move = move
     req.models.move = move
     req.models.person = person
 

--- a/app/move/controllers/assign/base.test.js
+++ b/app/move/controllers/assign/base.test.js
@@ -155,7 +155,7 @@ describe('Assign controllers', function() {
         expect(res.locals.person).to.equal('person')
       })
 
-      it('should set move on session model', function() {
+      it('should set move on session model with res.locals.move', function() {
         expect(req.sessionModel.set).to.be.calledWithExactly('move', moveFilled)
       })
 
@@ -179,8 +179,8 @@ describe('Assign controllers', function() {
         controller.setMove(req, res, nextSpy)
       })
 
-      it('should not set move object on session model', function() {
-        expect(req.sessionModel.set).to.not.be.called
+      it('should reset move object with the value in the session', function() {
+        expect(req.sessionModel.set).to.be.calledWithExactly('move', 'move')
       })
     })
   })

--- a/app/move/fields/index.js
+++ b/app/move/fields/index.js
@@ -24,7 +24,9 @@ const hasCourtCase = require('./has-court-case')
 const hasDateTo = require('./has-date-to')
 const lastName = require('./last-name')
 const moveAgreed = require('./move-agreed')
+const moveAgreedAssign = require('./move-agreed-assign')
 const moveAgreedBy = require('./move-agreed-by')
+const moveNotAgreedInstruction = require('./move-not-agreed-instruction')
 const moveType = require('./move-type')
 const people = require('./people')
 const policeNationalComputer = require('./police-national-computer')
@@ -41,6 +43,7 @@ const cancelFields = {
   cancellation_reason: cancellationReason,
   cancellation_reason_comment: cancellationReasonComment,
 }
+
 const createFields = {
   concealed_items: assessmentAnswer(),
   court_hearing__comments: courtHearingComments,
@@ -104,12 +107,16 @@ const createFields = {
   wheelchair: assessmentAnswer(),
   violent: assessmentAnswer(),
 }
+
 const updateFields = {
   ...cloneDeep(createFields),
   police_national_computer: policeNationalComputerUpdate,
 }
+
 const assignFields = {
   ...cloneDeep(createFields),
+  move_agreed: moveAgreedAssign,
+  move_not_agreed_instruction: moveNotAgreedInstruction,
   special_vehicle_check: specialVehicleCheck,
 }
 

--- a/app/move/fields/move-agreed-assign.js
+++ b/app/move/fields/move-agreed-assign.js
@@ -1,0 +1,8 @@
+const { cloneDeep } = require('lodash')
+
+const moveAgreed = require('./move-agreed')
+
+const moveAgreedAssign = cloneDeep(moveAgreed)
+moveAgreedAssign.items[1].conditional = 'move_not_agreed_instruction'
+
+module.exports = moveAgreedAssign

--- a/app/move/fields/move-not-agreed-instruction.js
+++ b/app/move/fields/move-not-agreed-instruction.js
@@ -1,0 +1,12 @@
+const moveNotAgreedInstruction = {
+  skip: true,
+  component: 'raw',
+  html:
+    '<p class="govuk-body">Complex cases must be discussed and agreed with the receiving prison.</p><p class="govuk-body">This includes:<p><ul class="govuk-list govuk-list--bullet"><li>Segregated prisoners</li><li>Self harm/prisoners on ACCT</li><li>Mental health issues</li><li>Integrated Drug Treatment System</li></ul>',
+  dependent: {
+    field: 'move_agreed',
+    value: 'false',
+  },
+}
+
+module.exports = moveNotAgreedInstruction

--- a/app/move/steps/assign.js
+++ b/app/move/steps/assign.js
@@ -23,6 +23,7 @@ const assignSteps = {
   '/agreement-status': {
     ...create['/agreement-status'],
     controller: controllers.AgreementStatus,
+    fields: ['move_agreed', 'move_agreed_by', 'move_not_agreed_instruction'],
     next: 'release-status',
   },
   '/release-status': {

--- a/common/components/raw/macro.njk
+++ b/common/components/raw/macro.njk
@@ -1,0 +1,3 @@
+{% macro raw(params) %}
+  {%- include "./template.njk" -%}
+{% endmacro %}

--- a/common/components/raw/raw.yaml
+++ b/common/components/raw/raw.yaml
@@ -1,0 +1,9 @@
+params:
+  - name: html
+    type: string
+    required: false
+    description: HTML to be rendered as is.
+examples:
+  - name: default
+    data:
+      html: "<p class=\"foo-bar\">Hello</p>"

--- a/common/components/raw/template.njk
+++ b/common/components/raw/template.njk
@@ -1,0 +1,1 @@
+{{ params.html | safe }}

--- a/common/components/raw/template.test.js
+++ b/common/components/raw/template.test.js
@@ -1,0 +1,26 @@
+const {
+  renderComponentHtmlToCheerio,
+  getExamples,
+} = require('../../../test/unit/component-helpers')
+
+const examples = getExamples('raw')
+
+describe('Raw component', function() {
+  context('by default', function() {
+    let $component
+
+    beforeEach(function() {
+      const $ = renderComponentHtmlToCheerio(
+        'raw',
+        examples.default,
+        false,
+        'raw'
+      )
+      $component = $('body')
+    })
+
+    it('should render', function() {
+      expect($component.html().trim()).to.equal('<p class="foo-bar">Hello</p>')
+    })
+  })
+})

--- a/common/templates/layouts/base.njk
+++ b/common/templates/layouts/base.njk
@@ -23,6 +23,7 @@
 {% from "moj/components/primary-navigation/macro.njk"     import mojPrimaryNavigation %}
 
 {# App level components #}
+{% from "raw/macro.njk"               import raw %}
 {% from "card/macro.njk"              import appCard %}
 {% from "data/macro.njk"              import appData %}
 {% from "filter/macro.njk"            import appFilter %}

--- a/test/unit/component-helpers.js
+++ b/test/unit/component-helpers.js
@@ -45,16 +45,23 @@ function _componentNameToMacroName(componentName) {
  * @param {string} componentName
  * @param {string} params parameters that are used in the component macro
  * @param {any} children any child components or text, pass the children to the macro
+ * @param {string} explicitMacroName Explicit macro name to use
  * @returns {function} returns cheerio (jQuery) instance of the macro for easy DOM querying
  */
-function renderComponentHtmlToCheerio(componentName, params, children = false) {
+function renderComponentHtmlToCheerio(
+  componentName,
+  params,
+  children = false,
+  explicitMacroName
+) {
   if (typeof params === 'undefined') {
     throw new Error(
       'Parameters passed to `render` should be an object but are undefined'
     )
   }
 
-  const macroName = _componentNameToMacroName(componentName)
+  const macroName =
+    explicitMacroName || _componentNameToMacroName(componentName)
   const macroParams = JSON.stringify(params, null, 2)
 
   let macroString = `{%- from "${componentName}/macro.njk" import ${macroName} -%}`


### PR DESCRIPTION
## Proposed changes

### What changed

Updates `agreement` step of move `assign` journey to use an extended version of the `move_agreed` field. Adds `move_not_agreed_instruction` as conditional field when `move_agreed` answer is`false`.

### Why did it change

Adds text with instructions of how to proceed if the move of a person to be assigned to an allocation has not yet been agreed.

### Issue tracking

- [P4-1445](https://dsdmoj.atlassian.net/browse/P4-1445)

## Screenshots

| Before | After |
| ------ | ----- |
|![Has_this_move_been_agreed_with_receiving_prison__-_person_assign](https://user-images.githubusercontent.com/4856/83184458-6775fd80-a121-11ea-8a39-7e6bfc5882d3.png)|![Has_this_move_been_agreed_with_receiving_prison__-_person_assign](https://user-images.githubusercontent.com/4856/83184230-10702880-a121-11ea-849c-80f0fb31d233.png) |

## Checklists

### Testing

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [x] Firefox

### Environment variables

- [x] No environment variables were added or changed

### Other considerations

- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics

