### PR TITLE
[P4-1419] - feat(moves): Give OCA users ability to cancel proposed moves

### DIFF
--- a/app/move/controllers/cancel.js
+++ b/app/move/controllers/cancel.js
@@ -1,12 +1,23 @@
 const { pick } = require('lodash')
 
 const FormWizardController = require('../../../common/controllers/form-wizard')
+const presenters = require('../../../common/presenters')
 const moveService = require('../../../common/services/move')
 
 class CancelController extends FormWizardController {
   middlewareChecks() {
     super.middlewareChecks()
     this.use(this.checkAllocation)
+    this.use(this.setAdditionalInfo)
+  }
+
+  setAdditionalInfo(req, res, next) {
+    const { move } = res.locals
+    res.locals.moveSummary = presenters.moveToMetaListComponent(move)
+    // TODO: update to use profile
+    res.locals.person = move.person || {}
+
+    next()
   }
 
   checkAllocation(req, res, next) {

--- a/app/move/controllers/view.js
+++ b/app/move/controllers/view.js
@@ -32,6 +32,12 @@ module.exports = function view(req, res) {
     assessment: presenters
       .assessmentAnswersByCategory(assessmentAnswers)
       .map(presenters.assessmentCategoryToPanelComponent),
+    canCancelMove:
+      (userPermissions.includes('move:cancel') &&
+        move.status === 'requested' &&
+        !move.allocation) ||
+      (userPermissions.includes('move:cancel:proposed') &&
+        move.status === 'proposed'),
     courtHearings: sortBy(move.court_hearings, 'start_time').map(
       courtHearing => {
         return {

--- a/app/move/index.js
+++ b/app/move/index.js
@@ -83,7 +83,7 @@ router.get(
 )
 router.use(
   '/:moveId/cancel',
-  protectRoute('move:cancel'),
+  protectRoute(['move:cancel', 'move:cancel:proposed']),
   wizard(cancelSteps, cancelFields, cancelConfig)
 )
 router.use('/:moveId/review', wizard(reviewSteps, reviewFields, reviewConfig))

--- a/app/move/views/cancel.njk
+++ b/app/move/views/cancel.njk
@@ -18,12 +18,13 @@
 {% endblock %}
 
 {% block formActions %}
-  {{ govukWarningText({
-    html: t("moves::cancel.warning", {
-      name: move.person.fullname | upper
-    }),
-    iconFallbackText: "Warning"
-  }) }}
-
+  {% if move.status != "proposed" %}
+    {{ govukWarningText({
+      html: t("moves::cancel.warning", {
+        name: move.person.fullname | upper
+      }),
+      iconFallbackText: "Warning"
+    }) }}
+  {% endif %}
   {{ super() }}
 {% endblock %}

--- a/app/move/views/view.njk
+++ b/app/move/views/view.njk
@@ -204,7 +204,7 @@
     }) }}
   {% endif %}
 
-  {% if canAccess("move:cancel") and move.status == "requested" and not move.allocation %}
+  {% if canCancelMove %}
     <p class="govuk-!-margin-bottom-0">
       <a href="{{ move.id }}/cancel" class="app-link--destructive">
         {{ t("actions::cancel_move") }}

--- a/common/lib/permissions.js
+++ b/common/lib/permissions.js
@@ -60,6 +60,7 @@ const ocaPermissions = [
   'allocation:person:assign',
   'moves:view:proposed',
   'moves:download',
+  'move:cancel:proposed',
   'move:view',
   'move:create',
   'move:create:prison_transfer',

--- a/common/lib/user.test.js
+++ b/common/lib/user.test.js
@@ -226,6 +226,7 @@ describe('User class', function () {
           'allocation:person:assign',
           'moves:view:proposed',
           'moves:download',
+          'move:cancel:proposed',
           'move:view',
           'move:create',
           'move:create:prison_transfer',
@@ -299,6 +300,7 @@ describe('User class', function () {
           'move:cancel',
           'locations:all',
           'dashboard:view',
+          'move:cancel:proposed',
           'moves:view:proposed',
           'move:create:prison_transfer',
         ]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

This PR allows the OCA user to cancel proposed moves. To this purpose it introduces a new permission: `move:cancel:proposed`.

### What changed

The cancel link is now displayed if the user has the right permissions and the move has a `proposed` status.

### Why did it change

We want the OCA users to be able to retract single requests.

### Issue tracking

- [P4-1419]()

## Screenshots
<!--- (Optional) Include screenshots if changes update interfaces or components -->
<!--- Delete/copy as appropriate --->

| Before | After |
| ------ | ----- |
| <kbd><img width="547" alt="Screenshot 2020-06-17 at 12 07 12" src="https://user-images.githubusercontent.com/853989/84891310-9124a380-b093-11ea-95a1-961ef510330e.png"></kbd> |<kbd><img width="566" alt="Screenshot 2020-06-17 at 12 04 52" src="https://user-images.githubusercontent.com/853989/84891343-9eda2900-b093-11ea-8241-2ef0815497e5.png"></kbd> |
||<kbd><img width="555" alt="Screenshot 2020-06-17 at 12 06 12" src="https://user-images.githubusercontent.com/853989/84891432-c5985f80-b093-11ea-8f82-d5b4a4304b5b.png"></kbd>|
||<kbd><img width="530" alt="Screenshot 2020-06-17 at 12 06 26" src="https://user-images.githubusercontent.com/853989/84891452-ce893100-b093-11ea-9ae1-a78d6b6a3b60.png"></kbd>|



## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [x] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed

### Other considerations

Commit messages with a `fix` or `feat` type are automatically used to generate the [changelog](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/CHANGELOG.md) and
[GitHub release notes](https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/releases) during the release task. Please make sure they will read well on their own in a
summary of changes and that the commit body gives a more detailed description of those changes if necessary.

- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
- [x] Update [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md) with any new instructions or tasks
