### PR TITLE
fix: Ensure end-to-end test assertions are called with a promise

### DIFF
--- a/test/e2e/allocation.new.test.js
+++ b/test/e2e/allocation.new.test.js
@@ -9,12 +9,19 @@ test('Create allocation and verify the result', async t => {
   const allocationId = await allocationJourney.createAllocation()
   await t.navigateTo(`/allocation/${allocationId}`)
   ;['summary', 'meta'].forEach(async section => {
-    for (const o of allocationJourney.allocationViewPage.nodes[section].keys) {
-      const textExists = allocationJourney.allocationViewPage.getDlDefinitionByKey(
-        allocationJourney.allocationViewPage.nodes[section].selector,
-        o
-      )
-      await t.expect(textExists).ok()
+    for (const key of allocationJourney.allocationViewPage.nodes[section]
+      .keys) {
+      const selector =
+        allocationJourney.allocationViewPage.nodes[section].selector
+
+      await t
+        .expect(
+          allocationJourney.allocationViewPage.getDlDefinitionByKey(
+            selector,
+            key
+          )
+        )
+        .ok()
     }
   })
 })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Update to e2e test assertion.

It also includes a small tweak to the variable names to make them a little
more readable.

### Why did it change

This method was assigning the result of a promise to a variable and not
using `await` to wait for the result. This fix ensures that the promise
will be waited for by passing it into TestCafe's `assert` method directly.

## Checklists

### Testing

#### Automated testing

- [ ] Added unit tests to cover changes
- [x] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [x] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed

### Other considerations

Commit messages with a `fix` or `feat` type are automatically used to generate the [changelog](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/CHANGELOG.md) and
[GitHub release notes](https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/releases) during the release task. Please make sure they will read well on their own in a
summary of changes and that the commit body gives a more detailed description of those changes if necessary.

- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
- [x] Update [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md) with any new instructions or tasks
