### PR TITLE
Add hasDocument meta tag to e2e tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,12 @@ To debug tests on local server run:
 npm run test-e2e:local
 ```
 
+To debug tests on local server against the API running locally, run:
+
+```
+npm run test-e2e:local:api
+```
+
 And to run test in specific browser run: `test-e2e:chrome` or `test-e2e:firefox`.
 
 The video recording of each test is stored in artifacts/video directory and is stored on CI under artifacts for review.

--- a/package.json
+++ b/package.json
@@ -203,6 +203,7 @@
     "test-e2e:chrome": "testcafe chrome test/e2e/*.test.js",
     "test-e2e:ci": "npm run test-e2e:chrome -- --color --reporter spec,xunit:reports/testcafe/results-chrome.xml",
     "test-e2e:local": "E2E_BASE_URL='' npm run test-e2e:chrome -- --debug-on-fail",
+    "test-e2e:local:api": "E2E_BASE_URL='' node test/e2e/run-without-document-tests.js",
     "update": "ncu -u",
     "update:check": "ncu -- --error-level 2",
     "watch:js:client": "webpack --watch --progress",

--- a/test/e2e/move.new.stc.test.js
+++ b/test/e2e/move.new.stc.test.js
@@ -10,7 +10,7 @@ fixture('New move from Secure Training Centre (STC) to Court').beforeEach(
   }
 )
 
-test('With a new person', async t => {
+test.meta('hasDocument', 'true')('With a new person', async t => {
   // PNC lookup
   await t
     .expect(page.getCurrentUrl())

--- a/test/e2e/move.update.stc.test.js
+++ b/test/e2e/move.update.stc.test.js
@@ -17,27 +17,30 @@ if (FEATURE_FLAGS.EDITABILITY) {
     await createCourtMove()
   })
 
-  test('User should be able to update move', async () => {
-    await checkUpdateLinks([
-      'personal_details',
-      'risk',
-      'health',
-      'court',
-      'move',
-      'date',
-      'document',
-    ])
+  test.meta('hasDocument', 'true')(
+    'User should be able to update move',
+    async () => {
+      await checkUpdateLinks([
+        'personal_details',
+        'risk',
+        'health',
+        'court',
+        'move',
+        'date',
+        'document',
+      ])
 
-    await checkUpdateDocuments()
+      await checkUpdateDocuments()
 
-    await checkUpdatePagesAccessible([
-      'personal_details',
-      'risk',
-      'health',
-      'court',
-      'move',
-      'date',
-      'document',
-    ])
-  })
+      await checkUpdatePagesAccessible([
+        'personal_details',
+        'risk',
+        'health',
+        'court',
+        'move',
+        'date',
+        'document',
+      ])
+    }
+  )
 }

--- a/test/e2e/run-without-document-tests.js
+++ b/test/e2e/run-without-document-tests.js
@@ -1,0 +1,28 @@
+const createTestCafe = require('testcafe')
+
+const runTests = async () => {
+  const testcafe = await createTestCafe('localhost', 1337, 1338)
+  const runner = testcafe.createRunner()
+  const failedCount = await runner
+    .src('./test/e2e/*.test.js')
+    .filter((testName, fixtureName, fixturePath, testMeta, fixtureMeta) => {
+      return !testMeta.hasDocument
+    })
+    .browsers(['chrome:headless'])
+    .run()
+
+  if (failedCount) {
+    // eslint-disable-next-line no-console
+    console.log(`
+Try running the failing tests individually in non-headless mode
+
+node_modules/.bin/testcafe chrome test/e2e/<path>.test.js --debug-on-fail
+`)
+    process.exit(1)
+  }
+
+  testcafe.close()
+  process.exit()
+}
+
+runTests()


### PR DESCRIPTION
## Proposed changes

- Add meta tag (`hasDocument=true`) to STC tests that involve uploading documents.
- Add script that runs all tests filtering out those with the `hasDocument` meta tag

### What changed

<!--- Describe the changes in detail - the "what"-->

### Why did it change

This enables us to skip tests which upload documents - currently runinng against a local API triggers errors such as:

> ActionController::BadRequest (Invalid request parameters: invalid byte sequence in UTF-8)

The documents with the tag can be skipped bu running the following script

`node test/e2e/run-without-document-tests.js`

### Issue tracking

n/a

## Screenshots

n/a

## Checklists

### Testing

#### Automated testing

n/a


### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed



### Other considerations

- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics

