### PR TITLE
[P4 1461] Change "Sentence length" to "Time left to serve"

### DIFF
--- a/app/allocation/fields/moves-count.js
+++ b/app/allocation/fields/moves-count.js
@@ -1,5 +1,5 @@
 const movesCount = {
-  validate: 'required',
+  validate: ['required', 'numeric'],
   component: 'govukInput',
   label: {
     text: 'fields::moves_count.label',

--- a/locales/en/allocations.json
+++ b/locales/en/allocations.json
@@ -8,7 +8,7 @@
     "view_by_from_location": "View {{from_location}} overview"
   },
   "allocation_details": {
-    "page_title": "Allocation details'"
+    "page_title": "Allocation details"
   },
   "allocation_criteria": {
     "page_title": "Allocation criteria"

--- a/locales/en/fields.json
+++ b/locales/en/fields.json
@@ -272,7 +272,7 @@
     "label": "Prisoner category"
   },
   "sentence_length": {
-    "label": "Sentence length",
+    "label": "Time left to serve",
     "items": {
       "length_long": "Over 16 months",
       "length_short": "16 months or less",


### PR DESCRIPTION
### What changed

Changed the label of the sentence length field to match the prototype: from "Sentence length" to "Time left to serve".
Also fixed a minor issue with another label, and the validation of prisoners number.

### Why did it change

Adherence to the prototype

### Issue tracking

- [P4-1461]()

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed

### Other considerations

- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
- [x] Update [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md) with any new instructions or tasks
