### PR TITLE
[P4-1737] Save responses for Person Escort Record

### DIFF
--- a/app/person-escort-record/controllers/framework-section.js
+++ b/app/person-escort-record/controllers/framework-section.js
@@ -1,0 +1,29 @@
+const { filter } = require('lodash')
+
+const presenters = require('../../../common/presenters')
+
+const FrameworksController = require('./frameworks')
+
+class FrameworkSectionController extends FrameworksController {
+  middlewareLocals() {
+    super.middlewareLocals()
+    this.use(this.setSectionSummary)
+  }
+
+  setSectionSummary(req, res, next) {
+    const { name, steps } = req.frameworkSection
+    const stepSummaries = Object.entries(steps).map(
+      presenters.frameworkStepToSummary(
+        req.form.options.allFields,
+        req.originalUrl
+      )
+    )
+
+    res.locals.sectionTitle = name
+    res.locals.summarySteps = filter(stepSummaries)
+
+    next()
+  }
+}
+
+module.exports = FrameworkSectionController

--- a/app/person-escort-record/controllers/framework-section.test.js
+++ b/app/person-escort-record/controllers/framework-section.test.js
@@ -1,0 +1,113 @@
+const presenters = require('../../../common/presenters')
+
+const Controller = require('./framework-section')
+const FrameworksController = require('./frameworks')
+
+const controller = new Controller({
+  route: '/',
+})
+
+describe('Person Escort Record controllers', function () {
+  describe('FrameworkSectionController', function () {
+    describe('#middlewareLocals()', function () {
+      beforeEach(function () {
+        sinon.stub(FrameworksController.prototype, 'middlewareLocals')
+        sinon.stub(controller, 'use')
+
+        controller.middlewareLocals()
+      })
+
+      it('should call parent method', function () {
+        expect(FrameworksController.prototype.middlewareLocals).to.have.been
+          .calledOnce
+      })
+
+      it('should call set models method', function () {
+        expect(controller.use.getCall(0)).to.have.been.calledWithExactly(
+          controller.setSectionSummary
+        )
+      })
+
+      it('should call correct number of middleware', function () {
+        expect(controller.use).to.be.callCount(1)
+      })
+    })
+
+    describe('#setSectionSummary', function () {
+      let mockReq, mockRes, nextSpy, mapStub
+
+      beforeEach(function () {
+        nextSpy = sinon.spy()
+        mockReq = {
+          originalUrl: '/original-url',
+          form: {
+            options: {
+              allFields: {
+                fieldOne: { name: 'field-one' },
+                fieldTwo: { name: 'field-two' },
+              },
+            },
+          },
+          frameworkSection: {
+            name: 'Foo',
+            steps: {
+              '/step-1': {},
+              '/step-2': {},
+              '/step-3': {},
+            },
+          },
+        }
+        mockRes = {
+          locals: {},
+        }
+        mapStub = sinon
+          .stub()
+          .onCall(0)
+          .returns(['/step-1', { url: '/step-one' }])
+          .onCall(1)
+          .returns(undefined)
+          .onCall(2)
+          .returns(['/step-3', { url: '/step-three' }])
+        sinon.stub(presenters, 'frameworkStepToSummary').returns(mapStub)
+
+        controller.setSectionSummary(mockReq, mockRes, nextSpy)
+      })
+
+      it('should set section title', function () {
+        expect(mockRes.locals.sectionTitle).to.equal('Foo')
+      })
+
+      it('should call presenter', function () {
+        expect(presenters.frameworkStepToSummary).to.be.calledOnceWithExactly(
+          mockReq.form.options.allFields,
+          mockReq.originalUrl
+        )
+      })
+
+      it('should map each item', function () {
+        expect(mapStub.callCount).to.equal(3)
+      })
+
+      it('should set summary steps filtering any falsy values', function () {
+        expect(mockRes.locals.summarySteps).to.deep.equal([
+          [
+            '/step-1',
+            {
+              url: '/step-one',
+            },
+          ],
+          [
+            '/step-3',
+            {
+              url: '/step-three',
+            },
+          ],
+        ])
+      })
+
+      it('should call next without error', function () {
+        expect(nextSpy).to.be.calledOnceWithExactly()
+      })
+    })
+  })
+})

--- a/app/person-escort-record/controllers/frameworks.js
+++ b/app/person-escort-record/controllers/frameworks.js
@@ -1,7 +1,7 @@
 const { filter } = require('lodash')
 
-const FormWizardController = require('../../common/controllers/form-wizard')
-const presenters = require('../../common/presenters')
+const FormWizardController = require('../../../common/controllers/form-wizard')
+const presenters = require('../../../common/presenters')
 
 class FrameworksController extends FormWizardController {
   middlewareSetup() {

--- a/app/person-escort-record/controllers/frameworks.js
+++ b/app/person-escort-record/controllers/frameworks.js
@@ -1,7 +1,4 @@
-const { filter } = require('lodash')
-
 const FormWizardController = require('../../../common/controllers/form-wizard')
-const presenters = require('../../../common/presenters')
 
 class FrameworksController extends FormWizardController {
   middlewareSetup() {
@@ -30,29 +27,4 @@ class FrameworksController extends FormWizardController {
   }
 }
 
-class FrameworkSectionController extends FrameworksController {
-  middlewareLocals() {
-    super.middlewareLocals()
-    this.use(this.setSectionSummary)
-  }
-
-  setSectionSummary(req, res, next) {
-    const { name, steps } = req.frameworkSection
-    const stepSummaries = Object.entries(steps).map(
-      presenters.frameworkStepToSummary(
-        req.form.options.allFields,
-        req.originalUrl
-      )
-    )
-
-    res.locals.sectionTitle = name
-    res.locals.summarySteps = filter(stepSummaries)
-
-    next()
-  }
-}
-
-module.exports = {
-  FrameworksController,
-  FrameworkSectionController,
-}
+module.exports = FrameworksController

--- a/app/person-escort-record/controllers/frameworks.test.js
+++ b/app/person-escort-record/controllers/frameworks.test.js
@@ -1,12 +1,11 @@
 const FormWizardController = require('../../../common/controllers/form-wizard')
-const presenters = require('../../../common/presenters')
 
-const controllers = require('./')
+const Controller = require('./frameworks')
+
+const controller = new Controller({ route: '/' })
 
 describe('Person Escort Record controllers', function () {
   describe('FrameworksController', function () {
-    const controller = new controllers.FrameworksController({ route: '/' })
-
     describe('#middlewareSetup()', function () {
       beforeEach(function () {
         sinon.stub(FormWizardController.prototype, 'middlewareSetup')
@@ -126,116 +125,6 @@ describe('Person Escort Record controllers', function () {
             FormWizardController.prototype.successHandler
           ).to.have.been.calledOnce
         })
-      })
-    })
-  })
-
-  describe('#FrameworkSectionController', function () {
-    const controller = new controllers.FrameworkSectionController({
-      route: '/',
-    })
-
-    describe('#middlewareLocals()', function () {
-      beforeEach(function () {
-        sinon.stub(
-          controllers.FrameworksController.prototype,
-          'middlewareLocals'
-        )
-        sinon.stub(controller, 'use')
-
-        controller.middlewareLocals()
-      })
-
-      it('should call parent method', function () {
-        expect(controllers.FrameworksController.prototype.middlewareLocals).to
-          .have.been.calledOnce
-      })
-
-      it('should call set models method', function () {
-        expect(controller.use.getCall(0)).to.have.been.calledWithExactly(
-          controller.setSectionSummary
-        )
-      })
-
-      it('should call correct number of middleware', function () {
-        expect(controller.use).to.be.callCount(1)
-      })
-    })
-
-    describe('#setSectionSummary', function () {
-      let mockReq, mockRes, nextSpy, mapStub
-
-      beforeEach(function () {
-        nextSpy = sinon.spy()
-        mockReq = {
-          originalUrl: '/original-url',
-          form: {
-            options: {
-              allFields: {
-                fieldOne: { name: 'field-one' },
-                fieldTwo: { name: 'field-two' },
-              },
-            },
-          },
-          frameworkSection: {
-            name: 'Foo',
-            steps: {
-              '/step-1': {},
-              '/step-2': {},
-              '/step-3': {},
-            },
-          },
-        }
-        mockRes = {
-          locals: {},
-        }
-        mapStub = sinon
-          .stub()
-          .onCall(0)
-          .returns(['/step-1', { url: '/step-one' }])
-          .onCall(1)
-          .returns(undefined)
-          .onCall(2)
-          .returns(['/step-3', { url: '/step-three' }])
-        sinon.stub(presenters, 'frameworkStepToSummary').returns(mapStub)
-
-        controller.setSectionSummary(mockReq, mockRes, nextSpy)
-      })
-
-      it('should set section title', function () {
-        expect(mockRes.locals.sectionTitle).to.equal('Foo')
-      })
-
-      it('should call presenter', function () {
-        expect(presenters.frameworkStepToSummary).to.be.calledOnceWithExactly(
-          mockReq.form.options.allFields,
-          mockReq.originalUrl
-        )
-      })
-
-      it('should map each item', function () {
-        expect(mapStub.callCount).to.equal(3)
-      })
-
-      it('should set summary steps filtering any falsy values', function () {
-        expect(mockRes.locals.summarySteps).to.deep.equal([
-          [
-            '/step-1',
-            {
-              url: '/step-one',
-            },
-          ],
-          [
-            '/step-3',
-            {
-              url: '/step-three',
-            },
-          ],
-        ])
-      })
-
-      it('should call next without error', function () {
-        expect(nextSpy).to.be.calledOnceWithExactly()
       })
     })
   })

--- a/app/person-escort-record/controllers/frameworks.test.js
+++ b/app/person-escort-record/controllers/frameworks.test.js
@@ -1,7 +1,7 @@
-const FormWizardController = require('../../common/controllers/form-wizard')
-const presenters = require('../../common/presenters')
+const FormWizardController = require('../../../common/controllers/form-wizard')
+const presenters = require('../../../common/presenters')
 
-const controllers = require('./controllers')
+const controllers = require('./')
 
 describe('Person Escort Record controllers', function () {
   describe('FrameworksController', function () {

--- a/app/person-escort-record/controllers/index.js
+++ b/app/person-escort-record/controllers/index.js
@@ -1,0 +1,7 @@
+const FrameworkSectionController = require('./framework-section')
+const FrameworksController = require('./framework-section')
+
+module.exports = {
+  FrameworksController,
+  FrameworkSectionController,
+}

--- a/common/services/framework-response.js
+++ b/common/services/framework-response.js
@@ -1,0 +1,17 @@
+const apiClient = require('../lib/api-client')()
+
+const noIdMessage = 'No resource ID supplied'
+
+const frameworkResponseService = {
+  update(data = {}) {
+    if (!data.id) {
+      return Promise.reject(new Error(noIdMessage))
+    }
+
+    return apiClient
+      .update('framework_response', data)
+      .then(response => response.data)
+  },
+}
+
+module.exports = frameworkResponseService

--- a/common/services/framework-response.test.js
+++ b/common/services/framework-response.test.js
@@ -1,0 +1,47 @@
+const apiClient = require('../lib/api-client')()
+
+const frameworkResponseService = require('./framework-response')
+
+const mockFrameworkResponse = {
+  id: '12345',
+}
+
+describe('Presenters', function () {
+  describe('Framework Response Service', function () {
+    describe('#update()', function () {
+      const mockResponse = {
+        data: mockFrameworkResponse,
+      }
+      let response
+
+      context('without resource ID', function () {
+        it('should reject with error', function () {
+          return expect(frameworkResponseService.update()).to.be.rejectedWith(
+            'No resource ID supplied'
+          )
+        })
+      })
+
+      context('with resource ID', function () {
+        beforeEach(async function () {
+          sinon.stub(apiClient, 'update').resolves(mockResponse)
+
+          response = await frameworkResponseService.update(
+            mockFrameworkResponse
+          )
+        })
+
+        it('should call update method with data', function () {
+          expect(apiClient.update).to.be.calledOnceWithExactly(
+            'framework_response',
+            mockFrameworkResponse
+          )
+        })
+
+        it('should return move', function () {
+          expect(response).to.deep.equal(mockResponse.data)
+        })
+      })
+    })
+  })
+})

--- a/common/services/index.js
+++ b/common/services/index.js
@@ -1,5 +1,6 @@
 const allocation = require('./allocation')
 const courtHearing = require('./court-hearing')
+const frameworkResponse = require('./framework-response')
 const frameworks = require('./frameworks')
 const move = require('./move')
 const person = require('./person')
@@ -15,5 +16,6 @@ module.exports = {
   person,
   personEscortRecord,
   referenceData,
+  frameworkResponse,
   singleRequest,
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

This extends the frameworks controller to support saving a response via the frameworks response service.

It uses the [form-wizard controller lifecycle](https://github.com/UKHomeOffice/passports-form-wizard#controller-lifecycle) to handle sending the values to the API at the appropriate point.

### Why did it change

We need a way to send the data from the form back to the API. 

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

- [P4-1737](https://dsdmoj.atlassian.net/browse/P4-1737)

## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [x] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed

### Other considerations

Commit messages with a `fix` or `feat` type are automatically used to generate the [changelog](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/CHANGELOG.md) and
[GitHub release notes](https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/releases) during the release task. Please make sure they will read well on their own in a
summary of changes and that the commit body gives a more detailed description of those changes if necessary.

- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
- [x] Update [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md) with any new instructions or tasks
