### PR TITLE
[P4-1678] Remove assessment answers from person service

### DIFF
--- a/common/lib/api-client/models.js
+++ b/common/lib/api-client/models.js
@@ -24,10 +24,6 @@ module.exports = {
         jsonApi: 'hasOne',
         type: 'profiles',
       },
-      person: {
-        jsonApi: 'hasOne',
-        type: 'people',
-      },
       from_location: {
         jsonApi: 'hasOne',
         type: 'locations',

--- a/common/services/person.js
+++ b/common/services/person.js
@@ -13,28 +13,6 @@ const identifierKeys = [
   'athena_reference',
 ]
 const dateKeys = ['date_of_birth']
-const assessmentKeys = [
-  // court
-  'solicitor',
-  'interpreter',
-  'other_court',
-  // risk
-  'violent',
-  'escape',
-  'hold_separately',
-  'self_harm',
-  'concealed_items',
-  'other_risks',
-  // health
-  'special_diet_or_allergy',
-  'health_issue',
-  'medication',
-  'wheelchair',
-  'pregnant',
-  'other_health',
-  'special_vehicle',
-]
-const explicitAssessmentKeys = ['special_vehicle', 'not_to_be_released']
 
 const personService = {
   transform(person) {
@@ -92,16 +70,12 @@ const personService = {
       identifier = identifierKeys,
       relationship = relationshipKeys,
       date = dateKeys,
-      assessment = assessmentKeys,
-      explicitAssessment = explicitAssessmentKeys,
     } = {}
   ) {
     return unformat(person, fields, {
       identifier,
       relationship,
       date,
-      assessment,
-      explicitAssessment,
     })
   },
 

--- a/common/services/person.test.js
+++ b/common/services/person.test.js
@@ -467,25 +467,6 @@ describe('Person Service', function () {
       ],
       relationship: ['gender', 'ethnicity'],
       date: ['date_of_birth'],
-      assessment: [
-        'solicitor',
-        'interpreter',
-        'other_court',
-        'violent',
-        'escape',
-        'hold_separately',
-        'self_harm',
-        'concealed_items',
-        'other_risks',
-        'special_diet_or_allergy',
-        'health_issue',
-        'medication',
-        'wheelchair',
-        'pregnant',
-        'other_health',
-        'special_vehicle',
-      ],
-      explicitAssessment: ['special_vehicle', 'not_to_be_released'],
     }
     const person = { id: '#personId' }
     const fields = ['foo']
@@ -530,8 +511,6 @@ describe('Person Service', function () {
           identifier: ['identifierField'],
           relationship: ['relationshipField'],
           date: ['dateField'],
-          assessment: ['assessmentField'],
-          explicitAssessment: ['explicitAssessmentField'],
         }
       })
 

--- a/common/services/person/person.unformat.js
+++ b/common/services/person/person.unformat.js
@@ -1,12 +1,5 @@
 const filters = require('../../../config/nunjucks/filters')
 
-const getAnswer = (person, field) => {
-  const assessments = person.assessment_answers || []
-  return assessments.filter(assessment => {
-    return assessment.key === field
-  })[0]
-}
-
 const mapMethods = {}
 
 mapMethods.identifier = (person, field) => {
@@ -34,37 +27,6 @@ mapMethods.date = (person, field) => {
   if (fieldValue) {
     return filters.formatDate(fieldValue)
   }
-}
-
-mapMethods.explicitAssessment = (person, field, assessmentCategories) => {
-  let value
-  const matchedAnswer = getAnswer(person, field)
-  const explicitKey = `${field}__explicit`
-
-  if (matchedAnswer) {
-    const questionId = matchedAnswer.assessment_question_id
-    value = matchedAnswer.comments
-    assessmentCategories[explicitKey] = questionId
-  } else {
-    assessmentCategories[explicitKey] = 'false'
-  }
-
-  return value
-}
-
-mapMethods.assessment = (person, field, assessmentCategories) => {
-  let value
-  const matchedAnswer = getAnswer(person, field)
-
-  if (matchedAnswer) {
-    const questionId = matchedAnswer.assessment_question_id
-    value = matchedAnswer.comments
-    const category = matchedAnswer.category
-    assessmentCategories[category] = assessmentCategories[category] || []
-    assessmentCategories[category].push(questionId)
-  }
-
-  return value
 }
 
 mapMethods.value = (person, field) => person[field]

--- a/common/services/person/person.unformat.test.js
+++ b/common/services/person/person.unformat.test.js
@@ -27,32 +27,6 @@ describe('Person Service', function () {
             value: 'ignoredValue',
           },
         ],
-        assessment_answers: [
-          {
-            key: 'assessmentField',
-            category: 'assessmentCategory',
-            assessment_question_id: 'assessmentId',
-            comments: 'assessmentValue',
-          },
-          {
-            key: 'anotherAssessmentField',
-            category: 'assessmentCategory',
-            assessment_question_id: 'anotherAssessmentId',
-            comments: 'anotherAssessmentValue',
-          },
-          {
-            key: 'explicitAssessmentField',
-            category: 'explicitAssessmentCategory',
-            assessment_question_id: 'explicitAssessmentId',
-            comments: 'explicitAssessmentValue',
-          },
-          {
-            key: 'ignored',
-            category: 'assessmentCategory',
-            assessment_question_id: 'ignoredId',
-            comments: 'ignoredValue',
-          },
-        ],
       }
     })
 
@@ -168,81 +142,6 @@ describe('Person Service', function () {
       })
     })
 
-    context('when asking for an assessment', function () {
-      before(function () {
-        fields = ['assessmentField']
-        keys = {
-          assessment: ['assessmentField'],
-        }
-      })
-      it('should return the assessment comment and matched values for the assessment category', function () {
-        expect(unformatted).to.deep.equal({
-          assessmentField: 'assessmentValue',
-          assessmentCategory: ['assessmentId'],
-        })
-      })
-
-      context('but it has no value', function () {
-        before(function () {
-          fields = ['missingAssessmentField']
-          keys = {
-            assessment: ['missingAssessmentField'],
-          }
-        })
-        it('should return undefined', function () {
-          expect(unformatted).to.deep.equal({
-            missingAssessmentField: undefined,
-          })
-        })
-      })
-
-      context('when asking for multiple', function () {
-        before(function () {
-          fields = ['assessmentField', 'anotherAssessmentField']
-          keys = {
-            assessment: ['assessmentField', 'anotherAssessmentField'],
-          }
-        })
-        it('should return the assessment comments and matched values for the assessment category', function () {
-          expect(unformatted).to.deep.equal({
-            assessmentField: 'assessmentValue',
-            anotherAssessmentField: 'anotherAssessmentValue',
-            assessmentCategory: ['assessmentId', 'anotherAssessmentId'],
-          })
-        })
-      })
-    })
-
-    context('when asking for an explicit assessment', function () {
-      before(function () {
-        fields = ['explicitAssessmentField']
-        keys = {
-          explicitAssessment: ['explicitAssessmentField'],
-        }
-      })
-      it('should return the assessment comment and matched values for the assessment category', function () {
-        expect(unformatted).to.deep.equal({
-          explicitAssessmentField: 'explicitAssessmentValue',
-          explicitAssessmentField__explicit: 'explicitAssessmentId',
-        })
-      })
-
-      context('but it has no value', function () {
-        before(function () {
-          fields = ['missingExplicitAssessmentField']
-          keys = {
-            explicitAssessment: ['missingExplicitAssessmentField'],
-          }
-        })
-        it('should return undefined and false for explicit value', function () {
-          expect(unformatted).to.deep.equal({
-            missingExplicitAssessmentField: undefined,
-            missingExplicitAssessmentField__explicit: 'false',
-          })
-        })
-      })
-    })
-
     context('when asking for multiple fields of differing type', function () {
       before(function () {
         fields = [
@@ -250,15 +149,11 @@ describe('Person Service', function () {
           'identifierField',
           'relationshipField',
           'dateField',
-          'assessmentField',
-          'explicitAssessmentField',
         ]
         keys = {
           identifier: ['identifierField'],
           relationship: ['relationshipField'],
           date: ['dateField'],
-          assessment: ['assessmentField'],
-          explicitAssessment: ['explicitAssessmentField'],
         }
       })
       it('should return all the expected values', function () {
@@ -267,10 +162,6 @@ describe('Person Service', function () {
           identifierField: 'identifierValue',
           relationshipField: 'relationshipValue',
           dateField: 'formattedDateValue',
-          assessmentField: 'assessmentValue',
-          explicitAssessmentField: 'explicitAssessmentValue',
-          assessmentCategory: ['assessmentId'],
-          explicitAssessmentField__explicit: 'explicitAssessmentId',
         })
       })
     })


### PR DESCRIPTION
## Proposed changes

### What changed

- Removes person from move model
- Removes formatting and unformatting of assessment_answers in person service
- Removes assesment_answers from person model

### Why did it change

Api improvements

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

- [P4-1678 - Remove assessment answers from person service](https://dsdmoj.atlassian.net/browse/P4-1678)

## Screenshots

Functionally identical

## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed

### Other considerations

- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics

