### PR TITLE
build: Fix reference to frameworks repo in package lockfile

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15452,7 +15452,7 @@
       }
     },
     "hmpps-book-secure-move-frameworks": {
-      "version": "github:ministryofjustice/hmpps-book-secure-move-frameworks#d616072d382ea492f40f266d4675a9c45326a6b1",
+      "version": "github:ministryofjustice/hmpps-book-secure-move-frameworks#e96d50016905b3acedbd9ec952501563992d0fff",
       "from": "github:ministryofjustice/hmpps-book-secure-move-frameworks"
     },
     "home-or-tmp": {


### PR DESCRIPTION
## Proposed changes

### What changed

Update the package-lock.json file

### Why did it change

The package-lock.json file was pointing to a commit that was on a branch
that has since been removed. This updates the package lock file to
point to a valid commit within the frameworks repo.

## Checklists

### Testing

#### Automated testing

- [ ] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [x] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed

### Other considerations

Commit messages with a `fix` or `feat` type are automatically used to generate the [changelog](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/CHANGELOG.md) and
[GitHub release notes](https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/releases) during the release task. Please make sure they will read well on their own in a
summary of changes and that the commit body gives a more detailed description of those changes if necessary.

- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
- [x] Update [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md) with any new instructions or tasks
