### PR TITLE
build: Use combined log format when in production-like envs

### DIFF
--- a/server.js
+++ b/server.js
@@ -83,7 +83,10 @@ app.use(
 
 // ensure i18n is loaded early as needed for error template
 app.use(i18nMiddleware.handle(i18n))
-app.use(morgan('dev'))
+
+const loggingFormat = config.IS_PRODUCTION ? 'combined' : 'dev'
+app.use(morgan(loggingFormat))
+
 app.use(compression())
 app.use(express.json())
 app.use(express.urlencoded({ extended: true, limit: '1mb' }))


### PR DESCRIPTION
## Proposed changes

### What changed

Use `combined` log format in production-like environements

### Why did it change

We were using `dev` before - which both has less info than we want plus colour-ctl sequences in the output

### Issue tracking

n/a

## Screenshots

n/a

## Checklists

### Testing

#### Automated testing

- [ ] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed


### Other considerations

- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics

