### PR TITLE
fix: Ensure selected person shown in sidebar when creating move

### DIFF
--- a/common/templates/form-wizard.njk
+++ b/common/templates/form-wizard.njk
@@ -86,7 +86,7 @@
   </form>
 {% endblock %}
 
-{% set sidebarHeading = sidebarHeading or (move.person.fullname | upper) or t("awaiting_person") %}
+{% set sidebarHeading = sidebarHeading or (person.fullname | upper) or t("awaiting_person") %}
 
 {% block contentSidebar %}
   {% if person.id or move.id %}


### PR DESCRIPTION
## Proposed changes

### What changed

Remove `move` from `move.person.fullname` when assigning sidebar heading value

### Why did it change

The addition of move caused the name to not be displayed when creating a new move

### Issue tracking
n/a

## Checklists

### Testing

#### Automated testing

- [ ] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed

### Other considerations

- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics

