### PR TITLE
test: Remove use of await in foreach loop

### DIFF
--- a/test/e2e/allocation.new.test.js
+++ b/test/e2e/allocation.new.test.js
@@ -5,10 +5,12 @@ import { allocationJourney } from './pages/'
 fixture('New PMU allocation').beforeEach(async t => {
   await t.useRole(pmuUser).navigateTo(newAllocation)
 })
+
 test('Create allocation and verify the result', async t => {
   const allocationId = await allocationJourney.createAllocation()
   await t.navigateTo(`/allocation/${allocationId}`)
-  ;['summary', 'meta'].forEach(async section => {
+
+  for (const section of ['summary', 'meta']) {
     for (const key of allocationJourney.allocationViewPage.nodes[section]
       .keys) {
       const selector =
@@ -23,8 +25,9 @@ test('Create allocation and verify the result', async t => {
         )
         .ok()
     }
-  })
+  }
 })
+
 test('Check validation errors on allocation details page', async t => {
   await allocationJourney.submitForm()
 
@@ -33,6 +36,7 @@ test('Check validation errors on allocation details page', async t => {
     await t.expect(error).ok()
   }
 })
+
 test('Check validation errors on allocation criteria page', async t => {
   await allocationJourney.triggerValidationOnAllocationCriteriaPage()
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

This fixes the use of an `await` within a `forEach` loop. 

### Why did it change

The forEach
loop doesn't wait for a promise called within `await` to be resolved or
rejected before it continues its loop.

This caused some issues with this test intermittently failing which
using a for...of loop should resolve.

## Checklists

### Testing

#### Automated testing

- [ ] Added unit tests to cover changes
- [x] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [x] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed

### Other considerations

Commit messages with a `fix` or `feat` type are automatically used to generate the [changelog](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/CHANGELOG.md) and
[GitHub release notes](https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/releases) during the release task. Please make sure they will read well on their own in a
summary of changes and that the commit body gives a more detailed description of those changes if necessary.

- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
- [x] Update [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md) with any new instructions or tasks
