### PR TITLE
[P4 1618] Add explicit include to nested personService methods

### DIFF
--- a/common/lib/api-client/middleware/request-include.js
+++ b/common/lib/api-client/middleware/request-include.js
@@ -19,7 +19,11 @@ module.exports = {
       include = include.sort().join(',')
     }
 
-    req.params.include = include
+    if (include) {
+      req.params.include = include
+    } else {
+      delete req.params.include
+    }
 
     return payload
   },

--- a/common/lib/api-client/middleware/request-include.test.js
+++ b/common/lib/api-client/middleware/request-include.test.js
@@ -44,6 +44,24 @@ describe('API Client', function () {
             })
           })
 
+          context('with include as an empty array', function () {
+            it('should not set the include', function () {
+              request.params.include = []
+              middleware.req({ req: request })
+
+              expect(request.params.include).to.not.exist
+            })
+          })
+
+          context('with include as an empty string', function () {
+            it('should not set the include', function () {
+              request.params.include = ''
+              middleware.req({ req: request })
+
+              expect(request.params.include).to.not.exist
+            })
+          })
+
           context('with default include on model', function () {
             it('should retain existing include', function () {
               request.params.include = 'authors,comments'
@@ -89,7 +107,7 @@ describe('API Client', function () {
             it('should not set include', function () {
               middleware.req({ req: request, jsonApi })
 
-              expect(request.params.include).to.be.undefined
+              expect(request.params.include).to.not.exist
             })
           })
         })

--- a/common/lib/api-client/models.js
+++ b/common/lib/api-client/models.js
@@ -115,6 +115,9 @@ module.exports = {
         type: 'locations',
       },
     },
+    options: {
+      defaultInclude: ['location'],
+    },
   },
   court_hearing: {
     fields: {
@@ -144,6 +147,7 @@ module.exports = {
     },
     options: {
       collectionPath: 'timetable',
+      defaultInclude: ['location'],
     },
   },
   gender: {

--- a/common/services/person.js
+++ b/common/services/person.js
@@ -119,6 +119,8 @@ const personService = {
       .all('court_case')
       .get({
         'filter[active]': true,
+        // TODO: remove if/when devour adds model info to get method
+        include: ['location'],
       })
       .then(response => response.data)
   },
@@ -136,6 +138,8 @@ const personService = {
           date_from: date,
           date_to: date,
         },
+        // TODO: remove if/when devour adds model info to get method
+        include: ['location'],
       })
       .then(response => response.data)
   },

--- a/common/services/person.test.js
+++ b/common/services/person.test.js
@@ -704,6 +704,7 @@ describe('Person Service', function () {
         expect(apiClient.all).to.be.calledOnceWithExactly('court_case')
         expect(apiClient.get).to.be.calledOnceWithExactly({
           'filter[active]': true,
+          include: ['location'],
         })
       })
 
@@ -757,6 +758,7 @@ describe('Person Service', function () {
               date_from: mockDate,
               date_to: mockDate,
             },
+            include: ['location'],
           })
         })
 
@@ -778,6 +780,7 @@ describe('Person Service', function () {
               date_from: undefined,
               date_to: undefined,
             },
+            include: ['location'],
           })
         })
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
    
 - Add `location` to personService's `getActiveCourtCases` and `getTimetableByDate` methods.
   
### Why did it change

Default includes will be removed from all endpoint under v2.

See https://github.com/ministryofjustice/hmpps-book-secure-move-api/pull/633

`court_case` and 'timetable` had been missed and were still relying on the default rather than explicit behaviour.

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

- [P4-1618 - Remove default includes wherever they are defined
](https://dsdmoj.atlassian.net/browse/P4-1618)

## Screenshots

Functionaly identical

## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed

### Other considerations

- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics

