### PR TITLE
[P4-1726] Show overview and progress of Person Escort Record

### DIFF
--- a/app/person-escort-record/controllers/framework-overview.js
+++ b/app/person-escort-record/controllers/framework-overview.js
@@ -1,0 +1,16 @@
+const presenters = require('../../../common/presenters')
+
+function frameworkOverview(req, res) {
+  const { originalUrl, framework, personEscortRecord } = req
+  const fullname = personEscortRecord?.profile?.person?.fullname
+  const taskList = presenters.frameworkToTaskListComponent(`${originalUrl}/`)(
+    framework
+  )
+
+  res.render('person-escort-record/views/framework-overview', {
+    taskList,
+    fullname,
+  })
+}
+
+module.exports = frameworkOverview

--- a/app/person-escort-record/controllers/framework-overview.test.js
+++ b/app/person-escort-record/controllers/framework-overview.test.js
@@ -1,0 +1,109 @@
+const presenters = require('../../../common/presenters')
+
+const controller = require('./framework-overview')
+
+const mockFramework = {
+  status: 'complete',
+  sections: {
+    'section-one': {},
+    'section-two': {},
+  },
+}
+
+describe('Person Escort Record controllers', function () {
+  describe('#frameworkOverview()', function () {
+    let mockReq, mockRes, frameworkToTaskListComponentStub
+
+    beforeEach(function () {
+      frameworkToTaskListComponentStub = sinon.stub().returnsArg(0)
+      sinon
+        .stub(presenters, 'frameworkToTaskListComponent')
+        .returns(frameworkToTaskListComponentStub)
+
+      mockReq = {
+        originalUrl: '/person-escort-record/1',
+        framework: mockFramework,
+      }
+      mockRes = {
+        render: sinon.spy(),
+      }
+    })
+
+    context('by default', function () {
+      beforeEach(function () {
+        controller(mockReq, mockRes)
+      })
+
+      it('should render template', function () {
+        const template = mockRes.render.args[0][0]
+
+        expect(mockRes.render.calledOnce).to.be.true
+        expect(template).to.equal(
+          'person-escort-record/views/framework-overview'
+        )
+      })
+
+      describe('params', function () {
+        let params
+
+        beforeEach(function () {
+          params = mockRes.render.args[0][1]
+        })
+
+        it('should pass correct number of params to template', function () {
+          expect(Object.keys(params)).to.have.length(2)
+        })
+
+        it('should set taskList', function () {
+          expect(params).to.have.property('taskList')
+          expect(params.taskList).to.deep.equal(mockFramework)
+        })
+
+        it('should not set fullname', function () {
+          expect(params).to.have.property('fullname')
+          expect(params.fullname).to.be.undefined
+        })
+      })
+
+      it('should call task list presenter', function () {
+        expect(
+          presenters.frameworkToTaskListComponent
+        ).to.have.been.calledOnceWithExactly('/person-escort-record/1/')
+        expect(
+          frameworkToTaskListComponentStub
+        ).to.have.been.calledOnceWithExactly(mockFramework)
+      })
+    })
+
+    context('with profile', function () {
+      beforeEach(function () {
+        controller(
+          {
+            ...mockReq,
+            personEscortRecord: {
+              profile: {
+                person: {
+                  fullname: 'John Doe',
+                },
+              },
+            },
+          },
+          mockRes
+        )
+      })
+
+      describe('params', function () {
+        let params
+
+        beforeEach(function () {
+          params = mockRes.render.args[0][1]
+        })
+
+        it('should set fullname', function () {
+          expect(params).to.have.property('fullname')
+          expect(params.fullname).to.equal('John Doe')
+        })
+      })
+    })
+  })
+})

--- a/app/person-escort-record/controllers/index.js
+++ b/app/person-escort-record/controllers/index.js
@@ -1,7 +1,9 @@
+const frameworkOverviewController = require('./framework-overview')
 const FrameworkSectionController = require('./framework-section')
 const FrameworksController = require('./framework-section')
 
 module.exports = {
   FrameworksController,
+  frameworkOverviewController,
   FrameworkSectionController,
 }

--- a/app/person-escort-record/index.js
+++ b/app/person-escort-record/index.js
@@ -6,6 +6,7 @@ const frameworksService = require('../../common/services/frameworks')
 const { setMove } = require('../move/middleware')
 
 const newApp = require('./app/new')
+const { frameworkOverviewController } = require('./controllers')
 const { setFramework, setPersonEscortRecord } = require('./middleware')
 const { defineFormWizards } = require('./router')
 
@@ -20,6 +21,7 @@ router.use(setFramework(framework))
 router.use(newApp.mountpath, newApp.router)
 
 // Define routes
+router.get('/:personEscortRecordId', frameworkOverviewController)
 defineFormWizards(framework, router)
 
 // Export

--- a/app/person-escort-record/views/framework-overview.njk
+++ b/app/person-escort-record/views/framework-overview.njk
@@ -1,0 +1,20 @@
+{% extends "layouts/two-column.njk" %}
+
+{% block contentHeader %}
+  <header class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <span class="govuk-caption-xl">
+        {{ t("person-escort-record::heading") }}
+      </span>
+      <h1 class="govuk-heading-xl">
+        {{ fullname | upper }}
+      </h1>
+    </div>
+  </header>
+{% endblock %}
+
+{% block contentMain %}
+  <section class="app-!-position-relative govuk-!-margin-bottom-8">
+    {{ appTaskList(taskList) }}
+  </section>
+{% endblock %}

--- a/common/assets/scss/components/_all.scss
+++ b/common/assets/scss/components/_all.scss
@@ -15,3 +15,4 @@
 @import "pagination/pagination";
 @import "panel/panel";
 @import "tag/tag";
+@import "task-list/task-list";

--- a/common/components/task-list/_task-list.scss
+++ b/common/components/task-list/_task-list.scss
@@ -1,0 +1,34 @@
+.app-task-list {
+  padding-left: 0;
+  margin: 0;
+  list-style-type: none;
+}
+
+.app-task-list__item {
+  @include govuk-clearfix;
+  @include govuk-font($size: 19);
+  padding: govuk-spacing(3) 0;
+  position: relative;
+  border-bottom: 1px solid $govuk-border-colour;
+}
+
+.app-task-list__item:first-child {
+  border-top: 1px solid $govuk-border-colour;
+}
+
+.app-task-list__task-name {
+  display: block;
+
+  @include govuk-media-query($from: tablet) {
+    float: left;
+  }
+}
+
+.app-task-list__tag {
+  margin-top: govuk-spacing(2);
+
+  @include govuk-media-query($from: tablet) {
+    float: right;
+    margin-top: 0;
+  }
+}

--- a/common/components/task-list/macro.njk
+++ b/common/components/task-list/macro.njk
@@ -1,0 +1,3 @@
+{% macro appTaskList(params) %}
+  {%- include "./template.njk" -%}
+{% endmacro %}

--- a/common/components/task-list/task-list.yaml
+++ b/common/components/task-list/task-list.yaml
@@ -1,0 +1,60 @@
+params:
+  - name: items
+    type: array
+    required: true
+    description: Array of task items. See items
+    params:
+    - name: text
+      type: string
+      required: true
+      description: If `html` is set, this is not required. Text to use within the task item. If `html` is provided, the `text` argument will be ignored.
+    - name: html
+      type: string
+      required: true
+      description: If `text` is set, this is not required. HTML to use within the task item. If `html` is provided, the `text` argument will be ignored.
+    - name: href
+      type: string
+      required: false
+      description: Link for the task item. If not specified, task item is a normal list item.
+    - name: tag
+      type: object
+      description: See GOV.UK Design System tag component
+
+examples:
+  - name: default
+    data:
+      items:
+        -
+          text: Task one
+          href: '/task-one'
+        -
+          text: Task two
+          href: '/task-two'
+        -
+          text: Task three
+          href: '/task-three'
+  - name: with tags
+    data:
+      items:
+        -
+          text: Your details
+          href: '/your-details'
+          tag:
+            text: Not started
+            classes: 'govuk-tag--grey'
+        -
+          text: Read declaration
+          href: '/declaration'
+          tag:
+            text: Incomplete
+            classes: 'govuk-tag--blue'
+        -
+          text: Company information
+          href: '/company-information'
+          tag:
+            text: Complete
+        -
+          text: Provide financial evidence
+          tag:
+            text: Cannot start yet
+            classes: 'govuk-tag--grey'

--- a/common/components/task-list/template.njk
+++ b/common/components/task-list/template.njk
@@ -1,0 +1,29 @@
+{% from "govuk/components/tag/macro.njk" import govukTag %}
+
+<ul class="app-task-list">
+  {% for item in params.items %}
+    <li class="app-task-list__item">
+      <span class="app-task-list__task-name">
+        {% if item.href %}
+          <a href="{{ item.href }}" aria-described-by="{{ item.text | urlencode }}-status">
+        {% endif %}
+
+        {{ item.html | safe if item.html else item.text }}
+
+        {% if item.href %}
+          </a>
+        {% endif %}
+      </span>
+
+      {% if item.tag %}
+        {{ govukTag({
+          attributes: {
+            id: item.text | urlencode + "-status"
+          },
+          text: item.tag.text,
+          classes: (item.tag.classes or "") + " app-task-list__tag"
+        }) }}
+      {% endif %}
+    </li>
+  {% endfor %}
+</ul>

--- a/common/components/task-list/template.test.js
+++ b/common/components/task-list/template.test.js
@@ -1,0 +1,199 @@
+const {
+  renderComponentHtmlToCheerio,
+  getExamples,
+} = require('../../../test/unit/component-helpers')
+
+const examples = getExamples('task-list')
+
+describe('Task list component', function () {
+  context('by default', function () {
+    let $, $component, items
+
+    beforeEach(function () {
+      $ = renderComponentHtmlToCheerio('task-list', examples.default)
+      $component = $('.app-task-list')
+      items = $component.find('.app-task-list__item')
+    })
+
+    it('should render component', function () {
+      expect($component.get(0).tagName).to.equal('ul')
+    })
+
+    describe('items', function () {
+      it('should render correct number of items', function () {
+        expect(items.length).to.equal(3)
+      })
+
+      it('should render items correctly', function () {
+        expect($(items[0]).text().trim()).to.equal('Task one')
+        expect($(items[1]).text().trim()).to.equal('Task two')
+        expect($(items[2]).text().trim()).to.equal('Task three')
+      })
+    })
+
+    describe('links', function () {
+      it('should contain correct hrefs', function () {
+        expect($(items[0]).find('a').attr('href')).to.equal('/task-one')
+        expect($(items[1]).find('a').attr('href')).to.equal('/task-two')
+        expect($(items[2]).find('a').attr('href')).to.equal('/task-three')
+      })
+
+      it('should contain aria described by', function () {
+        expect($(items[0]).find('a').attr('aria-described-by')).to.equal(
+          'Task%20one-status'
+        )
+        expect($(items[1]).find('a').attr('aria-described-by')).to.equal(
+          'Task%20two-status'
+        )
+        expect($(items[2]).find('a').attr('aria-described-by')).to.equal(
+          'Task%20three-status'
+        )
+      })
+    })
+  })
+
+  context('with tags', function () {
+    let $, $component
+
+    beforeEach(function () {
+      $ = renderComponentHtmlToCheerio('task-list', examples['with tags'])
+      $component = $('.app-task-list')
+    })
+
+    it('should render component', function () {
+      expect($component.get(0).tagName).to.equal('ul')
+    })
+
+    it('should render correct number of items', function () {
+      const items = $component.find('.app-task-list__item')
+      expect(items.length).to.equal(4)
+    })
+
+    describe('items', function () {
+      let items
+
+      beforeEach(function () {
+        items = $component.find('.app-task-list__task-name')
+      })
+
+      it('should render items correctly', function () {
+        expect($(items[0]).text().trim()).to.equal('Your details')
+        expect($(items[1]).text().trim()).to.equal('Read declaration')
+        expect($(items[2]).text().trim()).to.equal('Company information')
+        expect($(items[3]).text().trim()).to.equal('Provide financial evidence')
+      })
+    })
+
+    describe('links', function () {
+      let links
+
+      beforeEach(function () {
+        links = $component.find('.app-task-list__task-name a')
+      })
+
+      it('should contain hrefs for items with href attribute', function () {
+        expect(links.length).to.equal(3)
+      })
+
+      it('should not contain hrefs for items without href attribute', function () {
+        const items = $component.find('.app-task-list__task-name')
+        expect($(items[4]).find('a').length).to.equal(0)
+      })
+    })
+
+    describe('tags', function () {
+      let tags
+
+      beforeEach(function () {
+        tags = $component.find('.app-task-list__item .govuk-tag')
+      })
+
+      it('should contain correct number of tags', function () {
+        expect(tags.length).to.equal(4)
+      })
+
+      it('should render tag text', function () {
+        expect($(tags[0]).text().trim()).to.equal('Not started')
+        expect($(tags[1]).text().trim()).to.equal('Incomplete')
+        expect($(tags[2]).text().trim()).to.equal('Complete')
+        expect($(tags[3]).text().trim()).to.equal('Cannot start yet')
+      })
+
+      it('should render tag classes', function () {
+        expect($(tags[0]).attr('class')).to.equal(
+          'govuk-tag govuk-tag--grey app-task-list__tag'
+        )
+        expect($(tags[1]).attr('class')).to.equal(
+          'govuk-tag govuk-tag--blue app-task-list__tag'
+        )
+        expect($(tags[2]).attr('class')).to.equal(
+          'govuk-tag  app-task-list__tag'
+        )
+        expect($(tags[3]).attr('class')).to.equal(
+          'govuk-tag govuk-tag--grey app-task-list__tag'
+        )
+      })
+
+      it('should render tag ids', function () {
+        expect($(tags[0]).attr('id')).to.equal('Your%20details-status')
+        expect($(tags[1]).attr('id')).to.equal('Read%20declaration-status')
+        expect($(tags[2]).attr('id')).to.equal('Company%20information-status')
+        expect($(tags[3]).attr('id')).to.equal(
+          'Provide%20financial%20evidence-status'
+        )
+      })
+    })
+  })
+
+  context('when html is passed to text', function () {
+    it('should render escaped html', function () {
+      const $ = renderComponentHtmlToCheerio('task-list', {
+        items: [
+          {
+            text: 'A title with <strong>bold text</strong>',
+          },
+        ],
+      })
+
+      const $component = $('.app-task-list')
+      expect($component.html()).to.contain(
+        'A title with &lt;strong&gt;bold text&lt;/strong&gt;'
+      )
+    })
+  })
+
+  context('when html is passed to html', function () {
+    it('should render unescaped html', function () {
+      const $ = renderComponentHtmlToCheerio('task-list', {
+        items: [
+          {
+            html: 'A title with <strong>bold text</strong>',
+          },
+        ],
+      })
+
+      const $component = $('.app-task-list')
+      expect($component.html()).to.contain(
+        'A title with <strong>bold text</strong>'
+      )
+    })
+  })
+
+  context('when both html and text params are used', function () {
+    it('should render unescaped html', function () {
+      const $ = renderComponentHtmlToCheerio('task-list', {
+        items: [
+          {
+            html: 'A title with <strong>bold text</strong>',
+            text: 'A title with <strong>bold text</strong>',
+          },
+        ],
+      })
+
+      const $component = $('.app-task-list')
+      expect($component.html()).to.contain(
+        'A title with <strong>bold text</strong>'
+      )
+    })
+  })
+})

--- a/common/presenters/framework-to-task-list-component.js
+++ b/common/presenters/framework-to-task-list-component.js
@@ -1,0 +1,30 @@
+const i18n = require('../../config/i18n')
+
+const tagClasses = {
+  not_started: 'govuk-tag--grey',
+  incomplete: 'govuk-tag--blue',
+  default: '',
+}
+
+function frameworkToTaskListComponent(baseUrl = '') {
+  return ({ sections = {} } = {}) => {
+    const tasks = Object.entries(sections).map(([k, section]) => {
+      const { key, name, status } = section
+
+      return {
+        text: name,
+        href: baseUrl + key,
+        tag: {
+          text: i18n.t(`person-escort-record::statuses.${status}`),
+          classes: tagClasses[status] || tagClasses.default,
+        },
+      }
+    })
+
+    return {
+      items: tasks,
+    }
+  }
+}
+
+module.exports = frameworkToTaskListComponent

--- a/common/presenters/framework-to-task-list-component.test.js
+++ b/common/presenters/framework-to-task-list-component.test.js
@@ -1,0 +1,164 @@
+const i18n = require('../../config/i18n')
+
+const presenter = require('./framework-to-task-list-component')
+
+describe('Presenters', function () {
+  describe('#frameworkToTaskListComponent', function () {
+    let output
+
+    beforeEach(function () {
+      sinon.stub(i18n, 't').returnsArg(0)
+    })
+
+    context('without sections', function () {
+      beforeEach(function () {
+        output = presenter()()
+      })
+
+      it('should return empty items array', function () {
+        expect(output).to.deep.equal({
+          items: [],
+        })
+      })
+    })
+
+    context('with sections', function () {
+      const mockSections = {
+        incompleteSection: {
+          name: 'Incomplete section',
+          key: 'incomplete-section',
+          status: 'incomplete',
+        },
+        completeSection: {
+          name: 'Complete section',
+          key: 'complete-section',
+          status: 'complete',
+        },
+        notStartedSection: {
+          name: 'Not started section',
+          key: 'not-started-section',
+          status: 'not_started',
+        },
+      }
+
+      beforeEach(function () {
+        output = presenter()({
+          sections: mockSections,
+        })
+      })
+
+      it('should return correct number of keys', function () {
+        expect(Object.keys(output)).to.have.length(1)
+      })
+
+      it('should return correct number of items', function () {
+        expect(output.items).to.have.length(3)
+      })
+
+      describe('items', function () {
+        describe('incomplete section', function () {
+          it('should return correct number of keys', function () {
+            expect(Object.keys(output.items[0])).to.have.length(3)
+          })
+
+          it('should return text', function () {
+            expect(output.items[0].text).to.equal('Incomplete section')
+          })
+
+          it('should return href', function () {
+            expect(output.items[0].href).to.equal('incomplete-section')
+          })
+
+          it('should translate status', function () {
+            expect(i18n.t).to.be.calledWithExactly(
+              'person-escort-record::statuses.incomplete'
+            )
+          })
+
+          it('should return correct tag class', function () {
+            expect(output.items[0].tag).to.deep.equal({
+              text: 'person-escort-record::statuses.incomplete',
+              classes: 'govuk-tag--blue',
+            })
+          })
+        })
+
+        describe('complete section', function () {
+          it('should return correct number of keys', function () {
+            expect(Object.keys(output.items[1])).to.have.length(3)
+          })
+
+          it('should return text', function () {
+            expect(output.items[1].text).to.equal('Complete section')
+          })
+
+          it('should return href', function () {
+            expect(output.items[1].href).to.equal('complete-section')
+          })
+
+          it('should translate status', function () {
+            expect(i18n.t).to.be.calledWithExactly(
+              'person-escort-record::statuses.complete'
+            )
+          })
+
+          it('should return correct tag class', function () {
+            expect(output.items[1].tag).to.deep.equal({
+              text: 'person-escort-record::statuses.complete',
+              classes: '',
+            })
+          })
+        })
+
+        describe('not started section', function () {
+          it('should return correct number of keys', function () {
+            expect(Object.keys(output.items[2])).to.have.length(3)
+          })
+
+          it('should return text', function () {
+            expect(output.items[2].text).to.equal('Not started section')
+          })
+
+          it('should return href', function () {
+            expect(output.items[2].href).to.equal('not-started-section')
+          })
+
+          it('should translate status', function () {
+            expect(i18n.t).to.be.calledWithExactly(
+              'person-escort-record::statuses.not_started'
+            )
+          })
+
+          it('should return correct tag class', function () {
+            expect(output.items[2].tag).to.deep.equal({
+              text: 'person-escort-record::statuses.not_started',
+              classes: 'govuk-tag--grey',
+            })
+          })
+        })
+      })
+    })
+
+    context('with base URL', function () {
+      const mockSections = {
+        incompleteSection: {
+          name: 'Incomplete section',
+          key: 'incomplete-section',
+          status: 'incomplete',
+        },
+      }
+
+      beforeEach(function () {
+        output = presenter('/base-url/')({
+          sections: mockSections,
+        })
+      })
+
+      describe('items', function () {
+        it('should return href with base url', function () {
+          expect(output.items[0].href).to.equal('/base-url/incomplete-section')
+        })
+      })
+    })
+  })
+})

