### PR TITLE
feat(allocations): Remove single move from allocation

### DIFF
--- a/app/allocation/controllers/index.js
+++ b/app/allocation/controllers/index.js
@@ -2,6 +2,7 @@ const CancelController = require('./cancel')
 const AllocationCriteriaController = require('./create/allocation-criteria')
 const AllocationDetailsController = require('./create/allocation-details')
 const Save = require('./create/save')
+const RemoveMoveController = require('./remove-move')
 
 const createControllers = {
   AllocationCriteriaController,
@@ -12,7 +13,12 @@ const cancelControllers = {
   CancelController,
 }
 
+const removeMoveControllers = {
+  RemoveMoveController,
+}
+
 module.exports = {
   cancelControllers,
+  removeMoveControllers,
   createControllers,
 }

--- a/app/allocation/controllers/remove-move.js
+++ b/app/allocation/controllers/remove-move.js
@@ -1,0 +1,45 @@
+const FormWizardController = require('../../../common/controllers/form-wizard')
+const presenters = require('../../../common/presenters')
+const moveService = require('../../../common/services/move')
+
+class RemoveMoveController extends FormWizardController {
+  middlewareLocals() {
+    super.middlewareLocals()
+    this.use(this.setAdditionalLocals)
+  }
+
+  setAdditionalLocals(req, res, next) {
+    const movesCount = res.locals.allocation.moves.length
+    res.locals.moveSummary = presenters.moveToMetaListComponent(
+      res.locals.allocation
+    )
+    res.locals.sidebarHeading = req.t('allocation::view.summary.heading')
+    res.locals.pageText = req.t('moves::remove_from_allocation.message', {
+      movesCount,
+      newMovesCount: movesCount - 1,
+    })
+    next()
+  }
+
+  async successHandler(req, res, next) {
+    const { id: moveId } = res.locals.move
+    const { id: allocationId } = res.locals.allocation
+
+    try {
+      // TODO remove reason and comment once the backend supplies them as default
+      await moveService.cancel(moveId, {
+        reason: 'other',
+        comment: 'Cancelled by PMU',
+      })
+
+      req.journeyModel.reset()
+      req.sessionModel.reset()
+
+      res.redirect(`/allocation/${allocationId}`)
+    } catch (error) {
+      next(error)
+    }
+  }
+}
+
+module.exports = RemoveMoveController

--- a/app/allocation/controllers/view.js
+++ b/app/allocation/controllers/view.js
@@ -21,6 +21,18 @@ module.exports = function view(req, res) {
     )
   }
 
+  const removeMoveLink = move => {
+    if (
+      move.person ||
+      !permissions.check('allocation:cancel', userPermissions) ||
+      moves.length === 1
+    ) {
+      return
+    }
+
+    return `/allocation/${allocation.id}/${move.id}/remove`
+  }
+
   const locals = {
     // TODO: Find way to store the actual URL they came from: See similar solution within moves app
     dashboardUrl: '/allocations',
@@ -44,6 +56,7 @@ module.exports = function view(req, res) {
       .map(move => ({
         id: move.id,
         person: move.person,
+        removeMoveHref: removeMoveLink(move),
         card: moveToCardComponent(move),
       })),
   }

--- a/app/allocation/index.js
+++ b/app/allocation/index.js
@@ -3,12 +3,13 @@ const wizard = require('hmpo-form-wizard')
 
 const FormWizardController = require('../../common/controllers/form-wizard')
 const { protectRoute } = require('../../common/middleware/permissions')
+const { setMove } = require('../move/middleware')
 
 const confirmation = require('./controllers/create/confirmation')
 const view = require('./controllers/view')
 const { cancelFields, createFields } = require('./fields')
 const { setAllocation } = require('./middleware')
-const { cancelSteps, createSteps } = require('./steps')
+const { cancelSteps, removeMoveSteps, createSteps } = require('./steps')
 
 const wizardConfig = {
   controller: FormWizardController,
@@ -32,8 +33,18 @@ const cancelConfig = {
   journeyName: 'cancel-an-allocation',
   journeyPageTitle: 'actions::cancel_allocation',
 }
+const removeMoveConfig = {
+  ...wizardConfig,
+  controller: FormWizardController,
+  name: 'remove-a-move-from-an-allocation',
+  templatePath: 'allocation/views/cancel/',
+  template: '../../../form-wizard',
+  journeyName: 'remove-a-move-from-an-allocation',
+  journeyPageTitle: 'actions::cancel_move',
+}
 
 router.param('allocationId', setAllocation)
+router.param('moveId', setMove)
 
 router.use(
   '/new',
@@ -45,6 +56,12 @@ router.get(
   '/:allocationId/confirmation',
   protectRoute('allocation:create'),
   confirmation
+)
+
+router.use(
+  '/:allocationId/:moveId/remove',
+  protectRoute('allocation:cancel'),
+  wizard(removeMoveSteps, {}, removeMoveConfig)
 )
 
 router.use(

--- a/app/allocation/steps/index.js
+++ b/app/allocation/steps/index.js
@@ -1,7 +1,9 @@
 const cancelSteps = require('./cancel')
 const createSteps = require('./create')
+const removeMoveSteps = require('./remove-move')
 
 module.exports = {
+  removeMoveSteps,
   cancelSteps,
   createSteps,
 }

--- a/app/allocation/steps/remove-move.js
+++ b/app/allocation/steps/remove-move.js
@@ -1,0 +1,18 @@
+const { removeMoveControllers } = require('../controllers')
+
+module.exports = {
+  '/': {
+    entryPoint: true,
+    reset: true,
+    resetJourney: true,
+    skip: true,
+    next: 'confirm',
+  },
+  '/confirm': {
+    template: 'cancel-reason',
+    controller: removeMoveControllers.RemoveMoveController,
+    pageTitle: 'moves::remove_from_allocation.heading',
+    buttonText: 'moves::remove_from_allocation.button',
+    buttonClasses: 'govuk-button--warning',
+  },
+}

--- a/app/allocation/views/cancel/cancel-reason.njk
+++ b/app/allocation/views/cancel/cancel-reason.njk
@@ -8,3 +8,12 @@
 
   {{ super() }}
 {% endblock %}
+
+{% block contentMain %}
+  {% if pageText %}
+    <p class="govuk-list govuk-!-font-size-24 govuk-!-padding-left-0">
+      {{ pageText }}
+    </p>
+  {% endif %}
+  {{ super() }}
+{% endblock %}

--- a/app/allocation/views/view.njk
+++ b/app/allocation/views/view.njk
@@ -123,6 +123,15 @@
           })}}
         </p>
       {% endif %}
+
+      {% if move.removeMoveHref %}
+        <div>
+          <a class="app-!-position-top-right govuk-!-margin-top-7 govuk-!-margin-right-3 app-font-weight-normal" href="{{move.removeMoveHref}}">
+            {{ t("actions::person_unassign_confirmation") }}
+          </a>
+        </div>
+      {% endif %}
+
     </div>
   {% else %}
     {{ appMessage({

--- a/common/assets/scss/utilities/_typography.scss
+++ b/common/assets/scss/utilities/_typography.scss
@@ -1,3 +1,6 @@
 .app-secondary-text-colour {
   color: $govuk-secondary-text-colour
 }
+.app-font-weight-normal {
+  font-weight: normal;
+}

--- a/common/presenters/move-to-card-component.js
+++ b/common/presenters/move-to-card-component.js
@@ -11,7 +11,7 @@ function moveToCardComponent({
   hrefSuffix = '',
 } = {}) {
   return function item({ id, reference, person, status }) {
-    const href = `/move/${id}${hrefSuffix}`
+    const href = person ? `/move/${id}${hrefSuffix}` : ''
     const excludedBadgeStatuses = ['cancelled']
 
     const showStatusBadge =

--- a/common/presenters/move-to-card-component.test.js
+++ b/common/presenters/move-to-card-component.test.js
@@ -85,6 +85,21 @@ describe('Presenters', function() {
           })
         })
       })
+      context('when no person is associated to the move', function() {
+        beforeEach(function() {
+          transformedResponse = moveToCardComponent()({
+            id: '12345',
+            reference: 'AB12FG',
+            status: 'proposed',
+            person: null,
+          })
+        })
+        it('does not create the link on the card', function() {
+          expect(personToCardComponentItemStub).to.be.calledWithExactly({
+            href: '',
+          })
+        })
+      })
     })
 
     context('with href suffix', function() {

--- a/common/templates/form-wizard.njk
+++ b/common/templates/form-wizard.njk
@@ -86,13 +86,15 @@
   </form>
 {% endblock %}
 
+{% set sidebarHeading = sidebarHeading or (move.person.fullname | upper) or t("awaiting_person") %}
+
 {% block contentSidebar %}
   {% if person.id or move.id %}
     <div class="sticky-sidebar">
       <div class="sticky-sidebar__inner">
         {% block summaryPanelContent %}
           <h3 class="govuk-heading-m app-border-top-2 app-border--blue govuk-!-padding-top-4 govuk-!-margin-bottom-3">
-            {{ person.fullname | upper or t("awaiting_person") }}
+            {{ sidebarHeading }}
           </h3>
 
           {% if person.image_url %}

--- a/locales/en/moves.json
+++ b/locales/en/moves.json
@@ -220,5 +220,10 @@
   },
   "redirect_notes": "Requested by {{fullname}} (user_name:{{username}} / user_id:{{userId}})",
   "allocation_relationship": "This move is part of an allocation for $t(n_person)",
-  "allocation_relationship_with_link": "This move is part of <a href=\"{{href}}\">an allocation for $t(n_person)</a>"
+  "allocation_relationship_with_link": "This move is part of <a href=\"{{href}}\">an allocation for $t(n_person)</a>",
+  "remove_from_allocation": {
+    "heading": "Remove this empty spot from this allocation",
+    "message": "This will reduce the number of prisoners for this allocation from {{movesCount}} to {{newMovesCount}}",
+    "button": "Remove this spot"
+  }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

This PR adds the possibility of removing a single personless move from an allocation. This can be done only by PMU and only if there are at least two slots -- e.g. you cannot create a 0 slots allocation with it.

### What changed

A small journey was added in allocations, that reused the move services.

### Why did it change

It's a way of editing the unfilled allocations

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

- [P4-1662]()

## Screenshots
<!--- (Optional) Include screenshots if changes update interfaces or components -->
<!--- Delete/copy as appropriate --->

The initial state of the allocation. Note the "Remove from allocation" links.
<kbd><img width="664" alt="Screenshot 2020-06-11 at 17 14 56" src="https://user-images.githubusercontent.com/853989/84414880-f139c680-ac09-11ea-9010-88234ed76cdc.png"></kbd>
After clicking on "Remove from allocation"
<kbd><img width="682" alt="Screenshot 2020-06-11 at 17 24 27" src="https://user-images.githubusercontent.com/853989/84414954-fc8cf200-ac09-11ea-9475-f2a3c9a8904d.png"></kbd>
The allocation has now two slots.
<kbd><img width="652" alt="Screenshot 2020-06-11 at 17 15 24" src="https://user-images.githubusercontent.com/853989/84414991-0adb0e00-ac0a-11ea-9948-b1a34d88c47c.png"></kbd>
After removing one more slot. Note that the "Remove from allocation" link is not present.
<kbd><img width="673" alt="Screenshot 2020-06-11 at 17 38 30" src="https://user-images.githubusercontent.com/853989/84415404-a10f3400-ac0a-11ea-9532-e98e1b210382.png"></kbd>
Following @Andy-Millar feedback, I have added a commit that removes the link if the card doesn't include a person:
<kbd><img width="478" alt="Screenshot 2020-06-12 at 11 43 50" src="https://user-images.githubusercontent.com/853989/84495345-ed0db780-aca2-11ea-884f-63a1fc199a58.png"></kbd>

</kbd>

## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [x] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed

### Other considerations

Commit messages with a `fix` or `feat` type are automatically used to generate the [changelog](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/CHANGELOG.md) and
[GitHub release notes](https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/releases) during the release task. Please make sure they will read well on their own in a
summary of changes and that the commit body gives a more detailed description of those changes if necessary.

- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
- [x] Update [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md) with any new instructions or tasks
