### PR TITLE
build: Add API_TIMEOUT env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,7 @@ The TZ (timezone) environment variable is set to 'Europe/London' in `start.js`.
 | AUTH_PROVIDER_URL **(required)** | Base URL for the auth provider server | |
 | AUTH_EXPIRY_MARGIN | How close the user authentication should be to expiring before refreshing it | `300` (5 minutes) |
 | NOMIS_ELITE2_API_URL **(required)** | Base URL for the NOMIS Elite 2 API, without trailing slash | |
+| NOMIS_ELITE2_API_HEALTHCHECK_PATH | Path to which healthcheck pings for NOMIS Elite 2 API are sent | /health/ping |
 | SERVER_HOST **(required)** | The (accessible) hostname (and port) of the listening web server. Used by [Grant](https://github.com/simov/grant) to construct redirect URLs after OAuth authentication. For example `localhost:3000` | |
 | FEEDBACK_URL | URL for the feedback link in the phase banner at the top of the page. If empty, the link will not be displayed. | |
 | SUPPORT_EMAIL | Email address used to contact support or the team in parts of the app where the user may require further help. | |

--- a/README.md
+++ b/README.md
@@ -224,8 +224,9 @@ The TZ (timezone) environment variable is set to 'Europe/London' in `start.js`.
 | REDIS_URL **(required)** | Redis server URL, including port and protocol | |
 | REDIS_HOST **(required)** | Redis hostname. Can be used instead of `REDIS_URL`. Will override `REDIS_URL` if set | |
 | REDIS_AUTH_TOKEN | Optional auth token for the Redis instance | |
-| API_BASE_URL **(required)** | Base URL for the backend API server for this service without any path | `http://localhost:3000` |
-| API_PATH **(required)** | Base path for the API | `/api` |
+| API_BASE_URL **(required)** | Base URL for the backend API server for this service without any path | |
+| API_PATH **(required)** | Base path for the API | |
+| API_TIMEOUT | TimeAPI request timeout (ms) | 30000 |
 | API_VERSION **(required)** | API version to use | |
 | API_HEALTHCHECK_PATH **(required)** | Path to which healthcheck pings are sent | |
 | API_AUTH_PATH **(required)** | Path to which OAuth2 access token requests should be sent | |

--- a/config/index.js
+++ b/config/index.js
@@ -17,6 +17,8 @@ const API_BASE_URL = process.env.API_BASE_URL
 const AUTH_BASE_URL = process.env.AUTH_PROVIDER_URL
 const AUTH_KEY = process.env.AUTH_PROVIDER_KEY
 const NOMIS_ELITE2_API_BASE_URL = process.env.NOMIS_ELITE2_API_URL
+const NOMIS_ELITE2_API_HEALTHCHECK_PATH =
+  process.env.NOMIS_ELITE2_API_HEALTHCHECK_PATH || '/health/ping'
 const SESSION = {
   NAME: process.env.SESSION_NAME || 'book-secure-move.sid',
   SECRET: process.env.SESSION_SECRET,
@@ -117,7 +119,7 @@ module.exports = {
   DEFAULT_AUTH_PROVIDER: 'hmpps',
   NOMIS_ELITE2_API: {
     user_caseloads_url: `${NOMIS_ELITE2_API_BASE_URL}/api/users/me/caseLoads`,
-    healthcheck_url: `${NOMIS_ELITE2_API_BASE_URL}/ping`,
+    healthcheck_url: `${NOMIS_ELITE2_API_BASE_URL}${NOMIS_ELITE2_API_HEALTHCHECK_PATH}`,
   },
   ANALYTICS: {
     GA_ID: process.env.GOOGLE_ANALYTICS_ID,

--- a/config/index.js
+++ b/config/index.js
@@ -49,7 +49,7 @@ module.exports = {
     HEALTHCHECK_URL: API_BASE_URL + process.env.API_HEALTHCHECK_PATH,
     CLIENT_ID: process.env.API_CLIENT_ID,
     SECRET: process.env.API_SECRET,
-    TIMEOUT: 30000, // in milliseconds
+    TIMEOUT: Number(process.env.API_TIMEOUT || 30000), // in milliseconds
     CACHE_EXPIRY: process.env.API_CACHE_EXPIRY || 60 * 60 * 24 * 7, // in seconds (7 days)
     DISABLE_CACHE: process.env.API_DISABLE_CACHE,
   },


### PR DESCRIPTION
## Proposed changes

### What changed

Add `API_TIMEOUT` env var

### Why did it change

Enables us to customise the timeout of requests to the API


## Checklists

### Environment variables


<!--- Delete if changes DO NOT include new environment variables -->
- [x] Documented in the [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md)
- [ ] Added to [continous integration](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-book-secure-move-frontend)
- [ ] Added to staging environment (deployment repository)
- [ ] Added to preproduction environment (deployment repository)
- [ ] Added to production environment (deployment repository)

### Other considerations

- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics

