### PR TITLE
chore: Add missing include values to allocations

### DIFF
--- a/common/services/allocation.js
+++ b/common/services/allocation.js
@@ -5,7 +5,14 @@ const apiClient = require('../lib/api-client')()
 const personService = require('../services/person')
 
 const allocationService = {
-  defaultInclude: ['from_location', 'moves', 'to_location'],
+  defaultInclude: [
+    'from_location',
+    'moves',
+    'moves.person',
+    'moves.person.ethnicity',
+    'moves.person.gender',
+    'to_location',
+  ],
 
   cancel(allocationId) {
     const timestamp = dateFunctions.formatISO(new Date())

--- a/common/services/allocation.test.js
+++ b/common/services/allocation.test.js
@@ -58,6 +58,9 @@ describe('Allocation service', function() {
     expect(allocationService.defaultInclude).deep.equal([
       'from_location',
       'moves',
+      'moves.person',
+      'moves.person.ethnicity',
+      'moves.person.gender',
       'to_location',
     ])
   })


### PR DESCRIPTION
## Proposed changes

### What changed

Added `moves.person`, `moves.person.ethnicity` and `moves.person.gender` to default allocation `include` parameter

### Why did it change

Missed in previous api improvements - filled values fail to show correctly without them.

### Issue tracking
n/a

## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed


### Other considerations


- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics

