### PR TITLE
[P4-1734] feat: Add importer for Book a secure move frameworks

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -11,7 +11,7 @@ module.exports = {
     SharedArrayBuffer: 'readonly',
   },
   parserOptions: {
-    ecmaVersion: 2018,
+    ecmaVersion: 2020,
   },
   rules: {
     'prettier/prettier': 'error',

--- a/common/services/frameworks.js
+++ b/common/services/frameworks.js
@@ -1,0 +1,89 @@
+const { keyBy, set } = require('lodash')
+
+const labelPathMap = {
+  radio: 'fieldset.legend',
+  checkbox: 'fieldset.legend',
+  default: 'label',
+}
+const uiComponentMap = {
+  radio: 'govukRadios',
+  checkbox: 'govukCheckboxes',
+  textarea: 'govukTextarea',
+  default: 'govukInput',
+}
+
+function transformQuestion(
+  key,
+  { question, hint, options, validations = [], type }
+) {
+  const labelPath = labelPathMap[type] || labelPathMap.default
+  const component = uiComponentMap[type] || uiComponentMap.default
+  const field = {
+    question,
+    component,
+    id: key,
+    name: key,
+    validate: validations.map(validation => validation.name),
+  }
+
+  set(field, labelPath, {
+    text: question,
+    classes: 'govuk-label--s',
+  })
+
+  if (hint) {
+    set(field, 'hint.text', hint)
+  }
+
+  if (options) {
+    field.items = options.map(({ value, label, followup }) => {
+      return {
+        value,
+        text: label,
+        conditional: followup,
+      }
+    })
+  }
+
+  return field
+}
+
+function transformManifest(key, manifest) {
+  if (!manifest) {
+    return {}
+  }
+
+  const steps = (manifest.steps || []).map(
+    ({ questions = [], slug, name: pageTitle, next_step: nextStep }, index) => {
+      let next = manifest.steps[index + 1]?.slug
+
+      if (nextStep) {
+        const transformedKeys = JSON.stringify(nextStep)
+          .replace(/"question":/gi, '"field":')
+          .replace(/"next_step":/gi, '"next":')
+
+        next = JSON.parse(transformedKeys)
+      }
+
+      return {
+        slug,
+        next,
+        pageTitle,
+        key: `/${slug}`,
+        fields: questions,
+        pageCaption: manifest.name,
+      }
+    }
+  )
+
+  return {
+    key,
+    name: manifest.name,
+    steps: keyBy(steps, 'key'),
+  }
+}
+
+module.exports = {
+  transformManifest,
+  transformQuestion,
+}

--- a/common/services/frameworks.test.js
+++ b/common/services/frameworks.test.js
@@ -1,0 +1,538 @@
+const frameworksService = require('./frameworks')
+
+describe('Frameworks service', function () {
+  describe('#transformQuestion', function () {
+    context('with no options', function () {})
+
+    context('with options', function () {
+      let mockQuestion
+
+      beforeEach(function () {
+        mockQuestion = {
+          question: 'Question text',
+        }
+      })
+
+      context('by default', function () {
+        it('should format correctly', function () {
+          const transformed = frameworksService.transformQuestion(
+            'question-key',
+            mockQuestion
+          )
+          expect(transformed).to.deep.equal({
+            component: 'govukInput',
+            question: 'Question text',
+            id: 'question-key',
+            name: 'question-key',
+            label: {
+              text: 'Question text',
+              classes: 'govuk-label--s',
+            },
+            validate: [],
+          })
+        })
+      })
+
+      context('with hint text', function () {
+        beforeEach(function () {
+          mockQuestion = {
+            ...mockQuestion,
+            hint: 'Hint text',
+          }
+        })
+
+        it('should format correctly', function () {
+          const transformed = frameworksService.transformQuestion(
+            'question-key',
+            mockQuestion
+          )
+          expect(transformed).to.deep.equal({
+            component: 'govukInput',
+            question: 'Question text',
+            id: 'question-key',
+            name: 'question-key',
+            label: {
+              text: 'Question text',
+              classes: 'govuk-label--s',
+            },
+            hint: {
+              text: 'Hint text',
+            },
+            validate: [],
+          })
+        })
+      })
+
+      context('with validations', function () {
+        beforeEach(function () {
+          mockQuestion = {
+            ...mockQuestion,
+            validations: [
+              {
+                name: 'required',
+              },
+              {
+                name: 'date',
+              },
+            ],
+          }
+        })
+
+        it('should format correctly', function () {
+          const transformed = frameworksService.transformQuestion(
+            'question-key',
+            mockQuestion
+          )
+          expect(transformed).to.deep.equal({
+            component: 'govukInput',
+            question: 'Question text',
+            id: 'question-key',
+            name: 'question-key',
+            label: {
+              text: 'Question text',
+              classes: 'govuk-label--s',
+            },
+            validate: ['required', 'date'],
+          })
+        })
+      })
+
+      context('with options', function () {
+        beforeEach(function () {
+          mockQuestion = {
+            ...mockQuestion,
+            options: [
+              {
+                value: 'Yes',
+                label: 'Yes',
+                followup: 'conditional-field-1',
+              },
+              {
+                value: 'No',
+                label: 'No',
+                followup: ['conditional-field-2'],
+              },
+            ],
+          }
+        })
+
+        it('should format correctly', function () {
+          const transformed = frameworksService.transformQuestion(
+            'question-key',
+            mockQuestion
+          )
+          expect(transformed).to.deep.equal({
+            component: 'govukInput',
+            question: 'Question text',
+            id: 'question-key',
+            name: 'question-key',
+            label: {
+              text: 'Question text',
+              classes: 'govuk-label--s',
+            },
+            items: [
+              {
+                value: 'Yes',
+                text: 'Yes',
+                conditional: 'conditional-field-1',
+              },
+              {
+                value: 'No',
+                text: 'No',
+                conditional: ['conditional-field-2'],
+              },
+            ],
+            validate: [],
+          })
+        })
+      })
+    })
+
+    describe('question types', function () {
+      const mockQuestion = {
+        question: 'Question text',
+      }
+
+      describe('radio', function () {
+        it('should format type correctly', function () {
+          const transformed = frameworksService.transformQuestion(
+            'question-key',
+            { ...mockQuestion, type: 'radio' }
+          )
+
+          expect(transformed).to.deep.equal({
+            component: 'govukRadios',
+            question: 'Question text',
+            id: 'question-key',
+            name: 'question-key',
+            fieldset: {
+              legend: {
+                text: 'Question text',
+                classes: 'govuk-label--s',
+              },
+            },
+            validate: [],
+          })
+        })
+      })
+
+      describe('checkbox', function () {
+        it('should format type correctly', function () {
+          const transformed = frameworksService.transformQuestion(
+            'question-key',
+            { ...mockQuestion, type: 'checkbox' }
+          )
+
+          expect(transformed).to.deep.equal({
+            component: 'govukCheckboxes',
+            question: 'Question text',
+            id: 'question-key',
+            name: 'question-key',
+            fieldset: {
+              legend: {
+                text: 'Question text',
+                classes: 'govuk-label--s',
+              },
+            },
+            validate: [],
+          })
+        })
+      })
+
+      describe('textarea', function () {
+        it('should format type correctly', function () {
+          const transformed = frameworksService.transformQuestion(
+            'question-key',
+            { ...mockQuestion, type: 'textarea' }
+          )
+
+          expect(transformed).to.deep.equal({
+            component: 'govukTextarea',
+            question: 'Question text',
+            id: 'question-key',
+            name: 'question-key',
+            label: {
+              text: 'Question text',
+              classes: 'govuk-label--s',
+            },
+            validate: [],
+          })
+        })
+      })
+
+      describe('text', function () {
+        it('should format type correctly', function () {
+          const transformed = frameworksService.transformQuestion(
+            'question-key',
+            { ...mockQuestion, type: 'text' }
+          )
+
+          expect(transformed).to.deep.equal({
+            component: 'govukInput',
+            question: 'Question text',
+            id: 'question-key',
+            name: 'question-key',
+            label: {
+              text: 'Question text',
+              classes: 'govuk-label--s',
+            },
+            validate: [],
+          })
+        })
+      })
+    })
+  })
+
+  describe('#transformManifest', function () {
+    context('without manifest', function () {
+      it('should return an empty object', function () {
+        const transformed = frameworksService.transformManifest()
+        expect(transformed).to.deep.equal({})
+      })
+    })
+
+    context('with manifest', function () {
+      context('without steps', function () {
+        it('should return an empty steps object', function () {
+          const transformed = frameworksService.transformManifest('key', {
+            name: 'Manifest name',
+          })
+
+          expect(transformed).to.deep.equal({
+            key: 'key',
+            name: 'Manifest name',
+            steps: {},
+          })
+        })
+      })
+
+      context('with steps', function () {
+        let steps, transformed
+
+        beforeEach(function () {
+          steps = [
+            {
+              name: 'Step 1',
+              slug: 'step-1',
+              questions: ['question-1', 'question-2'],
+            },
+            {
+              name: 'Step 2',
+              slug: 'step-2',
+              questions: ['question-3', 'question-4'],
+            },
+            {
+              name: 'Step 3',
+              slug: 'step-3',
+              questions: ['question-5', 'question-6'],
+            },
+          ]
+
+          transformed = frameworksService.transformManifest('key', {
+            steps,
+            name: 'Manifest name',
+          })
+        })
+
+        it('should contain correct number of manifest keys', function () {
+          expect(Object.keys(transformed)).to.have.length(3)
+        })
+
+        it('should contain correct manifest key', function () {
+          expect(Object.keys(transformed)).to.deep.equal([
+            'key',
+            'name',
+            'steps',
+          ])
+        })
+
+        it('should set key', function () {
+          expect(transformed.key).to.equal('key')
+        })
+
+        it('should set name', function () {
+          expect(transformed.name).to.equal('Manifest name')
+        })
+
+        it('should transform steps correctly', function () {
+          expect(transformed.steps).to.deep.equal({
+            '/step-1': {
+              slug: 'step-1',
+              next: 'step-2',
+              pageTitle: 'Step 1',
+              key: '/step-1',
+              fields: ['question-1', 'question-2'],
+              pageCaption: 'Manifest name',
+            },
+            '/step-2': {
+              slug: 'step-2',
+              next: 'step-3',
+              pageTitle: 'Step 2',
+              key: '/step-2',
+              fields: ['question-3', 'question-4'],
+              pageCaption: 'Manifest name',
+            },
+            '/step-3': {
+              slug: 'step-3',
+              next: undefined,
+              pageTitle: 'Step 3',
+              key: '/step-3',
+              fields: ['question-5', 'question-6'],
+              pageCaption: 'Manifest name',
+            },
+          })
+        })
+
+        it('should set default `next` values correctly', function () {
+          expect(transformed.steps['/step-1'].next).to.equal('step-2')
+          expect(transformed.steps['/step-2'].next).to.equal('step-3')
+          expect(transformed.steps['/step-3'].next).to.be.undefined
+        })
+      })
+
+      context('with custom step next values', function () {
+        let steps, transformed
+
+        beforeEach(function () {
+          steps = [
+            {
+              name: 'Step 1',
+              slug: 'step-1',
+              next_step: 'simple-override',
+              questions: ['question-1', 'question-2'],
+            },
+            {
+              name: 'Step 2',
+              slug: 'step-2',
+              next_step: [
+                {
+                  question: 'question-1',
+                  value: 'Yes',
+                  next_step: 'step-3',
+                },
+                'step-4',
+              ],
+              questions: ['question-3', 'question-4'],
+            },
+            {
+              name: 'Step 3',
+              slug: 'step-3',
+              next_step: [
+                {
+                  question: 'question-1',
+                  value: 'Yes',
+                  next_step: [
+                    {
+                      question: 'question-2',
+                      value: 'Yes',
+                      next_step: [
+                        {
+                          question: 'question-1',
+                          value: 'No',
+                          next_step: 'step-3',
+                        },
+                        'step-4',
+                      ],
+                    },
+                    'step-4',
+                  ],
+                },
+                {
+                  question: 'question-1',
+                  value: 'No',
+                  next_step: 'step-4',
+                },
+                'step-4',
+              ],
+              questions: ['question-5', 'question-6'],
+            },
+            {
+              name: 'Step 4',
+              slug: 'step-4',
+              questions: [],
+            },
+          ]
+
+          transformed = frameworksService.transformManifest('key', {
+            steps,
+            name: 'Manifest name',
+          })
+        })
+
+        it('should set simple `next` override', function () {
+          expect(transformed.steps['/step-1'].next).to.equal('simple-override')
+        })
+
+        it('should set nested `next` override', function () {
+          expect(transformed.steps['/step-2'].next).to.deep.equal([
+            {
+              field: 'question-1',
+              value: 'Yes',
+              next: 'step-3',
+            },
+            'step-4',
+          ])
+        })
+
+        it('should set complex `next` override', function () {
+          expect(transformed.steps['/step-3'].next).to.deep.equal([
+            {
+              field: 'question-1',
+              value: 'Yes',
+              next: [
+                {
+                  field: 'question-2',
+                  value: 'Yes',
+                  next: [
+                    {
+                      field: 'question-1',
+                      value: 'No',
+                      next: 'step-3',
+                    },
+                    'step-4',
+                  ],
+                },
+                'step-4',
+              ],
+            },
+            {
+              field: 'question-1',
+              value: 'No',
+              next: 'step-4',
+            },
+            'step-4',
+          ])
+        })
+      })
+
+      context('without step questions', function () {
+        let steps, transformed
+
+        beforeEach(function () {
+          steps = [
+            {
+              name: 'Step 1',
+              slug: 'step-1',
+            },
+            {
+              name: 'Step 2',
+              slug: 'step-2',
+              questions: [],
+            },
+          ]
+
+          transformed = frameworksService.transformManifest('key', {
+            steps,
+            name: 'Manifest name',
+          })
+        })
+
+        it('should contain correct number of manifest keys', function () {
+          expect(Object.keys(transformed)).to.have.length(3)
+        })
+
+        it('should contain correct manifest key', function () {
+          expect(Object.keys(transformed)).to.deep.equal([
+            'key',
+            'name',
+            'steps',
+          ])
+        })
+
+        it('should set key', function () {
+          expect(transformed.key).to.equal('key')
+        })
+
+        it('should set name', function () {
+          expect(transformed.name).to.equal('Manifest name')
+        })
+
+        it('should transform steps correctly', function () {
+          expect(transformed.steps).to.deep.equal({
+            '/step-1': {
+              slug: 'step-1',
+              next: 'step-2',
+              pageTitle: 'Step 1',
+              key: '/step-1',
+              fields: [],
+              pageCaption: 'Manifest name',
+            },
+            '/step-2': {
+              slug: 'step-2',
+              next: undefined,
+              pageTitle: 'Step 2',
+              key: '/step-2',
+              fields: [],
+              pageCaption: 'Manifest name',
+            },
+          })
+        })
+
+        it('should set empty values for fields', function () {
+          expect(transformed.steps['/step-1'].fields).to.deep.equal([])
+          expect(transformed.steps['/step-2'].fields).to.deep.equal([])
+        })
+      })
+    })
+  })
+})

--- a/common/services/index.js
+++ b/common/services/index.js
@@ -1,5 +1,6 @@
 const allocation = require('./allocation')
 const courtHearing = require('./court-hearing')
+const frameworks = require('./frameworks')
 const move = require('./move')
 const person = require('./person')
 const referenceData = require('./reference-data')
@@ -10,6 +11,7 @@ module.exports = {
   courtHearing,
   move,
   person,
+  frameworks,
   referenceData,
   singleRequest,
 }

--- a/config/paths.js
+++ b/config/paths.js
@@ -1,10 +1,11 @@
 const path = require('path')
 
 const root = path.normalize(`${__dirname}/..`)
+const build = path.resolve(root, '.build')
 
 module.exports = {
   root,
-  build: path.resolve(root, '.build'),
+  build,
   app: path.resolve(root, 'app'),
   assets: path.resolve(root, 'common', 'assets'),
   templates: path.resolve(root, 'common', 'templates'),
@@ -18,4 +19,13 @@ module.exports = {
     'frontend'
   ),
   fixtures: path.resolve(root, 'test', 'fixtures'),
+  frameworks: {
+    source: path.resolve(
+      root,
+      'node_modules',
+      'hmpps-book-secure-move-frameworks',
+      'frameworks'
+    ),
+    output: path.resolve(build, 'frameworks'),
+  },
 }

--- a/nodemon.json
+++ b/nodemon.json
@@ -14,5 +14,5 @@
   "env": {
     "NODE_ENV": "development"
   },
-  "ext": "js json"
+  "ext": "js json yml"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8845,6 +8845,365 @@
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
       "dev": true
     },
+    "copy-webpack-plugin": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-6.0.2.tgz",
+      "integrity": "sha512-9Gm8X0c6eXlKnmltMPFCBeGOKjtcRIyTt4VaO3k1TkNgVTe5Ov2lYsYVuyLp0kp8DItO3apewflM+1GYgh6V2Q==",
+      "dev": true,
+      "requires": {
+        "cacache": "^15.0.4",
+        "fast-glob": "^3.2.2",
+        "find-cache-dir": "^3.3.1",
+        "glob-parent": "^5.1.1",
+        "globby": "^11.0.1",
+        "loader-utils": "^2.0.0",
+        "normalize-path": "^3.0.0",
+        "p-limit": "^2.3.0",
+        "schema-utils": "^2.7.0",
+        "serialize-javascript": "^3.1.0",
+        "webpack-sources": "^1.4.3"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "6.12.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.2.tgz",
+          "integrity": "sha512-k+V+hzjm5q/Mr8ef/1Y9goCmlsK4I6Sm74teeyGvFk1XrOsbsKLjEdrvny42CZ+a8sXbk8KWpY/bDwS+FLL2UQ==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "braces": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+          "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+          "dev": true,
+          "requires": {
+            "fill-range": "^7.0.1"
+          }
+        },
+        "cacache": {
+          "version": "15.0.4",
+          "resolved": "https://registry.npmjs.org/cacache/-/cacache-15.0.4.tgz",
+          "integrity": "sha512-YlnKQqTbD/6iyoJvEY3KJftjrdBYroCbxxYXzhOzsFLWlp6KX4BOlEf4mTx0cMUfVaTS3ENL2QtDWeRYoGLkkw==",
+          "dev": true,
+          "requires": {
+            "@npmcli/move-file": "^1.0.1",
+            "chownr": "^2.0.0",
+            "fs-minipass": "^2.0.0",
+            "glob": "^7.1.4",
+            "infer-owner": "^1.0.4",
+            "lru-cache": "^5.1.1",
+            "minipass": "^3.1.1",
+            "minipass-collect": "^1.0.2",
+            "minipass-flush": "^1.0.5",
+            "minipass-pipeline": "^1.2.2",
+            "mkdirp": "^1.0.3",
+            "p-map": "^4.0.0",
+            "promise-inflight": "^1.0.1",
+            "rimraf": "^3.0.2",
+            "ssri": "^8.0.0",
+            "tar": "^6.0.2",
+            "unique-filename": "^1.1.1"
+          }
+        },
+        "chownr": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+          "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+          "dev": true
+        },
+        "emojis-list": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
+          "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
+          "dev": true
+        },
+        "fast-deep-equal": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+          "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+          "dev": true
+        },
+        "fast-glob": {
+          "version": "3.2.4",
+          "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.4.tgz",
+          "integrity": "sha512-kr/Oo6PX51265qeuCYsyGypiO5uJFgBS0jksyG7FUeCyQzNwYnzrNIMR1NXfkZXsMYXYLRAHgISHBz8gQcxKHQ==",
+          "dev": true,
+          "requires": {
+            "@nodelib/fs.stat": "^2.0.2",
+            "@nodelib/fs.walk": "^1.2.3",
+            "glob-parent": "^5.1.0",
+            "merge2": "^1.3.0",
+            "micromatch": "^4.0.2",
+            "picomatch": "^2.2.1"
+          }
+        },
+        "fill-range": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+          "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+          "dev": true,
+          "requires": {
+            "to-regex-range": "^5.0.1"
+          }
+        },
+        "find-cache-dir": {
+          "version": "3.3.1",
+          "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.1.tgz",
+          "integrity": "sha512-t2GDMt3oGC/v+BMwzmllWDuJF/xcDtE5j/fCGbqDD7OLuJkj0cfh1YSA5VKPvwMeLFLNDBkwOKZ2X85jGLVftQ==",
+          "dev": true,
+          "requires": {
+            "commondir": "^1.0.1",
+            "make-dir": "^3.0.2",
+            "pkg-dir": "^4.1.0"
+          }
+        },
+        "find-up": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^5.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "glob-parent": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
+          "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
+          "dev": true,
+          "requires": {
+            "is-glob": "^4.0.1"
+          }
+        },
+        "globby": {
+          "version": "11.0.1",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.1.tgz",
+          "integrity": "sha512-iH9RmgwCmUJHi2z5o2l3eTtGBtXek1OYlHrbcxOYugyHLmAsZrPj43OtHThd62Buh/Vv6VyCBD2bdyWcGNQqoQ==",
+          "dev": true,
+          "requires": {
+            "array-union": "^2.1.0",
+            "dir-glob": "^3.0.1",
+            "fast-glob": "^3.1.1",
+            "ignore": "^5.1.4",
+            "merge2": "^1.3.0",
+            "slash": "^3.0.0"
+          }
+        },
+        "is-number": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+          "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+          "dev": true
+        },
+        "loader-utils": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
+          "integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
+          "dev": true,
+          "requires": {
+            "big.js": "^5.2.2",
+            "emojis-list": "^3.0.0",
+            "json5": "^2.1.2"
+          }
+        },
+        "locate-path": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^4.1.0"
+          }
+        },
+        "lru-cache": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+          "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+          "dev": true,
+          "requires": {
+            "yallist": "^3.0.2"
+          }
+        },
+        "make-dir": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+          "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+          "dev": true,
+          "requires": {
+            "semver": "^6.0.0"
+          }
+        },
+        "micromatch": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
+          "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+          "dev": true,
+          "requires": {
+            "braces": "^3.0.1",
+            "picomatch": "^2.0.5"
+          }
+        },
+        "minizlib": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.0.tgz",
+          "integrity": "sha512-EzTZN/fjSvifSX0SlqUERCN39o6T40AMarPbv0MrarSFtIITCBh7bi+dU8nxGFHuqs9jdIAeoYoKuQAAASsPPA==",
+          "dev": true,
+          "requires": {
+            "minipass": "^3.0.0",
+            "yallist": "^4.0.0"
+          },
+          "dependencies": {
+            "yallist": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+              "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+              "dev": true
+            }
+          }
+        },
+        "mkdirp": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+          "dev": true
+        },
+        "p-limit": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.2.0"
+          }
+        },
+        "p-map": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
+          "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
+          "dev": true,
+          "requires": {
+            "aggregate-error": "^3.0.0"
+          }
+        },
+        "path-exists": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+          "dev": true
+        },
+        "picomatch": {
+          "version": "2.2.2",
+          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
+          "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
+          "dev": true
+        },
+        "pkg-dir": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+          "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+          "dev": true,
+          "requires": {
+            "find-up": "^4.0.0"
+          }
+        },
+        "rimraf": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
+        "schema-utils": {
+          "version": "2.7.0",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.7.0.tgz",
+          "integrity": "sha512-0ilKFI6QQF5nxDZLFn2dMjvc4hjg/Wkg7rHd3jK6/A4a1Hl9VFdQWvgB1UMGoU94pad1P/8N7fMcEnLnSiju8A==",
+          "dev": true,
+          "requires": {
+            "@types/json-schema": "^7.0.4",
+            "ajv": "^6.12.2",
+            "ajv-keywords": "^3.4.1"
+          }
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        },
+        "serialize-javascript": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-3.1.0.tgz",
+          "integrity": "sha512-JIJT1DGiWmIKhzRsG91aS6Ze4sFUrYbltlkg2onR5OrnNM02Kl/hnY/T4FN2omvyeBbQmMJv+K4cPOpGzOTFBg==",
+          "dev": true,
+          "requires": {
+            "randombytes": "^2.1.0"
+          }
+        },
+        "ssri": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/ssri/-/ssri-8.0.0.tgz",
+          "integrity": "sha512-aq/pz989nxVYwn16Tsbj1TqFpD5LLrQxHf5zaHuieFV+R0Bbr4y8qUsOA45hXT/N4/9UNXTarBjnjVmjSOVaAA==",
+          "dev": true,
+          "requires": {
+            "minipass": "^3.1.1"
+          }
+        },
+        "tar": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/tar/-/tar-6.0.2.tgz",
+          "integrity": "sha512-Glo3jkRtPcvpDlAs/0+hozav78yoXKFr+c4wgw62NNMO3oo4AaJdCo21Uu7lcwr55h39W2XD1LMERc64wtbItg==",
+          "dev": true,
+          "requires": {
+            "chownr": "^2.0.0",
+            "fs-minipass": "^2.0.0",
+            "minipass": "^3.0.0",
+            "minizlib": "^2.1.0",
+            "mkdirp": "^1.0.3",
+            "yallist": "^4.0.0"
+          },
+          "dependencies": {
+            "yallist": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+              "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+              "dev": true
+            }
+          }
+        },
+        "to-regex-range": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+          "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+          "dev": true,
+          "requires": {
+            "is-number": "^7.0.0"
+          }
+        },
+        "yallist": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+          "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+          "dev": true
+        }
+      }
+    },
     "core-js": {
       "version": "3.6.5",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz",
@@ -15084,6 +15443,10 @@
           "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
         }
       }
+    },
+    "hmpps-book-secure-move-frameworks": {
+      "version": "github:ministryofjustice/hmpps-book-secure-move-frameworks#d616072d382ea492f40f266d4675a9c45326a6b1",
+      "from": "github:ministryofjustice/hmpps-book-secure-move-frameworks#initial-manifests"
     },
     "home-or-tmp": {
       "version": "2.0.0",
@@ -28175,6 +28538,15 @@
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.9.2"
+      }
+    },
+    "yamljs": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/yamljs/-/yamljs-0.3.0.tgz",
+      "integrity": "sha512-C/FsVVhht4iPQYXOInoxUM/1ELSf9EsgKH34FofQOp6hwCPrW4vG4w5++TED3xRUo8gD7l0P1J1dLlDYzODsTQ==",
+      "requires": {
+        "argparse": "^1.0.7",
+        "glob": "^7.0.5"
       }
     },
     "yargs": {

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "grant-express": "5.2.0",
     "helmet": "3.23.2",
     "hmpo-form-wizard": "11.6.1",
+    "hmpps-book-secure-move-frameworks": "github:ministryofjustice/hmpps-book-secure-move-frameworks",
     "i18next": "19.5.1",
     "i18next-express-middleware": "2.0.0",
     "i18next-sync-fs-backend": "1.1.1",
@@ -109,7 +110,8 @@
     "sticky-sidebar": "3.3.1",
     "stream-mock": "2.0.5",
     "uuid": "8.2.0",
-    "winston": "3.3.3"
+    "winston": "3.3.3",
+    "yamljs": "0.3.0"
   },
   "devDependencies": {
     "@babel/core": "7.10.3",
@@ -125,6 +127,7 @@
     "chai-as-promised": "7.1.1",
     "cheerio": "1.0.0-rc.3",
     "conventional-github-releaser": "3.1.3",
+    "copy-webpack-plugin": "6.0.2",
     "coveralls": "3.1.0",
     "css-loader": "3.6.0",
     "del-cli": "3.0.1",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

This change includes a new service to import and transform the YAML
files from the Book a secure move frameworks repo.

### Why did it change

It transforms these files into the appropriate structure so that they
can be used by the form-wizard library within the frontend app.

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

- [P4-1734](https://dsdmoj.atlassian.net/browse/P4-1734)

## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed

### Other considerations

Commit messages with a `fix` or `feat` type are automatically used to generate the [changelog](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/CHANGELOG.md) and
[GitHub release notes](https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/releases) during the release task. Please make sure they will read well on their own in a
summary of changes and that the commit body gives a more detailed description of those changes if necessary.

- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
- [x] Update [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md) with any new instructions or tasks
