### PR TITLE
[P4-1672] Rework create move flow to use profile

### DIFF
--- a/app/move/controllers/create/save.test.js
+++ b/app/move/controllers/create/save.test.js
@@ -4,7 +4,7 @@ const proxyquire = require('proxyquire')
 const analytics = require('../../../../common/lib/analytics')
 const courtHearingService = require('../../../../common/services/court-hearing')
 const moveService = require('../../../../common/services/move')
-const personService = require('../../../../common/services/person')
+const profileService = require('../../../../common/services/profile')
 const filters = require('../../../../config/nunjucks/filters')
 const shouldSaveCourtHearingsField = require('../../fields/should-save-court-hearings')
 
@@ -21,6 +21,9 @@ const controller = new Controller({ route: '/' })
 const mockPerson = {
   id: '3333',
   fullname: 'Full name',
+}
+const mockProfile = {
+  id: '2222',
 }
 const mockMove = {
   id: '4444',
@@ -85,7 +88,7 @@ describe('Move controllers', function () {
       let req, nextSpy
 
       beforeEach(function () {
-        sinon.stub(personService, 'update').resolves(mockPerson)
+        sinon.stub(profileService, 'create').resolves(mockProfile)
         sinon.stub(courtHearingService, 'create').resolvesArg(0)
         nextSpy = sinon.spy()
         req = {
@@ -114,19 +117,15 @@ describe('Move controllers', function () {
               reference: '',
               to_location: 'Court',
               from_location: 'Prison',
-              person: {
-                first_names: 'Steve',
-                last_name: 'Smith',
-              },
-              assessment: mockValues.assessment,
+              profile: mockProfile,
             })
           })
 
-          it('should call person update', function () {
-            expect(personService.update).to.be.calledOnceWithExactly({
-              ...mockValues.person,
-              assessment_answers: mockValues.assessment,
-            })
+          it('should create profile', function () {
+            expect(profileService.create).to.be.calledOnceWithExactly(
+              mockValues.person.id,
+              { assessment_answers: mockValues.assessment }
+            )
           })
 
           it('should not call court hearing service', function () {
@@ -177,20 +176,18 @@ describe('Move controllers', function () {
                 reference: '',
                 to_location: 'Court',
                 from_location: 'Prison',
-                person: {
-                  first_names: 'Steve',
-                  last_name: 'Smith',
-                },
-                assessment: mockValuesWithHearings.assessment,
+                profile: mockProfile,
                 court_hearings: mockValuesWithHearings.court_hearings,
               })
             })
 
-            it('should call person update', function () {
-              expect(personService.update).to.be.calledOnceWithExactly({
-                ...mockValuesWithHearings.person,
-                assessment_answers: mockValuesWithHearings.assessment,
-              })
+            it('should create profile', function () {
+              expect(profileService.create).to.be.calledOnceWithExactly(
+                mockValuesWithHearings.person.id,
+                {
+                  assessment_answers: mockValuesWithHearings.assessment,
+                }
+              )
             })
 
             it('should call court hearing service correct number of times', function () {
@@ -246,11 +243,7 @@ describe('Move controllers', function () {
                 reference: '',
                 to_location: 'Court',
                 from_location: 'Prison',
-                person: {
-                  first_names: 'Steve',
-                  last_name: 'Smith',
-                },
-                assessment: mockValuesWithHearings.assessment,
+                profile: mockProfile,
                 court_hearings: mockValuesWithHearings.court_hearings,
                 should_save_court_hearings: shouldSaveCourtHearingsFalseValue,
               })
@@ -296,10 +289,6 @@ describe('Move controllers', function () {
 
         it('should call next once', function () {
           expect(nextSpy).to.be.calledOnce
-        })
-
-        it('should not update person', function () {
-          expect(personService.update).not.to.be.called
         })
 
         it('should not save court hearings', function () {

--- a/common/lib/api-client/models.js
+++ b/common/lib/api-client/models.js
@@ -86,6 +86,10 @@ module.exports = {
         jsonApi: 'hasOne',
         type: 'ethnicities',
       },
+      profiles: {
+        jsonApi: 'hasMany',
+        type: 'profiles',
+      },
     },
     options: {
       defaultInclude: ['ethnicity', 'gender'],
@@ -100,7 +104,7 @@ module.exports = {
       },
     },
     options: {
-      defaultInclude: [],
+      defaultInclude: ['person'],
     },
   },
   court_case: {

--- a/common/lib/api-client/models.test.js
+++ b/common/lib/api-client/models.test.js
@@ -41,6 +41,14 @@ const testCases = {
       statusCode: 201,
     },
   ],
+  profile: [
+    {
+      method: 'create',
+      httpMock: 'post',
+      args: {},
+      statusCode: 201,
+    },
+  ],
   image: [
     {
       method: 'find',

--- a/common/presenters/assessment-answers-by-category.test.js
+++ b/common/presenters/assessment-answers-by-category.test.js
@@ -1,8 +1,8 @@
 const proxyquire = require('proxyquire')
 
 const {
-  data: mockPerson,
-} = require('../../test/fixtures/api-client/person.create.json')
+  data: mockProfile,
+} = require('../../test/fixtures/api-client/profile.create.json')
 const assessmentAnswersByCategory = proxyquire(
   './assessment-answers-by-category',
   {
@@ -31,7 +31,7 @@ describe('Presenters', function () {
 
       beforeEach(function () {
         transformedResponse = assessmentAnswersByCategory(
-          mockPerson.attributes.assessment_answers
+          mockProfile.attributes.assessment_answers
         )
       })
 

--- a/common/presenters/assessment-to-summary-list-component.test.js
+++ b/common/presenters/assessment-to-summary-list-component.test.js
@@ -1,17 +1,17 @@
 const {
-  data: mockPerson,
-} = require('../../test/fixtures/api-client/person.create.json')
+  data: mockProfile,
+} = require('../../test/fixtures/api-client/profile.create.json')
 
 const assessmentToSummaryListComponent = require('./assessment-to-summary-list-component')
 
 describe('Presenters', function () {
   describe('#assessmentToSummaryListComponent()', function () {
-    context('when provided with a mock person object', function () {
+    context('when provided with a mock profile object', function () {
       let transformedResponse
 
       beforeEach(function () {
         transformedResponse = assessmentToSummaryListComponent(
-          mockPerson.attributes.assessment_answers
+          mockProfile.attributes.assessment_answers
         )
       })
 
@@ -65,7 +65,7 @@ describe('Presenters', function () {
 
       beforeEach(function () {
         transformedResponse = assessmentToSummaryListComponent(
-          mockPerson.attributes.assessment_answers,
+          mockProfile.attributes.assessment_answers,
           'court'
         )
       })

--- a/common/services/profile.js
+++ b/common/services/profile.js
@@ -1,3 +1,5 @@
+const apiClient = require('../lib/api-client')()
+
 const personService = require('./person')
 
 const profileService = {
@@ -10,6 +12,19 @@ const profileService = {
       ...profile,
       person: personService.transform(profile.person),
     }
+  },
+
+  create(personId, data) {
+    if (!personId) {
+      return Promise.reject(new Error('No Person ID supplied'))
+    }
+
+    return apiClient
+      .one('person', personId)
+      .all('profile')
+      .post(data)
+      .then(response => response.data)
+      .then(profile => profileService.transform(profile))
   },
 }
 

--- a/common/services/profile.test.js
+++ b/common/services/profile.test.js
@@ -1,31 +1,86 @@
+const apiClient = require('../lib/api-client')()
+
 const personService = require('./person')
 const profileService = require('./profile')
 
 describe('Profile Service', function () {
   context('#transform', function () {
-    const mockPerson = {
-      id: '__person__',
-    }
-    let profile
-    beforeEach(function () {
-      sinon.stub(personService, 'transform').callsFake(person => {
-        return {
-          ...person,
+    context('When profile is not a valid object', function () {
+      it('should leave profile untouched', function () {
+        const profile = profileService.transform(null)
+        expect(profile).to.be.null
+      })
+    })
+
+    context('When profile is valid object', function () {
+      const mockPerson = {
+        id: '__person__',
+      }
+      let profile
+      beforeEach(function () {
+        sinon.stub(personService, 'transform').callsFake(person => {
+          return {
+            ...person,
+            foo: 'bar',
+          }
+        })
+        profile = profileService.transform({
+          id: '__profile__',
+          person: mockPerson,
+        })
+      })
+
+      it('should transform the person', function () {
+        expect(personService.transform).to.be.calledOnceWithExactly(mockPerson)
+      })
+
+      it('should update the person object on the profile', function () {
+        expect(profile.person).to.deep.equal({
+          ...mockPerson,
           foo: 'bar',
-        }
-      })
-      profile = profileService.transform({
-        id: '__profile__',
-        person: mockPerson,
+        })
       })
     })
-    it('should transform the person', function () {
-      expect(personService.transform).to.be.calledOnceWithExactly(mockPerson)
+  })
+
+  describe('#create()', function () {
+    const profileData = {
+      assessment_answer: [],
+    }
+    const mockResponse = {
+      data: {
+        id: '#createdProfile',
+      },
+    }
+
+    context('without person ID', function () {
+      it('should reject with error', function () {
+        return expect(profileService.create()).to.be.rejectedWith(
+          'No Person ID supplied'
+        )
+      })
     })
-    it('should update the person object on the profile', function () {
-      expect(profile.person).to.deep.equal({
-        ...mockPerson,
-        foo: 'bar',
+
+    context('with person ID', function () {
+      beforeEach(async function () {
+        sinon.spy(apiClient, 'one')
+        sinon.spy(apiClient, 'all')
+        sinon.stub(apiClient, 'post').resolves(mockResponse)
+        sinon.stub(profileService, 'transform')
+
+        await profileService.create('#personId', profileData)
+      })
+
+      it('should call create endpoint with data', function () {
+        expect(apiClient.one).to.be.calledOnceWithExactly('person', '#personId')
+        expect(apiClient.all).to.be.calledOnceWithExactly('profile')
+        expect(apiClient.post).to.be.calledOnceWithExactly(profileData)
+      })
+
+      it('should transform profile', function () {
+        expect(profileService.transform).to.be.calledOnceWithExactly({
+          id: '#createdProfile',
+        })
       })
     })
   })

--- a/test/fixtures/api-client/person.create.json
+++ b/test/fixtures/api-client/person.create.json
@@ -7,7 +7,8 @@
       "last_name": "Roberts",
       "date_of_birth": "1965-10-24",
       "gender_additional_information": "Additional information",
-      "assessment_answers": [{
+      "assessment_answers": [
+        {
           "title": "Violent",
           "comments": "Karate black belt",
           "date": null,
@@ -80,7 +81,8 @@
           "key": "other_information"
         }
       ],
-      "identifiers": []
+      "identifiers": [],
+      "profiles": []
     },
     "relationships": {
       "ethnicity": {
@@ -97,7 +99,8 @@
       }
     }
   },
-  "included": [{
+  "included": [
+    {
       "id": "b95bfb7c-18cd-419d-8119-2dee1506726f",
       "type": "ethnicities",
       "attributes": {

--- a/test/fixtures/api-client/profile.create.json
+++ b/test/fixtures/api-client/profile.create.json
@@ -1,0 +1,91 @@
+{
+  "data": {
+    "id": "b695d0f0-af8e-4b97-891e-92020d6820b9",
+    "type": "profiles",
+    "attributes": {
+      "assessment_answers": [
+        {
+          "title": "Violent",
+          "comments": "Karate black belt",
+          "date": null,
+          "expiry_date": null,
+          "assessment_question_id": "7448fb0c-d10e-4cab-9354-1732a4d17a30",
+          "category": "risk",
+          "key": "violent"
+        },
+        {
+          "title": "Escape",
+          "comments": "Large poster in cell",
+          "date": null,
+          "expiry_date": null,
+          "assessment_question_id": "d61c0068-cdb0-43de-88e5-c0a09adbf726",
+          "category": "risk",
+          "key": "escape"
+        },
+        {
+          "title": "Must be held separately",
+          "comments": "Incitement to riot",
+          "date": null,
+          "expiry_date": null,
+          "assessment_question_id": "745a50e8-ea8d-4667-8ba0-c09c62ee3fc5",
+          "category": "risk",
+          "key": "hold_separately"
+        },
+        {
+          "title": "Special diet or allergy",
+          "comments": "Vegan",
+          "date": null,
+          "expiry_date": null,
+          "assessment_question_id": "ff77c212-1244-4b2b-a441-81922d5c2ed8",
+          "category": "health",
+          "key": "special_diet_or_allergy"
+        },
+        {
+          "title": "Health issue",
+          "comments": "Claustophobic",
+          "date": null,
+          "expiry_date": null,
+          "assessment_question_id": "c1c8e0c1-4376-4f80-8515-dfb7d454a95c",
+          "category": "health",
+          "key": "health_issue"
+        },
+        {
+          "title": "Medication",
+          "comments": "Heart medication needed twice daily",
+          "date": null,
+          "expiry_date": null,
+          "assessment_question_id": "044cca13-b632-4f65-8111-8902e4913cfe",
+          "category": "health",
+          "key": "medication"
+        },
+        {
+          "title": "Solicitor or other legal representation",
+          "comments": "Johns & Sons",
+          "date": null,
+          "expiry_date": null,
+          "assessment_question_id": "a453daf5-cf1d-4a21-9dae-2846c465785d",
+          "category": "court",
+          "key": "solicitor"
+        },
+        {
+          "title": "Any other information",
+          "comments": "Former prison officer",
+          "date": null,
+          "expiry_date": null,
+          "assessment_question_id": "ffe852c4-9154-493b-9afb-18dde544f2cf",
+          "category": "court",
+          "key": "other_information"
+        }
+      ]
+    },
+    "relationships": {
+      "person": {
+        "data": {
+          "id": "ffe852c4-493b-9154-9afb-18dde544f2cf",
+          "type": "people"
+        }
+      }
+    }
+  },
+  "included": []
+}


### PR DESCRIPTION
## Proposed changes

### What changed

Save controller of create move now creates a profile and uses the resulting profile when creating the move.

### Why did it change

To support api-improvements

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

- [P4-1672 - Rework create move flow to use profile](https://dsdmoj.atlassian.net/browse/P4-1672)

## Screenshots

Functionally identical

## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome


### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed


### Other considerations

- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics

