### PR TITLE
[P4 1703] Update e2e fixtures to use profile

### DIFF
--- a/test/e2e/_move.js
+++ b/test/e2e/_move.js
@@ -286,13 +286,13 @@ export async function checkUpdatePage(
   checkMethod,
   { selectAll = true, fillInOptional = true } = {}
 ) {
-  const { person } = t.ctx.move
+  const { profile } = t.ctx.move
   const updateMovePage = await clickUpdateLink(page)
   const updatedFields = await updateMovePage[fillInMethod]({
     selectAll,
     fillInOptional,
   })
-  const updatedDetails = { ...person, ...updatedFields }
+  const updatedDetails = { ...profile, ...updatedFields }
 
   await updateMovePage.submitForm()
 


### PR DESCRIPTION
## Proposed changes

### What changed

- Use profile rather than person when creating a move for use in e2e tests.

### Why did it change

Api improvements


### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

- [P4-1703 - Update e2e fixtures to use profile]()

## Screenshots

Functionally identical

## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes


### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed

### Other considerations

- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
