### PR TITLE
[P4-1759] Add start/progress banner for Person Escort Record to move detail

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,7 @@ The TZ (timezone) environment variable is set to 'Europe/London' in `start.js`.
 | E2E_SUPPLIER_USERNAME | Supplier user username used for acceptance testing | |
 | E2E_SUPPLIER_PASSWORD | Supplier user password used for acceptance testing | |
 | LOCATIONS_BATCH_SIZE | Maximum number of location IDs to send in one request when requesting moves for all locations | 40 |
+| FEATURE_FLAG_PERSON_ESCORT_RECORD | Set to `true` to enable display of the Person Escort Record feature | |
 
 ### Development specific
 

--- a/app/move/controllers/view.js
+++ b/app/move/controllers/view.js
@@ -19,14 +19,29 @@ module.exports = function view(req, res) {
   const userPermissions = get(req.session, 'user.permissions')
   const updateUrls = getUpdateUrls(updateSteps, move.id, userPermissions)
   const updateActions = getUpdateLinks(updateSteps, updateUrls)
-  const { person, assessment_answers: assessmentAnswers = [] } = profile || {}
-
+  const {
+    person,
+    assessment_answers: assessmentAnswers = [],
+    person_escort_record: personEscortRecord,
+  } = profile || {}
+  const personEscortRecordIsComplete = personEscortRecord?.status === 'complete'
+  const personEscortRecordUrl = personEscortRecord?.id
+    ? `/person-escort-record/${personEscortRecord.id}`
+    : `/person-escort-record/new/${move.id}`
+  const showPersonEscortRecordBanner =
+    !personEscortRecordIsComplete &&
+    move.status === 'requested' &&
+    move.profile?.id !== undefined
   const urls = {
     update: updateUrls,
   }
 
   const locals = {
     move,
+    personEscortRecord,
+    personEscortRecordIsComplete,
+    personEscortRecordUrl,
+    showPersonEscortRecordBanner,
     moveSummary: presenters.moveToMetaListComponent(move, updateActions),
     personalDetailsSummary: presenters.personToSummaryListComponent(person),
     tagList: presenters.assessmentToTagList(assessmentAnswers),

--- a/app/move/controllers/view.js
+++ b/app/move/controllers/view.js
@@ -1,6 +1,7 @@
 const { get, sortBy } = require('lodash')
 
 const presenters = require('../../../common/presenters')
+const { FEATURE_FLAGS } = require('../../../config')
 const updateSteps = require('../steps/update')
 
 const getUpdateLinks = require('./view/view.update.links')
@@ -29,6 +30,7 @@ module.exports = function view(req, res) {
     ? `/person-escort-record/${personEscortRecord.id}`
     : `/person-escort-record/new/${move.id}`
   const showPersonEscortRecordBanner =
+    FEATURE_FLAGS.PERSON_ESCORT_RECORD &&
     !personEscortRecordIsComplete &&
     move.status === 'requested' &&
     move.profile?.id !== undefined

--- a/app/move/controllers/view.js
+++ b/app/move/controllers/view.js
@@ -7,7 +7,7 @@ const getUpdateLinks = require('./view/view.update.links')
 const getUpdateUrls = require('./view/view.update.urls')
 
 module.exports = function view(req, res) {
-  const { move = {} } = res.locals
+  const { move } = req
   const {
     profile,
     status,
@@ -19,13 +19,14 @@ module.exports = function view(req, res) {
   const userPermissions = get(req.session, 'user.permissions')
   const updateUrls = getUpdateUrls(updateSteps, move.id, userPermissions)
   const updateActions = getUpdateLinks(updateSteps, updateUrls)
-  const { person, assessment_answers: assessmentAnswers = [] } = profile
+  const { person, assessment_answers: assessmentAnswers = [] } = profile || {}
 
   const urls = {
     update: updateUrls,
   }
 
   const locals = {
+    move,
     moveSummary: presenters.moveToMetaListComponent(move, updateActions),
     personalDetailsSummary: presenters.personToSummaryListComponent(person),
     tagList: presenters.assessmentToTagList(assessmentAnswers),

--- a/app/move/controllers/view.test.js
+++ b/app/move/controllers/view.test.js
@@ -70,7 +70,7 @@ getUpdateLinks.returns(mockUpdateLinks)
 
 describe('Move controllers', function () {
   describe('#view()', function () {
-    let req, res
+    let req, res, params
     const userPermissions = ['permA']
 
     beforeEach(function () {
@@ -105,6 +105,7 @@ describe('Move controllers', function () {
     context('by default', function () {
       beforeEach(function () {
         controller(req, res)
+        params = res.render.args[0][1]
       })
 
       it('should render a template', function () {
@@ -112,7 +113,7 @@ describe('Move controllers', function () {
       })
 
       it('should pass correct number of locals to template', function () {
-        expect(Object.keys(res.render.args[0][1])).to.have.length(12)
+        expect(Object.keys(res.render.args[0][1])).to.have.length(16)
       })
 
       it('should call moveToMetaListComponent presenter with correct args', function () {
@@ -123,13 +124,33 @@ describe('Move controllers', function () {
       })
 
       it('should contain a move param', function () {
-        const params = res.render.args[0][1]
         expect(params).to.have.property('move')
         expect(params.move).to.deep.equal(mockMove)
       })
 
+      it('should contain a personEscortRecord param', function () {
+        expect(params).to.have.property('personEscortRecord')
+        expect(params.personEscortRecord).to.be.undefined
+      })
+
+      it('should contain a personEscortRecordIsComplete param', function () {
+        expect(params).to.have.property('personEscortRecordIsComplete')
+        expect(params.personEscortRecordIsComplete).to.be.false
+      })
+
+      it('should contain a personEscortRecordUrl param', function () {
+        expect(params).to.have.property('personEscortRecordUrl')
+        expect(params.personEscortRecordUrl).to.equal(
+          `/person-escort-record/new/${mockMove.id}`
+        )
+      })
+
+      it('should contain a showPersonEscortRecordBanner param', function () {
+        expect(params).to.have.property('showPersonEscortRecordBanner')
+        expect(params.showPersonEscortRecordBanner).to.be.false
+      })
+
       it('should contain a move summary param', function () {
-        const params = res.render.args[0][1]
         expect(params).to.have.property('moveSummary')
         expect(params.moveSummary).to.equal('__moveToMetaListComponent__')
       })
@@ -141,7 +162,6 @@ describe('Move controllers', function () {
       })
 
       it('should contain personal details summary param', function () {
-        const params = res.render.args[0][1]
         expect(params).to.have.property('personalDetailsSummary')
         expect(params.personalDetailsSummary).to.equal(mockMove.person)
       })
@@ -153,7 +173,6 @@ describe('Move controllers', function () {
       })
 
       it('should contain tag list param', function () {
-        const params = res.render.args[0][1]
         expect(params).to.have.property('tagList')
         expect(params.tagList).to.equal(mockAssessmentAnswers)
       })
@@ -165,7 +184,6 @@ describe('Move controllers', function () {
       })
 
       it('should contain assessment param', function () {
-        const params = res.render.args[0][1]
         expect(params).to.have.property('assessment')
         expect(params.assessment).to.deep.equal(mockAssessmentAnswers)
       })
@@ -177,12 +195,10 @@ describe('Move controllers', function () {
       })
 
       it('should contain court hearings param', function () {
-        const params = res.render.args[0][1]
         expect(params).to.have.property('courtHearings')
       })
 
       it('should order court hearings by start time', function () {
-        const params = res.render.args[0][1]
         expect(params.courtHearings).to.deep.equal([
           {
             id: '3',
@@ -224,19 +240,16 @@ describe('Move controllers', function () {
       })
 
       it('should contain court summary param', function () {
-        const params = res.render.args[0][1]
         expect(params).to.have.property('courtSummary')
         expect(params.courtSummary).to.equal(mockAssessmentAnswers)
       })
 
       it('should contain message title param', function () {
-        const params = res.render.args[0][1]
         expect(params).to.have.property('messageTitle')
         expect(params.messageTitle).to.equal(undefined)
       })
 
       it('should contain message content param', function () {
-        const params = res.render.args[0][1]
         expect(params).to.have.property('messageContent')
         expect(params.messageContent).to.equal('statuses::description')
       })
@@ -283,7 +296,7 @@ describe('Move controllers', function () {
       })
 
       it('should pass correct number of locals to template', function () {
-        expect(Object.keys(res.render.args[0][1])).to.have.length(12)
+        expect(Object.keys(res.render.args[0][1])).to.have.length(16)
       })
     })
 
@@ -368,6 +381,90 @@ describe('Move controllers', function () {
         expect(
           presenters.assessmentToSummaryListComponent
         ).to.be.calledOnceWithExactly([], 'court')
+      })
+    })
+
+    context('with Person Escort Record', function () {
+      const mockPersonEscortRecord = {
+        id: '67890',
+        status: 'incomplete',
+      }
+
+      beforeEach(function () {
+        req.move = {
+          ...req.move,
+          profile: {
+            id: '12345',
+            person_escort_record: mockPersonEscortRecord,
+          },
+        }
+      })
+
+      context('when record is incomplete', function () {
+        beforeEach(function () {
+          controller(req, res)
+          params = res.render.args[0][1]
+        })
+
+        it('should contain a personEscortRecord', function () {
+          expect(params).to.have.property('personEscortRecord')
+          expect(params.personEscortRecord).to.deep.equal(
+            mockPersonEscortRecord
+          )
+        })
+
+        it('should not show Person Escort Record as complete', function () {
+          expect(params).to.have.property('personEscortRecordIsComplete')
+          expect(params.personEscortRecordIsComplete).to.be.false
+        })
+
+        it('should contain url to Person Escort Record', function () {
+          expect(params).to.have.property('personEscortRecordUrl')
+          expect(params.personEscortRecordUrl).to.equal(
+            `/person-escort-record/${mockPersonEscortRecord.id}`
+          )
+        })
+
+        it('should show Person Escort Record banner', function () {
+          expect(params).to.have.property('showPersonEscortRecordBanner')
+          expect(params.showPersonEscortRecordBanner).to.be.true
+        })
+      })
+
+      context('when record is complete', function () {
+        beforeEach(function () {
+          req.move.profile.person_escort_record = {
+            ...mockPersonEscortRecord,
+            status: 'complete',
+          }
+          controller(req, res)
+          params = res.render.args[0][1]
+        })
+
+        it('should contain a personEscortRecord', function () {
+          expect(params).to.have.property('personEscortRecord')
+          expect(params.personEscortRecord).to.deep.equal({
+            ...mockPersonEscortRecord,
+            status: 'complete',
+          })
+        })
+
+        it('should show Person Escort Record as complete', function () {
+          expect(params).to.have.property('personEscortRecordIsComplete')
+          expect(params.personEscortRecordIsComplete).to.be.true
+        })
+
+        it('should contain url to Person Escort Record', function () {
+          expect(params).to.have.property('personEscortRecordUrl')
+          expect(params.personEscortRecordUrl).to.equal(
+            `/person-escort-record/${mockPersonEscortRecord.id}`
+          )
+        })
+
+        it('should not show Person Escort Record banner', function () {
+          expect(params).to.have.property('showPersonEscortRecordBanner')
+          expect(params.showPersonEscortRecordBanner).to.be.false
+        })
       })
     })
 

--- a/app/move/views/_includes/assessment.njk
+++ b/app/move/views/_includes/assessment.njk
@@ -25,7 +25,9 @@
       }) }}
     {% endfor %}
 
-    {{ updateLink(updateLinks[assessmentCategory.key]) }}
+    {% if not personEscortRecord %}
+      {{ updateLink(updateLinks[assessmentCategory.key]) }}
+    {% endif %}
   </section>
 {% endfor %}
 

--- a/app/move/views/view.njk
+++ b/app/move/views/view.njk
@@ -93,6 +93,36 @@
       }
     }) }}
   {% endif %}
+
+  {% if showPersonEscortRecordBanner %}
+    {% set html %}
+      <p>{{ t("messages::pending_person_escort_record.content") }}</p>
+
+      {% if personEscortRecord %}
+        <p>
+          <a href="{{ personEscortRecordUrl }}">
+            {{ t("actions::continue_person_escort_record") }}
+          </a>
+        </p>
+      {% else %}
+        {{ govukButton({
+          href: personEscortRecordUrl,
+          text: t("actions::start_person_escort_record")
+        }) }}
+      {% endif %}
+    {% endset %}
+
+    {{ appMessage({
+      allowDismiss: false,
+      classes: "app-message--instruction",
+      title: {
+        text: t("messages::pending_person_escort_record.heading")
+      },
+      content: {
+        html: html
+      }
+    }) }}
+  {% endif %}
 {% endblock %}
 
 {% block contentHeader %}
@@ -125,13 +155,13 @@
 {% endblock %}
 
 {% macro updateLink(link) %}
-    {% if link.href %}
+  {% if link.href %}
     <p class="app-!-position-top-right">
       <a href="{{ link.href }}" class="govuk-link" {%- for attribute, value in link.attributes %} {{attribute}}="{{value}}"{% endfor %}>
         {{ link.html | safe }}
       </a>
     </p>
-    {% endif %}
+  {% endif %}
 {% endmacro %}
 
 {% block contentMain %}
@@ -202,6 +232,14 @@
       }),
       classes: "govuk-!-margin-bottom-0"
     }) }}
+  {% endif %}
+
+  {% if personEscortRecordIsComplete %}
+    <p>
+      <a href="{{ personEscortRecordUrl }}">
+        {{ t("actions::view_person_escort_record") }}
+      </a>
+    </p>
   {% endif %}
 
   {% if canCancelMove %}

--- a/app/person-escort-record/controllers/frameworks.js
+++ b/app/person-escort-record/controllers/frameworks.js
@@ -47,7 +47,7 @@ class FrameworksController extends FormWizardController {
     const fields = req.form.options.fields
     const responses = req.personEscortRecord.responses
     const savedValues = responses
-      .filter(response => fields[response.question.key])
+      .filter(response => fields[response.question?.key])
       .filter(response => response.value)
       .reduce(this.reduceResponses, {})
 

--- a/app/person-escort-record/controllers/frameworks.test.js
+++ b/app/person-escort-record/controllers/frameworks.test.js
@@ -352,6 +352,30 @@ describe('Person Escort Record controllers', function () {
               })
             })
           })
+
+          context('when response has no question', function () {
+            beforeEach(function () {
+              mockReq.form.options.fields = {
+                'field-one': {},
+                'field-two': {},
+              }
+              mockReq.personEscortRecord.responses = [
+                { id: '1', value: 'Yes' },
+                { id: '2', value: 'No' },
+              ]
+              controller.getValues(mockReq, {}, callback)
+            })
+
+            it('should not call the reducer', function () {
+              expect(Controller.prototype.reduceResponses).not.to.be.called
+            })
+
+            it('should filter out responses', function () {
+              expect(callback).to.be.calledOnceWithExactly(null, {
+                foo: 'bar',
+              })
+            })
+          })
         })
 
         context('existing values', function () {

--- a/config/index.js
+++ b/config/index.js
@@ -162,4 +162,9 @@ module.exports = {
       },
     },
   },
+  FEATURE_FLAGS: {
+    PERSON_ESCORT_RECORD: /true/i.test(
+      process.env.FEATURE_FLAG_PERSON_ESCORT_RECORD
+    ),
+  },
 }

--- a/locales/en/actions.json
+++ b/locales/en/actions.json
@@ -39,5 +39,8 @@
   "save_and_continue": "Save and continue",
   "save_and_return_to_overview": "Save and return to overview",
   "view_more_information": "View more information",
-  "review": "Review"
+  "review": "Review",
+  "start_person_escort_record": "Start record",
+  "continue_person_escort_record": "Continue record",
+  "view_person_escort_record": "View Person Escort Record"
 }

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -18,6 +18,10 @@
     "heading": "Awaiting a person to be added",
     "content": "$t(moves::allocation_relationship) and is waiting for a person to be added."
   },
+  "pending_person_escort_record": {
+    "heading": "Incomplete Person Escort Record",
+    "content": "A Person Escort Record must be completed before this person can be moved."
+  },
   "cancel_allocation_move": {
     "content": "$t(moves::allocation_relationship). It can only be cancelled from the allocations page by a member of the Population Management Unit (PMU)."
   },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

This creates a new banner on the move detail page which allows
a new Person Escort Record to be created given certain business rules
or continued if one is in progress.

It uses the consistent action banner and a consistent position for the link to either
start or continue the Person Escort Record (PER).

If a PER has **not been started** yet, it displayed a green button in the banner to go to the journey to start
a new PER.

If a PER is **in progress**, it displays a link to continue the PER in the action banner.

If a PER has been **completed**, it no longer displays the banner and displays a link at the bottom
of the page to view the completed PER.

### Why did it change

The Person Escort Record is a new feature where users can fill in more detailed risk and health information. This
change creates a way for a user to begin or continue that process.

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

- [P4-1759](https://dsdmoj.atlassian.net/browse/P4-1759)

## Screenshots
<!--- (Optional) Include screenshots if changes update interfaces or components -->
<!--- Delete/copy as appropriate --->

### For requested move where PER hasn't been started

<kbd><img src="https://user-images.githubusercontent.com/3327997/87075246-f3e30800-c217-11ea-8262-5ff77ca6a48a.png"></kbd>

### Once PER has been started

<kbd><img src="https://user-images.githubusercontent.com/3327997/87075299-05c4ab00-c218-11ea-9d1f-6127f19f1010.png"></kbd>

### Once PER has been completed

<kbd><img src="https://user-images.githubusercontent.com/3327997/87075346-183ee480-c218-11ea-9c25-cee8b6af02be.png"></kbd>

## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [x] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] Documented in the [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md)
- [ ] Added to [continous integration](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-book-secure-move-frontend)
- [ ] Added to heroku review pipeline
- [ ] Added to staging environment (deployment repository)
- [ ] Added to preproduction environment (deployment repository)
- [ ] Added to production environment (deployment repository)

### Other considerations

Commit messages with a `fix` or `feat` type are automatically used to generate the [changelog](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/CHANGELOG.md) and
[GitHub release notes](https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/releases) during the release task. Please make sure they will read well on their own in a
summary of changes and that the commit body gives a more detailed description of those changes if necessary.

- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
- [x] Update [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md) with any new instructions or tasks
