### PR TITLE
[P4-1741] Support save and return in Person Escort Record steps

### DIFF
--- a/app/person-escort-record/controllers.js
+++ b/app/person-escort-record/controllers.js
@@ -1,0 +1,15 @@
+const FormWizardController = require('../../common/controllers/form-wizard')
+
+class FrameworksController extends FormWizardController {
+  successHandler(req, res, next) {
+    if (req.body.save_and_return_to_overview) {
+      return res.redirect(req.baseUrl)
+    }
+
+    super.successHandler(req, res, next)
+  }
+}
+
+module.exports = {
+  FrameworksController,
+}

--- a/app/person-escort-record/controllers.test.js
+++ b/app/person-escort-record/controllers.test.js
@@ -1,0 +1,63 @@
+const FormWizardController = require('../../common/controllers/form-wizard')
+
+const controllers = require('./controllers')
+
+describe('Person Escort Record controllers', function () {
+  describe('FrameworksController', function () {
+    const controller = new controllers.FrameworksController({ route: '/' })
+
+    describe('#successHandler', function () {
+      let mockReq, mockRes, nextSpy
+
+      beforeEach(function () {
+        mockReq = {
+          body: {},
+          baseUrl: '/base-url',
+        }
+        mockRes = {
+          redirect: sinon.stub(),
+        }
+        nextSpy = sinon.stub()
+
+        sinon.stub(FormWizardController.prototype, 'successHandler')
+      })
+
+      context('with save and return submission', function () {
+        beforeEach(function () {
+          mockReq.body = {
+            save_and_return_to_overview: '1',
+          }
+          controller.successHandler(mockReq, mockRes, nextSpy)
+        })
+
+        it('should redirect to base URL', function () {
+          expect(mockRes.redirect).to.have.been.calledOnceWithExactly(
+            '/base-url'
+          )
+        })
+
+        it('should not call parent success handler', function () {
+          expect(
+            FormWizardController.prototype.successHandler
+          ).not.to.have.been.called
+        })
+      })
+
+      context('with standard submission', function () {
+        beforeEach(function () {
+          controller.successHandler(mockReq, mockRes, nextSpy)
+        })
+
+        it('should not redirect to base URL', function () {
+          expect(mockRes.redirect).not.to.have.been.called
+        })
+
+        it('should call parent success handler', function () {
+          expect(
+            FormWizardController.prototype.successHandler
+          ).to.have.been.calledOnce
+        })
+      })
+    })
+  })
+})

--- a/app/person-escort-record/router.js
+++ b/app/person-escort-record/router.js
@@ -1,7 +1,6 @@
 const wizard = require('hmpo-form-wizard')
 
-const FormWizardController = require('../../common/controllers/form-wizard')
-
+const { FrameworksController } = require('./controllers')
 const middleware = require('./middleware')
 
 function defineFormWizards(framework, router) {
@@ -13,12 +12,13 @@ function defineFormWizards(framework, router) {
     const section = sections[sectionKey]
     const wizardConfig = {
       buttonText: 'actions::save_and_continue',
-      controller: FormWizardController,
+      controller: FrameworksController,
       entryPoint: true,
       journeyName: `person-escort-record-${sectionKey}`,
       journeyPageTitle: 'Person escort record',
       name: `person-escort-record-${sectionKey}`,
-      template: 'form-wizard',
+      template: 'form-step',
+      templatePath: 'person-escort-record/views/',
     }
     const steps = {
       '/': {

--- a/app/person-escort-record/router.test.js
+++ b/app/person-escort-record/router.test.js
@@ -1,7 +1,6 @@
 const proxyquire = require('proxyquire')
 
-const FormWizardController = require('../../common/controllers/form-wizard')
-
+const { FrameworksController } = require('./controllers')
 const middleware = require('./middleware')
 
 const wizardReqStub = sinon.stub()
@@ -58,6 +57,11 @@ describe('Person Escort Record router', function () {
       router.defineFormWizards(mockFramework, mockRouter)
     })
 
+    afterEach(function () {
+      wizardStub.resetHistory()
+      wizardReqStub.resetHistory()
+    })
+
     describe('router', function () {
       it('should setup setFramework middleware', function () {
         expect(mockRouter.use).to.be.calledWithExactly(
@@ -81,12 +85,13 @@ describe('Person Escort Record router', function () {
           }
           const config = {
             buttonText: 'actions::save_and_continue',
-            controller: FormWizardController,
+            controller: FrameworksController,
             entryPoint: true,
             journeyName: `person-escort-record-${key}`,
             journeyPageTitle: 'Person escort record',
             name: `person-escort-record-${key}`,
-            template: 'form-wizard',
+            template: 'form-step',
+            templatePath: 'person-escort-record/views/',
           }
 
           expect(mockRouter.use).to.be.calledWithExactly(
@@ -99,6 +104,10 @@ describe('Person Escort Record router', function () {
 
     describe('form wizard', function () {
       const sectionCount = Object.keys(mockFramework.sections).length
+
+      it('should call form wizard correct number of times', function () {
+        expect(wizardStub.callCount).to.equal(sectionCount)
+      })
 
       it('should call form wizard with correct number of arguments', function () {
         for (let index = 0; index < sectionCount.length; index++) {
@@ -117,12 +126,13 @@ describe('Person Escort Record router', function () {
           }
           const config = {
             buttonText: 'actions::save_and_continue',
-            controller: FormWizardController,
+            controller: FrameworksController,
             entryPoint: true,
             journeyName: `person-escort-record-${key}`,
             journeyPageTitle: 'Person escort record',
             name: `person-escort-record-${key}`,
-            template: 'form-wizard',
+            template: 'form-step',
+            templatePath: 'person-escort-record/views/',
           }
 
           expect(wizardStub).to.be.calledWithExactly(
@@ -132,10 +142,6 @@ describe('Person Escort Record router', function () {
           )
         }
       })
-
-      // it('should call form wizard handler', function () {
-      //   expect(wizardReqStub).to.be.calledWithExactly(mockReq, mockRes, nextSpy)
-      // })
     })
   })
 })

--- a/app/person-escort-record/views/form-step.njk
+++ b/app/person-escort-record/views/form-step.njk
@@ -1,0 +1,13 @@
+{% extends "form-wizard.njk" %}
+
+{% block submitAction %}
+  {{ super() }}
+
+  {{ govukButton({
+    text: t("actions::save_and_return_to_overview"),
+    name: "save_and_return_to_overview",
+    value: "1",
+    type: "submit",
+    classes: "govuk-button--secondary"
+  }) }}
+{% endblock %}

--- a/locales/en/actions.json
+++ b/locales/en/actions.json
@@ -34,6 +34,7 @@
   "switch_location": "Switch location",
   "confirm_and_save": "Confirm and save",
   "save_and_continue": "Save and continue",
+  "save_and_return_to_overview": "Save and return to overview",
   "view_more_information": "View more information",
   "review": "Review"
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

This creates a new base controller for a frameworks step.

It introduces a custom success handler that checks for the presence
of the save and return button.

If a user has clicked this button instead of the standard submit
button they will be taken back to the section overview.

**Note:** It's not possible to partially save a step. All fields must pass validation to be able to save and return
to the overview. If a user navigates away they will lose the progress of the current step, but this behaviour is
consistent with other journeys within the service and with many other web forms.

### Why did it change

Completing the Person Escort Record can be a lengthy process and users may need to save their progress
and return another time. This features allows them to save the current step and come back when they are
ready to complete more steps.

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

- [P4-1741](https://dsdmoj.atlassian.net/browse/P4-1741)

**Note:** This implementation uses the [secondary button](https://design-system.service.gov.uk/components/button/#secondary-buttons) from the GOV.UK Design System instead of a text link as seen in the prototype. The reason for this is because semantically it is a button and results in a form submission instead of link behaviour where a user is taken to another location on the web. Therefore it is better to communicate that both visually and semantically to the user. This implementation also matches the example on the Design System of second submit actions using the secondary button style instead of a link.

## Screenshots
<!--- (Optional) Include screenshots if changes update interfaces or components -->
<!--- Delete/copy as appropriate --->

<kbd><img src="https://user-images.githubusercontent.com/3327997/85871032-c5037580-b7c5-11ea-8126-da477a2aa0fd.png"></kbd>

## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [x] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed

### Other considerations

Commit messages with a `fix` or `feat` type are automatically used to generate the [changelog](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/CHANGELOG.md) and
[GitHub release notes](https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/releases) during the release task. Please make sure they will read well on their own in a
summary of changes and that the commit body gives a more detailed description of those changes if necessary.

- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
- [x] Update [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md) with any new instructions or tasks
