### PR TITLE
[P4-1608] Update move agreed field logic

### DIFF
--- a/app/move/controllers/assign/base.js
+++ b/app/move/controllers/assign/base.js
@@ -1,5 +1,3 @@
-const { pick } = require('lodash')
-
 const presenters = require('../../../../common/presenters')
 const CreateBaseController = require('../create/base')
 
@@ -17,14 +15,7 @@ class AssignBaseController extends CreateBaseController {
   }
 
   setMoveSummary(req, res, next) {
-    const currentLocation = req.session.currentLocation
-    // TODO remove pick when the api return move_agreed as null
-    // unless of course further unwanted properties have been added in the meantime
-    const moveSubset = pick(res.locals.move, ['to_location', 'date'])
-    res.locals.moveSummary = presenters.moveToMetaListComponent({
-      ...moveSubset,
-      from_location: currentLocation,
-    })
+    res.locals.moveSummary = presenters.moveToMetaListComponent(res.locals.move)
     next()
   }
 

--- a/app/move/controllers/assign/base.test.js
+++ b/app/move/controllers/assign/base.test.js
@@ -36,6 +36,7 @@ describe('Assign controllers', function() {
     describe('#setMoveSummary()', function() {
       let locals
       let next
+
       beforeEach(function() {
         next = sinon.stub()
         sinon
@@ -59,17 +60,16 @@ describe('Assign controllers', function() {
           next
         )
       })
+
       it('creates moveSummary on the locals', function() {
         expect(locals.moveSummary).to.exist
         expect(locals.moveSummary).to.deep.equal({ summary: {} })
       })
-      it('invokes moveToMetaListComponent with a subset of properties', function() {
+
+      it('invokes moveToMetaListComponent with move', function() {
         expect(
           presenters.moveToMetaListComponent
-        ).to.have.been.calledWithExactly({
-          from_location: 'a',
-          to_location: 'b',
-        })
+        ).to.have.been.calledWithExactly(locals.move)
       })
     })
 

--- a/common/presenters/move-to-meta-list-component.js
+++ b/common/presenters/move-to-meta-list-component.js
@@ -135,10 +135,7 @@ function moveToMetaListComponent(
         text: i18n.t('fields::move_agreed.label'),
       },
       value: {
-        text:
-          !isNil(moveAgreed) && moveType === 'prison_transfer'
-            ? agreementLabel
-            : undefined,
+        text: !isNil(moveAgreed) ? agreementLabel : undefined,
       },
     },
   ]

--- a/common/presenters/move-to-meta-list-component.test.js
+++ b/common/presenters/move-to-meta-list-component.test.js
@@ -585,7 +585,6 @@ describe('Presenters', function() {
           beforeEach(function() {
             transformedResponse = moveToMetaListComponent({
               ...mockMove,
-              move_type: 'prison_transfer',
               move_agreed: true,
             })
           })
@@ -614,7 +613,6 @@ describe('Presenters', function() {
           beforeEach(function() {
             transformedResponse = moveToMetaListComponent({
               ...mockMove,
-              move_type: 'prison_transfer',
               move_agreed: true,
               move_agreed_by: 'Jon Doe',
             })
@@ -637,24 +635,6 @@ describe('Presenters', function() {
                 name: 'Jon Doe',
               }
             )
-          })
-        })
-
-        context('when not a prison transfer', function() {
-          beforeEach(function() {
-            transformedResponse = moveToMetaListComponent({
-              ...mockMove,
-              move_agreed: true,
-            })
-          })
-
-          it('should not set move agreed item', function() {
-            expect(transformedResponse.items[7]).to.deep.equal({
-              key: { text: 'fields::move_agreed.label' },
-              value: {
-                text: undefined,
-              },
-            })
           })
         })
       })
@@ -664,7 +644,6 @@ describe('Presenters', function() {
           beforeEach(function() {
             transformedResponse = moveToMetaListComponent({
               ...mockMove,
-              move_type: 'prison_transfer',
               move_agreed: false,
             })
           })
@@ -693,7 +672,6 @@ describe('Presenters', function() {
           beforeEach(function() {
             transformedResponse = moveToMetaListComponent({
               ...mockMove,
-              move_type: 'prison_transfer',
               move_agreed: false,
               move_agreed_by: 'Jon Doe',
             })
@@ -716,24 +694,6 @@ describe('Presenters', function() {
                 name: 'Jon Doe',
               }
             )
-          })
-        })
-
-        context('when not a prison transfer', function() {
-          beforeEach(function() {
-            transformedResponse = moveToMetaListComponent({
-              ...mockMove,
-              move_agreed: false,
-            })
-          })
-
-          it('should not set move agreed item', function() {
-            expect(transformedResponse.items[7]).to.deep.equal({
-              key: { text: 'fields::move_agreed.label' },
-              value: {
-                text: undefined,
-              },
-            })
           })
         })
       })
@@ -743,7 +703,6 @@ describe('Presenters', function() {
           beforeEach(function() {
             transformedResponse = moveToMetaListComponent({
               ...mockMove,
-              move_type: 'prison_transfer',
               move_agreed: 'true',
             })
           })
@@ -772,7 +731,6 @@ describe('Presenters', function() {
           beforeEach(function() {
             transformedResponse = moveToMetaListComponent({
               ...mockMove,
-              move_type: 'prison_transfer',
               move_agreed: 'true',
               move_agreed_by: 'Jon Doe',
             })
@@ -795,25 +753,6 @@ describe('Presenters', function() {
                 name: 'Jon Doe',
               }
             )
-          })
-        })
-
-        context('when not a prison transfer', function() {
-          beforeEach(function() {
-            transformedResponse = moveToMetaListComponent({
-              ...mockMove,
-              move_agreed: 'true',
-              move_agreed_by: 'Jon Doe',
-            })
-          })
-
-          it('should not set move agreed item', function() {
-            expect(transformedResponse.items[7]).to.deep.equal({
-              key: { text: 'fields::move_agreed.label' },
-              value: {
-                text: undefined,
-              },
-            })
           })
         })
       })

--- a/common/services/move.js
+++ b/common/services/move.js
@@ -1,5 +1,5 @@
 const dateFunctions = require('date-fns')
-const { chunk, get, mapValues, pickBy, set } = require('lodash')
+const { chunk, get, mapValues, omitBy, isUndefined, set } = require('lodash')
 
 const { LOCATIONS_BATCH_SIZE } = require('../../config')
 const apiClient = require('../lib/api-client')()
@@ -79,7 +79,7 @@ const moveService = {
       'prison_transfer_reason',
     ]
 
-    return mapValues(pickBy(data), (value, key) => {
+    return mapValues(omitBy(data, isUndefined), (value, key) => {
       if (booleansAndNulls.includes(key)) {
         try {
           value = JSON.parse(value)

--- a/common/services/move.js
+++ b/common/services/move.js
@@ -261,8 +261,8 @@ const moveService = {
       person: {
         id: null,
       },
-      move_agreed: false,
-      move_agreed_by: '',
+      move_agreed: null,
+      move_agreed_by: null,
     })
   },
 

--- a/common/services/move.test.js
+++ b/common/services/move.test.js
@@ -177,11 +177,12 @@ describe('Move Service', function() {
           empty_string: '',
           false: false,
           undefined: undefined,
+          null: null,
           empty_array: [],
         })
       })
 
-      it('should remove falsey values', function() {
+      it('should remove undefined values', function() {
         expect(formatted).to.deep.equal({
           date: '2010-10-10',
           to_location: {
@@ -196,24 +197,34 @@ describe('Move Service', function() {
           prison_transfer_reason: {
             id: mockPrisonTransferReasonId,
           },
+          empty_string: '',
+          false: false,
+          null: null,
           empty_array: [],
         })
       })
     })
 
     context('with strings that be booleans', function() {
-      it('should `false` string as boolean', function() {
+      it('should treat `false` string as boolean', function() {
         const formatted = moveService.format({
           move_agreed: 'false',
         })
         expect(formatted.move_agreed).to.equal(false)
       })
 
-      it('should `true` string as boolean', function() {
+      it('should treat `true` string as boolean', function() {
         const formatted = moveService.format({
           move_agreed: 'true',
         })
         expect(formatted.move_agreed).to.equal(true)
+      })
+
+      it('should treat `null` string as null', function() {
+        const formatted = moveService.format({
+          move_agreed: null,
+        })
+        expect(formatted.move_agreed).to.equal(null)
       })
     })
   })

--- a/common/services/move.test.js
+++ b/common/services/move.test.js
@@ -1068,8 +1068,8 @@ describe('Move Service', function() {
             person: {
               id: null,
             },
-            move_agreed: false,
-            move_agreed_by: '',
+            move_agreed: null,
+            move_agreed_by: null,
           })
         })
       })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

This fix removes the checks from when to display the `move_agreed`
and `move_agreed_by` fields for a move.

This means that when assigning a person to an allocation you will now see the response
to the "Has this move been agreed with the receiving prison?" question in the summary
panel on the right hand side.

### Why did it change

Previously the API didn't support `null` values for these fields
which meant that on creation of new moves, it defaulted the value
to false. However, `false` actually means that the person has
answered that the move was not agreed with the receiving prison.

This broke in the case of moves within an allocation because this
question had never been asked as part of creating the move at any
point.

This supports the [change in the API](https://github.com/ministryofjustice/hmpps-book-secure-move-api/pull/296) that supports `null` for this
field and updates the display based on that new logic.

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

- [P4-1608](https://dsdmoj.atlassian.net/browse/P4-1608)

## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [x] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed

### Other considerations

Commit messages with a `fix` or `feat` type are automatically used to generate the [changelog](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/CHANGELOG.md) and
[GitHub release notes](https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/releases) during the release task. Please make sure they will read well on their own in a
summary of changes and that the commit body gives a more detailed description of those changes if necessary.

- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
- [x] Update [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md) with any new instructions or tasks
