### PR TITLE
chore: Bump moj-frontend to 0.19-alpha

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2286,11 +2286,18 @@
       }
     },
     "@ministryofjustice/frontend": {
-      "version": "0.0.17-alpha",
-      "resolved": "https://registry.npmjs.org/@ministryofjustice/frontend/-/frontend-0.0.17-alpha.tgz",
-      "integrity": "sha512-UOwqFA24kd8xJY6XrWxaQxM2xzr8BHdwb5L82xPk3rG7hgEnWRppk7vt9eszqSt3Hwdfj63pD8aaMTMsi89P4Q==",
+      "version": "0.0.19-alpha",
+      "resolved": "https://registry.npmjs.org/@ministryofjustice/frontend/-/frontend-0.0.19-alpha.tgz",
+      "integrity": "sha512-iNNJSIr+poRiBWxyoi4pxs2qcYRfFzVO9yh6ALPUeKDj9pCm1lWYReWhr02/jLgLEJ3nKdJDxIbGv0c/RxSR/w==",
       "requires": {
-        "moment": "^2.22.2"
+        "moment": "^2.26.0"
+      },
+      "dependencies": {
+        "moment": {
+          "version": "2.27.0",
+          "resolved": "https://registry.npmjs.org/moment/-/moment-2.27.0.tgz",
+          "integrity": "sha512-al0MUK7cpIcglMv3YF13qSgdAIqxHTO7brRtaz3DlSULbqfazqkc5kEjNrLDOM7fsjshoFIihnU8snrP7zUvhQ=="
+        }
       }
     },
     "@mrmlnc/readdir-enhanced": {

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "ministryofjustice"
   ],
   "dependencies": {
-    "@ministryofjustice/frontend": "0.0.17-alpha",
+    "@ministryofjustice/frontend": "0.0.19-alpha",
     "@sentry/node": "5.18.0",
     "accessible-autocomplete": "2.0.2",
     "axios": "0.19.2",


### PR DESCRIPTION
## Proposed changes

### What changed

Upgrade `@ministryofjustice/frontend` to `0.19-alpha`