--- a/common/presenters/index.js
+++ b/common/presenters/index.js
@@ -10,6 +10,7 @@ const courtCaseToCardComponent = require('./court-case-to-card-component')
 const courtHearingToSummaryListComponent = require('./court-hearing-to-summary-list-component')
 const frameworkFieldToSummaryListRow = require('./framework-field-summary-list-row')
 const frameworkStepToSummary = require('./framework-step-to-summary')
+const frameworkToTaskListComponent = require('./framework-to-task-list-component')
 const moveToCardComponent = require('./move-to-card-component')
 const moveToMetaListComponent = require('./move-to-meta-list-component')
 const moveTypesToFilterComponent = require('./move-type-for-filter')
@@ -34,6 +35,7 @@ module.exports = {
   courtHearingToSummaryListComponent,
   frameworkFieldToSummaryListRow,
   frameworkStepToSummary,
+  frameworkToTaskListComponent,
   moveToCardComponent,
   moveToMetaListComponent,
   profileToCardComponent,

--- a/common/templates/layouts/base.njk
+++ b/common/templates/layouts/base.njk
@@ -35,6 +35,7 @@
 {% from "panel/macro.njk"             import appPanel %}
 {% from "read-only-field/macro.njk"   import appReadOnlyField %}
 {% from "tag/macro.njk"               import appTag %}
+{% from "task-list/macro.njk"         import appTaskList %}
 {% from "time/macro.njk"              import appTime %}
 
 {% block head %}

--- a/locales/en/person-escort-record.json
+++ b/locales/en/person-escort-record.json
@@ -1,6 +1,11 @@
 {
   "heading": "Person Escort Record",
   "section_overview": "{{section}} overview",
+  "statuses": {
+    "not_started": "Not started",
+    "incomplete": "Incomplete",
+    "complete": "Complete"
+  },
   "create": {
     "steps": {
       "before_you_start": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

This adds a controller and route handler for the top level of the person escort record route:

```
/person-escort-record/:recordId
```

### Why did it change

It makes sense to show logical things at different stages of the URL. Currently we show the sections nested within
this URL structure so this adds a handler to show the status of the PER broken down by section. It uses a simplified
version of an existing [task list](https://govuk-prototype-kit.herokuapp.com/docs/templates/task-list) pattern used elsewhere in government.

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

- [P4-1726](https://dsdmoj.atlassian.net/browse/P4-1726)

## Screenshots
<!--- (Optional) Include screenshots if changes update interfaces or components -->
<!--- Delete/copy as appropriate --->

<kbd><img src="https://user-images.githubusercontent.com/3327997/87340293-c3fd7280-c53f-11ea-8683-7187ca0366c4.png"></kbd>

## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [x] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed

### Other considerations

Commit messages with a `fix` or `feat` type are automatically used to generate the [changelog](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/CHANGELOG.md) and
[GitHub release notes](https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/releases) during the release task. Please make sure they will read well on their own in a
summary of changes and that the commit body gives a more detailed description of those changes if necessary.

- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
- [x] Update [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md) with any new instructions or tasks
