### PR TITLE
Migrate documents from move to profile

### DIFF
--- a/app/move/controllers/create/save.js
+++ b/app/move/controllers/create/save.js
@@ -27,7 +27,7 @@ class SaveController extends CreateBaseController {
         'errors',
         'errorValues',
         'assessment',
-        'documents',
+        // 'documents', // TODO: reinstate when move to v2
         'person',
       ])
 

--- a/app/move/controllers/create/save.js
+++ b/app/move/controllers/create/save.js
@@ -21,16 +21,19 @@ class SaveController extends CreateBaseController {
       const sessionData = req.sessionModel.toJSON()
       const person = sessionData.person
       const assessment = sessionData.assessment
+      const documents = sessionData.documents
       const data = omit(sessionData, [
         'csrf-secret',
         'errors',
         'errorValues',
         'assessment',
+        'documents',
         'person',
       ])
 
       const profile = await profileService.create(person.id, {
         assessment_answers: assessment,
+        documents,
       })
 
       const moveData = {

--- a/app/move/controllers/create/save.test.js
+++ b/app/move/controllers/create/save.test.js
@@ -52,6 +52,9 @@ const mockValues = {
     first_names: 'Steve',
     last_name: 'Smith',
   },
+  profile: {
+    id: '__profile',
+  },
   assessment: {
     court: [
       {
@@ -80,6 +83,11 @@ const mockValues = {
       },
     ],
   },
+  documents: [
+    {
+      id: 'document_1',
+    },
+  ],
 }
 
 describe('Move controllers', function () {
@@ -124,7 +132,10 @@ describe('Move controllers', function () {
           it('should create profile', function () {
             expect(profileService.create).to.be.calledOnceWithExactly(
               mockValues.person.id,
-              { assessment_answers: mockValues.assessment }
+              {
+                assessment_answers: mockValues.assessment,
+                documents: mockValues.documents,
+              }
             )
           })
 
@@ -186,6 +197,7 @@ describe('Move controllers', function () {
                 mockValuesWithHearings.person.id,
                 {
                   assessment_answers: mockValuesWithHearings.assessment,
+                  documents: mockValuesWithHearings.documents,
                 }
               )
             })

--- a/app/move/controllers/create/save.test.js
+++ b/app/move/controllers/create/save.test.js
@@ -37,6 +37,12 @@ const mockMove = {
   },
   person: mockPerson,
 }
+const mockDocuments = [
+  {
+    id: 'document_1',
+  },
+]
+
 const mockValues = {
   'csrf-secret': 'secret',
   errors: null,
@@ -83,11 +89,7 @@ const mockValues = {
       },
     ],
   },
-  documents: [
-    {
-      id: 'document_1',
-    },
-  ],
+  documents: mockDocuments,
 }
 
 describe('Move controllers', function () {
@@ -126,6 +128,7 @@ describe('Move controllers', function () {
               to_location: 'Court',
               from_location: 'Prison',
               profile: mockProfile,
+              documents: mockDocuments, // TODO: remove when v2
             })
           })
 
@@ -134,7 +137,7 @@ describe('Move controllers', function () {
               mockValues.person.id,
               {
                 assessment_answers: mockValues.assessment,
-                documents: mockValues.documents,
+                documents: mockDocuments,
               }
             )
           })
@@ -189,6 +192,7 @@ describe('Move controllers', function () {
                 from_location: 'Prison',
                 profile: mockProfile,
                 court_hearings: mockValuesWithHearings.court_hearings,
+                documents: mockDocuments, // TODO: remove when v2
               })
             })
 
@@ -258,6 +262,7 @@ describe('Move controllers', function () {
                 profile: mockProfile,
                 court_hearings: mockValuesWithHearings.court_hearings,
                 should_save_court_hearings: shouldSaveCourtHearingsFalseValue,
+                documents: mockDocuments, // TODO: remove when v2
               })
             })
 

--- a/app/move/controllers/update/document.js
+++ b/app/move/controllers/update/document.js
@@ -1,4 +1,4 @@
-const { get } = require('lodash')
+const { get, pick } = require('lodash')
 
 const profileService = require('../../../../common/services/profile')
 const DocumentUploadController = require('../create/document')
