### PR TITLE
Fix/prevent dashboard showing incorrect allocations

### DIFF
--- a/app/allocations/middleware/set-body.allocations.js
+++ b/app/allocations/middleware/set-body.allocations.js
@@ -1,4 +1,4 @@
-const { map, set, get } = require('lodash')
+const { map, set } = require('lodash')
 
 const dateHelpers = require('../../../common/helpers/date')
 
@@ -6,7 +6,15 @@ function setBodyAllocations(req, res, next) {
   const { status, sortBy, sortDirection } = req.query
   const { dateRange } = req.params
 
-  const locations = get(req.session, 'currentRegion.locations', [])
+  let locations = req?.session?.currentRegion?.locations
+
+  if (!locations) {
+    const currentLocation = req?.session?.currentLocation
+
+    if (currentLocation) {
+      locations = [currentLocation]
+    }
+  }
 
   set(req, 'body.allocations', {
     status,

--- a/app/allocations/middleware/set-body.allocations.test.js
+++ b/app/allocations/middleware/set-body.allocations.test.js
@@ -62,5 +62,59 @@ describe('Allocations middleware', function () {
         expect(nextSpy).to.be.calledOnceWithExactly()
       })
     })
+
+    context('with current location', function () {
+      beforeEach(function () {
+        mockReq.session = {
+          currentLocation: {
+            id: '#locationId',
+          },
+        }
+        middleware(mockReq, mockRes, nextSpy)
+      })
+
+      it('should assign req.body correctly', function () {
+        expect(mockReq.body.allocations).to.deep.equal({
+          status: 'pending',
+          moveDate: ['2010-10-10', '2010-10-07'],
+          locations: ['#locationId'],
+          sortBy: 'moves_count',
+          sortDirection: 'asc',
+        })
+      })
+
+      it('should call next', function () {
+        expect(nextSpy).to.be.calledOnceWithExactly()
+      })
+    })
+
+    context('with current region', function () {
+      beforeEach(function () {
+        mockReq.session = {
+          currentRegion: {
+            locations: [
+              {
+                id: '#locationId',
+              },
+            ],
+          },
+        }
+        middleware(mockReq, mockRes, nextSpy)
+      })
+
+      it('should assign req.body correctly', function () {
+        expect(mockReq.body.allocations).to.deep.equal({
+          status: 'pending',
+          moveDate: ['2010-10-10', '2010-10-07'],
+          locations: ['#locationId'],
+          sortBy: 'moves_count',
+          sortDirection: 'asc',
+        })
+      })
+
+      it('should call next', function () {
+        expect(nextSpy).to.be.calledOnceWithExactly()
+      })
+    })
   })
 })

--- a/app/healthcheck/index.js
+++ b/app/healthcheck/index.js
@@ -7,7 +7,7 @@ const { checkDependencies } = require('./middleware')
 
 // Define routes
 router.get('/', checkDependencies, get)
-router.get('/ping', checkDependencies, ping)
+router.get('/ping', ping)
 
 // Export
 module.exports = {

--- a/app/locations/middleware.js
+++ b/app/locations/middleware.js
@@ -20,6 +20,7 @@ function setLocation(req, res, next) {
 
   const location = find(req.userLocations, { id: locationId })
 
+  req.session.currentRegion = null
   req.session.currentLocation = location
   next()
 }
@@ -54,6 +55,7 @@ function setAllLocations(req, res, next) {
     return next()
   }
 
+  req.session.currentRegion = null
   req.session.currentLocation = null
   next()
 }

--- a/app/locations/middleware.test.js
+++ b/app/locations/middleware.test.js
@@ -187,6 +187,11 @@ describe('Locations middleware', function () {
         expect(req.session.currentLocation).to.deep.equal(mockUserLocations[0])
       })
 
+      it('should set currentRegion to null', function () {
+        expect(req.session).to.have.property('currentRegion')
+        expect(req.session.currentRegion).to.be.null
+      })
+
       it('should call next without args', function () {
         expect(nextSpy).to.be.calledOnceWithExactly()
       })
@@ -243,9 +248,14 @@ describe('Locations middleware', function () {
         middleware.setAllLocations(req, {}, nextSpy)
       })
 
-      it('should set currentLocation', function () {
+      it('should unset currentLocation', function () {
         expect(req.session).to.have.property('currentLocation')
-        expect(req.session.currentLocation).to.equal(null)
+        expect(req.session.currentLocation).to.be.null
+      })
+
+      it('should unset currentRegion', function () {
+        expect(req.session).to.have.property('currentRegion')
+        expect(req.session.currentRegion).to.be.null
       })
 
       it('should call next without args', function () {
@@ -264,7 +274,9 @@ describe('Locations middleware', function () {
 
     beforeEach(function () {
       req = {
-        session: {},
+        session: {
+          currentLocation: { id: '#currentLocation' },
+        },
         params: {},
       }
       nextSpy = sinon.spy()
@@ -278,6 +290,7 @@ describe('Locations middleware', function () {
         )
         await proxiedMiddleware.setRegion(req, {}, nextSpy)
         expect(nextSpy).to.be.calledOnceWithExactly()
+        expect(req.session.currentLocation).to.be.null
         expect(req.session.currentRegion).to.deep.equal(currentRegion)
       })
     })


### PR DESCRIPTION
 Proposed changes

### What changed

- Ensures that currentRegion is unset when a location is chosen
- Ensures that currentLocation is unset when a region is chosen
- Ensures both unset when all locations are chosen

- Removes dependency check from ping

### Why did it change

Allocations for single locations were not filtered
Selecting a region caused allocations to be sticky when switching to a non-region location . 

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

- [P4-1928](https://dsdmoj.atlassian.net/browse/P4-1928)


## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed



### Other considerations


- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics

