### PR TITLE
[P4 1673] Rework assign person to allocation flow to use profile

### DIFF
--- a/app/move/controllers/assign/save.js
+++ b/app/move/controllers/assign/save.js
@@ -1,7 +1,7 @@
 const { get, omit } = require('lodash')
 
 const moveService = require('../../../../common/services/move')
-const personService = require('../../../../common/services/person')
+const profileService = require('../../../../common/services/profile')
 const MoveCreateSaveController = require('../create/save')
 
 const PersonAssignBase = require('./base')
@@ -15,15 +15,14 @@ class SaveController extends PersonAssignBase {
         'errorValues',
       ])
 
+      const profile = await profileService.create(data.person.id, {
+        assessment_answers: data.assessment,
+      })
+
       const move = await moveService.update({
         ...data,
         id: data.move.id,
-        person: data.person.id,
-      })
-
-      await personService.update({
-        ...data.person,
-        assessment_answers: data.assessment,
+        profile,
       })
 
       req.sessionModel.set('moveId', move.id)

--- a/common/services/move.js
+++ b/common/services/move.js
@@ -199,7 +199,7 @@ const moveService = {
   unassign(id) {
     return moveService.update({
       id,
-      person: {
+      profile: {
         id: null,
       },
       move_agreed: null,

--- a/common/services/move.test.js
+++ b/common/services/move.test.js
@@ -933,7 +933,7 @@ describe('Move Service', function () {
       const mockResponse = {
         data: {
           ...mockMove,
-          person: null,
+          profile: null,
         },
       }
 
@@ -949,7 +949,7 @@ describe('Move Service', function () {
         it('should call update method with data', function () {
           expect(moveService.update).to.be.calledOnceWithExactly({
             id: mockId,
-            person: {
+            profile: {
               id: null,
             },
             move_agreed: null,


### PR DESCRIPTION
Depends on https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/pull/611

## Proposed changes

### What changed

- Updates assign controller to use profile rather than person
- Updates unassign controller to use profile rather than person


### Why did it change

Support api improvements

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

- [P4 1673 - Rework assign person to allocation flow to use profile](https://dsdmoj.atlassian.net/browse/P4-1673)

## Screenshots

Functionally identical

## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome


### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed

### Other considerations

- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
