### PR TITLE
Maintain default include for resources within the model defintion

### DIFF
--- a/common/lib/api-client/index.js
+++ b/common/lib/api-client/index.js
@@ -2,7 +2,14 @@ const JsonApi = require('devour-client')
 
 const { API, IS_DEV, FILE_UPLOADS } = require('../../../config')
 
-const { auth, errors, request, requestTimeout, post } = require('./middleware')
+const {
+  auth,
+  errors,
+  post,
+  request,
+  requestInclude,
+  requestTimeout,
+} = require('./middleware')
 const models = require('./models')
 
 let instance
@@ -27,6 +34,7 @@ module.exports = function() {
     })
   )
   instance.insertMiddlewareBefore('axios-request', requestTimeout(API.TIMEOUT))
+  instance.insertMiddlewareBefore('axios-request', requestInclude)
   instance.insertMiddlewareBefore('axios-request', auth)
 
   // define models

--- a/common/lib/api-client/index.js
+++ b/common/lib/api-client/index.js
@@ -31,7 +31,7 @@ module.exports = function() {
 
   // define models
   Object.entries(models).forEach(([modelName, model]) => {
-    instance.define(modelName, model.attributes, model.options)
+    instance.define(modelName, model.fields, model.options)
   })
 
   return instance

--- a/common/lib/api-client/index.test.js
+++ b/common/lib/api-client/index.test.js
@@ -15,12 +15,12 @@ const mockConfig = {
 }
 const mockModels = {
   withoutOptions: {
-    attributes: {
+    fields: {
       reference: '',
     },
   },
   withOptions: {
-    attributes: {
+    fields: {
       name: '',
     },
     options: {
@@ -135,7 +135,7 @@ describe('Back-end API client', function() {
               JsonApiStub.prototype.define.firstCall
             ).to.be.calledWithExactly(
               'withoutOptions',
-              mockModels.withoutOptions.attributes,
+              mockModels.withoutOptions.fields,
               undefined
             )
           })
@@ -147,7 +147,7 @@ describe('Back-end API client', function() {
               JsonApiStub.prototype.define.secondCall
             ).to.be.calledWithExactly(
               'withOptions',
-              mockModels.withOptions.attributes,
+              mockModels.withOptions.fields,
               mockModels.withOptions.options
             )
           })

--- a/common/lib/api-client/middleware/index.js
+++ b/common/lib/api-client/middleware/index.js
@@ -2,12 +2,14 @@ const auth = require('./auth')
 const errors = require('./errors')
 const post = require('./post')
 const request = require('./request')
+const requestInclude = require('./request-include')
 const requestTimeout = require('./request-timeout')
 
 module.exports = {
   auth,
   errors,
-  request,
-  requestTimeout,
   post,
+  request,
+  requestInclude,
+  requestTimeout,
 }

--- a/common/lib/api-client/middleware/request-include.js
+++ b/common/lib/api-client/middleware/request-include.js
@@ -1,0 +1,26 @@
+const { get } = require('lodash')
+
+module.exports = {
+  name: 'req-include',
+  req: function req(payload = {}) {
+    if (!payload.req) {
+      return payload
+    }
+
+    const { req, jsonApi = {} } = payload
+    const defaultInclude = get(
+      jsonApi,
+      `models.${req.model}.options.defaultInclude`
+    )
+
+    let include = req.params.include || defaultInclude
+
+    if (Array.isArray(include)) {
+      include = include.sort().join(',')
+    }
+
+    req.params.include = include
+
+    return payload
+  },
+}

--- a/common/lib/api-client/middleware/request-include.test.js
+++ b/common/lib/api-client/middleware/request-include.test.js
@@ -1,0 +1,99 @@
+const middleware = require('./request-include')
+
+describe('API Client', function() {
+  describe('Request include middleware', function() {
+    describe('#req-include', function() {
+      context('when payload does not include a request', function() {
+        it('should return default payload', function() {
+          expect(middleware.req()).to.deep.equal({})
+        })
+      })
+
+      context('when payload contains a request', function() {
+        let request, jsonApi
+
+        beforeEach(function() {
+          request = {
+            params: {},
+          }
+          jsonApi = {
+            models: {
+              mockModel: {
+                options: {},
+              },
+            },
+          }
+        })
+
+        context('with existing include request param', function() {
+          context('with include as a string', function() {
+            it('should retain existing include', function() {
+              request.params.include = 'authors,comments'
+              middleware.req({ req: request })
+
+              expect(request.params.include).to.equal('authors,comments')
+            })
+          })
+
+          context('with include as an array', function() {
+            it('should convert include to string', function() {
+              request.params.include = ['authors', 'comments']
+              middleware.req({ req: request })
+
+              expect(request.params.include).to.equal('authors,comments')
+            })
+          })
+
+          context('with default include on model', function() {
+            it('should retain existing include', function() {
+              request.params.include = 'authors,comments'
+              jsonApi.models.mockModel.options = {
+                defaultInclude: 'authors',
+              }
+              request.model = 'mockModel'
+              middleware.req({ req: request, jsonApi })
+
+              expect(request.params.include).to.equal('authors,comments')
+            })
+          })
+        })
+
+        context('without existing include request param', function() {
+          context('with default include on model', function() {
+            beforeEach(function() {
+              request.model = 'mockModel'
+            })
+
+            context('with default include as a string', function() {
+              it('should retain existing include', function() {
+                jsonApi.models.mockModel.options = {
+                  defaultInclude: 'authors,comments',
+                }
+                middleware.req({ req: request, jsonApi })
+                expect(request.params.include).to.equal('authors,comments')
+              })
+            })
+
+            context('with default include as an array', function() {
+              it('should convert include to string', function() {
+                jsonApi.models.mockModel.options = {
+                  defaultInclude: ['authors', 'comments'],
+                }
+                middleware.req({ req: request, jsonApi })
+                expect(request.params.include).to.equal('authors,comments')
+              })
+            })
+          })
+
+          context('without default include on model', function() {
+            it('should not set include', function() {
+              middleware.req({ req: request, jsonApi })
+
+              expect(request.params.include).to.be.undefined
+            })
+          })
+        })
+      })
+    })
+  })
+})

--- a/common/lib/api-client/middleware/request.js
+++ b/common/lib/api-client/middleware/request.js
@@ -23,14 +23,6 @@ function requestMiddleware({ cacheExpiry = 60, disableCache = false } = {}) {
       const { req, jsonApi } = payload
       const pathname = new URL(req.url).pathname
 
-      if (Array.isArray(req.params.include)) {
-        req.params.include = req.params.include.sort().join(',')
-      }
-
-      if (!req.params.include) {
-        delete req.params.include
-      }
-
       const searchString = new URLSearchParams(req.params).toString()
       const key = `cache:${req.method}.${pathname}${
         searchString ? `?${searchString}` : ''

--- a/common/lib/api-client/middleware/request.test.js
+++ b/common/lib/api-client/middleware/request.test.js
@@ -184,52 +184,6 @@ describe('API Client', function() {
         })
       })
 
-      context('when request contains include param', function() {
-        beforeEach(function() {
-          getAsyncStub.resolves(null)
-          payload.req.params = {}
-        })
-
-        context('and passed as a string', function() {
-          beforeEach(async function() {
-            payload.req.params.include = 'foo,bar'
-            await requestMiddleware().req(payload)
-          })
-          it('should append include param as is to query', function() {
-            expect(payload.req.params.include).to.equal('foo,bar')
-            expect(getAsyncStub).to.be.calledOnceWithExactly(
-              'cache:GET./path/to/endpoint?include=foo%2Cbar'
-            )
-          })
-        })
-
-        context('and passed as a an array', function() {
-          beforeEach(async function() {
-            payload.req.params.include = ['foo', 'bar']
-            await requestMiddleware().req(payload)
-          })
-          it('should sort include params and append to query', function() {
-            expect(payload.req.params.include).to.equal('bar,foo')
-            expect(getAsyncStub).to.be.calledOnceWithExactly(
-              'cache:GET./path/to/endpoint?include=bar%2Cfoo'
-            )
-          })
-        })
-
-        context('and passed as a an empty array', function() {
-          beforeEach(async function() {
-            payload.req.params.include = []
-            await requestMiddleware().req(payload)
-          })
-          it('should not append include param to query', function() {
-            expect(payload.req.params.include).to.be.undefined
-            expect(getAsyncStub).to.be.calledOnceWithExactly(
-              'cache:GET./path/to/endpoint'
-            )
-          })
-        })
-      })
-
       describe('options', function() {
         beforeEach(async function() {
           getAsyncStub.resolves(null)

--- a/common/lib/api-client/models.js
+++ b/common/lib/api-client/models.js
@@ -1,6 +1,6 @@
 module.exports = {
   move: {
-    attributes: {
+    fields: {
       reference: '',
       status: '',
       move_type: '',
@@ -46,12 +46,12 @@ module.exports = {
     },
   },
   image: {
-    attributes: {
+    fields: {
       url: '',
     },
   },
   person: {
-    attributes: {
+    fields: {
       first_names: '',
       last_name: '',
       date_of_birth: '',
@@ -69,7 +69,7 @@ module.exports = {
     },
   },
   court_case: {
-    attributes: {
+    fields: {
       nomis_case_id: '',
       nomis_case_status: '',
       case_start_date: '',
@@ -82,7 +82,7 @@ module.exports = {
     },
   },
   court_hearing: {
-    attributes: {
+    fields: {
       start_time: '',
       case_number: '',
       case_type: '',
@@ -98,7 +98,7 @@ module.exports = {
     },
   },
   timetable_entry: {
-    attributes: {
+    fields: {
       start_time: '',
       nomis_type: '',
       reason: '',
@@ -112,7 +112,7 @@ module.exports = {
     },
   },
   gender: {
-    attributes: {
+    fields: {
       key: '',
       title: '',
       description: '',
@@ -125,7 +125,7 @@ module.exports = {
     },
   },
   ethnicity: {
-    attributes: {
+    fields: {
       key: '',
       title: '',
       description: '',
@@ -138,7 +138,7 @@ module.exports = {
     },
   },
   assessment_question: {
-    attributes: {
+    fields: {
       disabled_at: '',
       key: '',
       title: '',
@@ -152,7 +152,7 @@ module.exports = {
     },
   },
   location: {
-    attributes: {
+    fields: {
       key: '',
       title: '',
       location_type: '',
@@ -170,7 +170,7 @@ module.exports = {
     },
   },
   supplier: {
-    attributes: {
+    fields: {
       key: '',
       name: '',
     },
@@ -180,7 +180,7 @@ module.exports = {
     },
   },
   prison_transfer_reason: {
-    attributes: {
+    fields: {
       disabled_at: '',
       key: '',
       title: '',
@@ -191,7 +191,7 @@ module.exports = {
     },
   },
   document: {
-    attributes: {
+    fields: {
       file: '',
       filename: '',
       content_type: '',
@@ -200,7 +200,7 @@ module.exports = {
     },
   },
   allocation: {
-    attributes: {
+    fields: {
       from_location: {
         jsonApi: 'hasOne',
         type: 'locations',
@@ -230,7 +230,7 @@ module.exports = {
     },
   },
   allocation_complex_case: {
-    attributes: {
+    fields: {
       disabled_at: '',
       key: '',
       title: '',
@@ -241,7 +241,7 @@ module.exports = {
     },
   },
   event: {
-    attributes: {
+    fields: {
       event_name: '',
       timestamp: '',
       notes: '',
@@ -252,7 +252,7 @@ module.exports = {
     },
   },
   redirect: {
-    attributes: {
+    fields: {
       timestamp: '',
       notes: '',
       to_location: {

--- a/common/lib/api-client/models.js
+++ b/common/lib/api-client/models.js
@@ -44,6 +44,20 @@ module.exports = {
         type: 'allocations',
       },
     },
+    options: {
+      defaultInclude: [
+        'allocation',
+        'court_hearings',
+        'documents',
+        'from_location',
+        'from_location.suppliers',
+        'person',
+        'person.ethnicity',
+        'person.gender',
+        'prison_transfer_reason',
+        'to_location',
+      ],
+    },
   },
   image: {
     fields: {
@@ -66,6 +80,9 @@ module.exports = {
         jsonApi: 'hasOne',
         type: 'ethnicities',
       },
+    },
+    options: {
+      defaultInclude: ['ethnicity', 'gender'],
     },
   },
   court_case: {
@@ -167,6 +184,7 @@ module.exports = {
     options: {
       cache: true,
       collectionPath: 'reference/locations',
+      defaultInclude: ['suppliers'],
     },
   },
   supplier: {
@@ -227,6 +245,16 @@ module.exports = {
         jsonApi: 'hasMany',
         type: 'events',
       },
+    },
+    options: {
+      defaultInclude: [
+        'from_location',
+        'moves',
+        'moves.person',
+        'moves.person.ethnicity',
+        'moves.person.gender',
+        'to_location',
+      ],
     },
   },
   allocation_complex_case: {

--- a/common/lib/api-client/models.test.js
+++ b/common/lib/api-client/models.test.js
@@ -185,9 +185,7 @@ const getStatusMethods = (modelName, statusCode) => {
 }
 
 const expectProperties = ({ model, response }) => {
-  flatten([response.data]).forEach(item =>
-    checkProperties(item, model.attributes)
-  )
+  flatten([response.data]).forEach(item => checkProperties(item, model.fields))
 }
 
 const expectNoData = ({ response }) => {
@@ -209,7 +207,7 @@ describe('API client models', function() {
       const runStatusMethodTests = (
         statusCode,
         expectFn = expectProperties,
-        expectStr = 'should contain correct attributes'
+        expectStr = 'should contain correct fields'
       ) => {
         describe(`${statusCode} status code`, function() {
           forEach(getStatusMethods(modelName, statusCode), testCase => {

--- a/common/lib/api-client/models.test.js
+++ b/common/lib/api-client/models.test.js
@@ -169,9 +169,14 @@ const getResponse = ({ modelName, model, testCase } = {}) => {
 
   const nockedResponse =
     fixture.response !== undefined ? fixture.response : fixture
+  const defaultInclude = get(model, 'options.defaultInclude')
+  const include = defaultInclude ? `?include=${defaultInclude.join(',')}` : ''
 
   nock(mockConfig.API.BASE_URL)
-    .intercept(`/${apiPath}${testCase.mockPath || ''}`, testCase.httpMock)
+    .intercept(
+      `/${apiPath}${testCase.mockPath || ''}${include}`,
+      testCase.httpMock
+    )
     .reply(statusCode, nockedResponse)
 
   return client[testCase.method](modelName, testCase.args)

--- a/common/services/allocation.js
+++ b/common/services/allocation.js
@@ -5,15 +5,6 @@ const apiClient = require('../lib/api-client')()
 const personService = require('../services/person')
 
 const allocationService = {
-  defaultInclude: [
-    'from_location',
-    'moves',
-    'moves.person',
-    'moves.person.ethnicity',
-    'moves.person.gender',
-    'to_location',
-  ],
-
   cancel(allocationId) {
     const timestamp = dateFunctions.formatISO(new Date())
     return apiClient
@@ -109,7 +100,7 @@ const allocationService = {
     page = 1,
     includeCancelled = false,
     isAggregation = false,
-    include = this.defaultInclude,
+    include,
   } = {}) {
     return apiClient
       .findAll('allocation', {
@@ -138,7 +129,7 @@ const allocationService = {
         })
       })
   },
-  getById(id, { include = this.defaultInclude } = {}) {
+  getById(id, { include } = {}) {
     return apiClient
       .find('allocation', id, { include })
       .then(response => response.data)

--- a/common/services/allocation.test.js
+++ b/common/services/allocation.test.js
@@ -51,26 +51,7 @@ const mockAllocations = [
   },
 ]
 
-const mockDefaultInclude = ['default']
-
 describe('Allocation service', function() {
-  it('should have the correct default include', function() {
-    expect(allocationService.defaultInclude).deep.equal([
-      'from_location',
-      'moves',
-      'moves.person',
-      'moves.person.ethnicity',
-      'moves.person.gender',
-      'to_location',
-    ])
-  })
-})
-
-describe('Allocation service', function() {
-  beforeEach(function() {
-    allocationService.defaultInclude = mockDefaultInclude
-  })
-
   describe('cancel', function() {
     let outcome
     beforeEach(async function() {
@@ -320,7 +301,7 @@ describe('Allocation service', function() {
             {
               page: 1,
               per_page: 100,
-              include: mockDefaultInclude,
+              include: undefined,
             }
           )
         })
@@ -354,7 +335,7 @@ describe('Allocation service', function() {
               ...mockFilter,
               page: 1,
               per_page: 100,
-              include: mockDefaultInclude,
+              include: undefined,
             }
           )
         })
@@ -377,7 +358,7 @@ describe('Allocation service', function() {
             ...mockFilter,
             page: 1,
             per_page: 1,
-            include: mockDefaultInclude,
+            include: undefined,
           })
         })
 
@@ -399,7 +380,7 @@ describe('Allocation service', function() {
             {
               page: 1,
               per_page: 100,
-              include: mockDefaultInclude,
+              include: undefined,
             }
           )
         })
@@ -444,7 +425,7 @@ describe('Allocation service', function() {
             {
               page: 1,
               per_page: 100,
-              include: mockDefaultInclude,
+              include: undefined,
             }
           )
         })
@@ -455,7 +436,7 @@ describe('Allocation service', function() {
             {
               page: 2,
               per_page: 100,
-              include: mockDefaultInclude,
+              include: undefined,
             }
           )
         })
@@ -483,7 +464,7 @@ describe('Allocation service', function() {
               ...mockFilter,
               page: 1,
               per_page: 100,
-              include: mockDefaultInclude,
+              include: undefined,
             }
           )
         })
@@ -495,7 +476,7 @@ describe('Allocation service', function() {
               ...mockFilter,
               page: 2,
               per_page: 100,
-              include: mockDefaultInclude,
+              include: undefined,
             }
           )
         })
@@ -514,7 +495,7 @@ describe('Allocation service', function() {
             ...mockFilter,
             page: 1,
             per_page: 1,
-            include: mockDefaultInclude,
+            include: undefined,
           })
         })
 
@@ -743,16 +724,19 @@ describe('Allocation service', function() {
       })
     })
 
-    context('', function() {
+    context('when called without include parameter', function() {
       beforeEach(async function() {
         output = await allocationService.getById(
           '8567f1a5-2201-4bc2-b655-f6526401303a'
         )
       })
       it('calls the api service', function() {
-        expect(apiClient.find).to.have.been.calledOnceWith(
+        expect(apiClient.find).to.have.been.calledOnceWithExactly(
           'allocation',
-          '8567f1a5-2201-4bc2-b655-f6526401303a'
+          '8567f1a5-2201-4bc2-b655-f6526401303a',
+          {
+            include: undefined,
+          }
         )
       })
 

--- a/common/services/move.js
+++ b/common/services/move.js
@@ -22,14 +22,14 @@ function getAll({
   combinedData = [],
   page = 1,
   isAggregation = false,
-  include = {},
+  include,
 } = {}) {
   return apiClient
     .findAll('move', {
       ...filter,
+      include,
       page,
       per_page: isAggregation ? 1 : 100,
-      include,
     })
     .then(response => {
       const { data, links, meta } = response
@@ -57,19 +57,6 @@ function getAll({
 
 const noMoveIdMessage = 'No move ID supplied'
 const moveService = {
-  defaultInclude: [
-    'allocation',
-    'court_hearings',
-    'documents',
-    'from_location',
-    'from_location.suppliers',
-    'person',
-    'person.ethnicity',
-    'person.gender',
-    'prison_transfer_reason',
-    'to_location',
-  ],
-
   format(data) {
     const booleansAndNulls = ['move_agreed']
     const relationships = [
@@ -102,8 +89,6 @@ const moveService = {
     // would know to only return moves that a user has access to
     const fromPath = 'filter["filter[from_location_id]"]'
     const toPath = 'filter["filter[to_location_id]"]'
-
-    props.include = props.include || this.defaultInclude
 
     if (get(props, fromPath)) {
       return splitRequests(props, fromPath)
@@ -202,7 +187,7 @@ const moveService = {
     })
   },
 
-  getById(id, { include = this.defaultInclude } = {}) {
+  getById(id, { include } = {}) {
     if (!id) {
       return Promise.reject(new Error(noMoveIdMessage))
     }

--- a/common/services/move.test.js
+++ b/common/services/move.test.js
@@ -42,28 +42,8 @@ const mockMoves = [
   },
 ]
 
-const mockDefaultInclude = ['default']
-
-describe('Move Service', function() {
-  it('should have the correct default include', function() {
-    expect(moveService.defaultInclude).deep.equal([
-      'allocation',
-      'court_hearings',
-      'documents',
-      'from_location',
-      'from_location.suppliers',
-      'person',
-      'person.ethnicity',
-      'person.gender',
-      'prison_transfer_reason',
-      'to_location',
-    ])
-  })
-})
-
 describe('Move Service', function() {
   beforeEach(function() {
-    moveService.defaultInclude = mockDefaultInclude
     sinon.stub(personService, 'transform').returnsArg(0)
   })
 
@@ -277,7 +257,7 @@ describe('Move Service', function() {
           expect(apiClient.findAll.firstCall).to.be.calledWithExactly('move', {
             page: 1,
             per_page: 100,
-            include: mockDefaultInclude,
+            include: undefined,
           })
         })
 
@@ -302,7 +282,7 @@ describe('Move Service', function() {
             ...mockFilter,
             page: 1,
             per_page: 100,
-            include: mockDefaultInclude,
+            include: undefined,
           })
         })
 
@@ -324,7 +304,7 @@ describe('Move Service', function() {
             ...mockFilter,
             page: 1,
             per_page: 1,
-            include: mockDefaultInclude,
+            include: undefined,
           })
         })
 
@@ -356,7 +336,7 @@ describe('Move Service', function() {
           expect(apiClient.findAll.firstCall).to.be.calledWithExactly('move', {
             page: 1,
             per_page: 100,
-            include: mockDefaultInclude,
+            include: undefined,
           })
         })
 
@@ -364,7 +344,7 @@ describe('Move Service', function() {
           expect(apiClient.findAll.secondCall).to.be.calledWithExactly('move', {
             page: 2,
             per_page: 100,
-            include: mockDefaultInclude,
+            include: undefined,
           })
         })
 
@@ -389,7 +369,7 @@ describe('Move Service', function() {
             ...mockFilter,
             page: 1,
             per_page: 100,
-            include: mockDefaultInclude,
+            include: undefined,
           })
         })
 
@@ -398,7 +378,7 @@ describe('Move Service', function() {
             ...mockFilter,
             page: 2,
             per_page: 100,
-            include: mockDefaultInclude,
+            include: undefined,
           })
         })
       })
@@ -416,7 +396,7 @@ describe('Move Service', function() {
             ...mockFilter,
             page: 1,
             per_page: 1,
-            include: mockDefaultInclude,
+            include: undefined,
           })
         })
 
@@ -458,7 +438,7 @@ describe('Move Service', function() {
                 .join(','),
               page: 1,
               per_page: 100,
-              include: mockDefaultInclude,
+              include: undefined,
             })
           })
         }
@@ -856,13 +836,13 @@ describe('Move Service', function() {
         sinon.stub(apiClient, 'find').resolves(mockResponse)
       })
 
-      context('', function() {
+      context('when called without include parameter', function() {
         beforeEach(async function() {
           move = await moveService.getById(mockId)
         })
         it('should call find method with data', function() {
           expect(apiClient.find).to.be.calledOnceWithExactly('move', mockId, {
-            include: mockDefaultInclude,
+            include: undefined,
           })
         })
 

--- a/common/services/person.js
+++ b/common/services/person.js
@@ -37,8 +37,6 @@ const assessmentKeys = [
 const explicitAssessmentKeys = ['special_vehicle', 'not_to_be_released']
 
 const personService = {
-  defaultInclude: ['ethnicity', 'gender'],
-
   transform(person) {
     if (!person) {
       return undefined
@@ -168,7 +166,7 @@ const personService = {
       .then(response => response.data)
   },
 
-  getByIdentifiers(identifiers, { include = this.defaultInclude } = {}) {
+  getByIdentifiers(identifiers, { include } = {}) {
     const filter = {
       ...mapKeys(identifiers, (value, key) => `filter[${key}]`),
       include,

--- a/common/services/person.test.js
+++ b/common/services/person.test.js
@@ -17,19 +17,7 @@ const mockPerson = {
   last_name: 'Bloggs',
 }
 
-const mockDefaultInclude = ['default']
-
 describe('Person Service', function() {
-  it('should have the correct default include', function() {
-    expect(personService.defaultInclude).deep.equal(['ethnicity', 'gender'])
-  })
-})
-
-describe('Person Service', function() {
-  beforeEach(function() {
-    personService.defaultInclude = mockDefaultInclude
-  })
-
   describe('#transform()', function() {
     let transformed
 
@@ -829,7 +817,7 @@ describe('Person Service', function() {
 
       it('should call findAll method with empty object', function() {
         expect(apiClient.findAll).to.be.calledOnceWithExactly('person', {
-          include: mockDefaultInclude,
+          include: undefined,
         })
       })
 
@@ -854,7 +842,7 @@ describe('Person Service', function() {
         expect(apiClient.findAll).to.be.calledOnceWithExactly('person', {
           'filter[filterOne]': 'filter-one-value',
           'filter[filterTwo]': 'filter-two-value',
-          include: mockDefaultInclude,
+          include: undefined,
         })
       })
 

--- a/common/services/reference-data.js
+++ b/common/services/reference-data.js
@@ -3,8 +3,6 @@ const { flattenDeep, sortBy } = require('lodash')
 const apiClient = require('../lib/api-client')()
 
 const referenceDataService = {
-  locationsInclude: ['suppliers'],
-
   getGenders() {
     return apiClient.findAll('gender').then(response => response.data)
   },
@@ -21,12 +19,7 @@ const referenceDataService = {
       .then(response => response.data)
   },
 
-  getLocations({
-    filter,
-    combinedData,
-    page = 1,
-    include = this.locationsInclude,
-  } = {}) {
+  getLocations({ filter, combinedData, page = 1, include } = {}) {
     return apiClient
       .findAll('location', {
         ...filter,
@@ -53,7 +46,7 @@ const referenceDataService = {
       })
   },
 
-  getLocationById(id, { include = this.locationsInclude } = {}) {
+  getLocationById(id, { include } = {}) {
     if (!id) {
       return Promise.reject(new Error('No location ID supplied'))
     }

--- a/common/services/reference-data.test.js
+++ b/common/services/reference-data.test.js
@@ -55,17 +55,8 @@ const mockLocations = [
   },
 ]
 
-const mockLocationsInclude = ['default']
-
 describe('Reference Data Service', function() {
-  it('should have the correct default include', function() {
-    expect(referenceDataService.locationsInclude).deep.equal(['suppliers'])
-  })
   context('', function() {
-    beforeEach(function() {
-      referenceDataService.locationsInclude = mockLocationsInclude
-    })
-
     describe('#getGenders()', function() {
       const mockResponse = {
         data: mockGenders,
@@ -231,7 +222,7 @@ describe('Reference Data Service', function() {
               {
                 page: 1,
                 per_page: 100,
-                include: mockLocationsInclude,
+                include: undefined,
               }
             )
           })
@@ -255,7 +246,7 @@ describe('Reference Data Service', function() {
                 ...mockFilter,
                 page: 1,
                 per_page: 100,
-                include: mockLocationsInclude,
+                include: undefined,
               }
             )
           })
@@ -286,7 +277,7 @@ describe('Reference Data Service', function() {
               {
                 page: 1,
                 per_page: 100,
-                include: mockLocationsInclude,
+                include: undefined,
               }
             )
           })
@@ -297,7 +288,7 @@ describe('Reference Data Service', function() {
               {
                 page: 2,
                 per_page: 100,
-                include: mockLocationsInclude,
+                include: undefined,
               }
             )
           })
@@ -323,7 +314,7 @@ describe('Reference Data Service', function() {
                 ...mockFilter,
                 page: 1,
                 per_page: 100,
-                include: mockLocationsInclude,
+                include: undefined,
               }
             )
           })
@@ -335,7 +326,7 @@ describe('Reference Data Service', function() {
                 ...mockFilter,
                 page: 2,
                 per_page: 100,
-                include: mockLocationsInclude,
+                include: undefined,
               }
             )
           })
@@ -384,7 +375,7 @@ describe('Reference Data Service', function() {
           expect(apiClient.find).to.be.calledOnceWithExactly(
             'location',
             mockId,
-            { include: mockLocationsInclude }
+            { include: undefined }
           )
         })
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

This moves the default include used to call the API models to the
model options configuration and away from the service.

This should make maintaining the defaults required easier and keep
the concern within the same layer.

## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [x] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed

### Other considerations

Commit messages with a `fix` or `feat` type are automatically used to generate the [changelog](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/CHANGELOG.md) and
[GitHub release notes](https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/releases) during the release task. Please make sure they will read well on their own in a
summary of changes and that the commit body gives a more detailed description of those changes if necessary.

- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
- [x] Update [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md) with any new instructions or tasks
