### PR TITLE
[P4-1674] Rework update move flow to use profile

### DIFF
--- a/app/move/controllers/update/assessment.js
+++ b/app/move/controllers/update/assessment.js
@@ -1,6 +1,6 @@
 const { isEqual, pick } = require('lodash')
 
-const personService = require('../../../../common/services/person')
+const profileService = require('../../../../common/services/profile')
 const Assessment = require('../create/assessment')
 
 const UpdateBase = require('./base')
@@ -55,9 +55,8 @@ class UpdateAssessmentController extends UpdateBase {
       const newKeys = getAnswerKeys(updatedAssessments)
 
       if (!isEqual(oldKeys, newKeys)) {
-        const personId = req.getPersonId()
-        await personService.update({
-          id: personId,
+        await profileService.update({
+          ...profile,
           assessment_answers: updatedAssessments,
         })
 

--- a/app/move/controllers/update/assessment.test.js
+++ b/app/move/controllers/update/assessment.test.js
@@ -1,4 +1,4 @@
-const personService = require('../../../../common/services/person')
+const profileService = require('../../../../common/services/profile')
 const CreateAssessment = require('../create/assessment')
 
 const MixinProto = CreateAssessment.prototype
@@ -78,10 +78,9 @@ describe('Move controllers', function () {
       const res = {}
       let nextSpy
       beforeEach(function () {
-        sinon.stub(personService, 'update').resolves()
+        sinon.stub(profileService, 'update').resolves()
         sinon.stub(controller, 'setFlash')
         req = {
-          getPersonId: sinon.stub().returns('#personId'),
           getMove: sinon.stub().returns({
             profile: {
               id: '#profileId',
@@ -180,9 +179,9 @@ describe('Move controllers', function () {
       })
 
       context('When assessment answers are unchanged', function () {
-        it('should not update the person data', async function () {
+        it('should not update the profile data', async function () {
           await controller.saveValues(req, res, nextSpy)
-          expect(personService.update).to.not.be.called
+          expect(profileService.update).to.not.be.called
         })
 
         it('should not set the confirmation message', async function () {
@@ -192,12 +191,12 @@ describe('Move controllers', function () {
       })
 
       context('When assessment answers have changed', function () {
-        beforeEach(function () {
+        beforeEach(async function () {
           req.form.values.violent = '#violent'
-        })
-        it('should update the person data', async function () {
           await controller.saveValues(req, res, nextSpy)
-          expect(personService.update).to.be.calledOnceWithExactly({
+        })
+        it('should update the profile data', async function () {
+          expect(profileService.update).to.be.calledOnceWithExactly({
             assessment_answers: [
               {
                 assessment_question_id: 'af8cfc67-757c-4019-9d5e-618017de1617',
@@ -205,12 +204,11 @@ describe('Move controllers', function () {
                 key: 'violent',
               },
             ],
-            id: '#personId',
+            id: '#profileId',
           })
         })
 
         it('should set the confirmation message', async function () {
-          await controller.saveValues(req, res, nextSpy)
           expect(controller.setFlash).to.be.calledOnceWithExactly(req)
         })
       })
@@ -221,7 +219,7 @@ describe('Move controllers', function () {
         })
         it('should remove the comment from the assessment answer', async function () {
           await controller.saveValues(req, res, nextSpy)
-          expect(personService.update).to.be.calledOnceWithExactly({
+          expect(profileService.update).to.be.calledOnceWithExactly({
             assessment_answers: [
               {
                 assessment_question_id: 'af8cfc67-757c-4019-9d5e-618017de1617',
@@ -229,7 +227,7 @@ describe('Move controllers', function () {
                 key: 'violent',
               },
             ],
-            id: '#personId',
+            id: '#profileId',
           })
         })
       })
@@ -241,7 +239,7 @@ describe('Move controllers', function () {
         })
         it('should add the assessment answer and order the assessments', async function () {
           await controller.saveValues(req, res, nextSpy)
-          expect(personService.update).to.be.calledOnceWithExactly({
+          expect(profileService.update).to.be.calledOnceWithExactly({
             assessment_answers: [
               {
                 assessment_question_id: '4e7e54b4-a40c-488f-bdff-c6b2268ca4eb',
@@ -259,7 +257,7 @@ describe('Move controllers', function () {
                 key: 'violent',
               },
             ],
-            id: '#personId',
+            id: '#profileId',
           })
         })
       })
@@ -270,7 +268,7 @@ describe('Move controllers', function () {
         })
         it('should update the person data', async function () {
           await controller.saveValues(req, res, nextSpy)
-          expect(personService.update).to.be.calledOnceWithExactly({
+          expect(profileService.update).to.be.calledOnceWithExactly({
             assessment_answers: [
               {
                 assessment_question_id: 'af8cfc67-757c-4019-9d5e-618017de1617',
@@ -278,7 +276,7 @@ describe('Move controllers', function () {
                 key: 'violent',
               },
             ],
-            id: '#personId',
+            id: '#profileId',
           })
         })
       })
@@ -287,7 +285,7 @@ describe('Move controllers', function () {
         const err = new Error()
         beforeEach(function () {
           req.form.values.violent = '#changeme'
-          personService.update.throws(err)
+          profileService.update.throws(err)
         })
         it('should call next with the error thrown', async function () {
           try {

--- a/common/services/profile.js
+++ b/common/services/profile.js
@@ -1,3 +1,5 @@
+const { get } = require('lodash')
+
 const apiClient = require('../lib/api-client')()
 
 const personService = require('./person')
@@ -23,6 +25,21 @@ const profileService = {
       .one('person', personId)
       .all('profile')
       .post(data)
+      .then(response => response.data)
+      .then(profile => profileService.transform(profile))
+  },
+
+  async update(data) {
+    const personId = get(data, 'person.id')
+
+    if (!personId) {
+      return Promise.reject(new Error('No Person ID supplied'))
+    }
+
+    return apiClient
+      .one('person', personId)
+      .one('profile', data.id)
+      .patch(data)
       .then(response => response.data)
       .then(profile => profileService.transform(profile))
   },

--- a/common/services/profile.test.js
+++ b/common/services/profile.test.js
@@ -84,4 +84,55 @@ describe('Profile Service', function () {
       })
     })
   })
+
+  describe('#update()', function () {
+    const profileData = {
+      id: '#profileId',
+      assessment_answer: [],
+      person: {
+        id: '#personId',
+      },
+    }
+    const mockResponse = {
+      data: {
+        id: '#updatedProfile',
+      },
+    }
+
+    context('without person ID', function () {
+      it('should reject with error', function () {
+        return expect(profileService.update()).to.be.rejectedWith(
+          'No Person ID supplied'
+        )
+      })
+    })
+
+    context('with person ID', function () {
+      beforeEach(async function () {
+        sinon.spy(apiClient, 'one')
+        sinon.stub(apiClient, 'patch').resolves(mockResponse)
+        sinon.stub(profileService, 'transform')
+
+        await profileService.update(profileData)
+      })
+
+      it('should call patch endpoint with data', function () {
+        expect(apiClient.one.firstCall).to.be.calledWithExactly(
+          'person',
+          '#personId'
+        )
+        expect(apiClient.one.secondCall).to.be.calledWithExactly(
+          'profile',
+          '#profileId'
+        )
+        expect(apiClient.patch).to.be.calledOnceWithExactly(profileData)
+      })
+
+      it('should transform profile', function () {
+        expect(profileService.transform).to.be.calledOnceWithExactly({
+          id: '#updatedProfile',
+        })
+      })
+    })
+  })
 })


### PR DESCRIPTION
DEPENDS on https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/pull/610

## Proposed changes

### What changed

- Adds update profile method
- Updates update assessment controller to use profile rather than person

### Why did it change

Support api improvements

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

- [P4-1674 - Rework update move flow to use profile](https://dsdmoj.atlassian.net/browse/P4-1674)

## Screenshots

Functionally identical

## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome

### Environment variables

- [x] No environment variables were added or changed

### Other considerations

- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics

