### PR TITLE
build: Improve e2e parallelism

### DIFF
--- a/.testcaferc-with-video.json
+++ b/.testcaferc-with-video.json
@@ -1,9 +1,0 @@
-{
-  "timeout": 30000,
-  "pageLoadTimeout": 60000,
-  "videoPath": "artifacts/videos",
-  "videoOptions": {
-    "failedOnly": true,
-    "pathPattern": "${DATE}_${TIME}/${TEST}/${USERAGENT}/${FILE_INDEX}.mp4"
-  }
-}

--- a/.testcaferc.json
+++ b/.testcaferc.json
@@ -1,9 +1,4 @@
 {
   "timeout": 30000,
-  "pageLoadTimeout": 60000,
-  "videoPath": "artifacts/videos",
-  "videoOptions": {
-    "failedOnly": true,
-    "pathPattern": "${DATE}_${TIME}/${TEST}/${USERAGENT}/${FILE_INDEX}.mp4"
-  }
+  "pageLoadTimeout": 60000
 }

--- a/.testcaferc.json
+++ b/.testcaferc.json
@@ -1,4 +1,9 @@
 {
   "timeout": 30000,
-  "pageLoadTimeout": 60000
+  "pageLoadTimeout": 60000,
+  "videoPath": "artifacts/videos",
+  "videoOptions": {
+    "failedOnly": true,
+    "pathPattern": "${DATE}_${TIME}/${TEST}/${USERAGENT}/${FILE_INDEX}.mp4"
+  }
 }

--- a/README.md
+++ b/README.md
@@ -132,9 +132,20 @@ To debug tests on local server against the API running locally, run:
 npm run test-e2e:local:api
 ```
 
-And to run test in specific browser run: `test-e2e:chrome` or `test-e2e:firefox`.
+Further options can be passed to all these commands.
 
-The video recording of each test is stored in artifacts/video directory and is stored on CI under artifacts for review.
+Available options can be seen by running the command with the `-h` (help) option.
+
+```
+npm run test-e2e:ci -- -h
+npm run test-e2e:local -- -h
+```
+
+Screenshots are taken whenever a test fails.
+
+Videos are taken when a test fails if enabled (see the `--video` option).
+
+Video and screenshots are stored in `artifacts` directory.
 
 ### Code coverage
 
@@ -235,6 +246,7 @@ The TZ (timezone) environment variable is set to 'Europe/London' in `start.js`.
 | GOOGLE_ANALYTICS_ID | Google analytics tracking ID to use for the environment | |
 | E2E_BASE_URL | Base URL used for acceptance testing | `http://${process.env.SERVER_HOST}` |
 | E2E_MAX_PROCESSES | Max number of processes to use for end-to-end tests | 1 |
+| E2E_FAIL_FAST | Whether to stop all tests if an end-to-end tests fails | false |
 | E2E_VIDEO | Whether to capture video when end-to-end tests fail | false |
 | E2E_SKIP | Comma-delimited list of files to skip when running the end-to-end tests eg. test/e2/allocation.cancel.test.js | |
 | E2E_POLICE_USERNAME | Police user username used for acceptance testing | |

--- a/README.md
+++ b/README.md
@@ -235,6 +235,7 @@ The TZ (timezone) environment variable is set to 'Europe/London' in `start.js`.
 | GOOGLE_ANALYTICS_ID | Google analytics tracking ID to use for the environment | |
 | E2E_BASE_URL | Base URL used for acceptance testing | `http://${process.env.SERVER_HOST}` |
 | E2E_MAX_PROCESSES | Max number of processes to use for end-to-end tests | 1 |
+| E2E_VIDEO | Whether to capture video when end-to-end tests fail | false |
 | E2E_SKIP | Comma-delimited list of files to skip when running the end-to-end tests eg. test/e2/allocation.cancel.test.js | |
 | E2E_POLICE_USERNAME | Police user username used for acceptance testing | |
 | E2E_POLICE_PASSWORD | Police user password used for acceptance testing | |

--- a/package.json
+++ b/package.json
@@ -215,8 +215,6 @@
     "test-e2e:ci": "npm run test-e2e --",
     "test-e2e:local": "E2E_BASE_URL='' npm run test-e2e -- --debug --reporter false",
     "test-e2e:local:api": "E2E_BASE_URL='' npm run test-e2e -- --reporter false --skip test/e2e/move.new.stc.test.js --skip test/e2e/move.update.stc.test.js",
-    "test-e2e:video": "npm run test-e2e -- --config .testcaferc-with-video.json",
-    "testcafe": "testcafe",
     "update": "ncu -u",
     "update:check": "ncu -- --error-level 2",
     "watch:js:client": "webpack --watch --progress",

--- a/package.json
+++ b/package.json
@@ -216,6 +216,7 @@
     "test-e2e:local": "E2E_BASE_URL='' npm run test-e2e -- --debug --reporter false",
     "test-e2e:local:api": "E2E_BASE_URL='' npm run test-e2e -- --reporter false --skip test/e2e/move.new.stc.test.js --skip test/e2e/move.update.stc.test.js",
     "test-e2e:video": "npm run test-e2e -- --config .testcaferc-with-video.json",
+    "testcafe": "testcafe",
     "update": "ncu -u",
     "update:check": "ncu -- --error-level 2",
     "watch:js:client": "webpack --watch --progress",

--- a/test/e2e/parallel-runner.js
+++ b/test/e2e/parallel-runner.js
@@ -96,12 +96,8 @@ const config = args.config ? `--ts-config-path ${args.config}` : ''
 const testcafeArgs = args.testcafe || ''
 const skip = args.skip
 
-let tests = args.test
 const allTests = glob.sync('test/e2e/*.test.js')
-
-if (!tests) {
-  tests = allTests.reverse()
-}
+let tests = args.test || allTests
 
 const envSkip = (process.env.E2E_SKIP || '').split(',')
 tests = tests.filter(test => !envSkip.includes(test))


### PR DESCRIPTION
## Proposed changes

### What changed

Rather than creating a separate testcafe instance for each and every test,
this splits the tests into the number of buckets matching the max_processes
and spins up that number of Testcafes. NB. if max_processes is set to 1,
then the behaviour is exactly as if calling the original non-parallelised
script.

Additionally this has the side effect of making killing the process kill
all the child processes.

NB. If the process is killed before the browsers have connected to the
Testcafe runner server, those browsers will show as "Disconnected" and
have to be killed manually.


### Why did it change

The experience of attempting to cancel a run locally was beyond dreadful

### Issue tracking

n/a

## Screenshots

n/a

## Checklists

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed

### Other considerations

- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics

