### PR TITLE
chore: Increase end-to-end test timeout

### DIFF
--- a/.circleci/get-review-app-url.sh
+++ b/.circleci/get-review-app-url.sh
@@ -1,17 +1,18 @@
 #!/usr/bin/env bash
 
-GITHUB_DEPLOYMENTS_URL="https://api.github.com/repos/ministryofjustice/hmpps-book-secure-move-frontend/deployments"
+GITHUB_DEPLOYMENTS_URL="https://api.github.com/repos/ministryofjustice/hmpps-book-secure-move-frontend/deployments?ref=${CIRCLE_SHA1}"
 
 while true
 do
-  DEPLOYED_SHA=$(curl --silent -XGET -H "Authorization: token ${GITHUB_API_TOKEN}" $GITHUB_DEPLOYMENTS_URL?ref=${CIRCLE_SHA1} | jq -r '.[0].sha')
+  DEPLOYMENTS=$(curl --silent -XGET -H "Authorization: token ${GITHUB_API_TOKEN}" $GITHUB_DEPLOYMENTS_URL)
+  DEPLOYED_SHA=$(echo $DEPLOYMENTS | jq -r '.[0].sha')
   if [ "$DEPLOYED_SHA" = "$CIRCLE_SHA1" ]; then
     break
   fi
   sleep 5
 done
 
-GITHUB_DEPLOYMENT_STATUS_URL=$(curl --silent -XGET -H "Authorization: token ${GITHUB_API_TOKEN}" $GITHUB_DEPLOYMENTS_URL | jq -r '.[0].statuses_url')
+GITHUB_DEPLOYMENT_STATUS_URL=$(echo $DEPLOYMENTS | jq -r '.[0].statuses_url')
 
 while true
 do
@@ -23,4 +24,4 @@ do
 done
 
 # Output Review App URL
-curl --silent -XGET -H "Authorization: token ${GITHUB_API_TOKEN}" $GITHUB_DEPLOYMENTS_URL | jq -r '.[0].payload.web_url' | sed 's:/*$::'
+echo $DEPLOYMENTS | jq -r '.[0].payload.web_url' | sed 's:/*$::'

--- a/.testcaferc.json
+++ b/.testcaferc.json
@@ -1,5 +1,6 @@
 {
-  "pageLoadTimeout": 10000,
+  "timeout": 15000,
+  "pageLoadTimeout": 15000,
   "videoPath": "artifacts/videos",
   "videoOptions": {
     "failedOnly": true,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

This increase the default timeout for the TestCafe suite.

In some instances, like waiting for the next page after clicking a
link TestCafe fails an assertion as page loads can take a little while.

This increase that timeout to see if it will help some of the inconsistent
test failures we have seen recently.

### Why did it change

<!--- Describe the reason these changes were made - the "why" -->

## Checklists

### Testing

#### Automated testing

- [ ] Added unit tests to cover changes
- [x] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [x] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed

### Other considerations

Commit messages with a `fix` or `feat` type are automatically used to generate the [changelog](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/CHANGELOG.md) and
[GitHub release notes](https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/releases) during the release task. Please make sure they will read well on their own in a
summary of changes and that the commit body gives a more detailed description of those changes if necessary.

- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
- [x] Update [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md) with any new instructions or tasks
