### PR TITLE
chore: Prevent accidental commits to master #512

### DIFF
--- a/package.json
+++ b/package.json
@@ -189,6 +189,7 @@
     "coverage": "nyc --reporter=html --reporter=lcov npm test",
     "coverage:open": "npm run coverage && open-cli ./coverage/index.html",
     "develop": "run-p watch:js:*",
+    "git:checkbranch": "CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD); if [ \"$CURRENT_BRANCH\" = \"master\" ]; then echo 'Committing to the master branch is not allowed'; exit 1; fi",
     "lint": "eslint .",
     "lint-staged": "lint-staged",
     "postrelease": "npm run release:tags",
@@ -226,7 +227,7 @@
   "husky": {
     "hooks": {
       "commit-msg": "commitlint -E HUSKY_GIT_PARAMS",
-      "pre-commit": "lint-staged"
+      "pre-commit": "npm run git:checkbranch && lint-staged"
     }
   },
   "lint-staged": {

--- a/package.json
+++ b/package.json
@@ -194,7 +194,7 @@
     "lint-staged": "lint-staged",
     "postrelease": "npm run release:tags",
     "prerelease": "npm run update:check && npm run contributors",
-    "release": "standard-version -a",
+    "release": "standard-version --no-verify -a",
     "release:github": "conventional-github-releaser -p angular",
     "release:tags": "git push --follow-tags origin HEAD:master",
     "start": "node start.js",


### PR DESCRIPTION
## Proposed changes

### What changed

Adds an npm script that exits if it detects the current branch is master and runs that as the first step of the pre-commit hook.

### Why did it change

Accidental commits and pushes to master have been know to happen.

### Issue tracking

#512 

### Environment variables

- [x] No environment variables were added or changed

### Other considerations

- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
