### PR TITLE
[P4-1810] feat: Add support for Court users to access the service

### DIFF
--- a/common/lib/permissions.js
+++ b/common/lib/permissions.js
@@ -67,6 +67,13 @@ const pmuPermissions = [
   'move:review',
   'move:view',
 ]
+const courtPermissions = [
+  'dashboard:view',
+  'moves:view:outgoing',
+  'moves:view:incoming',
+  'moves:download',
+  'move:view',
+]
 
 const permissionsByRole = {
   ROLE_PECS_POLICE: policePermissions,
@@ -77,6 +84,7 @@ const permissionsByRole = {
   ROLE_PECS_OCA: ocaPermissions,
   ROLE_PECS_PMU: pmuPermissions,
   ROLE_PECS_SUPPLIER: supplierPermissions,
+  ROLE_PECS_COURT: courtPermissions,
 }
 
 module.exports = {

--- a/common/lib/user.test.js
+++ b/common/lib/user.test.js
@@ -261,6 +261,22 @@ describe('User class', function () {
       })
     })
 
+    context('when user has ROLE_PECS_COURT role', function () {
+      beforeEach(function () {
+        permissions = user.getPermissions(['ROLE_PECS_COURT'])
+      })
+
+      it('should contain correct permission', function () {
+        expect(permissions).to.deep.equal([
+          'dashboard:view',
+          'moves:view:outgoing',
+          'moves:view:incoming',
+          'moves:download',
+          'move:view',
+        ])
+      })
+    })
+
     context('when user has all roles', function () {
       beforeEach(function () {
         permissions = user.getPermissions([
@@ -272,6 +288,7 @@ describe('User class', function () {
           'ROLE_PECS_OCA',
           'ROLE_PECS_PMU',
           'ROLE_PECS_HMYOI',
+          'ROLE_PECS_COURT',
         ])
       })
 


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

This adds support for a new role for court users that gives them
access to the dashboard and incoming and outgoing moves views.

It also allows them to downloads moves as a CSV.

### Why did it change

The service is adding support for new roles, which this change will enable.

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

- [P4-1810](https://dsdmoj.atlassian.net/browse/P4-1810)
## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [x] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed

### Other considerations

Commit messages with a `fix` or `feat` type are automatically used to generate the [changelog](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/CHANGELOG.md) and
[GitHub release notes](https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/releases) during the release task. Please make sure they will read well on their own in a
summary of changes and that the commit body gives a more detailed description of those changes if necessary.

- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
- [x] Update [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md) with any new instructions or tasks
