### PR TITLE
[P4-1910] Use profile for assessment answers

### DIFF
--- a/app/move/controllers/create/base.js
+++ b/app/move/controllers/create/base.js
@@ -23,12 +23,15 @@ class CreateBaseController extends FormWizardController {
   _addModelMethods(req) {
     req.getMove = () => req.models.move || {}
     req.getMoveId = () => req.getMove().id
+    req.getProfile = () => req.models.profile || {}
+    req.getProfileId = () => req.getProfile().id
     req.getPerson = () => req.models.person || {}
     req.getPersonId = () => req.getPerson().id
   }
 
   _setModels(req) {
     req.models.move = req.sessionModel.toJSON()
+    req.models.profile = req.sessionModel.get('profile')
     req.models.person = req.sessionModel.get('person')
   }
 

--- a/app/move/controllers/create/base.test.js
+++ b/app/move/controllers/create/base.test.js
@@ -336,6 +336,9 @@ describe('Move controllers', function () {
       let req
       const mockSession = {
         id: '#move',
+        profile: {
+          id: '#profile',
+        },
         person: {
           id: '#person',
         },
@@ -345,7 +348,7 @@ describe('Move controllers', function () {
           models: {},
           sessionModel: {
             toJSON: sinon.stub().returns(mockSession),
-            get: sinon.stub().withArgs('person').returns(mockSession.person),
+            get: sinon.stub().callsFake(arg => mockSession[arg]),
           },
         }
         controller._setModels(req)
@@ -353,6 +356,10 @@ describe('Move controllers', function () {
 
       it('should add move model to req', function () {
         expect(req.models.move).to.deep.equal(mockSession)
+      })
+
+      it('should add profile model to req', function () {
+        expect(req.models.profile).to.deep.equal(mockSession.profile)
       })
 
       it('should add person model to req', function () {
@@ -373,6 +380,14 @@ describe('Move controllers', function () {
 
       it('should add getMoveId method to req', function () {
         expect(typeof req.getMoveId).to.equal('function')
+      })
+
+      it('should add getProfile method to req', function () {
+        expect(typeof req.getProfile).to.equal('function')
+      })
+
+      it('should add getProfileId method to req', function () {
+        expect(typeof req.getProfileId).to.equal('function')
       })
 
       it('should add getPerson method to req', function () {
@@ -401,6 +416,14 @@ describe('Move controllers', function () {
 
         it('req.getMoveId should return', function () {
           expect(req.getMoveId()).to.be.undefined
+        })
+
+        it('req.getProfile should return empty object', function () {
+          expect(req.getProfile()).to.deep.equal({})
+        })
+
+        it('req.getProfileId should return', function () {
+          expect(req.getProfileId()).to.be.undefined
         })
 
         it('req.getPerson should return empty object', function () {

--- a/app/move/controllers/create/save.js
+++ b/app/move/controllers/create/save.js
@@ -19,7 +19,6 @@ class SaveController extends CreateBaseController {
   async saveValues(req, res, next) {
     try {
       const sessionData = req.sessionModel.toJSON()
-      const person = sessionData.person
       const assessment = sessionData.assessment
       const documents = sessionData.documents
       const data = omit(sessionData, [
@@ -31,11 +30,7 @@ class SaveController extends CreateBaseController {
         'person',
       ])
 
-      const profile = await profileService.create(person.id, {
-        // TODO: reinstate when move to v2
-        // assessment_answers: assessment,
-        // documents,
-      })
+      const profile = req.getProfile()
 
       const moveData = {
         ...data,
@@ -57,13 +52,11 @@ class SaveController extends CreateBaseController {
         ),
       ])
 
-      // TODO: remove when v2
       await profileService.update({
         ...profile,
         assessment_answers: assessment,
         documents,
       })
-      // TODO: end remove when v2
 
       req.sessionModel.set('move', move)
 
@@ -75,7 +68,6 @@ class SaveController extends CreateBaseController {
 
   process(req, res, next) {
     const {
-      person,
       assessment,
       from_location_type: fromLocationType,
       to_location_type: toLocationType,
@@ -91,7 +83,9 @@ class SaveController extends CreateBaseController {
       return super.process(req, res, next)
     }
 
-    const existingAssessment = person.assessment_answers
+    const profile = req.getProfile()
+
+    const existingAssessment = profile.assessment_answers
       // keep all existing NOMIS alerts
       .filter(answer => answer.nomis_alert_code)
       // filter out requested answers

--- a/app/move/controllers/create/save.test.js
+++ b/app/move/controllers/create/save.test.js
@@ -98,11 +98,12 @@ describe('Move controllers', function () {
       let req, nextSpy
 
       beforeEach(function () {
-        sinon.stub(profileService, 'create').resolves(mockProfile)
+        // sinon.stub(profileService, 'create').resolves(mockProfile)
         sinon.stub(profileService, 'update').resolves({})
         sinon.stub(courtHearingService, 'create').resolvesArg(0)
         nextSpy = sinon.spy()
         req = {
+          getProfile: sinon.stub().returns(mockProfile),
           form: {
             values: {},
           },
@@ -132,26 +133,15 @@ describe('Move controllers', function () {
             })
           })
 
-          // it('should create profile', function () {
-          //   expect(profileService.create).to.be.calledOnceWithExactly(
-          //     mockValues.person.id,
-          //     {
-          //       assessment_answers: mockValues.assessment,
-          //       documents: mockDocuments,
-          //     }
-          //   )
-          // })
+          it('should fetch profile', function () {
+            expect(req.getProfile).to.be.calledOnceWithExactly()
+          })
 
-          // TODO - post v2, remove this and reinstate previous block
-          it('should create profile - v1', function () {
-            expect(profileService.create).to.be.calledOnceWithExactly(
-              mockValues.person.id,
-              {}
-            )
+          it('should patch profile', function () {
             expect(profileService.update).to.be.calledOnceWithExactly({
               ...mockProfile,
               assessment_answers: mockValues.assessment,
-              documents: mockDocuments,
+              documents: mockValues.documents,
             })
           })
 
@@ -208,22 +198,11 @@ describe('Move controllers', function () {
               })
             })
 
-            // it('should create profile', function () {
-            //   expect(profileService.create).to.be.calledOnceWithExactly(
-            //     mockValuesWithHearings.person.id,
-            //     {
-            //       assessment_answers: mockValuesWithHearings.assessment,
-            //       documents: mockValuesWithHearings.documents,
-            //     }
-            //   )
-            // })
+            it('should fetch profile', function () {
+              expect(req.getProfile).to.be.calledOnceWithExactly()
+            })
 
-            // TODO - post v2, remove this and reinstate previous block
-            it('should create profile - v1', function () {
-              expect(profileService.create).to.be.calledOnceWithExactly(
-                mockValuesWithHearings.person.id,
-                {}
-              )
+            it('should patch profile', function () {
               expect(profileService.update).to.be.calledOnceWithExactly({
                 ...mockProfile,
                 assessment_answers: mockValuesWithHearings.assessment,
@@ -512,6 +491,9 @@ describe('Move controllers', function () {
             'with `not_to_be_released` and `special_vehicle`',
             function () {
               beforeEach(function () {
+                req.getProfile = sinon
+                  .stub()
+                  .returns({ assessment_answers: [] })
                 req.form.values.assessment = mockCurrentAssessmentWithExplicit
                 controller.process(req, {}, {})
               })
@@ -566,6 +548,9 @@ describe('Move controllers', function () {
             'without `not_to_be_released` and `special_vehicle`',
             function () {
               beforeEach(function () {
+                req.getProfile = sinon
+                  .stub()
+                  .returns({ assessment_answers: [] })
                 controller.process(req, {}, {})
               })
 
@@ -613,6 +598,9 @@ describe('Move controllers', function () {
             'with `not_to_be_released` and `special_vehicle`',
             function () {
               beforeEach(function () {
+                req.getProfile = sinon
+                  .stub()
+                  .returns({ assessment_answers: mockExistingAssessment })
                 req.form.values.assessment = mockCurrentAssessmentWithExplicit
                 controller.process(req, {}, {})
               })
@@ -668,6 +656,9 @@ describe('Move controllers', function () {
             'without `not_to_be_released` and `special_vehicle`',
             function () {
               beforeEach(function () {
+                req.getProfile = sinon
+                  .stub()
+                  .returns({ assessment_answers: mockExistingAssessment })
                 req.form.values.assessment = mockCurrentAssessmentWithoutExplicit
                 controller.process(req, {}, {})
               })
@@ -743,6 +734,7 @@ describe('Move controllers', function () {
 
         context('when to location is also Prison', function () {
           beforeEach(function () {
+            req.getProfile = sinon.stub().returns({ assessment_answers: [] })
             req.form.values.to_location_type = 'prison'
             controller.process(req, {}, {})
           })

--- a/app/move/controllers/create/save.test.js
+++ b/app/move/controllers/create/save.test.js
@@ -98,7 +98,6 @@ describe('Move controllers', function () {
       let req, nextSpy
 
       beforeEach(function () {
-        // sinon.stub(profileService, 'create').resolves(mockProfile)
         sinon.stub(profileService, 'update').resolves({})
         sinon.stub(courtHearingService, 'create').resolvesArg(0)
         nextSpy = sinon.spy()

--- a/app/move/controllers/update/assessment.js
+++ b/app/move/controllers/update/assessment.js
@@ -1,4 +1,4 @@
-const { isEqual, pick } = require('lodash')
+const { isEqual, pick, keys, get } = require('lodash')
 
 const profileService = require('../../../../common/services/profile')
 const Assessment = require('../create/assessment')
@@ -29,9 +29,15 @@ class UpdateAssessmentController extends UpdateBase {
     this.use(this.setPreviousAssessment)
   }
 
+  getUpdateValues(req, res) {
+    const profile = req.getProfile()
+    const fields = keys(get(req, 'form.options.fields'))
+    return profileService.unformat(profile, fields)
+  }
+
   async saveValues(req, res, next) {
     try {
-      const { profile } = req.getMove()
+      const profile = req.getProfile()
       const assessments = profile.assessment_answers || []
       const fieldKeys = Object.keys(req.form.options.fields)
 

--- a/app/move/controllers/update/base.js
+++ b/app/move/controllers/update/base.js
@@ -14,8 +14,10 @@ class UpdateBaseController extends CreateBaseController {
 
   _setModels(req) {
     const res = req.res
-    req.models.move = res.locals.move
-    req.models.person = req.models.move.profile.person
+    const move = res.locals.move
+    req.models.move = move
+    req.models.profile = move.profile
+    req.models.person = move.profile.person
   }
 
   getBaseUrl(req) {

--- a/app/move/controllers/update/base.test.js
+++ b/app/move/controllers/update/base.test.js
@@ -247,6 +247,10 @@ describe('Move controllers', function () {
         expect(req.models.move).to.deep.equal(mockSession)
       })
 
+      it('should add profile model to req', function () {
+        expect(req.models.profile).to.deep.equal(mockSession.profile)
+      })
+
       it('should add person model to req', function () {
         expect(req.models.person).to.deep.equal(mockSession.profile.person)
       })

--- a/common/services/profile.js
+++ b/common/services/profile.js
@@ -3,6 +3,32 @@ const { get } = require('lodash')
 const apiClient = require('../lib/api-client')()
 
 const personService = require('./person')
+const unformat = require('./profile/profile.unformat')
+
+const assessmentKeys = [
+  // court
+  'solicitor',
+  'interpreter',
+  'other_court',
+  // risk
+  'violent',
+  'escape',
+  'hold_separately',
+  'self_harm',
+  'concealed_items',
+  'other_risks',
+  // health
+  'special_diet_or_allergy',
+  'health_issue',
+  'medication',
+  'wheelchair',
+  'pregnant',
+  'other_health',
+  'special_vehicle',
+]
+const explicitAssessmentKeys = ['special_vehicle', 'not_to_be_released']
+
+const allFields = [].concat(assessmentKeys, explicitAssessmentKeys)
 
 const profileService = {
   transform(profile) {
@@ -14,6 +40,20 @@ const profileService = {
       ...profile,
       person: personService.transform(profile.person),
     }
+  },
+
+  unformat(
+    profile,
+    fields = allFields,
+    {
+      assessment = assessmentKeys,
+      explicitAssessment = explicitAssessmentKeys,
+    } = {}
+  ) {
+    return unformat(profile, fields, {
+      assessment,
+      explicitAssessment,
+    })
   },
 
   create(personId, data) {

--- a/common/services/profile/profile.unformat.js
+++ b/common/services/profile/profile.unformat.js
@@ -1,0 +1,59 @@
+const getAnswer = (profile, field) => {
+  const assessments = profile.assessment_answers || []
+  return assessments.filter(assessment => {
+    return assessment.key === field
+  })[0]
+}
+
+const mapMethods = {}
+
+mapMethods.explicitAssessment = (profile, field, assessmentCategories) => {
+  let value
+  const matchedAnswer = getAnswer(profile, field)
+  const explicitKey = `${field}__explicit`
+
+  if (matchedAnswer) {
+    const questionId = matchedAnswer.assessment_question_id
+    value = matchedAnswer.comments
+    assessmentCategories[explicitKey] = questionId
+  } else {
+    assessmentCategories[explicitKey] = 'false'
+  }
+
+  return value
+}
+
+mapMethods.assessment = (profile, field, assessmentCategories) => {
+  let value
+  const matchedAnswer = getAnswer(profile, field)
+
+  if (matchedAnswer) {
+    const questionId = matchedAnswer.assessment_question_id
+    value = matchedAnswer.comments
+    const category = matchedAnswer.category
+    assessmentCategories[category] = assessmentCategories[category] || []
+    assessmentCategories[category].push(questionId)
+  }
+
+  return value
+}
+
+mapMethods.value = (profile, field) => profile[field]
+
+const mapKeys = Object.keys(mapMethods)
+
+const unformat = (profile, fields = [], fieldKeys = {}) => {
+  const assessmentCategories = {}
+
+  const fieldData = fields.map(field => {
+    const method =
+      mapKeys.filter(
+        key => fieldKeys[key] && fieldKeys[key].includes(field)
+      )[0] || 'value'
+    const value = mapMethods[method](profile, field, assessmentCategories)
+    return { [field]: value }
+  })
+  return Object.assign({}, ...fieldData, assessmentCategories)
+}
+
+module.exports = unformat

--- a/common/services/profile/profile.unformat.test.js
+++ b/common/services/profile/profile.unformat.test.js
@@ -1,0 +1,163 @@
+const unformat = require('./profile.unformat')
+
+describe('Profile Service', function () {
+  describe('#unformat()', function () {
+    let profile
+    let fields
+    let keys
+    let unformatted
+
+    before(function () {
+      profile = {
+        propertyField: 'propertyValue',
+        assessment_answers: [
+          {
+            key: 'assessmentField',
+            category: 'assessmentCategory',
+            assessment_question_id: 'assessmentId',
+            comments: 'assessmentValue',
+          },
+          {
+            key: 'anotherAssessmentField',
+            category: 'assessmentCategory',
+            assessment_question_id: 'anotherAssessmentId',
+            comments: 'anotherAssessmentValue',
+          },
+          {
+            key: 'explicitAssessmentField',
+            category: 'explicitAssessmentCategory',
+            assessment_question_id: 'explicitAssessmentId',
+            comments: 'explicitAssessmentValue',
+          },
+          {
+            key: 'ignored',
+            category: 'assessmentCategory',
+            assessment_question_id: 'ignoredId',
+            comments: 'ignoredValue',
+          },
+        ],
+      }
+    })
+
+    beforeEach(function () {
+      unformatted = unformat(profile, fields, keys)
+    })
+
+    context('when asking for a property', function () {
+      before(function () {
+        fields = ['propertyField']
+      })
+      it('should return the value as is', function () {
+        expect(unformatted).to.deep.equal({ propertyField: 'propertyValue' })
+      })
+
+      context('but it has no value', function () {
+        before(function () {
+          fields = ['missingPropertyField']
+          keys = {
+            date: ['missingPropertyField'],
+          }
+        })
+        it('should return undefined', function () {
+          expect(unformatted).to.deep.equal({
+            missingPropertyField: undefined,
+          })
+        })
+      })
+    })
+
+    context('when asking for an assessment', function () {
+      before(function () {
+        fields = ['assessmentField']
+        keys = {
+          assessment: ['assessmentField'],
+        }
+      })
+      it('should return the assessment comment and matched values for the assessment category', function () {
+        expect(unformatted).to.deep.equal({
+          assessmentField: 'assessmentValue',
+          assessmentCategory: ['assessmentId'],
+        })
+      })
+
+      context('but it has no value', function () {
+        before(function () {
+          fields = ['missingAssessmentField']
+          keys = {
+            assessment: ['missingAssessmentField'],
+          }
+        })
+        it('should return undefined', function () {
+          expect(unformatted).to.deep.equal({
+            missingAssessmentField: undefined,
+          })
+        })
+      })
+
+      context('when asking for multiple', function () {
+        before(function () {
+          fields = ['assessmentField', 'anotherAssessmentField']
+          keys = {
+            assessment: ['assessmentField', 'anotherAssessmentField'],
+          }
+        })
+        it('should return the assessment comments and matched values for the assessment category', function () {
+          expect(unformatted).to.deep.equal({
+            assessmentField: 'assessmentValue',
+            anotherAssessmentField: 'anotherAssessmentValue',
+            assessmentCategory: ['assessmentId', 'anotherAssessmentId'],
+          })
+        })
+      })
+    })
+
+    context('when asking for an explicit assessment', function () {
+      before(function () {
+        fields = ['explicitAssessmentField']
+        keys = {
+          explicitAssessment: ['explicitAssessmentField'],
+        }
+      })
+      it('should return the assessment comment and matched values for the assessment category', function () {
+        expect(unformatted).to.deep.equal({
+          explicitAssessmentField: 'explicitAssessmentValue',
+          explicitAssessmentField__explicit: 'explicitAssessmentId',
+        })
+      })
+
+      context('but it has no value', function () {
+        before(function () {
+          fields = ['missingExplicitAssessmentField']
+          keys = {
+            explicitAssessment: ['missingExplicitAssessmentField'],
+          }
+        })
+        it('should return undefined and false for explicit value', function () {
+          expect(unformatted).to.deep.equal({
+            missingExplicitAssessmentField: undefined,
+            missingExplicitAssessmentField__explicit: 'false',
+          })
+        })
+      })
+    })
+
+    context('when asking for multiple fields of differing type', function () {
+      before(function () {
+        fields = ['propertyField', 'assessmentField', 'explicitAssessmentField']
+        keys = {
+          assessment: ['assessmentField'],
+          explicitAssessment: ['explicitAssessmentField'],
+        }
+      })
+      it('should return all the expected values', function () {
+        expect(unformatted).to.deep.equal({
+          propertyField: 'propertyValue',
+          assessmentField: 'assessmentValue',
+          explicitAssessmentField: 'explicitAssessmentValue',
+          assessmentCategory: ['assessmentId'],
+          explicitAssessmentField__explicit: 'explicitAssessmentId',
+        })
+      })
+    })
+  })
+})


### PR DESCRIPTION
## Proposed changes

### What changed

Amends create and update controllers to use profile rather than person for getting the previous assessment answers

### Why did it change

Required to enable transition from v1 to v2 of the API

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

- [P4-1910](https://dsdmoj.atlassian.net/browse/P4-1910)

## Screenshots

Functionally identical

## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed



### Other considerations

- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics

