### PR TITLE
build: Copy frameworks service during docker build phase

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ RUN npm install
 COPY --chown=node:node webpack.config.js .
 COPY --chown=node:node webpack.config.production.js .
 COPY --chown=node:node config config
+COPY --chown=node:node common/services/frameworks.js common/services/frameworks.js
 COPY --chown=node:node common/assets common/assets
 COPY --chown=node:node common/components common/components
 


### PR DESCRIPTION
## Proposed changes

### What changed

Updates `Dockerfile` to copy `common/services/frameworks.js` during build phase 

### Why did it change

Build was broken without it

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

n/a

## Screenshots

n/a

## Checklists

### Testing


### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed


### Other considerations

- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics

