### PR TITLE
P4 1661 Handle null relationships

### DIFF
--- a/common/presenters/court-case-to-card-component.js
+++ b/common/presenters/court-case-to-card-component.js
@@ -4,7 +4,7 @@ const i18n = require('../../config/i18n')
 const filters = require('../../config/nunjucks/filters')
 
 function courtCaseToCardComponent({
-  location = {},
+  location,
   case_start_date: startDate,
   case_type: caseType,
   case_number: caseNumber,

--- a/common/presenters/move-to-card-component.js
+++ b/common/presenters/move-to-card-component.js
@@ -10,7 +10,7 @@ function moveToCardComponent({
   showStatus = true,
   hrefSuffix = '',
 } = {}) {
-  return function item({ id, reference, person = {}, status }) {
+  return function item({ id, reference, person, status }) {
     const href = `/move/${id}${hrefSuffix}`
     const excludedBadgeStatuses = ['cancelled']
 

--- a/common/presenters/move-to-meta-list-component.js
+++ b/common/presenters/move-to-meta-list-component.js
@@ -14,7 +14,7 @@ function moveToMetaListComponent(
     from_location: fromLocation,
     to_location: toLocation,
     additional_information: additionalInfo,
-    prison_transfer_reason: prisonTransferReason = {},
+    prison_transfer_reason: prisonTransferReason,
     move_agreed: moveAgreed,
     move_agreed_by: moveAgreedBy,
   } = {},
@@ -27,8 +27,11 @@ function moveToMetaListComponent(
       : destination
   const destinationSuffix =
     additionalInfo && moveType === 'prison_recall' ? ` — ${additionalInfo}` : ''
+  const prisonTransferReasonTitle = prisonTransferReason
+    ? prisonTransferReason.title
+    : ''
   const showPrisonTransferReason =
-    prisonTransferReason.title && moveType === 'prison_transfer'
+    prisonTransferReasonTitle && moveType === 'prison_transfer'
   const prisonTransferReasonSuffix = additionalInfo
     ? ` — ${additionalInfo}`
     : ''
@@ -105,7 +108,7 @@ function moveToMetaListComponent(
       },
       value: {
         text: showPrisonTransferReason
-          ? prisonTransferReason.title + prisonTransferReasonSuffix
+          ? prisonTransferReasonTitle + prisonTransferReasonSuffix
           : undefined,
       },
     },

--- a/common/presenters/person-to-card-component.js
+++ b/common/presenters/person-to-card-component.js
@@ -10,15 +10,16 @@ function personToCardComponent({
   showMeta = true,
   showTags = true,
 } = {}) {
-  return function item({
-    id,
-    href,
-    gender,
-    fullname,
-    image_url: imageUrl,
-    date_of_birth: dateOfBirth,
-    assessment_answers: assessmentAnswers,
-  } = {}) {
+  return function item(person) {
+    const {
+      id,
+      href,
+      gender,
+      fullname,
+      image_url: imageUrl,
+      date_of_birth: dateOfBirth,
+      assessment_answers: assessmentAnswers,
+    } = person || {}
     const card = {
       href,
       title: {

--- a/common/presenters/person-to-card-component.test.js
+++ b/common/presenters/person-to-card-component.test.js
@@ -424,21 +424,33 @@ describe('Presenters', function() {
       })
     })
 
+    const noPersonResponse = {
+      href: undefined,
+      classes: 'app-card--placeholder',
+      title: { text: '__translated__' },
+      meta: { items: [] },
+      tags: { items: [] },
+      image_path: undefined,
+      image_alt: '__translated__',
+    }
+
     context('with no arguments', function() {
       beforeEach(function() {
         transformedResponse = personToCardComponent()()
       })
 
       it('should use fallback values', function() {
-        expect(transformedResponse).to.deep.equal({
-          href: undefined,
-          classes: 'app-card--placeholder',
-          title: { text: '__translated__' },
-          meta: { items: [] },
-          tags: { items: [] },
-          image_path: undefined,
-          image_alt: '__translated__',
-        })
+        expect(transformedResponse).to.deep.equal(noPersonResponse)
+      })
+    })
+
+    context('with null', function() {
+      beforeEach(function() {
+        transformedResponse = personToCardComponent()(null)
+      })
+
+      it('should use fallback values', function() {
+        expect(transformedResponse).to.deep.equal(noPersonResponse)
       })
     })
   })

--- a/common/services/person.js
+++ b/common/services/person.js
@@ -39,7 +39,7 @@ const explicitAssessmentKeys = ['special_vehicle', 'not_to_be_released']
 const personService = {
   transform(person) {
     if (!person) {
-      return undefined
+      return person
     }
 
     return {

--- a/common/services/person.test.js
+++ b/common/services/person.test.js
@@ -92,6 +92,16 @@ describe('Person Service', function() {
         expect(transformed).to.be.undefined
       })
     })
+
+    context('with null', function() {
+      beforeEach(async function() {
+        transformed = await personService.transform(null)
+      })
+
+      it('should return only last name for full name', function() {
+        expect(transformed).to.be.null
+      })
+    })
   })
 
   describe('#format()', function() {


### PR DESCRIPTION
## Proposed changes

### What changed

Check relationship values explicitly since null values prevent defaults being assigned when destructruring function params.

Prevent person object being set to undefined when null returned (principle of least surprise).

### Why did it change

To support https://github.com/ministryofjustice/hmpps-book-secure-move-api/pull/551

### Issue tracking

- [P4-1661](https://dsdmoj.atlassian.net/browse/P4-1661)


## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes



### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed


### Other considerations

- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
