### PR TITLE
[P4-1416] fix(moves): Remove ability of OCA users to create court transfer moves

### DIFF
--- a/common/lib/permissions.js
+++ b/common/lib/permissions.js
@@ -62,7 +62,6 @@ const ocaPermissions = [
   'moves:download',
   'move:view',
   'move:create',
-  'move:create:court_appearance',
   'move:create:prison_transfer',
 ]
 const pmuPermissions = [

--- a/common/lib/user.test.js
+++ b/common/lib/user.test.js
@@ -228,7 +228,6 @@ describe('User class', function() {
           'moves:download',
           'move:view',
           'move:create',
-          'move:create:court_appearance',
           'move:create:prison_transfer',
         ])
       })


### PR DESCRIPTION
### What changed

OCA users lose the permission to create court transfer moves.

### Why did it change

Such users can only create prison transfer moves

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

- [P4-1416]()

## Screenshots

| Before | After |
| ------ | ----- |
| <kbd><img width="667" alt="Screenshot 2020-06-08 at 15 15 39" src="https://user-images.githubusercontent.com/853989/84041301-9307ac00-a99b-11ea-86a6-181516d57d9a.png"></kbd> | <kbd><img width="620" alt="Screenshot 2020-06-08 at 15 16 56" src="https://user-images.githubusercontent.com/853989/84041335-9e5ad780-a99b-11ea-9d6d-cafae34ecdce.png"></kbd> |

## Checklists

### Testing

#### Automated testing

- [ ] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed

### Other considerations

- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
- [x] Update [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md) with any new instructions or tasks
