### PR TITLE
[P4-1447] feat(allocations): Added sorting to allocation tables

### DIFF
--- a/app/allocations/constants.js
+++ b/app/allocations/constants.js
@@ -14,7 +14,7 @@ const COLLECTION_PATH = `/:period(week|day)/:date(${dateRegex})/:locationId(${uu
 
 const DEFAULTS = {
   QUERY: {
-    outgoing: { status: '' },
+    outgoing: { status: '', sortBy: 'date', sortDirection: 'asc' },
   },
   TIME_PERIOD: {
     outgoing: 'week',

--- a/app/allocations/middleware/set-body.allocations.js
+++ b/app/allocations/middleware/set-body.allocations.js
@@ -3,11 +3,13 @@ const { set } = require('lodash')
 const dateHelpers = require('../../../common/helpers/date-utils')
 
 function setBodyAllocations(req, res, next) {
-  const { status } = req.query
+  const { status, sortBy, sortDirection } = req.query
   const { dateRange, locationId } = req.params
 
   set(req, 'body.allocations', {
     status,
+    sortBy,
+    sortDirection,
     moveDate: dateRange || dateHelpers.getCurrentWeekAsRange(),
     fromLocationId: locationId,
   })

--- a/app/allocations/middleware/set-body.allocations.test.js
+++ b/app/allocations/middleware/set-body.allocations.test.js
@@ -18,6 +18,8 @@ describe('Allocations middleware', function() {
         },
         query: {
           status: 'pending',
+          sortBy: 'moves_count',
+          sortDirection: 'asc',
         },
       }
     })
@@ -32,6 +34,8 @@ describe('Allocations middleware', function() {
           status: 'pending',
           moveDate: ['2010-10-10', '2010-10-07'],
           fromLocationId: '7ebc8717-ff5b-4be0-8515-3e308e92700f',
+          sortBy: 'moves_count',
+          sortDirection: 'asc',
         })
       })
 
@@ -51,6 +55,8 @@ describe('Allocations middleware', function() {
           status: 'pending',
           moveDate: ['2020-10-10', '2020-10-10'],
           fromLocationId: '7ebc8717-ff5b-4be0-8515-3e308e92700f',
+          sortBy: 'moves_count',
+          sortDirection: 'asc',
         })
       })
 

--- a/app/allocations/middleware/set-results.allocations.js
+++ b/app/allocations/middleware/set-results.allocations.js
@@ -7,12 +7,14 @@ const allocationService = require('../../../common/services/allocation')
 async function setResultsAllocations(req, res, next) {
   const currentLocationId = get(req.session, 'currentLocation.id')
   const userPermissions = get(req.session, 'user.permissions')
+  const query = req.query
   const displayConfig = {
     showRemaining: permissions.check(
       'allocation:person:assign',
       userPermissions
     ),
     showFromLocation: !currentLocationId,
+    query,
   }
 
   try {
@@ -31,9 +33,10 @@ async function setResultsAllocations(req, res, next) {
       active: presenters.allocationsToTableComponent(displayConfig)(
         activeAllocations
       ),
-      cancelled: presenters.allocationsToTableComponent(displayConfig)(
-        cancelledAllocations
-      ),
+      cancelled: presenters.allocationsToTableComponent({
+        ...displayConfig,
+        isSortable: false,
+      })(cancelledAllocations),
     }
 
     next()

--- a/app/allocations/middleware/set-results.allocations.test.js
+++ b/app/allocations/middleware/set-results.allocations.test.js
@@ -38,6 +38,9 @@ describe('Allocations middleware', function() {
       res = {}
       req = {
         session: {},
+        query: {
+          status: 'approved',
+        },
         body: {
           allocations: {
             status: 'proposed',
@@ -103,6 +106,7 @@ describe('Allocations middleware', function() {
           expect(
             presenters.allocationsToTableComponent
           ).to.be.calledWithExactly({
+            query: { status: 'approved' },
             showRemaining: false,
             showFromLocation: true,
           })
@@ -137,6 +141,7 @@ describe('Allocations middleware', function() {
           expect(
             presenters.allocationsToTableComponent
           ).to.be.calledWithExactly({
+            query: { status: 'approved' },
             showRemaining: false,
             showFromLocation: false,
           })
@@ -157,6 +162,7 @@ describe('Allocations middleware', function() {
             expect(
               presenters.allocationsToTableComponent
             ).to.be.calledWithExactly({
+              query: { status: 'approved' },
               showRemaining: true,
               showFromLocation: true,
             })

--- a/common/assets/scss/components/_all.scss
+++ b/common/assets/scss/components/_all.scss
@@ -1,7 +1,8 @@
 @import "autocomplete";
+@import "icons";
+@import "sortable-table";
 @import "stack-trace";
 @import "sticky-sidebar";
-@import "icons";
 
 // Load components from the shared components folder
 @import "card/card";

--- a/common/assets/scss/components/_sortable-table.scss
+++ b/common/assets/scss/components/_sortable-table.scss
@@ -1,0 +1,69 @@
+.sortable-table__button {
+  display: inline-block;
+}
+
+[aria-sort] .sortable-table__button,
+[aria-sort] .sortable-table__button:hover {
+  background-color: transparent;
+  border-width: 0;
+  -webkit-box-shadow: 0 0 0 0;
+  -moz-box-shadow: 0 0 0 0;
+  box-shadow: 0 0 0 0;
+  color: #005ea5;
+  cursor: pointer;
+  font-family: inherit;
+  font-size: inherit;
+  font-weight: inherit;
+  position: relative;
+  text-align: inherit;
+  font-size: 1em;
+  margin: 0;
+}
+
+[aria-sort] .sortable-table__button:focus {
+  background-color: $govuk-focus-colour;
+  color: $govuk-focus-text-colour;
+  box-shadow: 0 -2px $govuk-focus-colour, 0 4px $govuk-focus-text-colour;
+  outline: none;
+}
+
+[aria-sort]:first-child .sortable-table__button {
+  right: auto;
+}
+
+[aria-sort] .sortable-table__button:before {
+  content: " \25bc";
+  position: absolute;
+  right: -20px;
+  top: 12px;
+  font-size: 0.5em;
+}
+
+[aria-sort] .sortable-table__button:after {
+  content: " \25b2";
+  position: absolute;
+  right: -20px;
+  top: 4px;
+  font-size: 0.5em;
+}
+
+[aria-sort="ascending"] .sortable-table__button:before,
+[aria-sort="descending"] .sortable-table__button:before {
+  content: none;
+}
+
+[aria-sort="ascending"] .sortable-table__button:after {
+  content: " \25b2";
+  font-size: .8em;
+  position: absolute;
+  right: -22px;
+  top: 4px;
+}
+
+[aria-sort="descending"] .sortable-table__button:after {
+  content: " \25bc";
+  font-size: .8em;
+  position: absolute;
+  right: -22px;
+  top: 4px;
+}

--- a/common/presenters/allocations-to-table-component.js
+++ b/common/presenters/allocations-to-table-component.js
@@ -27,11 +27,15 @@ function _byAdded(totalSlots, unfilledSlots) {
 function allocationsToTableComponent({
   showFromLocation = false,
   showRemaining = false,
+  query,
+  isSortable = true,
 } = {}) {
   const tableConfig = [
     {
       head: {
-        text: 'collections::labels.move_size',
+        isSortable,
+        sortKey: 'moves_count',
+        html: 'collections::labels.move_size',
         attributes: {
           width: '120',
         },
@@ -79,7 +83,11 @@ function allocationsToTableComponent({
     {
       /* eslint-disable indent */
       head: showFromLocation
-        ? { text: 'collections::labels.from_location' }
+        ? {
+            sortKey: 'from_location',
+            html: 'collections::labels.from_location',
+            isSortable,
+          }
         : undefined,
       /* eslint-enable indent */
       row: {
@@ -88,7 +96,9 @@ function allocationsToTableComponent({
     },
     {
       head: {
-        text: 'collections::labels.to_location',
+        isSortable,
+        sortKey: 'to_location',
+        html: 'collections::labels.to_location',
       },
       row: {
         text: 'to_location.title',
@@ -96,7 +106,9 @@ function allocationsToTableComponent({
     },
     {
       head: {
-        text: 'fields::date_custom.label',
+        isSortable,
+        sortKey: 'date',
+        html: 'fields::date_custom.label',
         attributes: {
           width: '135',
         },
@@ -110,7 +122,7 @@ function allocationsToTableComponent({
   return function buildTable(allocations) {
     return {
       head: tableConfig
-        .map(tablePresenters.objectToTableHead)
+        .map(tablePresenters.objectToTableHead(query))
         .filter(column => column),
       rows: allocations.map(tablePresenters.objectToTableRow(tableConfig)),
     }

--- a/common/presenters/allocations-to-table-component.test.js
+++ b/common/presenters/allocations-to-table-component.test.js
@@ -78,7 +78,9 @@ describe('#allocationsToTableComponent', function() {
     sinon.stub(i18n, 't').returnsArg(0)
     sinon.stub(componentService, 'getComponent').returnsArg(0)
     sinon.stub(filters, 'formatDate').returnsArg(0)
-    sinon.stub(tablePresenters, 'objectToTableHead').callsFake(arg => arg.head)
+    sinon
+      .stub(tablePresenters, 'objectToTableHead')
+      .returns(sinon.stub().callsFake(arg => arg.head))
     output = presenter()([])
   })
 
@@ -103,7 +105,9 @@ describe('#allocationsToTableComponent', function() {
       it('returns the table head correctly ordered', function() {
         expect(output.head).to.deep.equal([
           {
-            text: 'collections::labels.move_size',
+            html: 'collections::labels.move_size',
+            isSortable: true,
+            sortKey: 'moves_count',
             attributes: {
               width: '120',
             },
@@ -115,10 +119,14 @@ describe('#allocationsToTableComponent', function() {
             },
           },
           {
-            text: 'collections::labels.to_location',
+            html: 'collections::labels.to_location',
+            isSortable: true,
+            sortKey: 'to_location',
           },
           {
-            text: 'fields::date_custom.label',
+            html: 'fields::date_custom.label',
+            isSortable: true,
+            sortKey: 'date',
             attributes: {
               width: '135',
             },
@@ -272,7 +280,9 @@ describe('#allocationsToTableComponent', function() {
       it('returns the table head correctly ordered', function() {
         expect(output.head).to.deep.equal([
           {
-            text: 'collections::labels.move_size',
+            html: 'collections::labels.move_size',
+            isSortable: true,
+            sortKey: 'moves_count',
             attributes: {
               width: '120',
             },
@@ -284,13 +294,19 @@ describe('#allocationsToTableComponent', function() {
             },
           },
           {
-            text: 'collections::labels.from_location',
+            html: 'collections::labels.from_location',
+            isSortable: true,
+            sortKey: 'from_location',
           },
           {
-            text: 'collections::labels.to_location',
+            html: 'collections::labels.to_location',
+            isSortable: true,
+            sortKey: 'to_location',
           },
           {
-            text: 'fields::date_custom.label',
+            html: 'fields::date_custom.label',
+            isSortable: true,
+            sortKey: 'date',
             attributes: {
               width: '135',
             },
@@ -439,6 +455,64 @@ describe('#allocationsToTableComponent', function() {
             )
           })
         })
+      })
+    })
+
+    context('with query', function() {
+      beforeEach(function() {
+        output = presenter({
+          query: {
+            sortBy: 'date',
+            status: 'approved',
+          },
+        })(mockAllocations)
+      })
+      it('passes the query to objectToTableHead', function() {
+        expect(
+          tablePresenters.objectToTableHead
+        ).to.have.been.calledWithExactly({
+          sortBy: 'date',
+          status: 'approved',
+        })
+      })
+    })
+
+    context('with isSortable set to false', function() {
+      beforeEach(function() {
+        output = presenter({
+          isSortable: false,
+        })(mockAllocations)
+      })
+      it('should return allocations without sorting flag', function() {
+        expect(output.head).to.deep.equal([
+          {
+            attributes: {
+              width: '120',
+            },
+            html: 'collections::labels.move_size',
+            isSortable: false,
+            sortKey: 'moves_count',
+          },
+          {
+            attributes: {
+              width: '150',
+            },
+            text: 'collections::labels.progress',
+          },
+          {
+            html: 'collections::labels.to_location',
+            isSortable: false,
+            sortKey: 'to_location',
+          },
+          {
+            attributes: {
+              width: '135',
+            },
+            html: 'fields::date_custom.label',
+            isSortable: false,
+            sortKey: 'date',
+          },
+        ])
       })
     })
   })

--- a/common/presenters/table/object-to-table-head.js
+++ b/common/presenters/table/object-to-table-head.js
@@ -1,17 +1,67 @@
 const { pickBy } = require('lodash')
+const queryString = require('query-string')
 
 const i18n = require('../../../config/i18n')
 
-function objectToTableHead({ head } = {}) {
-  if (!head) {
-    return undefined
+function buildUrl({ sortKey }, query) {
+  return queryString.stringify({
+    ...query,
+    sortBy: sortKey,
+    sortDirection: query.sortDirection === 'asc' ? 'desc' : 'asc',
+  })
+}
+
+function buildAriaLabel(head, { sortDirection }) {
+  // the label indicates the result of the sorting action triggered by the link,
+  // which is the opposite of the current state
+  return i18n.t('sort', {
+    context: sortDirection === 'asc' ? 'descending' : 'ascending',
+    label: i18n.t(head.html).toLowerCase(),
+  })
+}
+
+function buildWrapper(head, query) {
+  const label = i18n.t(head.html)
+
+  if (!head.isSortable) {
+    return label
   }
 
-  return pickBy({
-    ...head,
-    html: head.html ? i18n.t(head.html) : undefined,
-    text: head.text ? i18n.t(head.text) : undefined,
-  })
+  const url = buildUrl(head, query)
+  const ariaLabel = buildAriaLabel(head, query)
+  return `<a aria-label="${ariaLabel}" class="sortable-table__button" role="button" href="?${url}">${label}</a>`
+}
+
+function assignSortAttributes(
+  { attributes, isSortable, sortKey },
+  { sortBy, sortDirection }
+) {
+  if (!isSortable) {
+    return attributes
+  }
+
+  const isCurrentSortColumn = sortKey === sortBy
+  const ariaSortDirection = sortDirection === 'asc' ? 'ascending' : 'descending'
+
+  return {
+    ...attributes,
+    'aria-sort': isCurrentSortColumn ? ariaSortDirection : 'none',
+  }
+}
+
+function objectToTableHead(query = {}) {
+  return function objectToTableHead({ head } = {}) {
+    if (!head) {
+      return undefined
+    }
+
+    return pickBy({
+      ...head,
+      attributes: assignSortAttributes(head, query),
+      html: head.html ? buildWrapper(head, query) : undefined,
+      text: head.text ? i18n.t(head.text) : undefined,
+    })
+  }
 }
 
 module.exports = objectToTableHead

--- a/common/presenters/table/object-to-table-head.test.js
+++ b/common/presenters/table/object-to-table-head.test.js
@@ -6,12 +6,14 @@ describe('table head presenter', function() {
   let output
 
   beforeEach(function() {
-    sinon.stub(i18n, 't').returnsArg(0)
+    sinon.stub(i18n, 't').callsFake(key => {
+      return `${key} (translated)`
+    })
   })
 
   context('with no args', function() {
     beforeEach(function() {
-      output = objectToTableHead()
+      output = objectToTableHead({})()
     })
 
     it('should return undefined', function() {
@@ -25,7 +27,7 @@ describe('table head presenter', function() {
 
   context('with html', function() {
     beforeEach(function() {
-      output = objectToTableHead({
+      output = objectToTableHead()({
         head: {
           html: 'move_type::label',
         },
@@ -34,7 +36,7 @@ describe('table head presenter', function() {
 
     it('should return correct header', function() {
       expect(output).to.deep.equal({
-        html: 'move_type::label',
+        html: 'move_type::label (translated)',
       })
     })
 
@@ -45,7 +47,7 @@ describe('table head presenter', function() {
 
   context('with text', function() {
     beforeEach(function() {
-      output = objectToTableHead({
+      output = objectToTableHead()({
         head: {
           text: 'move_type::label',
         },
@@ -54,7 +56,7 @@ describe('table head presenter', function() {
 
     it('should return correct header', function() {
       expect(output).to.deep.equal({
-        text: 'move_type::label',
+        text: 'move_type::label (translated)',
       })
     })
 
@@ -65,7 +67,7 @@ describe('table head presenter', function() {
 
   context('with attributes', function() {
     beforeEach(function() {
-      output = objectToTableHead({
+      output = objectToTableHead()({
         head: {
           html: 'move_type::label',
           attributes: {
@@ -77,7 +79,7 @@ describe('table head presenter', function() {
 
     it('should return correct header', function() {
       expect(output).to.deep.equal({
-        html: 'move_type::label',
+        html: 'move_type::label (translated)',
         attributes: {
           width: 1,
         },
@@ -91,7 +93,7 @@ describe('table head presenter', function() {
 
   context('with neither html nor test', function() {
     beforeEach(function() {
-      output = objectToTableHead({})
+      output = objectToTableHead()({})
     })
 
     it('should return undefined', function() {
@@ -105,7 +107,7 @@ describe('table head presenter', function() {
 
   context('with both html and text', function() {
     beforeEach(function() {
-      output = objectToTableHead({
+      output = objectToTableHead()({
         head: {
           html: 'move_type::label-html',
           text: 'move_type::label-text',
@@ -115,18 +117,95 @@ describe('table head presenter', function() {
 
     it('should return correct header', function() {
       expect(output).to.deep.equal({
-        html: 'move_type::label-html',
-        text: 'move_type::label-text',
+        html: 'move_type::label-html (translated)',
+        text: 'move_type::label-text (translated)',
       })
     })
 
-    it('should translate boths label', function() {
+    it('should translate both label', function() {
       expect(i18n.t).to.be.calledWithExactly('move_type::label-html')
       expect(i18n.t).to.be.calledWithExactly('move_type::label-text')
     })
 
     it('should translate correct number of times', function() {
       expect(i18n.t.callCount).to.equal(2)
+    })
+  })
+  context('with isSortable', function() {
+    context('with current column sorted', function() {
+      beforeEach(function() {
+        output = objectToTableHead({
+          sortBy: 'moves_count',
+          sortDirection: 'desc',
+          status: 'proposed',
+        })({
+          head: {
+            isSortable: true,
+            sortKey: 'moves_count',
+            html: 'moves_count::label-html',
+          },
+        })
+      })
+      it('outputs the aria sort attribute set to the current sorting', function() {
+        expect(output.attributes).to.deep.equal({
+          'aria-sort': 'descending',
+        })
+      })
+      it('outputs a link', function() {
+        expect(output.html).to.equal(
+          '<a aria-label="sort (translated)" class="sortable-table__button" role="button" href="?sortBy=moves_count&sortDirection=asc&status=proposed">moves_count::label-html (translated)</a>'
+        )
+      })
+      it('conserves the existing attributes', function() {
+        expect(output.isSortable).to.be.true
+        expect(output.sortKey).to.equal('moves_count')
+      })
+    })
+    context('with another column sorted', function() {
+      beforeEach(function() {
+        output = objectToTableHead({
+          sortBy: 'date',
+          sortDirection: 'asc',
+          status: 'proposed',
+        })({
+          head: {
+            isSortable: true,
+            sortKey: 'moves_count',
+            html: 'moves_count::label-html',
+          },
+        })
+      })
+      it('outputs the aria sort attribute set to none', function() {
+        expect(output.attributes).to.deep.equal({
+          'aria-sort': 'none',
+        })
+      })
+      it('outputs a link', function() {
+        expect(output.html).to.equal(
+          '<a aria-label="sort (translated)" class="sortable-table__button" role="button" href="?sortBy=moves_count&sortDirection=desc&status=proposed">moves_count::label-html (translated)</a>'
+        )
+      })
+    })
+  })
+  context('with isSortable set to false', function() {
+    beforeEach(function() {
+      output = objectToTableHead({
+        sortBy: 'date',
+        sortDirection: 'desc',
+        status: 'proposed',
+      })({
+        head: {
+          isSortable: false,
+          html: 'moves_count::label-html',
+        },
+      })
+    })
+    it('outputs the translated html', function() {
+      expect(output.html).to.equal('moves_count::label-html (translated)')
+    })
+    it('does not introduce spurious properties', function() {
+      expect(output.isSortable).to.be.undefined
+      expect(output.sortKey).to.be.undefined
     })
   })
 })

--- a/common/services/allocation.js
+++ b/common/services/allocation.js
@@ -62,6 +62,8 @@ const allocationService = {
     includeCancelled = false,
     isAggregation = false,
     status,
+    sortBy,
+    sortDirection,
   } = {}) {
     const [moveDateFrom, moveDateTo] = moveDate
 
@@ -74,6 +76,8 @@ const allocationService = {
         'filter[to_locations]': toLocationId,
         'filter[date_from]': moveDateFrom,
         'filter[date_to]': moveDateTo,
+        'sort[by]': sortBy,
+        'sort[direction]': sortDirection,
       }),
     })
   },

--- a/locales/en/default.json
+++ b/locales/en/default.json
@@ -18,6 +18,8 @@
   "opens_new_window": "Opens in a new window",
   "created_on": "Created on",
   "awaiting_person": "Person to be added",
+  "sort_ascending": "Sort {{label}} ascending",
+  "sort_descending": "Sort {{label}} descending",
   "primary_navigation": {
     "home": "Home",
     "outgoing": "Outgoing",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

This PR adds the ability to sort (server-side) to the allocation table (only the active allocations one. The cancelled one currently inherits the same filters but has no sorting capabilities of its own).

### What changed

Headers of the columns were changed to accomodate links that refresh the page with the various sorting options. If a column is sortable, the first click triggers a sort ascending. Further clicks will toggle the order. Clicking on another column triggers a sort ascending on that one, and so on.

### Why did it change

We want the users to be able to find allocations quickly.

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

- [P4-1447]()

## Screenshots
<img width="1060" alt="Screenshot 2020-06-04 at 11 41 35" src="https://user-images.githubusercontent.com/853989/83748997-f2dc1b00-a65a-11ea-8eb1-8679cdb4eb9e.png">

Detail of active current sort:
<img width="1049" alt="Screenshot 2020-06-04 at 12 01 54" src="https://user-images.githubusercontent.com/853989/83749281-5d8d5680-a65b-11ea-88f0-3167a8b810b7.png">



## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [x] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed

### Other considerations

Commit messages with a `fix` or `feat` type are automatically used to generate the [changelog](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/CHANGELOG.md) and
[GitHub release notes](https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/releases) during the release task. Please make sure they will read well on their own in a
summary of changes and that the commit body gives a more detailed description of those changes if necessary.

- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
- [x] Update [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md) with any new instructions or tasks
