### PR TITLE
Fix/allocations filtering

### DIFF
--- a/app/allocations/middleware/set-body.allocations.js
+++ b/app/allocations/middleware/set-body.allocations.js
@@ -1,10 +1,17 @@
 const { map, set } = require('lodash')
 
 const dateHelpers = require('../../../common/helpers/date')
+const permissions = require('../../../common/middleware/permissions')
 
 function setBodyAllocations(req, res, next) {
   const { status, sortBy, sortDirection } = req.query
   const { dateRange } = req.params
+  const userPermissions = req?.session?.user?.permissions
+  const hasAssignerPermission = permissions.check(
+    'allocation:person:assign',
+    userPermissions
+  )
+  const locationType = hasAssignerPermission ? 'fromLocations' : 'locations'
 
   let locations = req?.session?.currentRegion?.locations
 
@@ -21,7 +28,7 @@ function setBodyAllocations(req, res, next) {
     sortBy,
     sortDirection,
     moveDate: dateRange || dateHelpers.getCurrentWeekAsRange(),
-    locations: map(locations, 'id'),
+    [locationType]: map(locations, 'id'),
   })
 
   next()

--- a/app/allocations/middleware/set-body.allocations.test.js
+++ b/app/allocations/middleware/set-body.allocations.test.js
@@ -1,4 +1,5 @@
 const dateHelpers = require('../../../common/helpers/date')
+const permissions = require('../../../common/middleware/permissions')
 
 const middleware = require('./set-body.allocations')
 
@@ -107,6 +108,27 @@ describe('Allocations middleware', function () {
           status: 'pending',
           moveDate: ['2010-10-10', '2010-10-07'],
           locations: ['#locationId'],
+          sortBy: 'moves_count',
+          sortDirection: 'asc',
+        })
+      })
+
+      it('should call next', function () {
+        expect(nextSpy).to.be.calledOnceWithExactly()
+      })
+    })
+
+    context('when user has assign role', function () {
+      beforeEach(function () {
+        sinon.stub(permissions, 'check').returns(true)
+        middleware(mockReq, mockRes, nextSpy)
+      })
+
+      it('should use fromLocations rather than locations filter', function () {
+        expect(mockReq.body.allocations).to.deep.equal({
+          status: 'pending',
+          moveDate: ['2010-10-10', '2010-10-07'],
+          fromLocations: [],
           sortBy: 'moves_count',
           sortDirection: 'asc',
         })

--- a/app/allocations/middleware/set-results.allocations.js
+++ b/app/allocations/middleware/set-results.allocations.js
@@ -5,15 +5,16 @@ const presenters = require('../../../common/presenters')
 const allocationService = require('../../../common/services/allocation')
 
 async function setResultsAllocations(req, res, next) {
-  const currentLocationId = get(req.session, 'currentLocation.id')
   const userPermissions = get(req.session, 'user.permissions')
+  const hasAssignerPermission = permissions.check(
+    'allocation:person:assign',
+    userPermissions
+  )
   const query = req.query
+
   const displayConfig = {
-    showRemaining: permissions.check(
-      'allocation:person:assign',
-      userPermissions
-    ),
-    showFromLocation: !currentLocationId,
+    showFromLocation: !hasAssignerPermission,
+    showRemaining: hasAssignerPermission,
     query,
   }
 

--- a/app/allocations/middleware/set-results.allocations.test.js
+++ b/app/allocations/middleware/set-results.allocations.test.js
@@ -143,7 +143,7 @@ describe('Allocations middleware', function () {
           ).to.be.calledWithExactly({
             query: { status: 'approved' },
             showRemaining: false,
-            showFromLocation: false,
+            showFromLocation: true,
           })
         })
       })
@@ -164,7 +164,7 @@ describe('Allocations middleware', function () {
             ).to.be.calledWithExactly({
               query: { status: 'approved' },
               showRemaining: true,
-              showFromLocation: true,
+              showFromLocation: false,
             })
           })
         }

--- a/common/presenters/allocations-to-table-component.js
+++ b/common/presenters/allocations-to-table-component.js
@@ -25,7 +25,7 @@ function _byAdded(totalSlots, unfilledSlots) {
 }
 
 function allocationsToTableComponent({
-  showFromLocation = false,
+  showFromLocation = true,
   showRemaining = false,
   query,
   isSortable = true,

--- a/common/presenters/allocations-to-table-component.test.js
+++ b/common/presenters/allocations-to-table-component.test.js
@@ -119,6 +119,11 @@ describe('#allocationsToTableComponent', function () {
             },
           },
           {
+            html: 'collections::labels.from_location',
+            isSortable: true,
+            sortKey: 'from_location',
+          },
+          {
             html: 'collections::labels.to_location',
             isSortable: true,
             sortKey: 'to_location',
@@ -140,9 +145,9 @@ describe('#allocationsToTableComponent', function () {
         })
 
         it('should return correct number of columns', function () {
-          expect(Object.keys(output.rows[0])).to.have.length(4)
-          expect(Object.keys(output.rows[1])).to.have.length(4)
-          expect(Object.keys(output.rows[2])).to.have.length(4)
+          expect(Object.keys(output.rows[0])).to.have.length(5)
+          expect(Object.keys(output.rows[1])).to.have.length(5)
+          expect(Object.keys(output.rows[2])).to.have.length(5)
         })
 
         describe('filled allocation', function () {
@@ -156,6 +161,9 @@ describe('#allocationsToTableComponent', function () {
               },
               {
                 html: 'govukTag',
+              },
+              {
+                text: mockAllocations[0].from_location.title,
               },
               {
                 text: mockAllocations[0].to_location.title,
@@ -197,6 +205,9 @@ describe('#allocationsToTableComponent', function () {
               },
               {
                 html: 'govukTag',
+              },
+              {
+                text: mockAllocations[1].from_location.title,
               },
               {
                 text: mockAllocations[1].to_location.title,
@@ -240,6 +251,9 @@ describe('#allocationsToTableComponent', function () {
                 html: 'govukTag',
               },
               {
+                text: mockAllocations[2].from_location.title,
+              },
+              {
                 text: mockAllocations[2].to_location.title,
               },
               {
@@ -270,10 +284,10 @@ describe('#allocationsToTableComponent', function () {
       })
     })
 
-    context('with show from location option', function () {
+    context('with show from location option false', function () {
       beforeEach(function () {
         output = presenter({
-          showFromLocation: true,
+          showFromLocation: false,
         })(mockAllocations)
       })
 
@@ -294,11 +308,6 @@ describe('#allocationsToTableComponent', function () {
             },
           },
           {
-            html: 'collections::labels.from_location',
-            isSortable: true,
-            sortKey: 'from_location',
-          },
-          {
             html: 'collections::labels.to_location',
             isSortable: true,
             sortKey: 'to_location',
@@ -315,9 +324,9 @@ describe('#allocationsToTableComponent', function () {
       })
 
       it('should return correct number of columns for rows', function () {
-        expect(Object.keys(output.rows[0])).to.have.length(5)
-        expect(Object.keys(output.rows[1])).to.have.length(5)
-        expect(Object.keys(output.rows[2])).to.have.length(5)
+        expect(Object.keys(output.rows[0])).to.have.length(4)
+        expect(Object.keys(output.rows[1])).to.have.length(4)
+        expect(Object.keys(output.rows[2])).to.have.length(4)
       })
     })
 
@@ -344,6 +353,9 @@ describe('#allocationsToTableComponent', function () {
               },
               {
                 html: 'govukTag',
+              },
+              {
+                text: mockAllocations[0].from_location.title,
               },
               {
                 text: mockAllocations[0].to_location.title,
@@ -387,6 +399,9 @@ describe('#allocationsToTableComponent', function () {
                 html: 'govukTag',
               },
               {
+                text: mockAllocations[1].from_location.title,
+              },
+              {
                 text: mockAllocations[1].to_location.title,
               },
               {
@@ -426,6 +441,9 @@ describe('#allocationsToTableComponent', function () {
               },
               {
                 html: 'govukTag',
+              },
+              {
+                text: mockAllocations[2].from_location.title,
               },
               {
                 text: mockAllocations[2].to_location.title,
@@ -498,6 +516,11 @@ describe('#allocationsToTableComponent', function () {
               width: '150',
             },
             text: 'collections::labels.progress',
+          },
+          {
+            html: 'collections::labels.from_location',
+            isSortable: false,
+            sortKey: 'from_location',
           },
           {
             html: 'collections::labels.to_location',

--- a/common/services/allocation.js
+++ b/common/services/allocation.js
@@ -58,6 +58,8 @@ const allocationService = {
   },
   getByDateAndLocation({
     moveDate = [],
+    fromLocations = [],
+    toLocations = [],
     locations = [],
     includeCancelled = false,
     isAggregation = false,
@@ -72,6 +74,8 @@ const allocationService = {
       includeCancelled,
       filter: pickBy({
         'filter[status]': status,
+        'filter[from_locations]': fromLocations.join(','),
+        'filter[to_locations]': toLocations.join(','),
         'filter[locations]': locations.join(','),
         'filter[date_from]': moveDateFrom,
         'filter[date_to]': moveDateTo,

--- a/common/services/allocation.test.js
+++ b/common/services/allocation.test.js
@@ -631,6 +631,8 @@ describe('Allocation service', function () {
         beforeEach(async function () {
           results = await allocationService.getByDateAndLocation({
             moveDate: mockMoveDateRange,
+            fromLocations: [mockFromLocationId],
+            toLocations: [mockToLocationId],
             locations: [mockFromLocationId, mockToLocationId],
           })
         })
@@ -642,6 +644,8 @@ describe('Allocation service', function () {
             filter: {
               'filter[date_from]': mockMoveDateRange[0],
               'filter[date_to]': mockMoveDateRange[1],
+              'filter[from_locations]': mockFromLocationId,
+              'filter[to_locations]': mockToLocationId,
               'filter[locations]': `${mockFromLocationId},${mockToLocationId}`,
             },
           })


### PR DESCRIPTION
#568  Proposed changes

### What changed

When the user has the `allocation:person:assign` permission

- allocations are filtered by `from_locations`
- allocation table's `showFromLocation` is set to false


### Why did it change

This enables:

- PMU users to see outward and inward allocations
- OCA users to see only outbound allocations

OCA users do not need to see the from column in the allocations table since their allocations are implicitly from the same location

### Issue tracking

- [P4-1928](https://dsdmoj.atlassian.net/browse/P4-1928)

## Screenshots
<!--- (Optional) Include screenshots if changes update interfaces or components -->
<!--- Delete/copy as appropriate --->

|PMU|OCA|
| ------ | ----- |
| <kbd>![pmu__location__dashboard](https://user-images.githubusercontent.com/4856/87673195-0d320a00-c76c-11ea-9384-38b9eadd639a.png)</kbd> | <kbd>![oca_location_dashboard](https://user-images.githubusercontent.com/4856/87673212-1622db80-c76c-11ea-801f-e2a93f138ce9.png)</kbd> |
| <kbd>![pmu__location__allocations](https://user-images.githubusercontent.com/4856/87673233-21760700-c76c-11ea-82f6-b9ce724f3bb2.png)</kbd> | <kbd>![oca_location_allocations](https://user-images.githubusercontent.com/4856/87673264-2b980580-c76c-11ea-96fa-dd89b4d75407.png)</kbd> |



## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed

### Other considerations

- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics

