### PR TITLE
[P4-1736] Support custom validation messages in form wizard

### DIFF
--- a/common/controllers/form-wizard.js
+++ b/common/controllers/form-wizard.js
@@ -54,10 +54,10 @@ class FormController extends Controller {
 
   getErrors(req, res) {
     const errors = super.getErrors(req, res)
-    const errorList = map(errors, ({ key, type }) => {
+    const errorList = map(errors, error => {
       return {
-        html: fieldHelpers.getFieldErrorMessage(key, type),
-        href: `#${key}`,
+        html: fieldHelpers.getFieldErrorMessage(error),
+        href: `#${error.key}`,
       }
     })
 

--- a/common/controllers/form-wizard.test.js
+++ b/common/controllers/form-wizard.test.js
@@ -410,7 +410,7 @@ describe('Form wizard', function () {
     beforeEach(function () {
       sinon
         .stub(fieldHelpers, 'getFieldErrorMessage')
-        .callsFake((key, type) => {
+        .callsFake(({ key, type }) => {
           return `${key}.${type}`
         })
       sinon.stub(FormController.prototype, 'getErrors')
@@ -440,6 +440,7 @@ describe('Form wizard', function () {
           url: '/step-url',
         },
       }
+
       beforeEach(function () {
         FormController.prototype.getErrors.returns(mockErrors)
         const reqMock = {
@@ -454,12 +455,10 @@ describe('Form wizard', function () {
 
       it('should get error messages', function () {
         expect(fieldHelpers.getFieldErrorMessage).to.be.calledWithExactly(
-          mockErrors.fieldOne.key,
-          mockErrors.fieldOne.type
+          mockErrors.fieldOne
         )
         expect(fieldHelpers.getFieldErrorMessage).to.be.calledWithExactly(
-          mockErrors.fieldTwo.key,
-          mockErrors.fieldTwo.type
+          mockErrors.fieldTwo
         )
       })
 

--- a/common/helpers/field/get-field-error-message.js
+++ b/common/helpers/field/get-field-error-message.js
@@ -1,14 +1,26 @@
 const i18n = require('../../../config/i18n')
 
-function getFieldErrorMessage(field, errorType) {
-  const errorLabel = i18n.t(`fields::${field}.label`, {
+function getFieldErrorMessage({
+  message,
+  key: fieldKey,
+  type: errorType,
+} = {}) {
+  if (!fieldKey) {
+    return ''
+  }
+
+  if (message) {
+    return message
+  }
+
+  const errorLabel = i18n.t(`fields::${fieldKey}.label`, {
     context: 'with_error',
   })
   const fallback = i18n.t(`validation::${errorType}`, {
     context: 'with_label',
     label: errorLabel.toLowerCase(),
   })
-  return i18n.t([`fields::${field}.error_message`, fallback], {
+  return i18n.t([`fields::${fieldKey}.error_message`, fallback], {
     context: errorType,
   })
 }

--- a/common/helpers/field/get-field-error-message.test.js
+++ b/common/helpers/field/get-field-error-message.test.js
@@ -4,48 +4,81 @@ const getFieldErrorMessage = require('./get-field-error-message')
 
 describe('Field helpers', function () {
   describe('#getFieldErrorMessage()', function () {
-    const mockFieldKey = 'first_name'
-    const mockErrorType = 'required'
+    const mockFieldError = {
+      key: 'first_name',
+      type: 'required',
+    }
     let errorMessage
 
     beforeEach(function () {
       sinon.stub(i18n, 't').returnsArg(0)
       i18n.t
         .withArgs([
-          `fields::${mockFieldKey}.error_message`,
-          `validation::${mockErrorType}`,
+          `fields::${mockFieldError.key}.error_message`,
+          `validation::${mockFieldError.type}`,
         ])
         .returns('This field is not valid')
-      errorMessage = getFieldErrorMessage(mockFieldKey, mockErrorType)
     })
 
-    it('should translate label with error context', function () {
-      expect(i18n.t).to.be.calledWithExactly(`fields::${mockFieldKey}.label`, {
-        context: 'with_error',
+    context('with no argument', function () {
+      it('should return empty string', function () {
+        const errorMessage = getFieldErrorMessage()
+        expect(errorMessage).to.equal('')
       })
     })
 
-    it('should translate fallback label with label context', function () {
-      expect(i18n.t).to.be.calledWithExactly(`validation::${mockErrorType}`, {
-        context: 'with_label',
-        label: `fields::${mockFieldKey}.label`,
+    context('with custom error message', function () {
+      beforeEach(function () {
+        errorMessage = getFieldErrorMessage({
+          ...mockFieldError,
+          message: 'Custom error message',
+        })
+      })
+
+      it('should translate label with error context', function () {
+        expect(errorMessage).to.equal('Custom error message')
       })
     })
 
-    it('should translate with order preference', function () {
-      expect(i18n.t).to.be.calledWithExactly(
-        [
-          `fields::${mockFieldKey}.error_message`,
-          `validation::${mockErrorType}`,
-        ],
-        {
-          context: mockErrorType,
-        }
-      )
-    })
+    context('without custom error message', function () {
+      beforeEach(function () {
+        errorMessage = getFieldErrorMessage(mockFieldError)
+      })
 
-    it('should return error message', function () {
-      expect(errorMessage).to.deep.equal('This field is not valid')
+      it('should translate label with error context', function () {
+        expect(i18n.t).to.be.calledWithExactly(
+          `fields::${mockFieldError.key}.label`,
+          {
+            context: 'with_error',
+          }
+        )
+      })
+
+      it('should translate fallback label with label context', function () {
+        expect(i18n.t).to.be.calledWithExactly(
+          `validation::${mockFieldError.type}`,
+          {
+            context: 'with_label',
+            label: `fields::${mockFieldError.key}.label`,
+          }
+        )
+      })
+
+      it('should translate with order preference', function () {
+        expect(i18n.t).to.be.calledWithExactly(
+          [
+            `fields::${mockFieldError.key}.error_message`,
+            `validation::${mockFieldError.type}`,
+          ],
+          {
+            context: mockFieldError.type,
+          }
+        )
+      })
+
+      it('should return error message', function () {
+        expect(errorMessage).to.deep.equal('This field is not valid')
+      })
     })
   })
 })

--- a/common/helpers/field/set-field-error.js
+++ b/common/helpers/field/set-field-error.js
@@ -13,7 +13,7 @@ function setFieldError(errors) {
       {
         ...field,
         errorMessage: {
-          html: getFieldErrorMessage(fieldError.key, fieldError.type),
+          html: getFieldErrorMessage(fieldError),
         },
       },
     ]

--- a/common/helpers/field/set-field-error.test.js
+++ b/common/helpers/field/set-field-error.test.js
@@ -38,10 +38,9 @@ describe('Field helpers', function () {
         response = setFieldError(errors)(field)
       })
 
-      it('should get the error message', function () {
+      it('should call getFieldErrorMessage with error object', function () {
         expect(getFieldErrorMessageStub).to.be.calledOnceWithExactly(
-          'error_field',
-          'required'
+          errors.error_field
         )
       })
 

--- a/common/services/frameworks.js
+++ b/common/services/frameworks.js
@@ -32,8 +32,12 @@ function importFiles(folderPath) {
 
 function transformQuestion(
   key,
-  { question, hint, options, validations = [], type }
+  { question, hint, options, validations = [], type } = {}
 ) {
+  if (!key) {
+    return {}
+  }
+
   const labelPath = labelPathMap[type] || labelPathMap.default
   const component = uiComponentMap[type] || uiComponentMap.default
   const field = {
@@ -41,7 +45,7 @@ function transformQuestion(
     component,
     id: key,
     name: key,
-    validate: validations.map(validation => validation.name),
+    validate: validations,
   }
 
   set(field, labelPath, {

--- a/common/services/frameworks.test.js
+++ b/common/services/frameworks.test.js
@@ -14,7 +14,12 @@ const frameworksService = proxyquire('./frameworks', {
 
 describe('Frameworks service', function () {
   describe('#transformQuestion', function () {
-    context('with no options', function () {})
+    context('with no options', function () {
+      it('should return an empty object', function () {
+        const transformed = frameworksService.transformQuestion()
+        expect(transformed).to.deep.equal({})
+      })
+    })
 
     context('with options', function () {
       let mockQuestion
@@ -81,10 +86,12 @@ describe('Frameworks service', function () {
             ...mockQuestion,
             validations: [
               {
-                name: 'required',
+                type: 'required',
+                message: 'This field is required',
               },
               {
-                name: 'date',
+                type: 'date',
+                message: 'This must be a date',
               },
             ],
           }
@@ -104,7 +111,16 @@ describe('Frameworks service', function () {
               text: 'Question text',
               classes: 'govuk-label--s',
             },
-            validate: ['required', 'date'],
+            validate: [
+              {
+                type: 'required',
+                message: 'This field is required',
+              },
+              {
+                type: 'date',
+                message: 'This must be a date',
+              },
+            ],
           })
         })
       })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

This adds support to define a custom validation message within the
fields configuration that can be used to render the validation
message.

### Why did it change

The form wizard currently uses the translation files to build form validation messages.

However, when importing the frameworks we want to keep the validation message tied to the field
configuration. The manifest defines that the message can be supplied as part of the validation object.

With this change we can pass this directly to the form wizard and then extract that message 
so that it can be used to render the message in the error summary and on the field.

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

- [P4-1736](https://dsdmoj.atlassian.net/browse/P4-1736)

## Screenshots
<!--- (Optional) Include screenshots if changes update interfaces or components -->
<!--- Delete/copy as appropriate --->

| Validation message output | Manifest file defintion |
| ------ | ----- |
| <kbd><img src="https://user-images.githubusercontent.com/3327997/85864874-fcb9ef80-b7bc-11ea-9ee0-a7842a2e56c1.png"></kbd> | <kbd><img src="https://user-images.githubusercontent.com/3327997/85864907-08a5b180-b7bd-11ea-8253-cc1eefe7a792.png"></kbd> |

## Checklists

### Testing

#### Automated testing

- [ ] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [x] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed

### Other considerations

- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
- [x] Update [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md) with any new instructions or tasks
