### PR TITLE
[P4-2006] Support multiple versions of a Person escort record

### DIFF
--- a/app/move/controllers/view.js
+++ b/app/move/controllers/view.js
@@ -2,17 +2,14 @@ const { isEmpty, find, sortBy } = require('lodash')
 
 const permissionsMiddleware = require('../../../common/middleware/permissions')
 const presenters = require('../../../common/presenters')
-const frameworksService = require('../../../common/services/frameworks')
 const { FEATURE_FLAGS } = require('../../../config')
 const updateSteps = require('../steps/update')
 
 const getUpdateLinks = require('./view/view.update.links')
 const getUpdateUrls = require('./view/view.update.urls')
 
-const framework = frameworksService.getPersonEscortRecord()
-
 module.exports = function view(req, res) {
-  const { move, originalUrl } = req
+  const { move, originalUrl, framework = {} } = req
   const {
     profile,
     status,

--- a/app/move/controllers/view.test.js
+++ b/app/move/controllers/view.test.js
@@ -19,9 +19,6 @@ const pathStubs = {
   '../steps/update': updateSteps,
   './view/view.update.urls': getUpdateUrls,
   './view/view.update.links': getUpdateLinks,
-  '../../../common/services/frameworks': {
-    getPersonEscortRecord: () => frameworkStub,
-  },
 }
 const controller = proxyquire('./view', pathStubs)
 
@@ -169,7 +166,7 @@ describe('Move controllers', function () {
           presenters.frameworkToTaskListComponent
         ).to.be.calledOnceWithExactly({
           baseUrl: `${mockOriginalUrl}/person-escort-record/`,
-          frameworkSections: frameworkStub.sections,
+          frameworkSections: undefined,
           sectionProgress: undefined,
         })
       })
@@ -534,6 +531,7 @@ describe('Move controllers', function () {
             person_escort_record: mockPersonEscortRecord,
           },
         }
+        req.framework = frameworkStub
       })
 
       context('when record is not_started', function () {

--- a/app/move/index.js
+++ b/app/move/index.js
@@ -9,6 +9,7 @@ const FormWizardController = require('../../common/controllers/form-wizard')
 const { uuidRegex } = require('../../common/helpers/url')
 const { protectRoute } = require('../../common/middleware/permissions')
 const personEscortRecordApp = require('../person-escort-record')
+const { setFramework } = require('../person-escort-record/middleware')
 
 const { assign, confirmation, create, update, view } = require('./controllers')
 const {
@@ -90,7 +91,12 @@ router.use(
   protectRoute('move:create'),
   wizard(createSteps, createFields, createConfig)
 )
-router.use(`/:moveId(${uuidRegex})`, moveRouter)
+router.use(
+  `/:moveId(${uuidRegex})`,
+  setPersonEscortRecord,
+  setFramework,
+  moveRouter
+)
 
 moveRouter.get('/', protectRoute('move:view'), view)
 moveRouter.get(
@@ -99,11 +105,7 @@ moveRouter.get(
   setAllocation,
   confirmation
 )
-moveRouter.use(
-  personEscortRecordApp.mountpath,
-  setPersonEscortRecord,
-  personEscortRecordApp.router
-)
+moveRouter.use(personEscortRecordApp.mountpath, personEscortRecordApp.router)
 moveRouter.use(
   '/cancel',
   protectRoute(['move:cancel', 'move:cancel:proposed']),

--- a/app/person-escort-record/index.js
+++ b/app/person-escort-record/index.js
@@ -4,7 +4,6 @@ const router = require('express').Router({ mergeParams: true })
 // Local dependencies
 const { uuidRegex } = require('../../common/helpers/url')
 const { protectRoute } = require('../../common/middleware/permissions')
-const frameworksService = require('../../common/services/frameworks')
 
 const confirmApp = require('./app/confirm')
 const newApp = require('./app/new')
@@ -12,14 +11,14 @@ const {
   frameworkOverviewController,
   printRecordController,
 } = require('./controllers')
-const { setFramework, setPersonEscortRecord } = require('./middleware')
-const { defineFormWizards } = require('./router')
+const {
+  setFramework,
+  setFrameworkSection,
+  setPersonEscortRecord,
+} = require('./middleware')
+const { defineFormWizard } = require('./router')
 
-const framework = frameworksService.getPersonEscortRecord()
-const frameworkWizard = defineFormWizards(framework)
-
-// Define middlewares used by all routes and sub-apps
-router.use(setFramework(framework))
+router.param('section', setFrameworkSection)
 
 // Define "create" sub-app before ID sepcific middleware
 router.use(newApp.mountpath, newApp.router)
@@ -27,7 +26,7 @@ router.use(newApp.mountpath, newApp.router)
 // Define shared middleware
 router.use(protectRoute('person_escort_record:view'))
 router.use(setPersonEscortRecord)
-router.use(frameworkWizard)
+router.use(setFramework)
 
 // Define sub-apps
 router.use(confirmApp.mountpath, confirmApp.router)
@@ -35,6 +34,7 @@ router.use(confirmApp.mountpath, confirmApp.router)
 // Define routes
 router.get('/', frameworkOverviewController)
 router.get('/print', printRecordController)
+router.use('/:section', defineFormWizard)
 
 // Export
 module.exports = {

--- a/app/person-escort-record/middleware.js
+++ b/app/person-escort-record/middleware.js
@@ -1,17 +1,34 @@
+const frameworksService = require('../../common/services/frameworks')
 const personEscortRecordService = require('../../common/services/person-escort-record')
 
-function setFramework(framework) {
-  return (req, res, next) => {
-    req.framework = framework
+function setFramework(req, res, next) {
+  if (!req.personEscortRecord) {
+    return next()
+  }
+
+  try {
+    req.framework = frameworksService.getPersonEscortRecord(
+      req.personEscortRecord?.version
+    )
+
     next()
+  } catch (error) {
+    next(error)
   }
 }
 
-function setFrameworkSection(frameworkSection) {
-  return (req, res, next) => {
-    req.frameworkSection = frameworkSection
-    next()
+function setFrameworkSection(req, res, next, key) {
+  const section = req.framework?.sections[key]
+
+  if (section) {
+    req.frameworkSection = section
+    return next()
   }
+
+  const error = new Error('Framework section not found')
+  error.statusCode = 404
+
+  next(error)
 }
 
 async function setPersonEscortRecord(req, res, next) {

--- a/app/person-escort-record/router.test.js
+++ b/app/person-escort-record/router.test.js
@@ -1,22 +1,13 @@
 const proxyquire = require('proxyquire')
 
-const {
-  FrameworkSectionController,
-  FrameworkStepController,
-} = require('./controllers')
-const middleware = require('./middleware')
+const FrameworkSectionController = require('./controllers/framework-section')
+const FrameworkStepController = require('./controllers/framework-step')
 
 const wizardReqStub = sinon.stub()
 const wizardStub = sinon.stub().returns(wizardReqStub)
-const mockRouter = {
-  use: sinon.stub(),
-}
 
 const router = proxyquire('./router', {
   'hmpo-form-wizard': wizardStub,
-  express: {
-    Router: () => mockRouter,
-  },
 })
 
 const mockFramework = {
@@ -54,113 +45,73 @@ const mockFramework = {
 }
 
 describe('Person Escort Record router', function () {
-  describe('#defineFormWizards', function () {
-    let output
+  describe('#defineFormWizard', function () {
+    let req, res, next
 
     beforeEach(function () {
-      sinon.stub(middleware, 'setFrameworkSection')
+      req = {
+        framework: mockFramework,
+        frameworkSection: {
+          key: 'section-one',
+          steps: {
+            '/step-1': {},
+            '/step-2': {},
+            '/step-3': {},
+          },
+        },
+      }
+      res = {}
+      next = sinon.spy()
 
-      output = router.defineFormWizards(mockFramework)
+      router.defineFormWizard(req, res, next)
     })
 
     afterEach(function () {
-      mockRouter.use.resetHistory()
       wizardStub.resetHistory()
       wizardReqStub.resetHistory()
     })
 
-    describe('router', function () {
-      it('should call use correct number of times', function () {
-        expect(mockRouter.use.callCount).to.equal(3)
-      })
-
-      it('should setup router with form wizards', function () {
-        for (const [key, value] of Object.entries(mockFramework.sections)) {
-          const steps = {
-            '/': {
-              reset: true,
-              resetJourney: true,
-              skip: true,
-              next: Object.values(value.steps)[0].slug,
-            },
-            ...value.steps,
-            '/overview': {
-              controller: FrameworkSectionController,
-              reset: true,
-              resetJourney: true,
-              template: 'framework-section',
-            },
-          }
-          const config = {
-            controller: FrameworkStepController,
-            entryPoint: true,
-            journeyName: `person-escort-record-${key}`,
-            journeyPageTitle: 'Person escort record',
-            name: `person-escort-record-${key}`,
-            template: 'framework-step',
-            templatePath: 'person-escort-record/views/',
-          }
-
-          expect(mockRouter.use).to.be.calledWithExactly(
-            `/${key}`,
-            middleware.setFrameworkSection(value),
-            wizardStub(steps, mockFramework.questions, config)
-          )
-        }
-      })
-    })
-
     describe('form wizard', function () {
-      const sectionCount = Object.keys(mockFramework.sections).length
-
-      it('should call form wizard correct number of times', function () {
-        expect(wizardStub.callCount).to.equal(sectionCount)
-      })
-
       it('should call form wizard with correct number of arguments', function () {
-        for (let index = 0; index < sectionCount.length; index++) {
-          expect(wizardStub.args[index]).to.have.length(3)
-        }
+        expect(wizardStub.args[0]).to.have.length(3)
       })
 
       it('should call form wizard with steps', function () {
-        for (const [key, value] of Object.entries(mockFramework.sections)) {
-          const steps = {
-            '/': {
-              reset: true,
-              resetJourney: true,
-              skip: true,
-              next: Object.values(value.steps)[0].slug,
-            },
-            ...value.steps,
-            '/overview': {
-              controller: FrameworkSectionController,
-              reset: true,
-              resetJourney: true,
-              template: 'framework-section',
-            },
-          }
-          const config = {
-            controller: FrameworkStepController,
-            entryPoint: true,
-            journeyName: `person-escort-record-${key}`,
-            journeyPageTitle: 'Person escort record',
-            name: `person-escort-record-${key}`,
-            template: 'framework-step',
-            templatePath: 'person-escort-record/views/',
-          }
-
-          expect(wizardStub).to.be.calledWithExactly(
-            steps,
-            mockFramework.questions,
-            config
-          )
+        const steps = {
+          '/': {
+            reset: true,
+            resetJourney: true,
+            skip: true,
+            next: Object.values(req.frameworkSection.steps)[0].slug,
+          },
+          ...req.frameworkSection.steps,
+          '/overview': {
+            controller: FrameworkSectionController,
+            reset: true,
+            resetJourney: true,
+            template: 'framework-section',
+          },
         }
-      })
-    })
+        const config = {
+          controller: FrameworkStepController,
+          entryPoint: true,
+          journeyName: `person-escort-record-${req.frameworkSection.key}`,
+          journeyPageTitle: 'Person escort record',
+          name: `person-escort-record-${req.frameworkSection.key}`,
+          template: 'framework-step',
+          templatePath: 'person-escort-record/views/',
+        }
 
-    it('should return a router', function () {
-      expect(output).to.deep.equal(mockRouter)
+        expect(wizardStub).to.be.calledWithExactly(
+          steps,
+          mockFramework.questions,
+          config
+        )
+      })
+
+      it('should call form wizard with steps', function () {
+        expect(wizardReqStub).to.be.calledWithExactly(req, res, next)
+      })
     })
   })
 })

--- a/common/services/framework-response.test.js
+++ b/common/services/framework-response.test.js
@@ -6,7 +6,7 @@ const mockFrameworkResponse = {
   id: '12345',
 }
 
-describe('Presenters', function () {
+describe('Services', function () {
   describe('Framework Response Service', function () {
     describe('#update()', function () {
       const mockResponse = {

--- a/common/services/frameworks.js
+++ b/common/services/frameworks.js
@@ -47,7 +47,14 @@ function buildCommentField(
   return field
 }
 
-function importFiles(folderPath) {
+function importFiles(version, ...paths) {
+  const folderPath = path.resolve(
+    frameworks.output,
+    version,
+    'frameworks',
+    ...paths
+  )
+
   try {
     return fs.readdirSync(folderPath).map(filename => {
       const filepath = path.resolve(folderPath, filename)
@@ -56,7 +63,9 @@ function importFiles(folderPath) {
       return JSON.parse(contents)
     })
   } catch (e) {
-    const error = new Error('This version of the framework is not supported')
+    const error = new Error(
+      `Version ${version} of the framework is not supported`
+    )
     error.code = 'MISSING_FRAMEWORK'
 
     throw error
@@ -187,22 +196,8 @@ const frameworksService = {
   },
 
   getFramework({ framework = '', version = '' } = {}) {
-    const sectionsFolder = path.resolve(
-      frameworks.output,
-      version,
-      'frameworks',
-      framework,
-      'manifests'
-    )
-    const questionsFolder = path.resolve(
-      frameworks.output,
-      version,
-      'frameworks',
-      framework,
-      'questions'
-    )
-    const sections = importFiles(sectionsFolder)
-    const questions = importFiles(questionsFolder)
+    const sections = importFiles(version, framework, 'manifests')
+    const questions = importFiles(version, framework, 'questions')
 
     return {
       sections: keyBy(sections, 'key'),

--- a/common/services/frameworks.test.js
+++ b/common/services/frameworks.test.js
@@ -20,1125 +20,1129 @@ const frameworksService = proxyquire('./frameworks', {
   },
 })
 
-describe('Frameworks service', function () {
-  describe('#transformQuestion', function () {
-    beforeEach(function () {
-      sinon.stub(markdown, 'render').returnsArg(0)
-    })
-
-    context('with no options', function () {
-      it('should return an empty object', function () {
-        const transformed = frameworksService.transformQuestion()
-        expect(transformed).to.deep.equal({})
-      })
-    })
-
-    context('with options', function () {
-      let mockQuestion
-
+describe('Services', function () {
+  describe('Frameworks service', function () {
+    describe('#transformQuestion', function () {
       beforeEach(function () {
-        mockQuestion = {
+        sinon.stub(markdown, 'render').returnsArg(0)
+      })
+
+      context('with no options', function () {
+        it('should return an empty object', function () {
+          const transformed = frameworksService.transformQuestion()
+          expect(transformed).to.deep.equal({})
+        })
+      })
+
+      context('with options', function () {
+        let mockQuestion
+
+        beforeEach(function () {
+          mockQuestion = {
+            question: 'Question text',
+          }
+        })
+
+        context('by default', function () {
+          it('should format correctly', function () {
+            const transformed = frameworksService.transformQuestion(
+              'question-key',
+              mockQuestion
+            )
+            expect(transformed).to.deep.equal({
+              component: 'govukInput',
+              question: 'Question text',
+              description: undefined,
+              id: 'question-key',
+              name: 'question-key',
+              label: {
+                text: 'Question text',
+                classes: 'govuk-label--s',
+              },
+              validate: [],
+            })
+          })
+        })
+
+        context('with hint text', function () {
+          let transformed
+          beforeEach(function () {
+            mockQuestion = {
+              ...mockQuestion,
+              hint: 'Hint text',
+            }
+
+            transformed = frameworksService.transformQuestion(
+              'question-key',
+              mockQuestion
+            )
+          })
+
+          it('should render markdown for hint text', function () {
+            expect(markdown.render).to.be.calledOnceWithExactly('Hint text')
+          })
+
+          it('should format correctly', function () {
+            expect(transformed).to.deep.equal({
+              component: 'govukInput',
+              question: 'Question text',
+              description: undefined,
+              id: 'question-key',
+              name: 'question-key',
+              label: {
+                text: 'Question text',
+                classes: 'govuk-label--s',
+              },
+              hint: {
+                html: 'Hint text',
+                classes: 'markdown',
+              },
+              validate: [],
+            })
+          })
+        })
+
+        context('with description', function () {
+          beforeEach(function () {
+            mockQuestion = {
+              ...mockQuestion,
+              description: 'Short field description',
+            }
+          })
+
+          it('should format correctly', function () {
+            const transformed = frameworksService.transformQuestion(
+              'question-key',
+              mockQuestion
+            )
+            expect(transformed).to.deep.equal({
+              component: 'govukInput',
+              question: 'Question text',
+              description: 'Short field description',
+              id: 'question-key',
+              name: 'question-key',
+              label: {
+                text: 'Question text',
+                classes: 'govuk-label--s',
+              },
+              validate: [],
+            })
+          })
+        })
+
+        context('with validations', function () {
+          beforeEach(function () {
+            mockQuestion = {
+              ...mockQuestion,
+              validations: [
+                {
+                  type: 'required',
+                  message: 'This field is required',
+                },
+                {
+                  type: 'date',
+                  message: 'This must be a date',
+                },
+              ],
+            }
+          })
+
+          it('should format correctly', function () {
+            const transformed = frameworksService.transformQuestion(
+              'question-key',
+              mockQuestion
+            )
+            expect(transformed).to.deep.equal({
+              component: 'govukInput',
+              question: 'Question text',
+              description: undefined,
+              id: 'question-key',
+              name: 'question-key',
+              label: {
+                text: 'Question text',
+                classes: 'govuk-label--s',
+              },
+              validate: [
+                {
+                  type: 'required',
+                  message: 'This field is required',
+                },
+                {
+                  type: 'date',
+                  message: 'This must be a date',
+                },
+              ],
+            })
+          })
+        })
+
+        context('with followup', function () {
+          beforeEach(function () {
+            mockQuestion = {
+              ...mockQuestion,
+              options: [
+                {
+                  value: 'Yes',
+                  label: 'Yes',
+                  followup: 'conditional-field-1',
+                },
+                {
+                  value: 'No',
+                  label: 'No',
+                  followup: ['conditional-field-2', 'conditional-field-3'],
+                },
+              ],
+            }
+          })
+
+          it('should format correctly', function () {
+            const transformed = frameworksService.transformQuestion(
+              'question-key',
+              mockQuestion
+            )
+            expect(transformed).to.deep.equal({
+              component: 'govukInput',
+              question: 'Question text',
+              description: undefined,
+              id: 'question-key',
+              name: 'question-key',
+              label: {
+                text: 'Question text',
+                classes: 'govuk-label--s',
+              },
+              items: [
+                {
+                  value: 'Yes',
+                  text: 'Yes',
+                  followup: ['conditional-field-1'],
+                  conditional: ['conditional-field-1'],
+                },
+                {
+                  value: 'No',
+                  text: 'No',
+                  followup: ['conditional-field-2', 'conditional-field-3'],
+                  conditional: ['conditional-field-2', 'conditional-field-3'],
+                },
+              ],
+              validate: [],
+            })
+          })
+        })
+
+        context('with follow up comment', function () {
+          let transformed
+
+          beforeEach(function () {
+            mockQuestion = {
+              ...mockQuestion,
+              options: [
+                {
+                  value: 'Yes, I agree',
+                  label: 'Yes, I agree',
+                  followup_comment: {
+                    label: 'Give details',
+                    hint: 'Some hint information',
+                    validations: [
+                      {
+                        type: 'required',
+                        message: 'This field is required',
+                      },
+                    ],
+                  },
+                },
+                {
+                  value: 'No, I do not agree',
+                  label: 'No, I do not agree',
+                  followup_comment: {
+                    label: 'Give details',
+                  },
+                },
+              ],
+            }
+
+            transformed = frameworksService.transformQuestion(
+              'question-key',
+              mockQuestion
+            )
+          })
+
+          it('should render markdown for hint text', function () {
+            expect(markdown.render).to.be.calledOnceWithExactly(
+              'Some hint information'
+            )
+          })
+
+          it('should format correctly', function () {
+            expect(transformed).to.deep.equal({
+              component: 'govukInput',
+              question: 'Question text',
+              description: undefined,
+              id: 'question-key',
+              name: 'question-key',
+              label: {
+                text: 'Question text',
+                classes: 'govuk-label--s',
+              },
+              items: [
+                {
+                  value: 'Yes, I agree',
+                  text: 'Yes, I agree',
+                  conditional: {
+                    rows: 4,
+                    name: 'question-key--yes-i-agree',
+                    id: 'question-key--yes-i-agree',
+                    component: 'govukTextarea',
+                    classes: 'govuk-input--width-20',
+                    label: {
+                      text: 'Give details',
+                      classes: 'govuk-label--s',
+                    },
+                    hint: {
+                      html: 'Some hint information',
+                      classes: 'markdown',
+                    },
+                    validate: [
+                      {
+                        type: 'required',
+                        message: 'This field is required',
+                      },
+                    ],
+                  },
+                },
+                {
+                  value: 'No, I do not agree',
+                  text: 'No, I do not agree',
+                  conditional: {
+                    rows: 4,
+                    name: 'question-key--no-i-do-not-agree',
+                    id: 'question-key--no-i-do-not-agree',
+                    component: 'govukTextarea',
+                    classes: 'govuk-input--width-20',
+                    label: {
+                      text: 'Give details',
+                      classes: 'govuk-label--s',
+                    },
+                    validate: undefined,
+                  },
+                },
+              ],
+              validate: [],
+            })
+          })
+        })
+      })
+
+      describe('question types', function () {
+        const mockQuestion = {
           question: 'Question text',
         }
-      })
 
-      context('by default', function () {
-        it('should format correctly', function () {
-          const transformed = frameworksService.transformQuestion(
-            'question-key',
-            mockQuestion
-          )
-          expect(transformed).to.deep.equal({
-            component: 'govukInput',
-            question: 'Question text',
-            description: undefined,
-            id: 'question-key',
-            name: 'question-key',
-            label: {
-              text: 'Question text',
-              classes: 'govuk-label--s',
-            },
-            validate: [],
+        describe('radio', function () {
+          let transformed
+          beforeEach(function () {
+            transformed = frameworksService.transformQuestion('question-key', {
+              ...mockQuestion,
+              type: 'radio',
+              options: [
+                {
+                  label: 'Option one',
+                  hint: 'Hint text for option one',
+                  value: 'Option one',
+                },
+                {
+                  label: 'Option two',
+                  value: 'Option two',
+                },
+                {
+                  label: 'Option three',
+                  value: 'Option three',
+                },
+              ],
+            })
           })
-        })
-      })
 
-      context('with hint text', function () {
-        let transformed
-        beforeEach(function () {
-          mockQuestion = {
-            ...mockQuestion,
-            hint: 'Hint text',
-          }
-
-          transformed = frameworksService.transformQuestion(
-            'question-key',
-            mockQuestion
-          )
-        })
-
-        it('should render markdown for hint text', function () {
-          expect(markdown.render).to.be.calledOnceWithExactly('Hint text')
-        })
-
-        it('should format correctly', function () {
-          expect(transformed).to.deep.equal({
-            component: 'govukInput',
-            question: 'Question text',
-            description: undefined,
-            id: 'question-key',
-            name: 'question-key',
-            label: {
-              text: 'Question text',
-              classes: 'govuk-label--s',
-            },
-            hint: {
-              html: 'Hint text',
-              classes: 'markdown',
-            },
-            validate: [],
+          it('should render markdown for hint text', function () {
+            expect(markdown.render).to.be.calledOnceWithExactly(
+              'Hint text for option one'
+            )
           })
-        })
-      })
 
-      context('with description', function () {
-        beforeEach(function () {
-          mockQuestion = {
-            ...mockQuestion,
-            description: 'Short field description',
-          }
-        })
-
-        it('should format correctly', function () {
-          const transformed = frameworksService.transformQuestion(
-            'question-key',
-            mockQuestion
-          )
-          expect(transformed).to.deep.equal({
-            component: 'govukInput',
-            question: 'Question text',
-            description: 'Short field description',
-            id: 'question-key',
-            name: 'question-key',
-            label: {
-              text: 'Question text',
-              classes: 'govuk-label--s',
-            },
-            validate: [],
-          })
-        })
-      })
-
-      context('with validations', function () {
-        beforeEach(function () {
-          mockQuestion = {
-            ...mockQuestion,
-            validations: [
-              {
-                type: 'required',
-                message: 'This field is required',
-              },
-              {
-                type: 'date',
-                message: 'This must be a date',
-              },
-            ],
-          }
-        })
-
-        it('should format correctly', function () {
-          const transformed = frameworksService.transformQuestion(
-            'question-key',
-            mockQuestion
-          )
-          expect(transformed).to.deep.equal({
-            component: 'govukInput',
-            question: 'Question text',
-            description: undefined,
-            id: 'question-key',
-            name: 'question-key',
-            label: {
-              text: 'Question text',
-              classes: 'govuk-label--s',
-            },
-            validate: [
-              {
-                type: 'required',
-                message: 'This field is required',
-              },
-              {
-                type: 'date',
-                message: 'This must be a date',
-              },
-            ],
-          })
-        })
-      })
-
-      context('with followup', function () {
-        beforeEach(function () {
-          mockQuestion = {
-            ...mockQuestion,
-            options: [
-              {
-                value: 'Yes',
-                label: 'Yes',
-                followup: 'conditional-field-1',
-              },
-              {
-                value: 'No',
-                label: 'No',
-                followup: ['conditional-field-2', 'conditional-field-3'],
-              },
-            ],
-          }
-        })
-
-        it('should format correctly', function () {
-          const transformed = frameworksService.transformQuestion(
-            'question-key',
-            mockQuestion
-          )
-          expect(transformed).to.deep.equal({
-            component: 'govukInput',
-            question: 'Question text',
-            description: undefined,
-            id: 'question-key',
-            name: 'question-key',
-            label: {
-              text: 'Question text',
-              classes: 'govuk-label--s',
-            },
-            items: [
-              {
-                value: 'Yes',
-                text: 'Yes',
-                followup: ['conditional-field-1'],
-                conditional: ['conditional-field-1'],
-              },
-              {
-                value: 'No',
-                text: 'No',
-                followup: ['conditional-field-2', 'conditional-field-3'],
-                conditional: ['conditional-field-2', 'conditional-field-3'],
-              },
-            ],
-            validate: [],
-          })
-        })
-      })
-
-      context('with follow up comment', function () {
-        let transformed
-
-        beforeEach(function () {
-          mockQuestion = {
-            ...mockQuestion,
-            options: [
-              {
-                value: 'Yes, I agree',
-                label: 'Yes, I agree',
-                followup_comment: {
-                  label: 'Give details',
-                  hint: 'Some hint information',
-                  validations: [
-                    {
-                      type: 'required',
-                      message: 'This field is required',
-                    },
-                  ],
+          it('should format type correctly', function () {
+            expect(transformed).to.deep.equal({
+              component: 'govukRadios',
+              question: 'Question text',
+              description: undefined,
+              id: 'question-key',
+              name: 'question-key',
+              fieldset: {
+                legend: {
+                  text: 'Question text',
+                  classes: 'govuk-label--s',
                 },
               },
-              {
-                value: 'No, I do not agree',
-                label: 'No, I do not agree',
-                followup_comment: {
-                  label: 'Give details',
-                },
-              },
-            ],
-          }
-
-          transformed = frameworksService.transformQuestion(
-            'question-key',
-            mockQuestion
-          )
-        })
-
-        it('should render markdown for hint text', function () {
-          expect(markdown.render).to.be.calledOnceWithExactly(
-            'Some hint information'
-          )
-        })
-
-        it('should format correctly', function () {
-          expect(transformed).to.deep.equal({
-            component: 'govukInput',
-            question: 'Question text',
-            description: undefined,
-            id: 'question-key',
-            name: 'question-key',
-            label: {
-              text: 'Question text',
-              classes: 'govuk-label--s',
-            },
-            items: [
-              {
-                value: 'Yes, I agree',
-                text: 'Yes, I agree',
-                conditional: {
-                  rows: 4,
-                  name: 'question-key--yes-i-agree',
-                  id: 'question-key--yes-i-agree',
-                  component: 'govukTextarea',
-                  classes: 'govuk-input--width-20',
-                  label: {
-                    text: 'Give details',
-                    classes: 'govuk-label--s',
-                  },
+              items: [
+                {
+                  text: 'Option one',
+                  value: 'Option one',
                   hint: {
-                    html: 'Some hint information',
+                    html: 'Hint text for option one',
                     classes: 'markdown',
                   },
-                  validate: [
-                    {
-                      type: 'required',
-                      message: 'This field is required',
-                    },
-                  ],
+                  conditional: [undefined],
+                },
+                {
+                  text: 'Option two',
+                  value: 'Option two',
+                  conditional: [undefined],
+                },
+                {
+                  text: 'Option three',
+                  value: 'Option three',
+                  conditional: [undefined],
+                },
+              ],
+              validate: [],
+            })
+          })
+        })
+
+        describe('checkbox', function () {
+          it('should format type correctly', function () {
+            const transformed = frameworksService.transformQuestion(
+              'question-key',
+              { ...mockQuestion, type: 'checkbox' }
+            )
+
+            expect(transformed).to.deep.equal({
+              component: 'govukCheckboxes',
+              question: 'Question text',
+              description: undefined,
+              multiple: true,
+              id: 'question-key',
+              name: 'question-key',
+              fieldset: {
+                legend: {
+                  text: 'Question text',
+                  classes: 'govuk-label--s',
                 },
               },
-              {
-                value: 'No, I do not agree',
-                text: 'No, I do not agree',
-                conditional: {
-                  rows: 4,
-                  name: 'question-key--no-i-do-not-agree',
-                  id: 'question-key--no-i-do-not-agree',
-                  component: 'govukTextarea',
-                  classes: 'govuk-input--width-20',
-                  label: {
-                    text: 'Give details',
-                    classes: 'govuk-label--s',
-                  },
-                  validate: undefined,
-                },
+              validate: [],
+            })
+          })
+        })
+
+        describe('textarea', function () {
+          it('should format type correctly', function () {
+            const transformed = frameworksService.transformQuestion(
+              'question-key',
+              { ...mockQuestion, type: 'textarea' }
+            )
+
+            expect(transformed).to.deep.equal({
+              component: 'govukTextarea',
+              question: 'Question text',
+              description: undefined,
+              id: 'question-key',
+              name: 'question-key',
+              label: {
+                text: 'Question text',
+                classes: 'govuk-label--s',
               },
-            ],
-            validate: [],
+              validate: [],
+            })
+          })
+        })
+
+        describe('text', function () {
+          it('should format type correctly', function () {
+            const transformed = frameworksService.transformQuestion(
+              'question-key',
+              { ...mockQuestion, type: 'text' }
+            )
+
+            expect(transformed).to.deep.equal({
+              component: 'govukInput',
+              question: 'Question text',
+              description: undefined,
+              id: 'question-key',
+              name: 'question-key',
+              label: {
+                text: 'Question text',
+                classes: 'govuk-label--s',
+              },
+              validate: [],
+            })
           })
         })
       })
     })
 
-    describe('question types', function () {
-      const mockQuestion = {
-        question: 'Question text',
+    describe('#transformManifest', function () {
+      context('without manifest', function () {
+        it('should return an empty object', function () {
+          const transformed = frameworksService.transformManifest()
+          expect(transformed).to.deep.equal({})
+        })
+      })
+
+      context('with manifest', function () {
+        context('without steps', function () {
+          it('should return an empty steps object', function () {
+            const transformed = frameworksService.transformManifest('key', {
+              name: 'Manifest name',
+            })
+
+            expect(transformed).to.deep.equal({
+              key: 'key',
+              name: 'Manifest name',
+              order: undefined,
+              steps: {},
+            })
+          })
+        })
+
+        context('with steps', function () {
+          let steps, transformed
+
+          beforeEach(function () {
+            steps = [
+              {
+                name: 'Step 1',
+                slug: 'step-1',
+                questions: ['question-1', 'question-2'],
+              },
+              {
+                name: 'Step 2',
+                slug: 'step-2',
+                questions: ['question-3', 'question-4'],
+              },
+              {
+                name: 'Step 3',
+                slug: 'step-3',
+                questions: ['question-5', 'question-6'],
+              },
+            ]
+
+            transformed = frameworksService.transformManifest('key', {
+              steps,
+              name: 'Manifest name',
+            })
+          })
+
+          it('should contain correct number of manifest keys', function () {
+            expect(Object.keys(transformed)).to.have.length(4)
+          })
+
+          it('should contain correct manifest key', function () {
+            expect(Object.keys(transformed)).to.deep.equal([
+              'key',
+              'name',
+              'order',
+              'steps',
+            ])
+          })
+
+          it('should set key', function () {
+            expect(transformed.key).to.equal('key')
+          })
+
+          it('should set name', function () {
+            expect(transformed.name).to.equal('Manifest name')
+          })
+
+          it('should not set order', function () {
+            expect(transformed.order).to.equal(undefined)
+          })
+
+          it('should transform steps correctly', function () {
+            expect(transformed.steps).to.deep.equal({
+              '/step-1': {
+                slug: 'step-1',
+                next: 'step-2',
+                pageTitle: 'Step 1',
+                key: '/step-1',
+                fields: ['question-1', 'question-2'],
+                pageCaption: 'Manifest name',
+                stepType: undefined,
+                afterFieldsContent: undefined,
+                beforeFieldsContent: undefined,
+              },
+              '/step-2': {
+                slug: 'step-2',
+                next: 'step-3',
+                pageTitle: 'Step 2',
+                key: '/step-2',
+                fields: ['question-3', 'question-4'],
+                pageCaption: 'Manifest name',
+                stepType: undefined,
+                afterFieldsContent: undefined,
+                beforeFieldsContent: undefined,
+              },
+              '/step-3': {
+                slug: 'step-3',
+                next: undefined,
+                pageTitle: 'Step 3',
+                key: '/step-3',
+                fields: ['question-5', 'question-6'],
+                pageCaption: 'Manifest name',
+                stepType: undefined,
+                afterFieldsContent: undefined,
+                beforeFieldsContent: undefined,
+              },
+            })
+          })
+
+          it('should set default `next` values correctly', function () {
+            expect(transformed.steps['/step-1'].next).to.equal('step-2')
+            expect(transformed.steps['/step-2'].next).to.equal('step-3')
+            expect(transformed.steps['/step-3'].next).to.be.undefined
+          })
+        })
+
+        context('with custom step next values', function () {
+          let steps, transformed
+
+          beforeEach(function () {
+            steps = [
+              {
+                name: 'Step 1',
+                slug: 'step-1',
+                next_step: 'simple-override',
+                questions: ['question-1', 'question-2'],
+              },
+              {
+                name: 'Step 2',
+                slug: 'step-2',
+                next_step: [
+                  {
+                    question: 'question-1',
+                    value: 'Yes',
+                    next_step: 'step-3',
+                  },
+                  'step-4',
+                ],
+                questions: ['question-3', 'question-4'],
+              },
+              {
+                name: 'Step 3',
+                slug: 'step-3',
+                next_step: [
+                  {
+                    question: 'question-1',
+                    value: 'Yes',
+                    next_step: [
+                      {
+                        question: 'question-2',
+                        value: 'Yes',
+                        next_step: [
+                          {
+                            question: 'question-1',
+                            value: 'No',
+                            next_step: 'step-3',
+                          },
+                          'step-4',
+                        ],
+                      },
+                      'step-4',
+                    ],
+                  },
+                  {
+                    question: 'question-1',
+                    value: 'No',
+                    next_step: 'step-4',
+                  },
+                  'step-4',
+                ],
+                questions: ['question-5', 'question-6'],
+              },
+              {
+                name: 'Step 4',
+                slug: 'step-4',
+                questions: [],
+              },
+            ]
+
+            transformed = frameworksService.transformManifest('key', {
+              steps,
+              name: 'Manifest name',
+            })
+          })
+
+          it('should set simple `next` override', function () {
+            expect(transformed.steps['/step-1'].next).to.equal(
+              'simple-override'
+            )
+          })
+
+          it('should set nested `next` override', function () {
+            expect(transformed.steps['/step-2'].next).to.deep.equal([
+              {
+                field: 'question-1',
+                value: 'Yes',
+                next: 'step-3',
+              },
+              'step-4',
+            ])
+          })
+
+          it('should set complex `next` override', function () {
+            expect(transformed.steps['/step-3'].next).to.deep.equal([
+              {
+                field: 'question-1',
+                value: 'Yes',
+                next: [
+                  {
+                    field: 'question-2',
+                    value: 'Yes',
+                    next: [
+                      {
+                        field: 'question-1',
+                        value: 'No',
+                        next: 'step-3',
+                      },
+                      'step-4',
+                    ],
+                  },
+                  'step-4',
+                ],
+              },
+              {
+                field: 'question-1',
+                value: 'No',
+                next: 'step-4',
+              },
+              'step-4',
+            ])
+          })
+        })
+
+        context('without step questions', function () {
+          let steps, transformed
+
+          beforeEach(function () {
+            steps = [
+              {
+                name: 'Step 1',
+                slug: 'step-1',
+              },
+              {
+                name: 'Step 2',
+                slug: 'step-2',
+                questions: [],
+              },
+            ]
+
+            transformed = frameworksService.transformManifest('key', {
+              steps,
+              name: 'Manifest name',
+            })
+          })
+
+          it('should contain correct number of manifest keys', function () {
+            expect(Object.keys(transformed)).to.have.length(4)
+          })
+
+          it('should contain correct manifest key', function () {
+            expect(Object.keys(transformed)).to.deep.equal([
+              'key',
+              'name',
+              'order',
+              'steps',
+            ])
+          })
+
+          it('should set key', function () {
+            expect(transformed.key).to.equal('key')
+          })
+
+          it('should set name', function () {
+            expect(transformed.name).to.equal('Manifest name')
+          })
+
+          it('should transform steps correctly', function () {
+            expect(transformed.steps).to.deep.equal({
+              '/step-1': {
+                slug: 'step-1',
+                next: 'step-2',
+                pageTitle: 'Step 1',
+                key: '/step-1',
+                fields: [],
+                pageCaption: 'Manifest name',
+                stepType: undefined,
+                afterFieldsContent: undefined,
+                beforeFieldsContent: undefined,
+              },
+              '/step-2': {
+                slug: 'step-2',
+                next: undefined,
+                pageTitle: 'Step 2',
+                key: '/step-2',
+                fields: [],
+                pageCaption: 'Manifest name',
+                stepType: undefined,
+                afterFieldsContent: undefined,
+                beforeFieldsContent: undefined,
+              },
+            })
+          })
+
+          it('should set empty values for fields', function () {
+            expect(transformed.steps['/step-1'].fields).to.deep.equal([])
+            expect(transformed.steps['/step-2'].fields).to.deep.equal([])
+          })
+        })
+
+        context('with content', function () {
+          let steps, transformed
+
+          beforeEach(function () {
+            steps = [
+              {
+                name: 'Step 1',
+                slug: 'step-1',
+                content_before_questions:
+                  '# Some before content\nContent paragraph',
+              },
+              {
+                name: 'Step 2',
+                slug: 'step-2',
+                content_after_questions:
+                  '# Some after content\nContent paragraph',
+              },
+            ]
+
+            transformed = frameworksService.transformManifest('key', {
+              steps,
+              name: 'Manifest name',
+            })
+          })
+
+          it('should contain correct number of manifest keys', function () {
+            expect(Object.keys(transformed)).to.have.length(4)
+          })
+
+          it('should contain correct manifest key', function () {
+            expect(Object.keys(transformed)).to.deep.equal([
+              'key',
+              'name',
+              'order',
+              'steps',
+            ])
+          })
+
+          it('should set key', function () {
+            expect(transformed.key).to.equal('key')
+          })
+
+          it('should set name', function () {
+            expect(transformed.name).to.equal('Manifest name')
+          })
+
+          it('should transform content correctly', function () {
+            expect(transformed.steps).to.deep.equal({
+              '/step-1': {
+                slug: 'step-1',
+                next: 'step-2',
+                pageTitle: 'Step 1',
+                key: '/step-1',
+                fields: [],
+                pageCaption: 'Manifest name',
+                stepType: undefined,
+                beforeFieldsContent: '# Some before content\nContent paragraph',
+                afterFieldsContent: undefined,
+              },
+              '/step-2': {
+                slug: 'step-2',
+                next: undefined,
+                pageTitle: 'Step 2',
+                key: '/step-2',
+                fields: [],
+                pageCaption: 'Manifest name',
+                stepType: undefined,
+                beforeFieldsContent: undefined,
+                afterFieldsContent: '# Some after content\nContent paragraph',
+              },
+            })
+          })
+
+          it('should set empty values for fields', function () {
+            expect(transformed.steps['/step-1'].fields).to.deep.equal([])
+            expect(transformed.steps['/step-2'].fields).to.deep.equal([])
+          })
+        })
+
+        context('with step type', function () {
+          let steps, transformed
+
+          beforeEach(function () {
+            steps = [
+              {
+                name: 'Step 1',
+                slug: 'step-1',
+              },
+              {
+                name: 'Step 2',
+                slug: 'step-2',
+                type: 'interruption-card',
+              },
+            ]
+
+            transformed = frameworksService.transformManifest('key', {
+              steps,
+              name: 'Manifest name',
+            })
+          })
+
+          it('should contain correct number of manifest keys', function () {
+            expect(Object.keys(transformed)).to.have.length(4)
+          })
+
+          it('should contain correct manifest key', function () {
+            expect(Object.keys(transformed)).to.deep.equal([
+              'key',
+              'name',
+              'order',
+              'steps',
+            ])
+          })
+
+          it('should set key', function () {
+            expect(transformed.key).to.equal('key')
+          })
+
+          it('should set name', function () {
+            expect(transformed.name).to.equal('Manifest name')
+          })
+
+          it('should transform content correctly', function () {
+            expect(transformed.steps).to.deep.equal({
+              '/step-1': {
+                slug: 'step-1',
+                next: 'step-2',
+                pageTitle: 'Step 1',
+                key: '/step-1',
+                fields: [],
+                pageCaption: 'Manifest name',
+                stepType: undefined,
+                beforeFieldsContent: undefined,
+                afterFieldsContent: undefined,
+              },
+              '/step-2': {
+                slug: 'step-2',
+                next: undefined,
+                pageTitle: 'Step 2',
+                key: '/step-2',
+                fields: [],
+                pageCaption: 'Manifest name',
+                stepType: 'interruption-card',
+                beforeFieldsContent: undefined,
+                afterFieldsContent: undefined,
+              },
+            })
+          })
+
+          it('should set empty values for fields', function () {
+            expect(transformed.steps['/step-1'].fields).to.deep.equal([])
+            expect(transformed.steps['/step-2'].fields).to.deep.equal([])
+          })
+        })
+
+        context('with order', function () {
+          let transformed
+
+          beforeEach(function () {
+            transformed = frameworksService.transformManifest('key', {
+              name: 'Manifest name',
+              order: 2,
+            })
+          })
+
+          it('should contain correct number of manifest keys', function () {
+            expect(Object.keys(transformed)).to.have.length(4)
+          })
+
+          it('should set order', function () {
+            expect(transformed.order).to.equal(2)
+          })
+        })
+      })
+    })
+
+    describe('#getFramework', function () {
+      let framework
+
+      context('with files', function () {
+        afterEach(function () {
+          mockFs.restore()
+        })
+
+        context('without framework and version', function () {
+          beforeEach(function () {
+            const sectionsFolder = path.resolve(
+              mockFrameworksFolder,
+              'frameworks',
+              'manifests'
+            )
+            const questionsFolder = path.resolve(
+              mockFrameworksFolder,
+              'frameworks',
+              'questions'
+            )
+
+            mockFs({
+              [sectionsFolder]: {
+                'section-one': '{"key": "section-one"}',
+                'section-two': '{"key": "section-two"}',
+              },
+              [questionsFolder]: {
+                'question-one': '{"name": "question-one"}',
+                'question-two': '{"name": "question-two"}',
+              },
+            })
+
+            framework = frameworksService.getFramework()
+          })
+
+          it('should return the framework', function () {
+            expect(framework).to.deep.equal({
+              sections: {
+                'section-one': {
+                  key: 'section-one',
+                },
+                'section-two': {
+                  key: 'section-two',
+                },
+              },
+              questions: {
+                'question-one': {
+                  name: 'question-one',
+                },
+                'question-two': {
+                  name: 'question-two',
+                },
+              },
+            })
+          })
+        })
+
+        context('with framework and version', function () {
+          const mockFramework = 'framework-name'
+          const mockVersion = '2.0.1'
+
+          beforeEach(function () {
+            const sectionsFolder = path.resolve(
+              mockFrameworksFolder,
+              mockVersion,
+              'frameworks',
+              mockFramework,
+              'manifests'
+            )
+            const questionsFolder = path.resolve(
+              mockFrameworksFolder,
+              mockVersion,
+              'frameworks',
+              mockFramework,
+              'questions'
+            )
+
+            mockFs({
+              [sectionsFolder]: {
+                'section-one': '{"key": "section-one"}',
+                'section-two': '{"key": "section-two"}',
+              },
+              [questionsFolder]: {
+                'question-one': '{"name": "question-one"}',
+                'question-two': '{"name": "question-two"}',
+              },
+            })
+
+            framework = frameworksService.getFramework({
+              framework: mockFramework,
+              version: mockVersion,
+            })
+          })
+
+          it('should return the framework', function () {
+            expect(framework).to.deep.equal({
+              sections: {
+                'section-one': {
+                  key: 'section-one',
+                },
+                'section-two': {
+                  key: 'section-two',
+                },
+              },
+              questions: {
+                'question-one': {
+                  name: 'question-one',
+                },
+                'question-two': {
+                  name: 'question-two',
+                },
+              },
+            })
+          })
+        })
+      })
+
+      context('without files', function () {
+        it('should throw an error', function () {
+          expect(() => frameworksService.getFramework({ version: '0.1.0' }))
+            .to.throw(Error, 'Version 0.1.0 of the framework is not supported')
+            .with.property('code', 'MISSING_FRAMEWORK')
+        })
+      })
+    })
+
+    describe('#getPersonEscortRecord', function () {
+      let framework
+      const mockFramework = {
+        sections: ['a', 'b'],
+        questions: ['1', '2'],
       }
 
-      describe('radio', function () {
-        let transformed
-        beforeEach(function () {
-          transformed = frameworksService.transformQuestion('question-key', {
-            ...mockQuestion,
-            type: 'radio',
-            options: [
-              {
-                label: 'Option one',
-                hint: 'Hint text for option one',
-                value: 'Option one',
-              },
-              {
-                label: 'Option two',
-                value: 'Option two',
-              },
-              {
-                label: 'Option three',
-                value: 'Option three',
-              },
-            ],
-          })
-        })
-
-        it('should render markdown for hint text', function () {
-          expect(markdown.render).to.be.calledOnceWithExactly(
-            'Hint text for option one'
-          )
-        })
-
-        it('should format type correctly', function () {
-          expect(transformed).to.deep.equal({
-            component: 'govukRadios',
-            question: 'Question text',
-            description: undefined,
-            id: 'question-key',
-            name: 'question-key',
-            fieldset: {
-              legend: {
-                text: 'Question text',
-                classes: 'govuk-label--s',
-              },
-            },
-            items: [
-              {
-                text: 'Option one',
-                value: 'Option one',
-                hint: {
-                  html: 'Hint text for option one',
-                  classes: 'markdown',
-                },
-                conditional: [undefined],
-              },
-              {
-                text: 'Option two',
-                value: 'Option two',
-                conditional: [undefined],
-              },
-              {
-                text: 'Option three',
-                value: 'Option three',
-                conditional: [undefined],
-              },
-            ],
-            validate: [],
-          })
-        })
+      beforeEach(function () {
+        sinon.stub(frameworksService, 'getFramework').returns(mockFramework)
       })
 
-      describe('checkbox', function () {
-        it('should format type correctly', function () {
-          const transformed = frameworksService.transformQuestion(
-            'question-key',
-            { ...mockQuestion, type: 'checkbox' }
-          )
-
-          expect(transformed).to.deep.equal({
-            component: 'govukCheckboxes',
-            question: 'Question text',
-            description: undefined,
-            multiple: true,
-            id: 'question-key',
-            name: 'question-key',
-            fieldset: {
-              legend: {
-                text: 'Question text',
-                classes: 'govuk-label--s',
-              },
-            },
-            validate: [],
-          })
-        })
-      })
-
-      describe('textarea', function () {
-        it('should format type correctly', function () {
-          const transformed = frameworksService.transformQuestion(
-            'question-key',
-            { ...mockQuestion, type: 'textarea' }
-          )
-
-          expect(transformed).to.deep.equal({
-            component: 'govukTextarea',
-            question: 'Question text',
-            description: undefined,
-            id: 'question-key',
-            name: 'question-key',
-            label: {
-              text: 'Question text',
-              classes: 'govuk-label--s',
-            },
-            validate: [],
-          })
-        })
-      })
-
-      describe('text', function () {
-        it('should format type correctly', function () {
-          const transformed = frameworksService.transformQuestion(
-            'question-key',
-            { ...mockQuestion, type: 'text' }
-          )
-
-          expect(transformed).to.deep.equal({
-            component: 'govukInput',
-            question: 'Question text',
-            description: undefined,
-            id: 'question-key',
-            name: 'question-key',
-            label: {
-              text: 'Question text',
-              classes: 'govuk-label--s',
-            },
-            validate: [],
-          })
-        })
-      })
-    })
-  })
-
-  describe('#transformManifest', function () {
-    context('without manifest', function () {
-      it('should return an empty object', function () {
-        const transformed = frameworksService.transformManifest()
-        expect(transformed).to.deep.equal({})
-      })
-    })
-
-    context('with manifest', function () {
-      context('without steps', function () {
-        it('should return an empty steps object', function () {
-          const transformed = frameworksService.transformManifest('key', {
-            name: 'Manifest name',
-          })
-
-          expect(transformed).to.deep.equal({
-            key: 'key',
-            name: 'Manifest name',
-            order: undefined,
-            steps: {},
-          })
-        })
-      })
-
-      context('with steps', function () {
-        let steps, transformed
+      context('with version', function () {
+        const mockVersion = '0.1.2'
 
         beforeEach(function () {
-          steps = [
-            {
-              name: 'Step 1',
-              slug: 'step-1',
-              questions: ['question-1', 'question-2'],
-            },
-            {
-              name: 'Step 2',
-              slug: 'step-2',
-              questions: ['question-3', 'question-4'],
-            },
-            {
-              name: 'Step 3',
-              slug: 'step-3',
-              questions: ['question-5', 'question-6'],
-            },
-          ]
-
-          transformed = frameworksService.transformManifest('key', {
-            steps,
-            name: 'Manifest name',
-          })
+          framework = frameworksService.getPersonEscortRecord(mockVersion)
         })
 
-        it('should contain correct number of manifest keys', function () {
-          expect(Object.keys(transformed)).to.have.length(4)
-        })
-
-        it('should contain correct manifest key', function () {
-          expect(Object.keys(transformed)).to.deep.equal([
-            'key',
-            'name',
-            'order',
-            'steps',
-          ])
-        })
-
-        it('should set key', function () {
-          expect(transformed.key).to.equal('key')
-        })
-
-        it('should set name', function () {
-          expect(transformed.name).to.equal('Manifest name')
-        })
-
-        it('should not set order', function () {
-          expect(transformed.order).to.equal(undefined)
-        })
-
-        it('should transform steps correctly', function () {
-          expect(transformed.steps).to.deep.equal({
-            '/step-1': {
-              slug: 'step-1',
-              next: 'step-2',
-              pageTitle: 'Step 1',
-              key: '/step-1',
-              fields: ['question-1', 'question-2'],
-              pageCaption: 'Manifest name',
-              stepType: undefined,
-              afterFieldsContent: undefined,
-              beforeFieldsContent: undefined,
-            },
-            '/step-2': {
-              slug: 'step-2',
-              next: 'step-3',
-              pageTitle: 'Step 2',
-              key: '/step-2',
-              fields: ['question-3', 'question-4'],
-              pageCaption: 'Manifest name',
-              stepType: undefined,
-              afterFieldsContent: undefined,
-              beforeFieldsContent: undefined,
-            },
-            '/step-3': {
-              slug: 'step-3',
-              next: undefined,
-              pageTitle: 'Step 3',
-              key: '/step-3',
-              fields: ['question-5', 'question-6'],
-              pageCaption: 'Manifest name',
-              stepType: undefined,
-              afterFieldsContent: undefined,
-              beforeFieldsContent: undefined,
-            },
-          })
-        })
-
-        it('should set default `next` values correctly', function () {
-          expect(transformed.steps['/step-1'].next).to.equal('step-2')
-          expect(transformed.steps['/step-2'].next).to.equal('step-3')
-          expect(transformed.steps['/step-3'].next).to.be.undefined
-        })
-      })
-
-      context('with custom step next values', function () {
-        let steps, transformed
-
-        beforeEach(function () {
-          steps = [
-            {
-              name: 'Step 1',
-              slug: 'step-1',
-              next_step: 'simple-override',
-              questions: ['question-1', 'question-2'],
-            },
-            {
-              name: 'Step 2',
-              slug: 'step-2',
-              next_step: [
-                {
-                  question: 'question-1',
-                  value: 'Yes',
-                  next_step: 'step-3',
-                },
-                'step-4',
-              ],
-              questions: ['question-3', 'question-4'],
-            },
-            {
-              name: 'Step 3',
-              slug: 'step-3',
-              next_step: [
-                {
-                  question: 'question-1',
-                  value: 'Yes',
-                  next_step: [
-                    {
-                      question: 'question-2',
-                      value: 'Yes',
-                      next_step: [
-                        {
-                          question: 'question-1',
-                          value: 'No',
-                          next_step: 'step-3',
-                        },
-                        'step-4',
-                      ],
-                    },
-                    'step-4',
-                  ],
-                },
-                {
-                  question: 'question-1',
-                  value: 'No',
-                  next_step: 'step-4',
-                },
-                'step-4',
-              ],
-              questions: ['question-5', 'question-6'],
-            },
-            {
-              name: 'Step 4',
-              slug: 'step-4',
-              questions: [],
-            },
-          ]
-
-          transformed = frameworksService.transformManifest('key', {
-            steps,
-            name: 'Manifest name',
-          })
-        })
-
-        it('should set simple `next` override', function () {
-          expect(transformed.steps['/step-1'].next).to.equal('simple-override')
-        })
-
-        it('should set nested `next` override', function () {
-          expect(transformed.steps['/step-2'].next).to.deep.equal([
-            {
-              field: 'question-1',
-              value: 'Yes',
-              next: 'step-3',
-            },
-            'step-4',
-          ])
-        })
-
-        it('should set complex `next` override', function () {
-          expect(transformed.steps['/step-3'].next).to.deep.equal([
-            {
-              field: 'question-1',
-              value: 'Yes',
-              next: [
-                {
-                  field: 'question-2',
-                  value: 'Yes',
-                  next: [
-                    {
-                      field: 'question-1',
-                      value: 'No',
-                      next: 'step-3',
-                    },
-                    'step-4',
-                  ],
-                },
-                'step-4',
-              ],
-            },
-            {
-              field: 'question-1',
-              value: 'No',
-              next: 'step-4',
-            },
-            'step-4',
-          ])
-        })
-      })
-
-      context('without step questions', function () {
-        let steps, transformed
-
-        beforeEach(function () {
-          steps = [
-            {
-              name: 'Step 1',
-              slug: 'step-1',
-            },
-            {
-              name: 'Step 2',
-              slug: 'step-2',
-              questions: [],
-            },
-          ]
-
-          transformed = frameworksService.transformManifest('key', {
-            steps,
-            name: 'Manifest name',
-          })
-        })
-
-        it('should contain correct number of manifest keys', function () {
-          expect(Object.keys(transformed)).to.have.length(4)
-        })
-
-        it('should contain correct manifest key', function () {
-          expect(Object.keys(transformed)).to.deep.equal([
-            'key',
-            'name',
-            'order',
-            'steps',
-          ])
-        })
-
-        it('should set key', function () {
-          expect(transformed.key).to.equal('key')
-        })
-
-        it('should set name', function () {
-          expect(transformed.name).to.equal('Manifest name')
-        })
-
-        it('should transform steps correctly', function () {
-          expect(transformed.steps).to.deep.equal({
-            '/step-1': {
-              slug: 'step-1',
-              next: 'step-2',
-              pageTitle: 'Step 1',
-              key: '/step-1',
-              fields: [],
-              pageCaption: 'Manifest name',
-              stepType: undefined,
-              afterFieldsContent: undefined,
-              beforeFieldsContent: undefined,
-            },
-            '/step-2': {
-              slug: 'step-2',
-              next: undefined,
-              pageTitle: 'Step 2',
-              key: '/step-2',
-              fields: [],
-              pageCaption: 'Manifest name',
-              stepType: undefined,
-              afterFieldsContent: undefined,
-              beforeFieldsContent: undefined,
-            },
-          })
-        })
-
-        it('should set empty values for fields', function () {
-          expect(transformed.steps['/step-1'].fields).to.deep.equal([])
-          expect(transformed.steps['/step-2'].fields).to.deep.equal([])
-        })
-      })
-
-      context('with content', function () {
-        let steps, transformed
-
-        beforeEach(function () {
-          steps = [
-            {
-              name: 'Step 1',
-              slug: 'step-1',
-              content_before_questions:
-                '# Some before content\nContent paragraph',
-            },
-            {
-              name: 'Step 2',
-              slug: 'step-2',
-              content_after_questions:
-                '# Some after content\nContent paragraph',
-            },
-          ]
-
-          transformed = frameworksService.transformManifest('key', {
-            steps,
-            name: 'Manifest name',
-          })
-        })
-
-        it('should contain correct number of manifest keys', function () {
-          expect(Object.keys(transformed)).to.have.length(4)
-        })
-
-        it('should contain correct manifest key', function () {
-          expect(Object.keys(transformed)).to.deep.equal([
-            'key',
-            'name',
-            'order',
-            'steps',
-          ])
-        })
-
-        it('should set key', function () {
-          expect(transformed.key).to.equal('key')
-        })
-
-        it('should set name', function () {
-          expect(transformed.name).to.equal('Manifest name')
-        })
-
-        it('should transform content correctly', function () {
-          expect(transformed.steps).to.deep.equal({
-            '/step-1': {
-              slug: 'step-1',
-              next: 'step-2',
-              pageTitle: 'Step 1',
-              key: '/step-1',
-              fields: [],
-              pageCaption: 'Manifest name',
-              stepType: undefined,
-              beforeFieldsContent: '# Some before content\nContent paragraph',
-              afterFieldsContent: undefined,
-            },
-            '/step-2': {
-              slug: 'step-2',
-              next: undefined,
-              pageTitle: 'Step 2',
-              key: '/step-2',
-              fields: [],
-              pageCaption: 'Manifest name',
-              stepType: undefined,
-              beforeFieldsContent: undefined,
-              afterFieldsContent: '# Some after content\nContent paragraph',
-            },
-          })
-        })
-
-        it('should set empty values for fields', function () {
-          expect(transformed.steps['/step-1'].fields).to.deep.equal([])
-          expect(transformed.steps['/step-2'].fields).to.deep.equal([])
-        })
-      })
-
-      context('with step type', function () {
-        let steps, transformed
-
-        beforeEach(function () {
-          steps = [
-            {
-              name: 'Step 1',
-              slug: 'step-1',
-            },
-            {
-              name: 'Step 2',
-              slug: 'step-2',
-              type: 'interruption-card',
-            },
-          ]
-
-          transformed = frameworksService.transformManifest('key', {
-            steps,
-            name: 'Manifest name',
-          })
-        })
-
-        it('should contain correct number of manifest keys', function () {
-          expect(Object.keys(transformed)).to.have.length(4)
-        })
-
-        it('should contain correct manifest key', function () {
-          expect(Object.keys(transformed)).to.deep.equal([
-            'key',
-            'name',
-            'order',
-            'steps',
-          ])
-        })
-
-        it('should set key', function () {
-          expect(transformed.key).to.equal('key')
-        })
-
-        it('should set name', function () {
-          expect(transformed.name).to.equal('Manifest name')
-        })
-
-        it('should transform content correctly', function () {
-          expect(transformed.steps).to.deep.equal({
-            '/step-1': {
-              slug: 'step-1',
-              next: 'step-2',
-              pageTitle: 'Step 1',
-              key: '/step-1',
-              fields: [],
-              pageCaption: 'Manifest name',
-              stepType: undefined,
-              beforeFieldsContent: undefined,
-              afterFieldsContent: undefined,
-            },
-            '/step-2': {
-              slug: 'step-2',
-              next: undefined,
-              pageTitle: 'Step 2',
-              key: '/step-2',
-              fields: [],
-              pageCaption: 'Manifest name',
-              stepType: 'interruption-card',
-              beforeFieldsContent: undefined,
-              afterFieldsContent: undefined,
-            },
-          })
-        })
-
-        it('should set empty values for fields', function () {
-          expect(transformed.steps['/step-1'].fields).to.deep.equal([])
-          expect(transformed.steps['/step-2'].fields).to.deep.equal([])
-        })
-      })
-
-      context('with order', function () {
-        let transformed
-
-        beforeEach(function () {
-          transformed = frameworksService.transformManifest('key', {
-            name: 'Manifest name',
-            order: 2,
-          })
-        })
-
-        it('should contain correct number of manifest keys', function () {
-          expect(Object.keys(transformed)).to.have.length(4)
-        })
-
-        it('should set order', function () {
-          expect(transformed.order).to.equal(2)
-        })
-      })
-    })
-  })
-
-  describe('#getFramework', function () {
-    let framework
-
-    context('with files', function () {
-      afterEach(function () {
-        mockFs.restore()
-      })
-
-      context('without framework and version', function () {
-        beforeEach(function () {
-          const sectionsFolder = path.resolve(
-            mockFrameworksFolder,
-            'frameworks',
-            'manifests'
-          )
-          const questionsFolder = path.resolve(
-            mockFrameworksFolder,
-            'frameworks',
-            'questions'
-          )
-
-          mockFs({
-            [sectionsFolder]: {
-              'section-one': '{"key": "section-one"}',
-              'section-two': '{"key": "section-two"}',
-            },
-            [questionsFolder]: {
-              'question-one': '{"name": "question-one"}',
-              'question-two': '{"name": "question-two"}',
-            },
-          })
-
-          framework = frameworksService.getFramework()
-        })
-
-        it('should return the framework', function () {
-          expect(framework).to.deep.equal({
-            sections: {
-              'section-one': {
-                key: 'section-one',
-              },
-              'section-two': {
-                key: 'section-two',
-              },
-            },
-            questions: {
-              'question-one': {
-                name: 'question-one',
-              },
-              'question-two': {
-                name: 'question-two',
-              },
-            },
-          })
-        })
-      })
-
-      context('with framework and version', function () {
-        const mockFramework = 'framework-name'
-        const mockVersion = '2.0.1'
-
-        beforeEach(function () {
-          const sectionsFolder = path.resolve(
-            mockFrameworksFolder,
-            mockVersion,
-            'frameworks',
-            mockFramework,
-            'manifests'
-          )
-          const questionsFolder = path.resolve(
-            mockFrameworksFolder,
-            mockVersion,
-            'frameworks',
-            mockFramework,
-            'questions'
-          )
-
-          mockFs({
-            [sectionsFolder]: {
-              'section-one': '{"key": "section-one"}',
-              'section-two': '{"key": "section-two"}',
-            },
-            [questionsFolder]: {
-              'question-one': '{"name": "question-one"}',
-              'question-two': '{"name": "question-two"}',
-            },
-          })
-
-          framework = frameworksService.getFramework({
-            framework: mockFramework,
+        it('should call getFramework method with version argument', function () {
+          expect(
+            frameworksService.getFramework
+          ).to.have.been.calledOnceWithExactly({
+            framework: 'person-escort-record',
             version: mockVersion,
           })
         })
 
-        it('should return the framework', function () {
-          expect(framework).to.deep.equal({
-            sections: {
-              'section-one': {
-                key: 'section-one',
-              },
-              'section-two': {
-                key: 'section-two',
-              },
-            },
-            questions: {
-              'question-one': {
-                name: 'question-one',
-              },
-              'question-two': {
-                name: 'question-two',
-              },
-            },
+        it('should return a framework', function () {
+          expect(framework).to.deep.equal(mockFramework)
+        })
+      })
+
+      context('without version', function () {
+        beforeEach(function () {
+          frameworksService.getPersonEscortRecord()
+        })
+
+        it('should call getFramework method with config version', function () {
+          expect(
+            frameworksService.getFramework
+          ).to.have.been.calledOnceWithExactly({
+            framework: 'person-escort-record',
+            version: mockFrameworksVersion,
           })
         })
-      })
-    })
 
-    context('without files', function () {
-      it('should throw an error', function () {
-        expect(() => frameworksService.getFramework())
-          .to.throw(Error, 'This version of the framework is not supported')
-          .with.property('code', 'MISSING_FRAMEWORK')
-      })
-    })
-  })
-
-  describe('#getPersonEscortRecord', function () {
-    let framework
-    const mockFramework = {
-      sections: ['a', 'b'],
-      questions: ['1', '2'],
-    }
-
-    beforeEach(function () {
-      sinon.stub(frameworksService, 'getFramework').returns(mockFramework)
-    })
-
-    context('with version', function () {
-      const mockVersion = '0.1.2'
-
-      beforeEach(function () {
-        framework = frameworksService.getPersonEscortRecord(mockVersion)
-      })
-
-      it('should call getFramework method with version argument', function () {
-        expect(
-          frameworksService.getFramework
-        ).to.have.been.calledOnceWithExactly({
-          framework: 'person-escort-record',
-          version: mockVersion,
+        it('should return a framework', function () {
+          expect(framework).to.deep.equal(mockFramework)
         })
-      })
-
-      it('should return a framework', function () {
-        expect(framework).to.deep.equal(mockFramework)
-      })
-    })
-
-    context('without version', function () {
-      beforeEach(function () {
-        frameworksService.getPersonEscortRecord()
-      })
-
-      it('should call getFramework method with config version', function () {
-        expect(
-          frameworksService.getFramework
-        ).to.have.been.calledOnceWithExactly({
-          framework: 'person-escort-record',
-          version: mockFrameworksVersion,
-        })
-      })
-
-      it('should return a framework', function () {
-        expect(framework).to.deep.equal(mockFramework)
       })
     })
   })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

This changes the way the Person Escort Record frameworks are rendered on the frontend.

Previously the necessary controllers and form wizards were created once upon app start which was more efficient and
meant a lot of the route handling could be passed directly to Express.

This change moves the logic to be more dynamic and to support loading the framework version of the
current Person Escort Record returned from the API.

#### Todo

- [x] Cache frameworks so that we don't need to load from files on every request

### Why did it change

In order to support multiple versions we need to load in the version based on the version the API returns
for that Person Escort Record.

The structure of the form journeys are based on a particular version of the framework so these need to be known
at the point of building those routes, for example, a step or question may not exist in particular versions so we
can't always render the form journeys based on the current latest version.

At the moment we have tried to build the move detail views in a manner that will support questions/answers
dynamically but if there are any particular new types it will likely require extra work to support those types.

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

- [P4-2006](https://dsdmoj.atlassian.net/browse/P4-2006)

## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [x] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed

### Other considerations

Commit messages with a `fix` or `feat` type are automatically used to generate the [changelog](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/CHANGELOG.md) and
[GitHub release notes](https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/releases) during the release task. Please make sure they will read well on their own in a
summary of changes and that the commit body gives a more detailed description of those changes if necessary.

- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
- [x] Update [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md) with any new instructions or tasks
