### PR TITLE
[P4-1734] Update form wizard to support ingesting YAML framework

### DIFF
--- a/app/allocation/fields/cancellation_reason_comment.js
+++ b/app/allocation/fields/cancellation_reason_comment.js
@@ -1,16 +1,11 @@
 const cancellationReasonComment = {
   validate: 'required',
-  skip: true,
   rows: 3,
   component: 'govukTextarea',
   classes: 'govuk-input--width-20',
   label: {
     text: 'fields::cancellation_reason_comment.label',
     classes: 'govuk-label--s',
-  },
-  dependent: {
-    field: 'cancellation_reason',
-    value: 'other',
   },
 }
 

--- a/app/allocation/fields/other-criteria.js
+++ b/app/allocation/fields/other-criteria.js
@@ -1,17 +1,13 @@
 const otherCriteria = {
   id: 'other_criteria',
   name: 'other_criteria',
-  skip: true,
+  validate: 'required',
   rows: 3,
   component: 'govukTextarea',
   classes: 'govuk-input--width-20',
   label: {
     text: 'fields::other_criteria.label',
     classes: 'govuk-label--s',
-  },
-  dependent: {
-    field: 'has_other_criteria',
-    value: 'true',
   },
 }
 

--- a/app/move/controllers/create/base.test.js
+++ b/app/move/controllers/create/base.test.js
@@ -1,5 +1,6 @@
 const FormController = require('hmpo-form-wizard').Controller
 
+const FormWizardController = require('../../../../common/controllers/form-wizard')
 const presenters = require('../../../../common/presenters')
 
 const CreateBaseController = require('./base')
@@ -30,14 +31,15 @@ describe('Move controllers', function () {
 
     describe('#middlewareSetup()', function () {
       beforeEach(function () {
-        sinon.stub(FormController.prototype, 'middlewareSetup')
+        sinon.stub(FormWizardController.prototype, 'middlewareSetup')
         sinon.stub(controller, 'use')
 
         controller.middlewareSetup()
       })
 
       it('should call parent method', function () {
-        expect(FormController.prototype.middlewareSetup).to.have.been.calledOnce
+        expect(FormWizardController.prototype.middlewareSetup).to.have.been
+          .calledOnce
       })
 
       it('should call set models method', function () {

--- a/app/move/controllers/create/document.test.js
+++ b/app/move/controllers/create/document.test.js
@@ -3,6 +3,8 @@ const FormError = require('hmpo-form-wizard/lib/error')
 const multer = require('multer')
 const proxyquire = require('proxyquire').noCallThru()
 
+const FormWizardController = require('../../../../common/controllers/form-wizard')
+
 function MulterStub() {}
 
 MulterStub.prototype.array = sinon.stub()
@@ -61,7 +63,7 @@ describe('Move controllers', function () {
 
     describe('#middlewareSetup()', function () {
       beforeEach(function () {
-        sinon.stub(FormController.prototype, 'middlewareSetup')
+        sinon.stub(FormWizardController.prototype, 'middlewareSetup')
         sinon.stub(controller, 'use')
         sinon.stub(controller, 'setNextStep')
 
@@ -69,7 +71,8 @@ describe('Move controllers', function () {
       })
 
       it('should call parent method', function () {
-        expect(FormController.prototype.middlewareSetup).to.have.been.calledOnce
+        expect(FormWizardController.prototype.middlewareSetup).to.have.been
+          .calledOnce
       })
 
       it('should setup multer middleware', function () {

--- a/app/move/fields/cancellation-reason-comment.js
+++ b/app/move/fields/cancellation-reason-comment.js
@@ -1,16 +1,11 @@
 const cancellationReasonComment = {
   validate: 'required',
-  skip: true,
   rows: 3,
   component: 'govukTextarea',
   classes: 'govuk-input--width-20',
   label: {
     text: 'fields::cancellation_reason_comment.label',
     classes: 'govuk-label--s',
-  },
-  dependent: {
-    field: 'cancellation_reason',
-    value: 'other',
   },
 }
 

--- a/app/move/fields/court-hearing-comments.js
+++ b/app/move/fields/court-hearing-comments.js
@@ -1,17 +1,12 @@
 const courtHearingComments = {
   id: 'court_hearing__comments',
   name: 'court_hearing__comments',
-  skip: true,
   rows: 3,
   component: 'govukTextarea',
   classes: 'govuk-input--width-20',
   label: {
     text: 'fields::court_hearing__comments.label',
     classes: 'govuk-label--s',
-  },
-  dependent: {
-    field: 'has_court_case',
-    value: 'true',
   },
 }
 

--- a/app/move/fields/court-hearing-court-case.js
+++ b/app/move/fields/court-hearing-court-case.js
@@ -3,7 +3,6 @@ const courtHearingCourtCase = {
   validate: 'required',
   component: 'govukRadios',
   items: [],
-  skip: true,
   fieldset: {
     legend: {
       text: 'fields::court_hearing__court_case.label',
@@ -12,10 +11,6 @@ const courtHearingCourtCase = {
   },
   hint: {
     text: 'fields::court_hearing__court_case.hint',
-  },
-  dependent: {
-    field: 'has_court_case',
-    value: 'true',
   },
 }
 

--- a/app/move/fields/court-hearing-start-time.js
+++ b/app/move/fields/court-hearing-start-time.js
@@ -9,17 +9,12 @@ const courtHearingStartTime = {
   component: 'govukInput',
   classes: 'govuk-input--width-10',
   autocomplete: 'off',
-  skip: true,
   label: {
     html: 'fields::court_hearing__start_time.label',
     classes: 'govuk-label--s',
   },
   hint: {
     text: 'fields::court_hearing__start_time.hint',
-  },
-  dependent: {
-    field: 'has_court_case',
-    value: 'true',
   },
 }
 

--- a/app/move/fields/date-custom.js
+++ b/app/move/fields/date-custom.js
@@ -5,11 +5,6 @@ const commonDateField = require('./common.date')
 const dateCustom = {
   ...cloneDeep(commonDateField),
   validate: [...commonDateField.validate, 'required', 'after'],
-  skip: true,
-  dependent: {
-    field: 'date_type',
-    value: 'custom',
-  },
   id: 'date_custom',
   name: 'date_custom',
   label: {

--- a/app/move/fields/date-to.js
+++ b/app/move/fields/date-to.js
@@ -4,12 +4,7 @@ const commonDateField = require('./common.date')
 
 const dateTo = {
   ...cloneDeep(commonDateField),
-  skip: true,
   validate: [...commonDateField.validate, 'required', 'after'],
-  dependent: {
-    field: 'has_date_to',
-    value: 'yes',
-  },
   id: 'date_to',
   name: 'date_to',
   label: {

--- a/app/move/fields/move-agreed-by.js
+++ b/app/move/fields/move-agreed-by.js
@@ -1,7 +1,6 @@
 const moveAgreedBy = {
   id: 'move_agreed_by',
   name: 'move_agreed_by',
-  skip: true,
   component: 'govukInput',
   classes: 'govuk-input--width-20',
   label: {
@@ -9,10 +8,6 @@ const moveAgreedBy = {
     classes: 'govuk-label--s',
   },
   validate: 'required',
-  dependent: {
-    field: 'move_agreed',
-    value: 'true',
-  },
 }
 
 module.exports = moveAgreedBy

--- a/app/move/fields/move-not-agreed-instruction.js
+++ b/app/move/fields/move-not-agreed-instruction.js
@@ -1,12 +1,7 @@
 const moveNotAgreedInstruction = {
-  skip: true,
   component: 'raw',
   html:
     '<p class="govuk-body">Complex cases must be discussed and agreed with the receiving prison.</p><p class="govuk-body">This includes:<p><ul class="govuk-list govuk-list--bullet"><li>Segregated prisoners</li><li>Self harm/prisoners on ACCT</li><li>Mental health issues</li><li>Integrated Drug Treatment System</li></ul>',
-  dependent: {
-    field: 'move_agreed',
-    value: 'false',
-  },
 }
 
 module.exports = moveNotAgreedInstruction

--- a/app/move/fields/review/cancellation-reason-comment.js
+++ b/app/move/fields/review/cancellation-reason-comment.js
@@ -1,16 +1,11 @@
 const cancellationReasonComment = {
   name: 'cancellation_reason_comment',
-  skip: true,
   rows: 3,
   component: 'govukTextarea',
   classes: 'govuk-input--width-20',
   label: {
-    text: 'fields::cancellation_reason_comment.label',
+    text: 'fields::cancellation_reason_comment.label_optional',
     classes: 'govuk-label--s',
-  },
-  dependent: {
-    field: 'review_decision',
-    value: 'reject',
   },
 }
 

--- a/app/move/fields/review/move-date.js
+++ b/app/move/fields/review/move-date.js
@@ -5,11 +5,6 @@ const commonDateField = require('../common.date')
 const moveDate = {
   ...cloneDeep(commonDateField),
   validate: [...commonDateField.validate, 'required', 'after'],
-  skip: true,
-  dependent: {
-    field: 'review_decision',
-    value: 'approve',
-  },
   id: 'move_date',
   name: 'move_date',
   label: {

--- a/app/move/fields/review/rebook.js
+++ b/app/move/fields/review/rebook.js
@@ -2,14 +2,13 @@ const rebook = {
   validate: 'required',
   component: 'govukRadios',
   name: 'rebook',
-  skip: true,
   label: {
     text: 'fields::rebook.label',
   },
   fieldset: {
     legend: {
       text: 'fields::rebook.label',
-      classes: 'govuk-fieldset__legend--m',
+      classes: 'govuk-fieldset__legend--s',
     },
   },
   items: [
@@ -26,10 +25,6 @@ const rebook = {
       text: 'fields::rebook.items.do_not_rebook',
     },
   ],
-  dependent: {
-    field: 'review_decision',
-    value: 'reject',
-  },
 }
 
 module.exports = rebook

--- a/app/move/fields/review/rejection-reason.js
+++ b/app/move/fields/review/rejection-reason.js
@@ -2,14 +2,13 @@ const rejectionReason = {
   validate: 'required',
   component: 'govukRadios',
   name: 'rejection_reason',
-  skip: true,
   label: {
     text: 'fields::rejection_reason.label',
   },
   fieldset: {
     legend: {
       text: 'fields::rejection_reason.label',
-      classes: 'govuk-fieldset__legend--m',
+      classes: 'govuk-fieldset__legend--s',
     },
   },
   items: [
@@ -22,10 +21,6 @@ const rejectionReason = {
       text: 'fields::rejection_reason.items.no_transport_available',
     },
   ],
-  dependent: {
-    field: 'review_decision',
-    value: 'reject',
-  },
 }
 
 module.exports = rejectionReason

--- a/app/move/fields/to-location-court-appearance.js
+++ b/app/move/fields/to-location-court-appearance.js
@@ -5,10 +5,6 @@ const toLocationCourtAppearance = {
   id: 'to_location_court_appearance',
   name: 'to_location_court_appearance',
   validate: 'required',
-  dependent: {
-    field: 'move_type',
-    value: 'court_appearance',
-  },
   label: {
     text: 'fields::to_location_court_appearance.label',
     classes: 'govuk-label--s',

--- a/app/move/fields/to-location-prison-transfer.js
+++ b/app/move/fields/to-location-prison-transfer.js
@@ -5,10 +5,6 @@ const toLocationPrisonTransfer = {
   id: 'to_location_prison_transfer',
   name: 'to_location_prison_transfer',
   validate: 'required',
-  dependent: {
-    field: 'move_type',
-    value: 'prison_transfer',
-  },
   label: {
     text: 'fields::to_location_prison_transfer.label',
     classes: 'govuk-label--s',

--- a/common/helpers/field/index.js
+++ b/common/helpers/field/index.js
@@ -81,17 +81,17 @@ function renderConditionalFields([key, field], index, obj) {
       items: field.items.map(item => {
         const conditionalFields = concat([], item.conditional)
 
-        const components = conditionalFields.map(conditionalField => {
-          const field = fields[conditionalField]
+        const components = conditionalFields.map(conditionalFieldKey => {
+          const conditionalField = fields[conditionalFieldKey]
 
-          if (!field) {
+          if (!conditionalField) {
             return
           }
 
-          return componentService.getComponent(field.component, {
-            ...field,
-            id: conditionalField,
-            name: conditionalField,
+          return componentService.getComponent(conditionalField.component, {
+            ...conditionalField,
+            id: conditionalFieldKey,
+            name: conditionalFieldKey,
           })
         })
 

--- a/common/templates/form-wizard.njk
+++ b/common/templates/form-wizard.njk
@@ -33,6 +33,11 @@
   <header class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       {% block pageHeading %}
+        {% if options.pageCaption %}
+          <span class="govuk-caption-xl">
+            {{ t(options.pageCaption) }}
+          </span>
+        {% endif %}
         <h1 class="govuk-heading-xl">
           {{ t(options.pageTitle) }}
         </h1>

--- a/locales/en/fields.json
+++ b/locales/en/fields.json
@@ -189,7 +189,8 @@
     }
   },
   "cancellation_reason_comment": {
-    "label": "Additional information (optional)",
+    "label": "Additional information",
+    "label_optional": "Additional information (optional)",
     "label_with_error": "Additional information"
   },
   "rebook": {
@@ -215,9 +216,6 @@
         "label": "Another reason"
       }
     }
-  },
-  "cancellation_reason_comment": {
-    "label": "Give details"
   },
   "other_court": {
     "label": "Any other information details"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

This addition means that the form wizard will always set the correct
`dependent` property on a field if it is added as a conditional
field within another field's options.

This PR also includes a small change to an existing helper and the addition of
page caption support within a form wizard step.

### Why did it change

Previously creating conditional fields was a two step process that
involved adding a field as a conditional option to a parent as well
as adding a dependent property to the child field to ensure validation
is only applied in the correct circumstances.

This change doesn't affect any previous implementations but makes this
process easier moving forward so that when dynamically creating fields,
like will be the case for the Person Escort Record framework, you
don't need to loop over the fields again to set the dependent values.
This is now taken care of within the form wizard itself.

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

- [P4-1734](https://dsdmoj.atlassian.net/browse/P4-1734)

## Checklists

### Testing

#### Automated testing

- [ ] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [x] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed

### Other considerations

Commit messages with a `fix` or `feat` type are automatically used to generate the [changelog](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/CHANGELOG.md) and
[GitHub release notes](https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/releases) during the release task. Please make sure they will read well on their own in a
summary of changes and that the commit body gives a more detailed description of those changes if necessary.

- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
- [x] Update [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md) with any new instructions or tasks
