### PR TITLE
P4 1510 support query include in moves endpoint

### DIFF
--- a/common/lib/api-client/middleware/request.js
+++ b/common/lib/api-client/middleware/request.js
@@ -22,6 +22,14 @@ function requestMiddleware({ cacheExpiry = 60, disableCache = false } = {}) {
     req: async function req(payload) {
       const { req, jsonApi } = payload
       const pathname = new URL(req.url).pathname
+
+      if (Array.isArray(req.params.include)) {
+        req.params.include = req.params.include.sort().join(',')
+      }
+      if (!req.params.include) {
+        delete req.params.include
+      }
+
       const searchString = new URLSearchParams(req.params).toString()
       const key = `cache:${req.method}.${pathname}${
         searchString ? `?${searchString}` : ''

--- a/common/lib/api-client/middleware/request.test.js
+++ b/common/lib/api-client/middleware/request.test.js
@@ -184,6 +184,52 @@ describe('API Client', function() {
         })
       })
 
+      context('when request contains include param', function() {
+        beforeEach(function() {
+          getAsyncStub.resolves(null)
+          payload.req.params = {}
+        })
+
+        context('and passed as a string', function() {
+          beforeEach(async function() {
+            payload.req.params.include = 'foo,bar'
+            await requestMiddleware().req(payload)
+          })
+          it('should append include param as is to query', function() {
+            expect(payload.req.params.include).to.equal('foo,bar')
+            expect(getAsyncStub).to.be.calledOnceWithExactly(
+              'cache:GET./path/to/endpoint?include=foo%2Cbar'
+            )
+          })
+        })
+
+        context('and passed as a an array', function() {
+          beforeEach(async function() {
+            payload.req.params.include = ['foo', 'bar']
+            await requestMiddleware().req(payload)
+          })
+          it('should sort include params and append to query', function() {
+            expect(payload.req.params.include).to.equal('bar,foo')
+            expect(getAsyncStub).to.be.calledOnceWithExactly(
+              'cache:GET./path/to/endpoint?include=bar%2Cfoo'
+            )
+          })
+        })
+
+        context('and passed as a an empty array', function() {
+          beforeEach(async function() {
+            payload.req.params.include = []
+            await requestMiddleware().req(payload)
+          })
+          it('should not append include param to query', function() {
+            expect(payload.req.params.include).to.be.undefined
+            expect(getAsyncStub).to.be.calledOnceWithExactly(
+              'cache:GET./path/to/endpoint'
+            )
+          })
+        })
+      })
+
       describe('options', function() {
         beforeEach(async function() {
           getAsyncStub.resolves(null)

--- a/common/services/allocation.js
+++ b/common/services/allocation.js
@@ -5,6 +5,8 @@ const apiClient = require('../lib/api-client')()
 const personService = require('../services/person')
 
 const allocationService = {
+  defaultInclude: ['from_location', 'moves', 'to_location'],
+
   cancel(allocationId) {
     const timestamp = dateFunctions.formatISO(new Date())
     return apiClient
@@ -100,12 +102,14 @@ const allocationService = {
     page = 1,
     includeCancelled = false,
     isAggregation = false,
+    include = this.defaultInclude,
   } = {}) {
     return apiClient
       .findAll('allocation', {
         ...filter,
         page,
         per_page: isAggregation ? 1 : 100,
+        include,
       })
       .then(response => {
         const { data, links, meta } = response
@@ -123,12 +127,13 @@ const allocationService = {
           filter,
           combinedData: results,
           page: page + 1,
+          include,
         })
       })
   },
-  getById(id) {
+  getById(id, { include = this.defaultInclude } = {}) {
     return apiClient
-      .find('allocation', id)
+      .find('allocation', id, { include })
       .then(response => response.data)
       .then(allocationService.transform())
   },

--- a/common/services/person.js
+++ b/common/services/person.js
@@ -37,6 +37,8 @@ const assessmentKeys = [
 const explicitAssessmentKeys = ['special_vehicle', 'not_to_be_released']
 
 const personService = {
+  defaultInclude: ['ethnicity', 'gender'],
+
   transform(person) {
     if (!person) {
       return undefined
@@ -166,8 +168,11 @@ const personService = {
       .then(response => response.data)
   },
 
-  getByIdentifiers(identifiers) {
-    const filter = mapKeys(identifiers, (value, key) => `filter[${key}]`)
+  getByIdentifiers(identifiers, { include = this.defaultInclude } = {}) {
+    const filter = {
+      ...mapKeys(identifiers, (value, key) => `filter[${key}]`),
+      include,
+    }
 
     return apiClient
       .findAll('person', filter)

--- a/common/services/person.test.js
+++ b/common/services/person.test.js
@@ -17,7 +17,19 @@ const mockPerson = {
   last_name: 'Bloggs',
 }
 
+const mockDefaultInclude = ['default']
+
 describe('Person Service', function() {
+  it('should have the correct default include', function() {
+    expect(personService.defaultInclude).deep.equal(['ethnicity', 'gender'])
+  })
+})
+
+describe('Person Service', function() {
+  beforeEach(function() {
+    personService.defaultInclude = mockDefaultInclude
+  })
+
   describe('#transform()', function() {
     let transformed
 
@@ -816,7 +828,9 @@ describe('Person Service', function() {
       })
 
       it('should call findAll method with empty object', function() {
-        expect(apiClient.findAll).to.be.calledOnceWithExactly('person', {})
+        expect(apiClient.findAll).to.be.calledOnceWithExactly('person', {
+          include: mockDefaultInclude,
+        })
       })
 
       it('should transform response data', function() {
@@ -840,6 +854,7 @@ describe('Person Service', function() {
         expect(apiClient.findAll).to.be.calledOnceWithExactly('person', {
           'filter[filterOne]': 'filter-one-value',
           'filter[filterTwo]': 'filter-two-value',
+          include: mockDefaultInclude,
         })
       })
 
@@ -849,6 +864,21 @@ describe('Person Service', function() {
 
       it('should return data property', function() {
         expect(person).to.deep.equal(mockResponse.data)
+      })
+    })
+
+    context('with include parameter', function() {
+      beforeEach(async function() {
+        person = await personService.getByIdentifiers(
+          {},
+          { include: ['foo', 'bar'] }
+        )
+      })
+
+      it('should pass include parameter to api client', function() {
+        expect(apiClient.findAll).to.be.calledOnceWithExactly('person', {
+          include: ['foo', 'bar'],
+        })
       })
     })
   })

--- a/common/services/reference-data.js
+++ b/common/services/reference-data.js
@@ -3,6 +3,8 @@ const { flattenDeep, sortBy } = require('lodash')
 const apiClient = require('../lib/api-client')()
 
 const referenceDataService = {
+  locationsInclude: ['suppliers'],
+
   getGenders() {
     return apiClient.findAll('gender').then(response => response.data)
   },
@@ -19,12 +21,18 @@ const referenceDataService = {
       .then(response => response.data)
   },
 
-  getLocations({ filter, combinedData, page = 1 } = {}) {
+  getLocations({
+    filter,
+    combinedData,
+    page = 1,
+    include = this.locationsInclude,
+  } = {}) {
     return apiClient
       .findAll('location', {
         ...filter,
         page,
         per_page: 100,
+        include,
       })
       .then(response => {
         const { data, links } = response
@@ -40,16 +48,19 @@ const referenceDataService = {
           filter,
           page: page + 1,
           combinedData: locations,
+          include,
         })
       })
   },
 
-  getLocationById(id) {
+  getLocationById(id, { include = this.locationsInclude } = {}) {
     if (!id) {
       return Promise.reject(new Error('No location ID supplied'))
     }
 
-    return apiClient.find('location', id).then(response => response.data)
+    return apiClient
+      .find('location', id, { include })
+      .then(response => response.data)
   },
 
   getLocationByNomisAgencyId(nomisAgencyId) {

--- a/common/services/reference-data.test.js
+++ b/common/services/reference-data.test.js
@@ -55,429 +55,498 @@ const mockLocations = [
   },
 ]
 
+const mockLocationsInclude = ['default']
+
 describe('Reference Data Service', function() {
-  describe('#getGenders()', function() {
-    const mockResponse = {
-      data: mockGenders,
-    }
-    let response
-
-    beforeEach(async function() {
-      sinon.stub(apiClient, 'findAll')
-      apiClient.findAll.withArgs('gender').resolves(mockResponse)
-
-      response = await referenceDataService.getGenders()
-    })
-
-    it('should call API client', function() {
-      expect(apiClient.findAll).to.be.calledOnceWithExactly('gender')
-    })
-
-    it('should correct number of results', function() {
-      expect(response.length).to.deep.equal(mockGenders.length)
-    })
-
-    it('should return response data', function() {
-      expect(response).to.equal(mockGenders)
-    })
+  it('should have the correct default include', function() {
+    expect(referenceDataService.locationsInclude).deep.equal(['suppliers'])
   })
-
-  describe('#getEthnicities()', function() {
-    const mockResponse = {
-      data: mockEthnicities,
-    }
-    let response
-
-    beforeEach(async function() {
-      sinon.stub(apiClient, 'findAll')
-      apiClient.findAll.withArgs('ethnicity').resolves(mockResponse)
-
-      response = await referenceDataService.getEthnicities()
-    })
-
-    it('should call API client', function() {
-      expect(apiClient.findAll).to.be.calledOnceWithExactly('ethnicity')
-    })
-
-    it('should correct number of results', function() {
-      expect(response.length).to.deep.equal(mockEthnicities.length)
-    })
-
-    it('should return response data', function() {
-      expect(response).to.equal(mockEthnicities)
-    })
-  })
-
-  describe('#getAssessmentQuestions()', function() {
-    const mockResponse = {
-      data: mockAssessmentQuestions,
-    }
-    let response
-
-    beforeEach(async function() {
-      sinon.stub(apiClient, 'findAll')
-    })
-
-    context('with no category', function() {
-      beforeEach(async function() {
-        apiClient.findAll
-          .withArgs('assessment_question', {
-            'filter[category]': undefined,
-          })
-          .resolves(mockResponse)
-
-        response = await referenceDataService.getAssessmentQuestions()
-      })
-
-      it('should call API client with undefined category', function() {
-        expect(apiClient.findAll).to.be.calledOnceWithExactly(
-          'assessment_question',
-          {
-            'filter[category]': undefined,
-          }
-        )
-      })
-
-      it('should correct number of results', function() {
-        expect(response.length).to.deep.equal(mockAssessmentQuestions.length)
-      })
-
-      it('should return response data', function() {
-        expect(response).to.equal(mockAssessmentQuestions)
-      })
-    })
-
-    context('with category', function() {
-      const mockCategory = 'risk'
-
-      beforeEach(async function() {
-        apiClient.findAll
-          .withArgs('assessment_question', {
-            'filter[category]': mockCategory,
-          })
-          .resolves(mockResponse)
-
-        response = await referenceDataService.getAssessmentQuestions(
-          mockCategory
-        )
-      })
-
-      it('should call API client with category', function() {
-        expect(apiClient.findAll).to.be.calledOnceWithExactly(
-          'assessment_question',
-          {
-            'filter[category]': mockCategory,
-          }
-        )
-      })
-
-      it('should correct number of results', function() {
-        expect(response.length).to.deep.equal(mockAssessmentQuestions.length)
-      })
-
-      it('should return response data', function() {
-        expect(response).to.equal(mockAssessmentQuestions)
-      })
-    })
-  })
-
-  describe('#getLocations()', function() {
-    const mockResponse = {
-      data: mockLocations,
-      links: {},
-    }
-    const mockMultiPageResponse = {
-      data: mockLocations,
-      links: {
-        next: 'http://next-page.com',
-      },
-    }
-    const mockFilter = {
-      filterOne: 'foo',
-    }
-    let locations
-
+  context('', function() {
     beforeEach(function() {
-      sinon.stub(apiClient, 'findAll')
+      referenceDataService.locationsInclude = mockLocationsInclude
     })
 
-    context('with only one page', function() {
-      beforeEach(function() {
-        apiClient.findAll.resolves(mockResponse)
-      })
-
-      context('by default', function() {
-        beforeEach(async function() {
-          locations = await referenceDataService.getLocations()
-        })
-
-        it('should call the API client once', function() {
-          expect(apiClient.findAll).to.be.calledOnce
-        })
-
-        it('should call the API client with default options', function() {
-          expect(apiClient.findAll.firstCall).to.be.calledWithExactly(
-            'location',
-            {
-              page: 1,
-              per_page: 100,
-            }
-          )
-        })
-
-        it('should return locations sorted by title', function() {
-          expect(locations).to.deep.equal(sortBy(mockLocations, 'title'))
-        })
-      })
-
-      context('with filter', function() {
-        beforeEach(async function() {
-          locations = await referenceDataService.getLocations({
-            filter: mockFilter,
-          })
-        })
-
-        it('should call the API client with filter', function() {
-          expect(apiClient.findAll.firstCall).to.be.calledWithExactly(
-            'location',
-            {
-              ...mockFilter,
-              page: 1,
-              per_page: 100,
-            }
-          )
-        })
-      })
-    })
-
-    context('with multiple pages', function() {
-      beforeEach(function() {
-        apiClient.findAll
-          .onFirstCall()
-          .resolves(mockMultiPageResponse)
-          .onSecondCall()
-          .resolves(mockResponse)
-      })
-
-      context('by default', function() {
-        beforeEach(async function() {
-          locations = await referenceDataService.getLocations()
-        })
-
-        it('should call the API client twice', function() {
-          expect(apiClient.findAll).to.be.calledTwice
-        })
-
-        it('should call API client with default options on first call', function() {
-          expect(apiClient.findAll.firstCall).to.be.calledWithExactly(
-            'location',
-            {
-              page: 1,
-              per_page: 100,
-            }
-          )
-        })
-
-        it('should call API client with second page on second call', function() {
-          expect(apiClient.findAll.secondCall).to.be.calledWithExactly(
-            'location',
-            {
-              page: 2,
-              per_page: 100,
-            }
-          )
-        })
-
-        it('should return locations sorted by title', function() {
-          expect(locations).to.deep.equal(
-            sortBy([...mockLocations, ...mockLocations], 'title')
-          )
-        })
-      })
-
-      context('with filter', function() {
-        beforeEach(async function() {
-          locations = await referenceDataService.getLocations({
-            filter: mockFilter,
-          })
-        })
-
-        it('should call API client with filter on first call', function() {
-          expect(apiClient.findAll.firstCall).to.be.calledWithExactly(
-            'location',
-            {
-              ...mockFilter,
-              page: 1,
-              per_page: 100,
-            }
-          )
-        })
-
-        it('should call API client with filter on second call', function() {
-          expect(apiClient.findAll.secondCall).to.be.calledWithExactly(
-            'location',
-            {
-              ...mockFilter,
-              page: 2,
-              per_page: 100,
-            }
-          )
-        })
-      })
-    })
-  })
-
-  describe('#getLocationById()', function() {
-    context('without location ID', function() {
-      it('should reject with error', function() {
-        return expect(
-          referenceDataService.getLocationById()
-        ).to.be.rejectedWith('No location ID supplied')
-      })
-    })
-
-    context('with location ID', function() {
-      const mockId = 'b695d0f0-af8e-4b97-891e-92020d6820b9'
+    describe('#getGenders()', function() {
       const mockResponse = {
-        data: mockLocations[0],
+        data: mockGenders,
       }
-      let location
+      let response
 
       beforeEach(async function() {
-        sinon.stub(apiClient, 'find').resolves(mockResponse)
+        sinon.stub(apiClient, 'findAll')
+        apiClient.findAll.withArgs('gender').resolves(mockResponse)
 
-        location = await referenceDataService.getLocationById(mockId)
+        response = await referenceDataService.getGenders()
       })
 
-      it('should call update method with data', function() {
-        expect(apiClient.find).to.be.calledOnceWithExactly('location', mockId)
+      it('should call API client', function() {
+        expect(apiClient.findAll).to.be.calledOnceWithExactly('gender')
       })
 
-      it('should return location', function() {
-        expect(location).to.deep.equal(mockResponse.data)
-      })
-    })
-  })
-
-  describe('#getLocationByNomisAgencyId()', function() {
-    const mockResponse = mockLocations
-    let locations
-
-    beforeEach(async function() {
-      sinon.stub(referenceDataService, 'getLocations').resolves(mockResponse)
-    })
-
-    context('without arguments', function() {
-      beforeEach(async function() {
-        locations = await referenceDataService.getLocationByNomisAgencyId()
+      it('should correct number of results', function() {
+        expect(response.length).to.deep.equal(mockGenders.length)
       })
 
-      it('should call getLocations methods', function() {
-        expect(referenceDataService.getLocations).to.be.calledOnce
-      })
-
-      it('should return first result', function() {
-        expect(locations).to.deep.equal(mockResponse[0])
-      })
-
-      describe('filters', function() {
-        let filters
-
-        beforeEach(function() {
-          filters = referenceDataService.getLocations.args[0][0].filter
-        })
-
-        it('should set nomis_agency_id filter to undefined', function() {
-          expect(filters).to.contain.property('filter[nomis_agency_id]')
-          expect(filters['filter[nomis_agency_id]']).to.equal(undefined)
-        })
+      it('should return response data', function() {
+        expect(response).to.equal(mockGenders)
       })
     })
 
-    context('with arguments', function() {
-      const mockAgencyId = 'PNT'
+    describe('#getEthnicities()', function() {
+      const mockResponse = {
+        data: mockEthnicities,
+      }
+      let response
 
       beforeEach(async function() {
-        locations = await referenceDataService.getLocationByNomisAgencyId(
-          mockAgencyId
-        )
+        sinon.stub(apiClient, 'findAll')
+        apiClient.findAll.withArgs('ethnicity').resolves(mockResponse)
+
+        response = await referenceDataService.getEthnicities()
       })
 
-      it('should call getLocations methods', function() {
-        expect(referenceDataService.getLocations).to.be.calledOnce
+      it('should call API client', function() {
+        expect(apiClient.findAll).to.be.calledOnceWithExactly('ethnicity')
       })
 
-      it('should return first result', function() {
-        expect(locations).to.deep.equal(mockResponse[0])
+      it('should correct number of results', function() {
+        expect(response.length).to.deep.equal(mockEthnicities.length)
       })
 
-      describe('filters', function() {
-        let filters
-
-        beforeEach(function() {
-          filters = referenceDataService.getLocations.args[0][0].filter
-        })
-
-        it('should set nomis_agency_id filter to agency ID', function() {
-          expect(filters).to.contain.property('filter[nomis_agency_id]')
-          expect(filters['filter[nomis_agency_id]']).to.equal(mockAgencyId)
-        })
+      it('should return response data', function() {
+        expect(response).to.equal(mockEthnicities)
       })
     })
-  })
 
-  describe('#getLocationsByNomisAgencyId()', function() {
-    const mockAgencyIds = ['GCS', 'PNT', 'AFR']
-    let locations
+    describe('#getAssessmentQuestions()', function() {
+      const mockResponse = {
+        data: mockAssessmentQuestions,
+      }
+      let response
 
-    beforeEach(function() {
-      sinon.spy(referenceDataService, 'mapLocationIdsToLocations')
-    })
+      beforeEach(async function() {
+        sinon.stub(apiClient, 'findAll')
+      })
 
-    context('with list of IDs', function() {
-      context('when locations are found', function() {
+      context('with no category', function() {
         beforeEach(async function() {
-          sinon
-            .stub(referenceDataService, 'getLocationByNomisAgencyId')
-            .resolvesArg(0)
+          apiClient.findAll
+            .withArgs('assessment_question', {
+              'filter[category]': undefined,
+            })
+            .resolves(mockResponse)
 
-          locations = await referenceDataService.getLocationsByNomisAgencyId(
-            mockAgencyIds
+          response = await referenceDataService.getAssessmentQuestions()
+        })
+
+        it('should call API client with undefined category', function() {
+          expect(apiClient.findAll).to.be.calledOnceWithExactly(
+            'assessment_question',
+            {
+              'filter[category]': undefined,
+            }
           )
         })
 
-        it('should attempt to map each location', function() {
-          expect(
-            referenceDataService.mapLocationIdsToLocations
-          ).to.be.calledOnce
-          expect(
-            referenceDataService.getLocationByNomisAgencyId.callCount
-          ).to.equal(mockAgencyIds.length)
+        it('should correct number of results', function() {
+          expect(response.length).to.deep.equal(mockAssessmentQuestions.length)
         })
 
-        it('should return an list of locations', function() {
-          expect(locations).to.deep.equal(mockAgencyIds)
+        it('should return response data', function() {
+          expect(response).to.equal(mockAssessmentQuestions)
         })
       })
 
-      context('when locations are not found', function() {
-        beforeEach(async function() {
-          sinon
-            .stub(referenceDataService, 'getLocationByNomisAgencyId')
-            .rejects()
+      context('with category', function() {
+        const mockCategory = 'risk'
 
-          locations = await referenceDataService.getLocationsByNomisAgencyId(
-            mockAgencyIds
+        beforeEach(async function() {
+          apiClient.findAll
+            .withArgs('assessment_question', {
+              'filter[category]': mockCategory,
+            })
+            .resolves(mockResponse)
+
+          response = await referenceDataService.getAssessmentQuestions(
+            mockCategory
           )
         })
 
-        it('should attempt to map each location', function() {
-          expect(
-            referenceDataService.mapLocationIdsToLocations
-          ).to.be.calledOnce
-          expect(
-            referenceDataService.getLocationByNomisAgencyId.callCount
-          ).to.equal(mockAgencyIds.length)
+        it('should call API client with category', function() {
+          expect(apiClient.findAll).to.be.calledOnceWithExactly(
+            'assessment_question',
+            {
+              'filter[category]': mockCategory,
+            }
+          )
+        })
+
+        it('should correct number of results', function() {
+          expect(response.length).to.deep.equal(mockAssessmentQuestions.length)
+        })
+
+        it('should return response data', function() {
+          expect(response).to.equal(mockAssessmentQuestions)
+        })
+      })
+    })
+
+    describe('#getLocations()', function() {
+      const mockResponse = {
+        data: mockLocations,
+        links: {},
+      }
+      const mockMultiPageResponse = {
+        data: mockLocations,
+        links: {
+          next: 'http://next-page.com',
+        },
+      }
+      const mockFilter = {
+        filterOne: 'foo',
+      }
+      let locations
+
+      beforeEach(function() {
+        sinon.stub(apiClient, 'findAll')
+      })
+
+      context('with only one page', function() {
+        beforeEach(function() {
+          apiClient.findAll.resolves(mockResponse)
+        })
+
+        context('by default', function() {
+          beforeEach(async function() {
+            locations = await referenceDataService.getLocations()
+          })
+
+          it('should call the API client once', function() {
+            expect(apiClient.findAll).to.be.calledOnce
+          })
+
+          it('should call the API client with default options', function() {
+            expect(apiClient.findAll.firstCall).to.be.calledWithExactly(
+              'location',
+              {
+                page: 1,
+                per_page: 100,
+                include: mockLocationsInclude,
+              }
+            )
+          })
+
+          it('should return locations sorted by title', function() {
+            expect(locations).to.deep.equal(sortBy(mockLocations, 'title'))
+          })
+        })
+
+        context('with filter', function() {
+          beforeEach(async function() {
+            locations = await referenceDataService.getLocations({
+              filter: mockFilter,
+            })
+          })
+
+          it('should call the API client with filter', function() {
+            expect(apiClient.findAll.firstCall).to.be.calledWithExactly(
+              'location',
+              {
+                ...mockFilter,
+                page: 1,
+                per_page: 100,
+                include: mockLocationsInclude,
+              }
+            )
+          })
+        })
+      })
+
+      context('with multiple pages', function() {
+        beforeEach(function() {
+          apiClient.findAll
+            .onFirstCall()
+            .resolves(mockMultiPageResponse)
+            .onSecondCall()
+            .resolves(mockResponse)
+        })
+
+        context('by default', function() {
+          beforeEach(async function() {
+            locations = await referenceDataService.getLocations()
+          })
+
+          it('should call the API client twice', function() {
+            expect(apiClient.findAll).to.be.calledTwice
+          })
+
+          it('should call API client with default options on first call', function() {
+            expect(apiClient.findAll.firstCall).to.be.calledWithExactly(
+              'location',
+              {
+                page: 1,
+                per_page: 100,
+                include: mockLocationsInclude,
+              }
+            )
+          })
+
+          it('should call API client with second page on second call', function() {
+            expect(apiClient.findAll.secondCall).to.be.calledWithExactly(
+              'location',
+              {
+                page: 2,
+                per_page: 100,
+                include: mockLocationsInclude,
+              }
+            )
+          })
+
+          it('should return locations sorted by title', function() {
+            expect(locations).to.deep.equal(
+              sortBy([...mockLocations, ...mockLocations], 'title')
+            )
+          })
+        })
+
+        context('with filter', function() {
+          beforeEach(async function() {
+            locations = await referenceDataService.getLocations({
+              filter: mockFilter,
+            })
+          })
+
+          it('should call API client with filter on first call', function() {
+            expect(apiClient.findAll.firstCall).to.be.calledWithExactly(
+              'location',
+              {
+                ...mockFilter,
+                page: 1,
+                per_page: 100,
+                include: mockLocationsInclude,
+              }
+            )
+          })
+
+          it('should call API client with filter on second call', function() {
+            expect(apiClient.findAll.secondCall).to.be.calledWithExactly(
+              'location',
+              {
+                ...mockFilter,
+                page: 2,
+                per_page: 100,
+                include: mockLocationsInclude,
+              }
+            )
+          })
+        })
+      })
+
+      context('when called with include parameter', function() {
+        beforeEach(async function() {
+          apiClient.findAll.resetHistory()
+          apiClient.findAll.resolves(mockResponse)
+          await referenceDataService.getLocations({ include: ['foo', 'bar'] })
+        })
+        it('should pass include paramter to api client', function() {
+          expect(apiClient.findAll).to.be.calledOnceWithExactly('location', {
+            page: 1,
+            per_page: 100,
+            include: ['foo', 'bar'],
+          })
+        })
+      })
+    })
+
+    describe('#getLocationById()', function() {
+      context('without location ID', function() {
+        it('should reject with error', function() {
+          return expect(
+            referenceDataService.getLocationById()
+          ).to.be.rejectedWith('No location ID supplied')
+        })
+      })
+
+      context('with location ID', function() {
+        const mockId = 'b695d0f0-af8e-4b97-891e-92020d6820b9'
+        const mockResponse = {
+          data: mockLocations[0],
+        }
+        let location
+
+        beforeEach(async function() {
+          sinon.stub(apiClient, 'find').resolves(mockResponse)
+
+          location = await referenceDataService.getLocationById(mockId)
+        })
+
+        it('should call update method with data', function() {
+          expect(apiClient.find).to.be.calledOnceWithExactly(
+            'location',
+            mockId,
+            { include: mockLocationsInclude }
+          )
+        })
+
+        it('should return location', function() {
+          expect(location).to.deep.equal(mockResponse.data)
+        })
+      })
+
+      context('with explict include parameter', function() {
+        const mockId = 'b695d0f0-af8e-4b97-891e-92020d6820b9'
+        const mockResponse = {
+          data: mockLocations[0],
+        }
+
+        beforeEach(async function() {
+          sinon.stub(apiClient, 'find').resolves(mockResponse)
+
+          await referenceDataService.getLocationById(mockId, {
+            include: ['foo', 'bar'],
+          })
+        })
+
+        it('should pass include parameter to api client', function() {
+          expect(apiClient.find).to.be.calledOnceWithExactly(
+            'location',
+            mockId,
+            { include: ['foo', 'bar'] }
+          )
+        })
+      })
+    })
+
+    describe('#getLocationByNomisAgencyId()', function() {
+      const mockResponse = mockLocations
+      let locations
+
+      beforeEach(async function() {
+        sinon.stub(referenceDataService, 'getLocations').resolves(mockResponse)
+      })
+
+      context('without arguments', function() {
+        beforeEach(async function() {
+          locations = await referenceDataService.getLocationByNomisAgencyId()
+        })
+
+        it('should call getLocations methods', function() {
+          expect(referenceDataService.getLocations).to.be.calledOnce
+        })
+
+        it('should return first result', function() {
+          expect(locations).to.deep.equal(mockResponse[0])
+        })
+
+        describe('filters', function() {
+          let filters
+
+          beforeEach(function() {
+            filters = referenceDataService.getLocations.args[0][0].filter
+          })
+
+          it('should set nomis_agency_id filter to undefined', function() {
+            expect(filters).to.contain.property('filter[nomis_agency_id]')
+            expect(filters['filter[nomis_agency_id]']).to.equal(undefined)
+          })
+        })
+      })
+
+      context('with arguments', function() {
+        const mockAgencyId = 'PNT'
+
+        beforeEach(async function() {
+          locations = await referenceDataService.getLocationByNomisAgencyId(
+            mockAgencyId
+          )
+        })
+
+        it('should call getLocations methods', function() {
+          expect(referenceDataService.getLocations).to.be.calledOnce
+        })
+
+        it('should return first result', function() {
+          expect(locations).to.deep.equal(mockResponse[0])
+        })
+
+        describe('filters', function() {
+          let filters
+
+          beforeEach(function() {
+            filters = referenceDataService.getLocations.args[0][0].filter
+          })
+
+          it('should set nomis_agency_id filter to agency ID', function() {
+            expect(filters).to.contain.property('filter[nomis_agency_id]')
+            expect(filters['filter[nomis_agency_id]']).to.equal(mockAgencyId)
+          })
+        })
+      })
+    })
+
+    describe('#getLocationsByNomisAgencyId()', function() {
+      const mockAgencyIds = ['GCS', 'PNT', 'AFR']
+      let locations
+
+      beforeEach(function() {
+        sinon.spy(referenceDataService, 'mapLocationIdsToLocations')
+      })
+
+      context('with list of IDs', function() {
+        context('when locations are found', function() {
+          beforeEach(async function() {
+            sinon
+              .stub(referenceDataService, 'getLocationByNomisAgencyId')
+              .resolvesArg(0)
+
+            locations = await referenceDataService.getLocationsByNomisAgencyId(
+              mockAgencyIds
+            )
+          })
+
+          it('should attempt to map each location', function() {
+            expect(
+              referenceDataService.mapLocationIdsToLocations
+            ).to.be.calledOnce
+            expect(
+              referenceDataService.getLocationByNomisAgencyId.callCount
+            ).to.equal(mockAgencyIds.length)
+          })
+
+          it('should return an list of locations', function() {
+            expect(locations).to.deep.equal(mockAgencyIds)
+          })
+        })
+
+        context('when locations are not found', function() {
+          beforeEach(async function() {
+            sinon
+              .stub(referenceDataService, 'getLocationByNomisAgencyId')
+              .rejects()
+
+            locations = await referenceDataService.getLocationsByNomisAgencyId(
+              mockAgencyIds
+            )
+          })
+
+          it('should attempt to map each location', function() {
+            expect(
+              referenceDataService.mapLocationIdsToLocations
+            ).to.be.calledOnce
+            expect(
+              referenceDataService.getLocationByNomisAgencyId.callCount
+            ).to.equal(mockAgencyIds.length)
+          })
+
+          it('should return an empty array', function() {
+            expect(locations).to.be.an('array').that.is.empty
+          })
+        })
+      })
+
+      context('with empty list of IDs', function() {
+        beforeEach(async function() {
+          locations = await referenceDataService.getLocationsByNomisAgencyId()
         })
 
         it('should return an empty array', function() {
@@ -486,258 +555,257 @@ describe('Reference Data Service', function() {
       })
     })
 
-    context('with empty list of IDs', function() {
-      beforeEach(async function() {
-        locations = await referenceDataService.getLocationsByNomisAgencyId()
-      })
-
-      it('should return an empty array', function() {
-        expect(locations).to.be.an('array').that.is.empty
-      })
-    })
-  })
-
-  describe('#getLocationsByType()', function() {
-    const mockResponse = mockLocations
-    let locations
-
-    beforeEach(async function() {
-      sinon.stub(referenceDataService, 'getLocations').resolves(mockResponse)
-    })
-
-    context('without type', function() {
-      beforeEach(async function() {
-        locations = await referenceDataService.getLocationsByType()
-      })
-
-      it('should call getMoves methods', function() {
-        expect(referenceDataService.getLocations).to.be.calledOnce
-      })
-
-      it('should return first result', function() {
-        expect(locations).to.deep.equal(mockResponse)
-      })
-
-      describe('filters', function() {
-        let filters
-
-        beforeEach(function() {
-          filters = referenceDataService.getLocations.args[0][0].filter
-        })
-
-        it('should set location_type filter to undefined', function() {
-          expect(filters).to.contain.property('filter[location_type]')
-          expect(filters['filter[location_type]']).to.equal(undefined)
-        })
-      })
-    })
-
-    context('with type', function() {
-      const mockType = 'court'
+    describe('#getLocationsByType()', function() {
+      const mockResponse = mockLocations
+      let locations
 
       beforeEach(async function() {
-        locations = await referenceDataService.getLocationsByType(mockType)
+        sinon.stub(referenceDataService, 'getLocations').resolves(mockResponse)
       })
 
-      it('should call getMoves methods', function() {
-        expect(referenceDataService.getLocations).to.be.calledOnce
-      })
-
-      it('should return first result', function() {
-        expect(locations).to.deep.equal(mockResponse)
-      })
-
-      describe('filters', function() {
-        let filters
-
-        beforeEach(function() {
-          filters = referenceDataService.getLocations.args[0][0].filter
+      context('without type', function() {
+        beforeEach(async function() {
+          locations = await referenceDataService.getLocationsByType()
         })
 
-        it('should set location_type filter to agency ID', function() {
-          expect(filters).to.contain.property('filter[location_type]')
-          expect(filters['filter[location_type]']).to.equal(mockType)
-        })
-      })
-    })
-  })
-
-  describe('#getLocationsBySupplierId()', function() {
-    const mockResponse = mockLocations
-    let locations
-
-    beforeEach(async function() {
-      sinon.stub(referenceDataService, 'getLocations').resolves(mockResponse)
-    })
-
-    context('without id', function() {
-      beforeEach(async function() {
-        locations = await referenceDataService.getLocationsBySupplierId()
-      })
-
-      it('should call getMoves methods', function() {
-        expect(referenceDataService.getLocations).to.be.calledOnce
-      })
-
-      it('should return first result', function() {
-        expect(locations).to.deep.equal(mockResponse)
-      })
-
-      describe('filters', function() {
-        let filters
-
-        beforeEach(function() {
-          filters = referenceDataService.getLocations.args[0][0].filter
+        it('should call getMoves methods', function() {
+          expect(referenceDataService.getLocations).to.be.calledOnce
         })
 
-        it('should set location_type filter to undefined', function() {
-          expect(filters).to.contain.property('filter[supplier_id]')
-          expect(filters['filter[supplier_id]']).to.equal(undefined)
+        it('should return first result', function() {
+          expect(locations).to.deep.equal(mockResponse)
         })
 
-        it('should set cache to false', function() {
-          expect(filters).to.contain.property('cache')
-          expect(filters.cache).to.equal(false)
+        describe('filters', function() {
+          let filters
+
+          beforeEach(function() {
+            filters = referenceDataService.getLocations.args[0][0].filter
+          })
+
+          it('should set location_type filter to undefined', function() {
+            expect(filters).to.contain.property('filter[location_type]')
+            expect(filters['filter[location_type]']).to.equal(undefined)
+          })
+        })
+      })
+
+      context('with type', function() {
+        const mockType = 'court'
+
+        beforeEach(async function() {
+          locations = await referenceDataService.getLocationsByType(mockType)
+        })
+
+        it('should call getMoves methods', function() {
+          expect(referenceDataService.getLocations).to.be.calledOnce
+        })
+
+        it('should return first result', function() {
+          expect(locations).to.deep.equal(mockResponse)
+        })
+
+        describe('filters', function() {
+          let filters
+
+          beforeEach(function() {
+            filters = referenceDataService.getLocations.args[0][0].filter
+          })
+
+          it('should set location_type filter to agency ID', function() {
+            expect(filters).to.contain.property('filter[location_type]')
+            expect(filters['filter[location_type]']).to.equal(mockType)
+          })
         })
       })
     })
 
-    context('with id', function() {
-      const mockId = 'd335715f-c9d1-415c-a7c8-06e830158214'
+    describe('#getLocationsBySupplierId()', function() {
+      const mockResponse = mockLocations
+      let locations
 
       beforeEach(async function() {
-        locations = await referenceDataService.getLocationsBySupplierId(mockId)
+        sinon.stub(referenceDataService, 'getLocations').resolves(mockResponse)
       })
 
-      it('should call getMoves methods', function() {
-        expect(referenceDataService.getLocations).to.be.calledOnce
-      })
-
-      it('should return first result', function() {
-        expect(locations).to.deep.equal(mockResponse)
-      })
-
-      describe('filters', function() {
-        let filters
-
-        beforeEach(function() {
-          filters = referenceDataService.getLocations.args[0][0].filter
+      context('without id', function() {
+        beforeEach(async function() {
+          locations = await referenceDataService.getLocationsBySupplierId()
         })
 
-        it('should set location_type filter to agency ID', function() {
-          expect(filters).to.contain.property('filter[supplier_id]')
-          expect(filters['filter[supplier_id]']).to.equal(mockId)
+        it('should call getMoves methods', function() {
+          expect(referenceDataService.getLocations).to.be.calledOnce
         })
 
-        it('should set cache to false', function() {
-          expect(filters).to.contain.property('cache')
-          expect(filters.cache).to.equal(false)
+        it('should return first result', function() {
+          expect(locations).to.deep.equal(mockResponse)
+        })
+
+        describe('filters', function() {
+          let filters
+
+          beforeEach(function() {
+            filters = referenceDataService.getLocations.args[0][0].filter
+          })
+
+          it('should set location_type filter to undefined', function() {
+            expect(filters).to.contain.property('filter[supplier_id]')
+            expect(filters['filter[supplier_id]']).to.equal(undefined)
+          })
+
+          it('should set cache to false', function() {
+            expect(filters).to.contain.property('cache')
+            expect(filters.cache).to.equal(false)
+          })
+        })
+      })
+
+      context('with id', function() {
+        const mockId = 'd335715f-c9d1-415c-a7c8-06e830158214'
+
+        beforeEach(async function() {
+          locations = await referenceDataService.getLocationsBySupplierId(
+            mockId
+          )
+        })
+
+        it('should call getMoves methods', function() {
+          expect(referenceDataService.getLocations).to.be.calledOnce
+        })
+
+        it('should return first result', function() {
+          expect(locations).to.deep.equal(mockResponse)
+        })
+
+        describe('filters', function() {
+          let filters
+
+          beforeEach(function() {
+            filters = referenceDataService.getLocations.args[0][0].filter
+          })
+
+          it('should set location_type filter to agency ID', function() {
+            expect(filters).to.contain.property('filter[supplier_id]')
+            expect(filters['filter[supplier_id]']).to.equal(mockId)
+          })
+
+          it('should set cache to false', function() {
+            expect(filters).to.contain.property('cache')
+            expect(filters.cache).to.equal(false)
+          })
         })
       })
     })
-  })
 
-  describe('#getSuppliers()', function() {
-    const mockResponse = {
-      data: mockSuppliers,
-    }
-    let response
-
-    beforeEach(async function() {
-      sinon.stub(apiClient, 'findAll')
-      apiClient.findAll.withArgs('supplier').resolves(mockResponse)
-
-      response = await referenceDataService.getSuppliers()
-    })
-
-    it('should call API client', function() {
-      expect(apiClient.findAll).to.be.calledOnceWithExactly('supplier')
-    })
-
-    it('should correct number of results', function() {
-      expect(response.length).to.deep.equal(mockSuppliers.length)
-    })
-
-    it('should return response data', function() {
-      expect(response).to.equal(mockSuppliers)
-    })
-  })
-
-  describe('#getSupplierByKey()', function() {
-    context('without supplier key', function() {
-      it('should reject with error', function() {
-        return expect(
-          referenceDataService.getSupplierByKey()
-        ).to.be.rejectedWith('No supplier key provided')
-      })
-    })
-
-    context('with location key', function() {
-      const mockKey = 'serco'
+    describe('#getSuppliers()', function() {
       const mockResponse = {
-        data: mockSuppliers[0],
+        data: mockSuppliers,
       }
       let response
 
       beforeEach(async function() {
-        sinon.stub(apiClient, 'find').resolves(mockResponse)
+        sinon.stub(apiClient, 'findAll')
+        apiClient.findAll.withArgs('supplier').resolves(mockResponse)
 
-        response = await referenceDataService.getSupplierByKey(mockKey)
+        response = await referenceDataService.getSuppliers()
       })
 
-      it('should call update method with data', function() {
-        expect(apiClient.find).to.be.calledOnceWithExactly('supplier', mockKey)
+      it('should call API client', function() {
+        expect(apiClient.findAll).to.be.calledOnceWithExactly('supplier')
       })
 
-      it('should return supplier', function() {
+      it('should correct number of results', function() {
+        expect(response.length).to.deep.equal(mockSuppliers.length)
+      })
+
+      it('should return response data', function() {
+        expect(response).to.equal(mockSuppliers)
+      })
+    })
+
+    describe('#getSupplierByKey()', function() {
+      context('without supplier key', function() {
+        it('should reject with error', function() {
+          return expect(
+            referenceDataService.getSupplierByKey()
+          ).to.be.rejectedWith('No supplier key provided')
+        })
+      })
+
+      context('with location key', function() {
+        const mockKey = 'serco'
+        const mockResponse = {
+          data: mockSuppliers[0],
+        }
+        let response
+
+        beforeEach(async function() {
+          sinon.stub(apiClient, 'find').resolves(mockResponse)
+
+          response = await referenceDataService.getSupplierByKey(mockKey)
+        })
+
+        it('should call update method with data', function() {
+          expect(apiClient.find).to.be.calledOnceWithExactly(
+            'supplier',
+            mockKey
+          )
+        })
+
+        it('should return supplier', function() {
+          expect(response).to.deep.equal(mockResponse.data)
+        })
+      })
+    })
+
+    describe('#getPrisonTransferReasons()', function() {
+      const mockResponse = {
+        data: ['item1', 'item2'],
+      }
+
+      let response
+      let stubForFind
+
+      beforeEach(async function() {
+        stubForFind = sinon.stub(apiClient, 'findAll').resolves(mockResponse)
+
+        response = await referenceDataService.getPrisonTransferReasons()
+      })
+
+      it('should request the list of reasons for transfer', function() {
+        expect(stubForFind).to.be.calledOnceWithExactly(
+          'prison_transfer_reason'
+        )
+      })
+
+      it('should return response.data', function() {
         expect(response).to.deep.equal(mockResponse.data)
       })
     })
-  })
 
-  describe('#getPrisonTransferReasons()', function() {
-    const mockResponse = {
-      data: ['item1', 'item2'],
-    }
+    describe('#getAllocationComplexCases', function() {
+      const mockResponse = {
+        data: ['item1', 'item2'],
+      }
 
-    let response
-    let stubForFind
+      let response
+      let serviceStub
 
-    beforeEach(async function() {
-      stubForFind = sinon.stub(apiClient, 'findAll').resolves(mockResponse)
+      beforeEach(async function() {
+        serviceStub = sinon.stub(apiClient, 'findAll').resolves(mockResponse)
 
-      response = await referenceDataService.getPrisonTransferReasons()
-    })
+        response = await referenceDataService.getAllocationComplexCases()
+      })
 
-    it('should request the list of reasons for transfer', function() {
-      expect(stubForFind).to.be.calledOnceWithExactly('prison_transfer_reason')
-    })
+      it('should request the list of allocation complex cases', function() {
+        expect(serviceStub).to.be.calledOnceWithExactly(
+          'allocation_complex_case'
+        )
+      })
 
-    it('should return response.data', function() {
-      expect(response).to.deep.equal(mockResponse.data)
-    })
-  })
-
-  describe('#getAllocationComplexCases', function() {
-    const mockResponse = {
-      data: ['item1', 'item2'],
-    }
-
-    let response
-    let serviceStub
-
-    beforeEach(async function() {
-      serviceStub = sinon.stub(apiClient, 'findAll').resolves(mockResponse)
-
-      response = await referenceDataService.getAllocationComplexCases()
-    })
-
-    it('should request the list of allocation complex cases', function() {
-      expect(serviceStub).to.be.calledOnceWithExactly('allocation_complex_case')
-    })
-
-    it('should return response.data', function() {
-      expect(response).to.deep.equal(mockResponse.data)
+      it('should return response.data', function() {
+        expect(response).to.deep.equal(mockResponse.data)
+      })
     })
   })
 })


### PR DESCRIPTION
## Proposed changes

### What changed

Updates api-client calls to explicitly use `include` parameter to have the backend return requested relationship types in returned `included` object.

### Why did it change

1. We were not following the JSON-API specs
2. This will allow us to fine-tune requests to only ask for the requests we actually need.

### Issue tracking

- [P4-1510 - Support query include in moves endpoint](https://dsdmoj.atlassian.net/browse/P4-1510)
- [P4-1507 - Support query include in allocations endpoint](https://dsdmoj.atlassian.net/browse/P4-1507)
- [P4-1513 - Support query include in people endpoint](https://dsdmoj.atlassian.net/browse/P4-1513)
- [P4-1611 - Support query include in locations endpoints](https://dsdmoj.atlassian.net/browse/P4-1611)

## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed

<!--- Delete if changes DO NOT include new environment variables -->

### Other considerations

- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
