### PR TITLE
fix: Set app timezone to be Europe/London explicitly

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,8 @@ It will also start a new deployment specific [job on CircleCI](https://app.circl
 
 ## Environment variables
 
+The TZ (timezone) environment variable is set to 'Europe/London' in `start.js`.
+
 | Name | Description | Default |
 |:-----|:------------|:--------|
 | PORT | Port the web server listens on | `3000` |

--- a/start.js
+++ b/start.js
@@ -4,6 +4,9 @@ const { PORT } = require('./config')
 const logger = require('./config/logger')
 const app = require('./server')
 
+// eslint-disable-next-line no-process-env
+process.env.TZ = 'Europe/London'
+
 /**
  * Get port from config and store in Express.
  */


### PR DESCRIPTION
Datetimes were being sent as UTC since container does not have zone info.

This brings the behaviour in line with the rails app for the API


### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed

### Other considerations

- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics

