### PR TITLE
style: Add linting warning for paddding between statements

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -46,6 +46,13 @@ module.exports = {
         'index',
       ]
     }],
+    'padding-line-between-statements': [
+      'warn',
+      { blankLine: 'always', prev: '*', next: 'block' },
+      { blankLine: 'always', prev: 'block', next: '*' },
+      { blankLine: 'always', prev: '*', next: 'block-like' },
+      { blankLine: 'always', prev: 'block-like', next: '*' },
+    ]
   },
   overrides: [
     {

--- a/app/allocation/controllers/create/confirmation.js
+++ b/app/allocation/controllers/create/confirmation.js
@@ -1,4 +1,5 @@
 function Confirmation(req, res) {
   res.render('allocation/views/confirmation', res.locals)
 }
+
 module.exports = Confirmation

--- a/app/allocation/controllers/create/save.js
+++ b/app/allocation/controllers/create/save.js
@@ -24,6 +24,7 @@ class SaveController extends CreateAllocationBaseController {
 
   async successHandler(req, res, next) {
     const { id } = req.sessionModel.get('allocation')
+
     try {
       req.journeyModel.reset()
       req.sessionModel.reset()

--- a/app/allocation/middleware.js
+++ b/app/allocation/middleware.js
@@ -4,6 +4,7 @@ async function setAllocation(req, res, next, allocationId) {
   if (!allocationId) {
     return next()
   }
+
   try {
     res.locals.allocation = await allocationService.getById(allocationId)
     next()

--- a/app/auth/middleware.js
+++ b/app/auth/middleware.js
@@ -28,6 +28,7 @@ function processAuthResponse() {
         if (error) {
           return next(error)
         }
+
         req.session.authExpiry = decodedAccessToken.exp
         req.session.user = new User({
           fullname,
@@ -42,9 +43,11 @@ function processAuthResponse() {
           if (req.session[key]) {
             return
           }
+
           if (key === 'grant') {
             return
           }
+
           req.session[key] = previousSession[key]
         })
 

--- a/app/move/controllers/create/document.js
+++ b/app/move/controllers/create/document.js
@@ -30,6 +30,7 @@ class DocumentUploadController extends CreateBaseController {
     if (req.body.upload || req.body.delete) {
       req.form.options.next = req.originalUrl
     }
+
     next()
   }
 

--- a/app/move/controllers/create/document.test.js
+++ b/app/move/controllers/create/document.test.js
@@ -4,11 +4,13 @@ const multer = require('multer')
 const proxyquire = require('proxyquire').noCallThru()
 
 function MulterStub() {}
+
 MulterStub.prototype.array = sinon.stub()
 
 function multerStub() {
   return new MulterStub()
 }
+
 multerStub.MulterError = multer.MulterError
 
 const BaseController = require('./base')

--- a/app/move/controllers/create/save.test.js
+++ b/app/move/controllers/create/save.test.js
@@ -237,6 +237,7 @@ describe('Move controllers', function() {
                   should_save_court_hearings: shouldSaveCourtHearingsFalseValue,
                 }
               }
+
               await controller.saveValues(req, {}, nextSpy)
             })
 

--- a/app/move/controllers/unassign.js
+++ b/app/move/controllers/unassign.js
@@ -13,6 +13,7 @@ class UnassignController extends FormWizardController {
     if (!move.allocation) {
       return res.redirect(`/move/${move.id}`)
     }
+
     if (!move.person) {
       return res.redirect(`/allocation/${move.allocation.id}`)
     }

--- a/app/move/controllers/update/assessment.js
+++ b/app/move/controllers/update/assessment.js
@@ -7,13 +7,16 @@ const UpdateBase = require('./base')
 
 const compare = (a, b) => {
   const key = 'assessment_question_id'
+
   if (a[key] < b[key]) {
     return -1
   }
+
   if (a[key] > b[key]) {
     return 1
   }
 }
+
 const getAnswerKeys = answers => {
   return answers
     .map(x => pick(x, ['key', 'assessment_question_id', 'comments']))

--- a/app/move/controllers/update/assessment.test.js
+++ b/app/move/controllers/update/assessment.test.js
@@ -290,6 +290,7 @@ describe('Move controllers', function() {
           try {
             await controller.saveValues(req, res, nextSpy)
           } catch (error) {}
+
           expect(nextSpy).to.be.calledOnceWithExactly(err)
         })
       })

--- a/app/move/controllers/update/base.js
+++ b/app/move/controllers/update/base.js
@@ -37,14 +37,17 @@ class UpdateBaseController extends CreateBaseController {
   setInitialStep(req, res, next) {
     let initialStep = false
     const referrer = req.get('referrer')
+
     if (!referrer) {
       initialStep = true
     } else {
       const { pathname } = new URL(referrer)
+
       if (pathname === this.getBaseUrl(req)) {
         initialStep = true
       }
     }
+
     req.initialStep = initialStep
     next()
   }
@@ -53,6 +56,7 @@ class UpdateBaseController extends CreateBaseController {
     const fields = req.form.options.fields
     Object.keys(fields).forEach(key => {
       const field = fields[key]
+
       if (field.readOnly && values[key] !== undefined && values[key] !== null) {
         fields[key] = {
           ...field,
@@ -67,6 +71,7 @@ class UpdateBaseController extends CreateBaseController {
     if (req.initialStep) {
       return {}
     }
+
     return super.getErrors(req, res)
   }
 
@@ -78,9 +83,11 @@ class UpdateBaseController extends CreateBaseController {
 
       try {
         const initialValues = this.getUpdateValues(req, res)
+
         if (req.initialStep) {
           values = initialValues
         }
+
         this.protectReadOnlyFields(req, initialValues)
       } catch (error) {
         return callback(error)
@@ -101,6 +108,7 @@ class UpdateBaseController extends CreateBaseController {
       const fields = this.saveFields || Object.keys(req.form.options.fields)
       const newValues = pick(req.form.values, fields)
       const oldValues = pick(req.getMove(), fields)
+
       if (!isEqual(newValues, oldValues)) {
         const id = req.getMoveId()
         const data = {

--- a/app/move/controllers/update/court.test.js
+++ b/app/move/controllers/update/court.test.js
@@ -28,6 +28,7 @@ describe('Move controllers', function() {
           args = []
           error = {}
           controller.configure(req, res, nextSpy)
+
           try {
             args = nextSpy.getCall(0).args
             error = args[0]

--- a/app/move/controllers/update/document.js
+++ b/app/move/controllers/update/document.js
@@ -11,6 +11,7 @@ class UpdateDocumentUploadController extends UpdateBase {
       req,
       'session.currentLocation.can_upload_documents'
     )
+
     if (!canUploadDocuments) {
       const error = new Error(
         'Document upload is not possible for this location'
@@ -18,18 +19,23 @@ class UpdateDocumentUploadController extends UpdateBase {
       error.statusCode = 404
       return next(error)
     }
+
     DocumentUploadController.prototype.configure.apply(this, [req, res, next])
   }
 
   getUpdateValues(req, res) {
     const move = req.getMove()
+
     if (!move) {
       return {}
     }
+
     const values = {}
+
     if (req.initialStep) {
       req.sessionModel.set('documents', move.documents)
     }
+
     values.documents = req.sessionModel.get('documents')
     return values
   }
@@ -42,6 +48,7 @@ class UpdateDocumentUploadController extends UpdateBase {
         next,
       ])
     }
+
     try {
       await moveService.update({
         id: req.getMoveId(),

--- a/app/move/controllers/update/document.test.js
+++ b/app/move/controllers/update/document.test.js
@@ -90,6 +90,7 @@ describe('Move controllers', function() {
           error = {}
           req.session.currentLocation.can_upload_documents = false
           controller.configure(req, res, nextSpy)
+
           try {
             args = nextSpy.getCall(0).args
             error = args[0]

--- a/app/move/controllers/update/move-date.js
+++ b/app/move/controllers/update/move-date.js
@@ -11,6 +11,7 @@ class UpdateMoveDetailsController extends UpdateBase {
 
   getUpdateValues(req, res) {
     const move = req.getMove()
+
     if (!move) {
       return {}
     }
@@ -22,9 +23,11 @@ class UpdateMoveDetailsController extends UpdateBase {
       [formatDate(res.locals.TODAY, dateFormat)]: 'today',
       [formatDate(res.locals.TOMORROW, dateFormat)]: 'tomorrow',
     }
+
     if (dates[move.date]) {
       values.date_type = dates[move.date]
     }
+
     if (values.date_type === 'custom') {
       values.date_custom = formatDate(move.date)
     }

--- a/app/move/controllers/update/move-details.js
+++ b/app/move/controllers/update/move-details.js
@@ -13,6 +13,7 @@ class UpdateMoveDetailsController extends UpdateBase {
 
   getUpdateValues(req, res) {
     const move = req.getMove()
+
     if (!move) {
       return {}
     }
@@ -20,10 +21,13 @@ class UpdateMoveDetailsController extends UpdateBase {
     const values = pick(move, ['move_type', 'additional_information'])
 
     const moveType = move.move_type
+
     if (values.additional_information) {
       values[`${moveType}_comments`] = values.additional_information
     }
+
     const toLocation = get(move, 'to_location.id')
+
     if (toLocation) {
       values[`to_location_${moveType}`] = toLocation
     }

--- a/app/move/controllers/view/view.update.links.js
+++ b/app/move/controllers/view/view.update.links.js
@@ -4,10 +4,13 @@ const getUpdateLinks = (updateSteps, urls) => {
   const updateLinks = {}
   updateSteps.forEach(updateJourney => {
     const category = updateJourney.key
+
     if (!urls[category]) {
       return
     }
+
     const categoryText = i18n.t(`moves::update_link.categories.${category}`)
+
     if (categoryText) {
       updateLinks[category] = {
         category,

--- a/app/move/controllers/view/view.update.links.test.js
+++ b/app/move/controllers/view/view.update.links.test.js
@@ -41,6 +41,7 @@ describe('Move controllers', function() {
           if (args) {
             return `Update ${args.category}`
           }
+
           return key.replace(/moves::update_link.categories./, '')
         })
         updateLinks = getUpdateLinks(updateSteps, urls)

--- a/app/move/controllers/view/view.update.urls.js
+++ b/app/move/controllers/view/view.update.urls.js
@@ -6,6 +6,7 @@ const getUpdateUrls = (updateSteps, moveId, userPermissions) => {
     if (!check(updateJourney.permission, userPermissions)) {
       return
     }
+
     const steps = updateJourney.steps
     const entryPointUrl = Object.keys(steps).filter(
       step => steps[step].entryPoint

--- a/common/assets/javascripts/application.js
+++ b/common/assets/javascripts/application.js
@@ -52,6 +52,7 @@ nodeListForEach($autocompletes, function($autocomplete) {
 })
 
 const $stickySidebars = document.querySelectorAll('.sticky-sidebar')
+
 if ($stickySidebars.length) {
   // eslint-disable-next-line no-new
   new StickySidebar('.sticky-sidebar', {

--- a/common/assets/javascripts/utils.js
+++ b/common/assets/javascripts/utils.js
@@ -7,6 +7,7 @@ function nodeListForEach(nodes, callback) {
   if (window.NodeList.prototype.forEach) {
     return nodes.forEach(callback)
   }
+
   for (var i = 0; i < nodes.length; i++) {
     callback.call(window, nodes[i], i, nodes)
   }

--- a/common/components/internal-header/internal-header.js
+++ b/common/components/internal-header/internal-header.js
@@ -5,12 +5,14 @@ function Header($module) {
 Header.prototype.init = function() {
   // Check for module
   var $module = this.$module
+
   if (!$module) {
     return
   }
 
   // Check for button
   var $toggleButton = $module.querySelector('.js-header-toggle')
+
   if (!$toggleButton) {
     return
   }

--- a/common/components/message/message.js
+++ b/common/components/message/message.js
@@ -39,6 +39,7 @@ Message.prototype = {
     link.innerHTML = 'Dismiss'
     link.className = 'app-message__close'
     link.href = '#'
+
     link.onclick = e => {
       e.preventDefault()
       this.removeElement($element)

--- a/common/components/multi-file-upload/multi-file-upload.js
+++ b/common/components/multi-file-upload/multi-file-upload.js
@@ -118,9 +118,11 @@ MultiFileUpload.prototype = {
         })
         .catch(error => {
           let errorMessage = 'could not be deleted'
+
           if (error.response && error.response.data) {
             errorMessage = error.response.data
           }
+
           const row = target.closest('.dz-success')
           row.classList.remove('dz-success')
           row.classList.add('dz-error')

--- a/common/components/read-only-field/template.test.js
+++ b/common/components/read-only-field/template.test.js
@@ -4,6 +4,7 @@ const {
 } = require('../../../test/unit/component-helpers')
 
 const examples = getExamples('read-only-field')
+
 const getComponent = example => {
   const $ = renderComponentHtmlToCheerio('read-only-field', examples[example])
   return $('.app-read-only-field')

--- a/common/helpers/date-utils.js
+++ b/common/helpers/date-utils.js
@@ -28,6 +28,7 @@ module.exports = {
     if (!validDate) {
       return null
     }
+
     return format(parsedDate, DATE_FORMATS.URL_PARAM)
   },
   getDateRange: (date, timePeriod) => {

--- a/common/helpers/field/index.js
+++ b/common/helpers/field/index.js
@@ -154,6 +154,7 @@ function translateField([key, field]) {
 
   translationPaths.forEach(path => {
     const key = get(translated, path)
+
     if (key) {
       set(translated, path, i18n.t(key))
     }

--- a/common/lib/api-client/index.test.js
+++ b/common/lib/api-client/index.test.js
@@ -28,6 +28,7 @@ const mockModels = {
     },
   },
 }
+
 function JsonApiStub(opts = {}) {
   this.init(opts)
 }

--- a/common/lib/api-client/middleware/auth.test.js
+++ b/common/lib/api-client/middleware/auth.test.js
@@ -1,6 +1,7 @@
 const proxyquire = require('proxyquire')
 
 function MockAuth() {}
+
 MockAuth.prototype.getAccessToken = sinon.stub()
 
 const authMiddleware = proxyquire('./auth', {

--- a/common/lib/api-client/middleware/request-timeout.js
+++ b/common/lib/api-client/middleware/request-timeout.js
@@ -5,6 +5,7 @@ module.exports = function requestTimeout(timeout) {
       if (payload.req) {
         payload.req.timeout = timeout
       }
+
       return payload
     },
   }

--- a/common/lib/api-client/models.test.js
+++ b/common/lib/api-client/models.test.js
@@ -199,11 +199,13 @@ describe('API client models', function() {
     describe(`${startCase(modelName)} model`, function() {
       // ensure all methods have a statusCode defined
       const noStatusMethods = getStatusMethods(modelName, undefined)
+
       if (noStatusMethods[0]) {
         throw new Error(
           `${modelName}.${noStatusMethods[0].method} has no statusCode`
         )
       }
+
       const runStatusMethodTests = (
         statusCode,
         expectFn = expectProperties,

--- a/common/lib/permissions.js
+++ b/common/lib/permissions.js
@@ -33,6 +33,7 @@ const secureTrainingCentrePermissions = [
   'move:create:court_appearance',
   'move:cancel',
 ]
+
 if (FEATURE_FLAGS.EDITABILITY) {
   secureTrainingCentrePermissions.push('move:update')
 }

--- a/common/lib/user.test.js
+++ b/common/lib/user.test.js
@@ -127,9 +127,11 @@ describe('User class', function() {
           'move:create:prison_recall',
           'move:cancel',
         ]
+
         if (FEATURE_FLAGS.EDITABILITY) {
           policePermissions.push('move:update')
         }
+
         expect(permissions).to.deep.equal(policePermissions)
       })
     })
@@ -167,9 +169,11 @@ describe('User class', function() {
           'move:create:court_appearance',
           'move:cancel',
         ]
+
         if (FEATURE_FLAGS.EDITABILITY) {
           stcPermissions.push('move:update')
         }
+
         expect(permissions).to.deep.equal(stcPermissions)
       })
     })
@@ -299,9 +303,11 @@ describe('User class', function() {
           'moves:view:proposed',
           'move:create:prison_transfer',
         ]
+
         if (FEATURE_FLAGS.EDITABILITY) {
           allPermissions.push('move:update')
         }
+
         expect(permissions.sort()).to.deep.equal(allPermissions.sort())
       })
     })

--- a/common/middleware/collection/set-actions.js
+++ b/common/middleware/collection/set-actions.js
@@ -4,4 +4,5 @@ function setActions(actions) {
     next()
   }
 }
+
 module.exports = setActions

--- a/common/middleware/development.js
+++ b/common/middleware/development.js
@@ -8,6 +8,7 @@ function bypassAuth(bypass) {
       const future = getTime(addDays(new Date(), 30))
       req.session.authExpiry = Math.floor(future / 1000)
     }
+
     next()
   }
 }
@@ -18,6 +19,7 @@ function setUserPermissions(permissions) {
       req.session.user = req.session.user || {}
       req.session.user.permissions = permissions.split(',')
     }
+
     next()
   }
 }
@@ -31,6 +33,7 @@ function setUserLocations(locations) {
         locations.split(',')
       )
     }
+
     next()
   }
 }

--- a/common/middleware/ensure-authenticated.js
+++ b/common/middleware/ensure-authenticated.js
@@ -13,9 +13,11 @@ module.exports = function ensureAuthenticated({
 } = {}) {
   return (req, res, next) => {
     let authExpiry = req.session.authExpiry
+
     if (req.method === 'GET' && expiryMargin) {
       authExpiry -= expiryMargin
     }
+
     if (whitelist.includes(req.url) || !_isExpired(authExpiry)) {
       return next()
     }
@@ -25,6 +27,7 @@ module.exports = function ensureAuthenticated({
     if (req.method === 'POST') {
       const contentType = req.get('content-type') || ''
       const isMultipart = contentType.startsWith('multipart/form-data;')
+
       if (isMultipart || req.xhr) {
         const error = new Error(
           req.t('validation::AUTH_EXPIRED', {
@@ -37,6 +40,7 @@ module.exports = function ensureAuthenticated({
 
       req.session.originalRequestBody = req.body
     }
+
     res.redirect(`/connect/${provider}`)
   }
 }

--- a/common/middleware/permissions.js
+++ b/common/middleware/permissions.js
@@ -4,6 +4,7 @@ function check(permissions, userPermissions = []) {
   if (!Array.isArray(permissions)) {
     permissions = [permissions]
   }
+
   return permissions.some(permission => userPermissions.includes(permission))
 }
 

--- a/common/middleware/process-original-request-body.js
+++ b/common/middleware/process-original-request-body.js
@@ -2,12 +2,14 @@ module.exports = function processOriginalRequestBody(authMountpoint = '/auth') {
   return (req, res, next) => {
     if (!req.url.startsWith(authMountpoint)) {
       const originalBody = req.session.originalRequestBody
+
       if (originalBody) {
         delete req.session.originalRequestBody
         req.body = originalBody
         req.method = 'POST'
       }
     }
+
     next()
   }
 }

--- a/common/middleware/set-location-items.js
+++ b/common/middleware/set-location-items.js
@@ -30,4 +30,5 @@ function setLocationItems(locationType, fieldName) {
     }
   }
 }
+
 module.exports = setLocationItems

--- a/common/presenters/allocation-to-meta-list-component.js
+++ b/common/presenters/allocation-to-meta-list-component.js
@@ -56,4 +56,5 @@ function allocationToMetaListComponent(allocation) {
     ],
   }
 }
+
 module.exports = allocationToMetaListComponent

--- a/common/presenters/allocation-to-summary-list-component.js
+++ b/common/presenters/allocation-to-summary-list-component.js
@@ -37,4 +37,5 @@ function allocationToSummaryListComponent(allocation) {
     ],
   }
 }
+
 module.exports = allocationToSummaryListComponent

--- a/common/presenters/assessment-to-summary-list-component.js
+++ b/common/presenters/assessment-to-summary-list-component.js
@@ -14,6 +14,7 @@ function _filterAnswer(category) {
     if (!category) {
       return true
     }
+
     return answer.category === category
   }
 }

--- a/common/presenters/move-type-for-filter.js
+++ b/common/presenters/move-type-for-filter.js
@@ -4,4 +4,5 @@ function moveTypesToFilterComponent(item) {
   item.label = i18n.t(item.label).toLowerCase()
   return item
 }
+
 module.exports = moveTypesToFilterComponent

--- a/common/presenters/table/object-to-table-row.js
+++ b/common/presenters/table/object-to-table-row.js
@@ -28,4 +28,5 @@ function objectToTableRow(schema) {
       .filter(row => row)
   }
 }
+
 module.exports = objectToTableRow

--- a/common/services/allocation.js
+++ b/common/services/allocation.js
@@ -26,9 +26,11 @@ const allocationService = {
           value = JSON.parse(value)
         } catch (e) {}
       }
+
       if (relationships.includes(key) && typeof value === 'string') {
         return { id: value }
       }
+
       return value
     })
   },

--- a/common/services/court-hearing.js
+++ b/common/services/court-hearing.js
@@ -10,6 +10,7 @@ const courtHearingService = {
       if (relationships.includes(key) && typeof value === 'string') {
         return { id: value }
       }
+
       return value
     })
   },

--- a/common/services/document.test.js
+++ b/common/services/document.test.js
@@ -1,6 +1,7 @@
 const proxyquire = require('proxyquire')
 
 function MockFormData() {}
+
 MockFormData.prototype.append = sinon.stub()
 
 const documentService = proxyquire('./document', {

--- a/common/services/move.js
+++ b/common/services/move.js
@@ -69,9 +69,11 @@ const moveService = {
           value = JSON.parse(value)
         } catch (e) {}
       }
+
       if (relationships.includes(key) && typeof value === 'string') {
         return { id: value }
       }
+
       return value
     })
   },
@@ -83,11 +85,12 @@ const moveService = {
     // Once Auth is moved to the API we would be able to remove this as the API
     // would know to only return moves that a user has access to
     const fromPath = 'filter["filter[from_location_id]"]'
+    const toPath = 'filter["filter[to_location_id]"]'
+
     if (get(props, fromPath)) {
       return splitRequests(props, fromPath)
     }
 
-    const toPath = 'filter["filter[to_location_id]"]'
     if (get(props, toPath)) {
       return splitRequests(props, toPath)
     }
@@ -211,6 +214,7 @@ const moveService = {
     if (!data.id) {
       return Promise.reject(new Error(noMoveIdMessage))
     }
+
     const timestamp = dateFunctions.formatISO(new Date())
     return apiClient
       .one('move', data.id)

--- a/common/services/person/person.unformat.js
+++ b/common/services/person/person.unformat.js
@@ -14,6 +14,7 @@ mapMethods.identifier = (person, field) => {
   const identifier = identifiers.filter(
     identifier => identifier.identifier_type === field
   )[0]
+
   if (identifier) {
     return identifier.value
   }
@@ -21,6 +22,7 @@ mapMethods.identifier = (person, field) => {
 
 mapMethods.relationship = (person, field) => {
   const relationship = person[field]
+
   if (relationship) {
     return relationship.id
   }
@@ -28,6 +30,7 @@ mapMethods.relationship = (person, field) => {
 
 mapMethods.date = (person, field) => {
   const fieldValue = person[field]
+
   if (fieldValue) {
     return filters.formatDate(fieldValue)
   }
@@ -45,6 +48,7 @@ mapMethods.explicitAssessment = (person, field, assessmentCategories) => {
   } else {
     assessmentCategories[explicitKey] = 'false'
   }
+
   return value
 }
 
@@ -59,6 +63,7 @@ mapMethods.assessment = (person, field, assessmentCategories) => {
     assessmentCategories[category] = assessmentCategories[category] || []
     assessmentCategories[category].push(questionId)
   }
+
   return value
 }
 

--- a/common/services/single-request.js
+++ b/common/services/single-request.js
@@ -20,6 +20,7 @@ const singleRequestService = {
     const [createdAtFrom, createdAtTo] = createdAtDate
 
     let statusFilter
+
     switch (status) {
       case 'pending':
         statusFilter = {

--- a/common/services/user.js
+++ b/common/services/user.js
@@ -60,9 +60,11 @@ function getAuthLocations(token) {
         if (error.statusCode === 404) {
           return Promise.resolve([])
         }
+
         return Promise.reject(error)
       }
     }
+
     return getLocationsByNomisAgencyId(groups)
   })
 }

--- a/config/nunjucks/filters.js
+++ b/config/nunjucks/filters.js
@@ -33,11 +33,13 @@ function formatDate(value, formattedDateStr = DATE_FORMATS.LONG) {
   if (!value) {
     return value
   }
+
   const date = isDate(value) ? value : parseISO(value)
 
   if (!isValidDate(date)) {
     return value
   }
+
   return format(date, formattedDateStr)
 }
 
@@ -124,6 +126,7 @@ function formatISOWeek(dateRange) {
   if (!Array.isArray(dateRange) || dateRange.length !== 2) {
     return dateRange
   }
+
   const [startDate, endDate] = dateRange
   return startDate === endDate
     ? startDate
@@ -184,6 +187,7 @@ function calculateAge(value) {
   if (!isValidDate(parsedDate)) {
     return value
   }
+
   return differenceInYears(new Date(), parsedDate)
 }
 

--- a/config/redis-store.test.js
+++ b/config/redis-store.test.js
@@ -5,6 +5,7 @@ function MockRedisStore(opts = {}) {
   this.isStore = true
   this.init(opts)
 }
+
 MockRedisStore.prototype.init = opts => this
 
 const mockRedisClient = {

--- a/server.js
+++ b/server.js
@@ -119,6 +119,7 @@ app.use(
     ...config.AUTH_PROVIDERS,
   })
 )
+
 // Development environment helpers
 if (config.IS_DEV) {
   require('axios-debug-log')
@@ -127,6 +128,7 @@ if (config.IS_DEV) {
   app.use(development.setUserPermissions(config.USER_PERMISSIONS))
   app.use(development.setUserLocations(config.USER_LOCATIONS))
 }
+
 app.use(
   ensureAuthenticated({
     provider: config.DEFAULT_AUTH_PROVIDER,

--- a/test/e2e/_helpers.js
+++ b/test/e2e/_helpers.js
@@ -112,11 +112,13 @@ export async function createPersonFixture(overrides = {}) {
  */
 const getRandomLocation = async locationType => {
   let locations
+
   if (locationType) {
     locations = await referenceDataService.getLocationsByType(locationType)
   } else {
     locations = await referenceDataService.getLocations()
   }
+
   return faker.random.arrayElement(locations.map(({ id }) => id))
 }
 
@@ -208,6 +210,7 @@ async function selectOption({ options, value }) {
   }
 
   let option
+
   if (!isNil(value) && typeof value === 'string') {
     option = await options.withText(value)
   } else if (!isNil(value) && typeof value === 'number') {
@@ -219,6 +222,7 @@ async function selectOption({ options, value }) {
   }
 
   const optionFor = await option.getAttribute('for')
+
   if (optionFor) {
     const idOption = Selector('#' + optionFor)
     await t.click(idOption)
@@ -374,12 +378,15 @@ export function createLogger(baseUrl) {
     if (request.url.match(/\.(js|css|woff|woff2|gif|svg|jpg|png)$/)) {
       return false
     }
+
     if (request.url.startsWith(`${baseUrl}/connect`)) {
       return false
     }
+
     if (request.url.startsWith(`${baseUrl}/browser-sync`)) {
       return false
     }
+
     return request.url.startsWith(baseUrl)
   })
 }

--- a/test/e2e/_move.js
+++ b/test/e2e/_move.js
@@ -133,6 +133,7 @@ const filterUpdatePages = (pages = updatePages, exclude = false) => {
   if (exclude) {
     ;[show, hide] = [hide, show]
   }
+
   return {
     show,
     hide,
@@ -154,6 +155,7 @@ export async function checkUpdateLinks(pages, exclude) {
   for await (const cat of filteredPages.show) {
     await checkUpdateLink(cat)
   }
+
   for await (const cat of filteredPages.hide) {
     await checkNoUpdateLink(cat)
   }
@@ -208,6 +210,7 @@ export async function checkUpdatePagesAccessible(pages, negated) {
   for await (const page of filteredPages.show) {
     await checkUpdatePageStatus(page, 200)
   }
+
   for await (const page of filteredPages.hide) {
     await checkUpdatePageStatus(page, 404)
   }
@@ -355,6 +358,7 @@ export async function checkUpdateMoveDetails() {
   const { moveType } = t.ctx.move
 
   const data = {}
+
   if (moveType === 'prison_recall') {
     data.additionalInformation = {
       selector: updateMovePage.fields.prisonRecallComments,
@@ -446,6 +450,7 @@ export async function checkUpdateDocuments() {
   await checkDocumentList()
 
   await addDocuments(['a-random-text-file.txt', 'leo-the-cat.png'])
+
   // eslint-disable-next-line no-unmodified-loop-condition
   while (documentCount) {
     await deleteDocument()

--- a/test/e2e/pages/create-move.js
+++ b/test/e2e/pages/create-move.js
@@ -193,6 +193,7 @@ class CreateMovePage extends Page {
         type: 'radio',
       },
     }
+
     if (exclude) {
       data = omit(data, exclude)
     } else if (include) {
@@ -261,6 +262,7 @@ class CreateMovePage extends Page {
     let dateCustom
 
     let dateType = dateValue
+
     if (dateType !== 'Today' && dateType !== 'Tomorrow') {
       dateType = 'Another date'
       dateCustom = dateValue
@@ -273,6 +275,7 @@ class CreateMovePage extends Page {
         type: 'radio',
       },
     }
+
     if (dateCustom) {
       data.dateCustom = {
         selector: this.fields.dateCustom,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

This adds an [eslint rule](https://eslint.org/docs/rules/padding-line-between-statements) to warn when a padding line isn't provided between particular
types of statements.

### Why did it change

This rule can help to break up large blocks of code and suggest a padding line between blocks at the same level. This can help when scanning the code and to distinguish between different blocks.

## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [x] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed

### Other considerations

Commit messages with a `fix` or `feat` type are automatically used to generate the [changelog](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/CHANGELOG.md) and
[GitHub release notes](https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/releases) during the release task. Please make sure they will read well on their own in a
summary of changes and that the commit body gives a more detailed description of those changes if necessary.

- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
- [x] Update [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md) with any new instructions or tasks