@@ -50,7 +50,7 @@ class UpdateDocumentUploadController extends UpdateBase {
     }
 
     try {
-      const profile = req.getMove().profile
+      const profile = pick(req.getMove().profile, ['id', 'person'])
 
       await profileService.update({
         ...profile,

--- a/app/move/controllers/update/document.js
+++ b/app/move/controllers/update/document.js
@@ -1,6 +1,6 @@
 const { get } = require('lodash')
 
-const moveService = require('../../../../common/services/move')
+const profileService = require('../../../../common/services/profile')
 const DocumentUploadController = require('../create/document')
 
 const UpdateBase = require('./base')
@@ -33,7 +33,7 @@ class UpdateDocumentUploadController extends UpdateBase {
     const values = {}
 
     if (req.initialStep) {
-      req.sessionModel.set('documents', move.documents)
+      req.sessionModel.set('documents', move.profile.documents)
     }
 
     values.documents = req.sessionModel.get('documents')
@@ -50,8 +50,10 @@ class UpdateDocumentUploadController extends UpdateBase {
     }
 
     try {
-      await moveService.update({
-        id: req.getMoveId(),
+      const profile = req.getMove().profile
+
+      await profileService.update({
+        ...profile,
         documents: req.form.values.documents,
       })
       return res.redirect(this.getBaseUrl(req))

--- a/app/move/controllers/update/document.test.js
+++ b/app/move/controllers/update/document.test.js
@@ -1,4 +1,4 @@
-const moveService = require('../../../../common/services/move')
+const profileService = require('../../../../common/services/profile')
 const CreateDocument = require('../create/document')
 
 const UpdateBaseController = require('./base')
@@ -139,7 +139,7 @@ describe('Move controllers', function () {
       })
 
       context('When a move exists', function () {
-        const move = { id: '#move', documents }
+        const move = { id: '#move', profile: { id: '#profile', documents } }
         let values
         beforeEach(function () {
           req.getMove.returns(move)
@@ -185,10 +185,11 @@ describe('Move controllers', function () {
       let res = {}
       let nextSpy
       const documents = [{ id: 'foo' }, { id: 'bar' }]
+      const profile = { id: '#profile' }
 
       beforeEach(async function () {
         req = {
-          getMoveId: sinon.stub().returns('__moveId__'),
+          getMove: sinon.stub().returns({ profile }),
           form: {
             values: {
               documents,
@@ -198,7 +199,7 @@ describe('Move controllers', function () {
         res = {
           redirect: sinon.stub(),
         }
-        sinon.stub(moveService, 'update').resolves({})
+        sinon.stub(profileService, 'update').resolves({})
         sinon.stub(controller, 'getBaseUrl').returns('__url__')
         sinon.stub(MixinProto, 'successHandler')
         nextSpy = sinon.spy()
@@ -209,8 +210,8 @@ describe('Move controllers', function () {
           await controller.successHandler(req, res, nextSpy)
         })
         it('should update the move', async function () {
-          expect(moveService.update).to.be.calledOnceWithExactly({
-            id: '__moveId__',
+          expect(profileService.update).to.be.calledOnceWithExactly({
+            ...profile,
             documents,
           })
         })
@@ -232,7 +233,7 @@ describe('Move controllers', function () {
       context('When saving fails', function () {
         const error = new Error('boom')
         beforeEach(async function () {
-          moveService.update.throws(error)
+          profileService.update.throws(error)
           await controller.successHandler(req, res, nextSpy)
         })
 
@@ -248,7 +249,7 @@ describe('Move controllers', function () {
         })
 
         it('should not update the move', async function () {
-          expect(moveService.update).not.to.be.called
+          expect(profileService.update).not.to.be.called
         })
 
         it('should invoke mixin’s successHandler', async function () {

--- a/app/move/controllers/update/document.test.js
+++ b/app/move/controllers/update/document.test.js
@@ -185,11 +185,12 @@ describe('Move controllers', function () {
       let res = {}
       let nextSpy
       const documents = [{ id: 'foo' }, { id: 'bar' }]
-      const profile = { id: '#profile' }
+      const profile = { id: '#profile', person: { id: '#person' } }
+      const mockProfile = { ...profile, foo: 'bar' }
 
       beforeEach(async function () {
         req = {
-          getMove: sinon.stub().returns({ profile }),
+          getMove: sinon.stub().returns({ profile: mockProfile }),
           form: {
             values: {
               documents,

--- a/app/move/views/view.njk
+++ b/app/move/views/view.njk
@@ -153,13 +153,13 @@
         <section class="app-!-position-relative">
           <h2 class="govuk-heading-m govuk-!-margin-top-7">
             {{ t("moves::detail.documents.heading", {
-              count: move.documents.length if move.documents.length > 1
+              count: move.profile.documents.length if move.profile.documents.length > 1
             }) }}
           </h2>
 
-          {% if move.documents | length %}
+          {% if move.profile.documents | length %}
             <ul class="govuk-list">
-              {% for document in move.documents %}
+              {% for document in move.profile.documents %}
                 <li class="govuk-!-margin-bottom-3">
                   <a href="{{ document.url }}"
                     class="govuk-link"

--- a/common/lib/api-client/models.js
+++ b/common/lib/api-client/models.js
@@ -54,6 +54,7 @@ module.exports = {
         'from_location.suppliers',
         'prison_transfer_reason',
         'profile',
+        'profile.documents',
         'profile.person',
         'profile.person.ethnicity',
         'profile.person.gender',

--- a/common/lib/api-client/models.js
+++ b/common/lib/api-client/models.js
@@ -98,9 +98,13 @@ module.exports = {
         jsonApi: 'hasOne',
         type: 'people',
       },
+      documents: {
+        jsonApi: 'hasMany',
+        type: 'documents',
+      },
     },
     options: {
-      defaultInclude: ['person'],
+      defaultInclude: ['person', 'documents'],
     },
   },
   court_case: {

--- a/test/fixtures/api-client/profile.create.json
+++ b/test/fixtures/api-client/profile.create.json
@@ -84,6 +84,9 @@
           "id": "ffe852c4-493b-9154-9afb-18dde544f2cf",
           "type": "people"
         }
+      },
+      "documents": {
+        "data": []
       }
     }
   },


### PR DESCRIPTION
## Proposed changes

### What changed

Store and fetch documents on/from profile rather than move

https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/pull/636/commits/fc45e930eddf510aee34c046d7c6121b550a3a08 can be reverted when we update to v2 of the API

### Why did it change

API improvements

### Issue tracking

n/a

## Screenshots

Functionally identical

## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed


### Other considerations

- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics

