### PR TITLE
fix: Prevent infinite calls to moves endpoint

### DIFF
--- a/common/services/allocation.js
+++ b/common/services/allocation.js
@@ -121,7 +121,9 @@ const allocationService = {
           return meta.pagination.total_objects
         }
 
-        if (!links.next) {
+        const hasNext = links.next && data.length !== 0
+
+        if (!hasNext) {
           return results.map(allocationService.transform({ includeCancelled }))
         }
 

--- a/common/services/allocation.test.js
+++ b/common/services/allocation.test.js
@@ -281,6 +281,17 @@ describe('Allocation service', function () {
         },
       },
     }
+    const mockEmptyPageResponse = {
+      data: [],
+      links: {
+        next: 'http://next-page.com',
+      },
+      meta: {
+        pagination: {
+          total_objects: 10,
+        },
+      },
+    }
     const mockFilter = {
       filterOne: 'foo',
     }
@@ -513,6 +524,21 @@ describe('Allocation service', function () {
         it('should return a count', function () {
           expect(moves).to.equal(10)
         })
+      })
+    })
+
+    context('with next but no data', function () {
+      beforeEach(async function () {
+        apiClient.findAll.resolves(mockEmptyPageResponse)
+        moves = await allocationService.getAll()
+      })
+
+      it('should call the API client once', function () {
+        expect(apiClient.findAll).to.be.calledOnce
+      })
+
+      it('should return no moves', function () {
+        expect(moves).to.deep.equal([])
       })
     })
 

--- a/common/services/move.js
+++ b/common/services/move.js
@@ -39,7 +39,9 @@ function getAll({
         return meta.pagination.total_objects
       }
 
-      if (!links.next) {
+      const hasNext = links.next && data.length !== 0
+
+      if (!hasNext) {
         return moves.map(move => ({
           ...move,
           person: personService.transform(move.person),

--- a/common/services/move.test.js
+++ b/common/services/move.test.js
@@ -230,6 +230,17 @@ describe('Move Service', function () {
         },
       },
     }
+    const mockEmptyPageResponse = {
+      data: [],
+      links: {
+        next: 'http://next-page.com',
+      },
+      meta: {
+        pagination: {
+          total_objects: 10,
+        },
+      },
+    }
     const mockFilter = {
       filterOne: 'foo',
     }
@@ -403,6 +414,21 @@ describe('Move Service', function () {
         it('should return a count', function () {
           expect(moves).to.equal(10)
         })
+      })
+    })
+
+    context('with next but no data', function () {
+      beforeEach(async function () {
+        apiClient.findAll.resolves(mockEmptyPageResponse)
+        moves = await moveService.getAll()
+      })
+
+      it('should call the API client once', function () {
+        expect(apiClient.findAll).to.be.calledOnce
+      })
+
+      it('should return no moves', function () {
+        expect(moves).to.deep.equal([])
       })
     })
 

--- a/common/services/reference-data.js
+++ b/common/services/reference-data.js
@@ -33,7 +33,9 @@ const referenceDataService = {
           ? flattenDeep([combinedData, ...response.data])
           : data
 
-        if (!links.next) {
+        const hasNext = links.next && data.length !== 0
+
+        if (!hasNext) {
           return sortBy(locations, 'title')
         }
 

--- a/common/services/reference-data.test.js
+++ b/common/services/reference-data.test.js
@@ -193,6 +193,12 @@ describe('Reference Data Service', function () {
           next: 'http://next-page.com',
         },
       }
+      const mockEmptyPageResponse = {
+        data: [],
+        links: {
+          next: 'http://next-page.com',
+        },
+      }
       const mockFilter = {
         filterOne: 'foo',
       }
@@ -330,6 +336,21 @@ describe('Reference Data Service', function () {
               }
             )
           })
+        })
+      })
+
+      context('with next but no data', function () {
+        beforeEach(async function () {
+          apiClient.findAll.resolves(mockEmptyPageResponse)
+          locations = await referenceDataService.getLocations()
+        })
+
+        it('should call the API client once', function () {
+          expect(apiClient.findAll).to.be.calledOnce
+        })
+
+        it('should return no moves', function () {
+          expect(locations).to.deep.equal([])
         })
       })
 


### PR DESCRIPTION
Double-check that data contains moves before attempting to use next link

This commit also closes the same out-of-bounds error for allocations and locations


## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes

### Environment variables

- [x] No environment variables were added or changed


### Other considerations

- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
