### PR TITLE
[P4-1767] fix(frameworks): Add multiple flag to checkbox fields from framework

### DIFF
--- a/common/services/frameworks.js
+++ b/common/services/frameworks.js
@@ -83,6 +83,10 @@ function transformQuestion(
     set(field, 'hint.text', hint)
   }
 
+  if (type === 'checkbox') {
+    field.multiple = true
+  }
+
   if (options) {
     field.items = options.map(
       ({ value, label, followup, followup_comment: followupComment }) => {

--- a/common/services/frameworks.test.js
+++ b/common/services/frameworks.test.js
@@ -340,6 +340,7 @@ describe('Frameworks service', function () {
             component: 'govukCheckboxes',
             question: 'Question text',
             description: undefined,
+            multiple: true,
             id: 'question-key',
             name: 'question-key',
             fieldset: {


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Set the `multiple` to `true` for checkbox questions from the framework when converting to the expected form wizard format.

### Why did it change

The form wizard requires a multiple property to be set on fields that
can contain multiple items in the value, for example a checkbox
field.

This adds the property to the field in the framework transformer so
that the form wizard can support checkboxes as expected.

## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [x] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed

### Other considerations

Commit messages with a `fix` or `feat` type are automatically used to generate the [changelog](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/CHANGELOG.md) and
[GitHub release notes](https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/releases) during the release task. Please make sure they will read well on their own in a
summary of changes and that the commit body gives a more detailed description of those changes if necessary.

- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
- [x] Update [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md) with any new instructions or tasks
