### PR TITLE
[P4-1710] Add journey to "confirm" Person Escort Record

### DIFF
--- a/app/move/controllers/view.js
+++ b/app/move/controllers/view.js
@@ -32,7 +32,7 @@ module.exports = function view(req, res) {
   const personEscortRecordUrl = `${originalUrl}/person-escort-record`
   const showPersonEscortRecordBanner =
     FEATURE_FLAGS.PERSON_ESCORT_RECORD &&
-    !personEscortRecordIsComplete &&
+    personEscortRecord?.status !== 'confirmed' &&
     move.status === 'requested' &&
     move.profile?.id !== undefined
   const personEscortRecordtaskList = presenters.frameworkToTaskListComponent({

--- a/app/move/controllers/view.test.js
+++ b/app/move/controllers/view.test.js
@@ -534,6 +534,22 @@ describe('Move controllers', function () {
           )
         })
 
+        it('should show Person Escort Record banner', function () {
+          expect(params).to.have.property('showPersonEscortRecordBanner')
+          expect(params.showPersonEscortRecordBanner).to.be.true
+        })
+      })
+
+      context('when record is confirmed', function () {
+        beforeEach(function () {
+          req.move.profile.person_escort_record = {
+            ...mockPersonEscortRecord,
+            status: 'confirmed',
+          }
+          controller(req, res)
+          params = res.render.args[0][1]
+        })
+
         it('should not show Person Escort Record banner', function () {
           expect(params).to.have.property('showPersonEscortRecordBanner')
           expect(params.showPersonEscortRecordBanner).to.be.false

--- a/app/move/views/view.njk
+++ b/app/move/views/view.njk
@@ -96,7 +96,7 @@
 
   {% if showPersonEscortRecordBanner and not personEscortRecord %}
     {% set html %}
-      <p>{{ t("messages::pending_person_escort_record.content") }}</p>
+      <p>{{ t("messages::person_escort_record_pending.content") }}</p>
 
       {{ govukButton({
         href: personEscortRecordUrl + "/new",
@@ -108,7 +108,7 @@
       allowDismiss: false,
       classes: "app-message--instruction",
       title: {
-        text: t("messages::pending_person_escort_record.heading")
+        text: t("messages::person_escort_record_pending.heading")
       },
       content: {
         html: html
@@ -121,6 +121,17 @@
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
           {{ appTaskList(personEscortRecordtaskList) }}
+
+          {% if personEscortRecordIsComplete %}
+            <p>
+              {{ t("messages::person_escort_record_complete.content") }}
+            </p>
+
+            {{ govukButton({
+              href: personEscortRecordUrl + "/confirm",
+              text: t("actions::provide_confirmation")
+            }) }}
+          {% endif %}
         </div>
       </div>
     {% endset %}
@@ -129,7 +140,7 @@
       allowDismiss: false,
       classes: "app-message--instruction govuk-!-padding-right-0",
       title: {
-        text: t("messages::incomplete_person_escort_record.heading")
+        text: t("messages::person_escort_record_complete.heading") if personEscortRecordIsComplete else t("messages::person_escort_record_incomplete.heading")
       },
       content: {
         html: html

--- a/app/person-escort-record/app/confirm/config.js
+++ b/app/person-escort-record/app/confirm/config.js
@@ -1,0 +1,8 @@
+module.exports = {
+  hideSidebar: true,
+  name: 'create-person-escort-record',
+  journeyName: 'create-person-escort-record',
+  journeyPageTitle: 'person-escort-record::heading',
+  templatePath: 'person-escort-record/app/confirm/views/',
+  template: '../../../../form-wizard',
+}

--- a/app/person-escort-record/app/confirm/controllers.js
+++ b/app/person-escort-record/app/confirm/controllers.js
@@ -12,6 +12,22 @@ class ConfirmPersonEscortRecordController extends FormWizardController {
     next()
   }
 
+  middlewareChecks() {
+    super.middlewareChecks()
+    this.use(this.checkStatus)
+  }
+
+  checkStatus(req, res, next) {
+    const moveId = req.move?.id
+    const isCompleted = req?.personEscortRecord?.status === 'completed'
+
+    if (isCompleted) {
+      return next()
+    }
+
+    res.redirect(`/move/${moveId}`)
+  }
+
   async saveValues(req, res, next) {
     try {
       await personEscortRecordService.confirm(req.personEscortRecord.id)

--- a/app/person-escort-record/app/confirm/controllers.js
+++ b/app/person-escort-record/app/confirm/controllers.js
@@ -1,0 +1,34 @@
+const FormWizardController = require('../../../../common/controllers/form-wizard')
+const personEscortRecordService = require('../../../../common/services/person-escort-record')
+
+class ConfirmPersonEscortRecordController extends FormWizardController {
+  middlewareLocals() {
+    super.middlewareLocals()
+    this.use(this.setMoveId)
+  }
+
+  setMoveId(req, res, next) {
+    res.locals.moveId = req.move?.id
+    next()
+  }
+
+  async saveValues(req, res, next) {
+    try {
+      await personEscortRecordService.confirm(req.personEscortRecord.id)
+      next()
+    } catch (err) {
+      next(err)
+    }
+  }
+
+  successHandler(req, res) {
+    req.journeyModel.reset()
+    req.sessionModel.reset()
+
+    res.redirect(`/move/${req.move.id}`)
+  }
+}
+
+module.exports = {
+  ConfirmPersonEscortRecordController,
+}

--- a/app/person-escort-record/app/confirm/controllers.test.js
+++ b/app/person-escort-record/app/confirm/controllers.test.js
@@ -30,6 +30,81 @@ describe('Person Escort Record controllers', function () {
       })
     })
 
+    describe('#middlewareChecks', function () {
+      beforeEach(function () {
+        sinon.stub(FormWizardController.prototype, 'middlewareChecks')
+        sinon.stub(controller, 'use')
+        sinon.stub(controller, 'checkStatus')
+
+        controller.middlewareChecks()
+      })
+
+      it('should call parent method', function () {
+        expect(FormWizardController.prototype.middlewareChecks).to.have.been
+          .calledOnce
+      })
+
+      it('should call checkStatus middleware', function () {
+        expect(controller.use).to.have.been.calledWith(controller.checkStatus)
+      })
+
+      it('should call correct number of middleware', function () {
+        expect(controller.use.callCount).to.equal(1)
+      })
+    })
+
+    describe('#checkStatus', function () {
+      let mockReq, mockRes, nextSpy
+
+      beforeEach(function () {
+        nextSpy = sinon.spy()
+        mockReq = {
+          move: {
+            id: '12345',
+          },
+          personEscortRecord: {
+            id: '12345',
+          },
+        }
+        mockRes = {
+          redirect: sinon.spy(),
+        }
+      })
+
+      context('with completed status', function () {
+        beforeEach(function () {
+          mockReq.personEscortRecord.status = 'completed'
+          controller.checkStatus(mockReq, mockRes, nextSpy)
+        })
+
+        it('should not redirect', function () {
+          expect(mockRes.redirect).not.to.be.called
+        })
+
+        it('should call next', function () {
+          expect(nextSpy).to.be.calledOnceWithExactly()
+        })
+      })
+
+      const statuses = ['incomplete', 'confirmed']
+      statuses.forEach(status => {
+        context(`with ${status} status`, function () {
+          beforeEach(function () {
+            mockReq.personEscortRecord.status = status
+            controller.checkStatus(mockReq, mockRes, nextSpy)
+          })
+
+          it('should redirect to move', function () {
+            expect(mockRes.redirect).to.be.calledOnceWithExactly('/move/12345')
+          })
+
+          it('should not call next', function () {
+            expect(nextSpy).not.to.be.called
+          })
+        })
+      })
+    })
+
     describe('#setMoveId', function () {
       let req, res, next
 

--- a/app/person-escort-record/app/confirm/controllers.test.js
+++ b/app/person-escort-record/app/confirm/controllers.test.js
@@ -1,0 +1,162 @@
+const FormWizardController = require('../../../../common/controllers/form-wizard')
+const personEscortRecordService = require('../../../../common/services/person-escort-record')
+
+const { ConfirmPersonEscortRecordController } = require('./controllers')
+
+const controller = new ConfirmPersonEscortRecordController({ route: '/' })
+
+describe('Person Escort Record controllers', function () {
+  describe('ConfirmPersonEscortRecordController', function () {
+    describe('#middlewareLocals', function () {
+      beforeEach(function () {
+        sinon.stub(FormWizardController.prototype, 'middlewareLocals')
+        sinon.stub(controller, 'use')
+        sinon.stub(controller, 'setMoveId')
+
+        controller.middlewareLocals()
+      })
+
+      it('should call parent method', function () {
+        expect(FormWizardController.prototype.middlewareLocals).to.have.been
+          .calledOnce
+      })
+
+      it('should call setMoveId middleware', function () {
+        expect(controller.use).to.have.been.calledWith(controller.setMoveId)
+      })
+
+      it('should call correct number of middleware', function () {
+        expect(controller.use.callCount).to.equal(1)
+      })
+    })
+
+    describe('#setMoveId', function () {
+      let req, res, next
+
+      beforeEach(function () {
+        next = sinon.stub()
+        req = {}
+        res = {
+          locals: {},
+        }
+      })
+
+      context('with move', function () {
+        beforeEach(function () {
+          req = {
+            move: {
+              id: '12345',
+            },
+          }
+
+          controller.setMoveId(req, res, next)
+        })
+
+        it('should set moveId on locals', function () {
+          expect(res.locals.moveId).to.equal('12345')
+        })
+
+        it('should call next without error', function () {
+          expect(next).to.be.calledOnceWithExactly()
+        })
+      })
+
+      context('without move', function () {
+        beforeEach(function () {
+          controller.setMoveId(req, res, next)
+        })
+
+        it('should not set moveId on locals', function () {
+          expect(res.locals.moveId).to.be.undefined
+        })
+
+        it('should call next without error', function () {
+          expect(next).to.be.calledOnceWithExactly()
+        })
+      })
+    })
+
+    describe('#saveValues', function () {
+      const mockPERId = 'c756d3fb-d5c0-4cf4-9416-6691a89570f2'
+      let req, nextSpy
+
+      beforeEach(function () {
+        sinon.stub(personEscortRecordService, 'confirm')
+        nextSpy = sinon.spy()
+        req = {
+          personEscortRecord: {
+            id: mockPERId,
+          },
+        }
+      })
+
+      context('when save is successful', function () {
+        beforeEach(async function () {
+          personEscortRecordService.confirm.resolves({})
+          await controller.saveValues(req, {}, nextSpy)
+        })
+
+        it('should confirm person escort record', function () {
+          expect(personEscortRecordService.confirm).to.be.calledOnceWithExactly(
+            mockPERId
+          )
+        })
+
+        it('should not throw an error', function () {
+          expect(nextSpy).to.be.calledOnceWithExactly()
+        })
+      })
+
+      context('when save fails', function () {
+        const errorMock = new Error('Problem')
+
+        beforeEach(async function () {
+          personEscortRecordService.confirm.throws(errorMock)
+          await controller.saveValues(req, {}, nextSpy)
+        })
+
+        it('should call next with the error', function () {
+          expect(nextSpy).to.be.calledOnceWithExactly(errorMock)
+        })
+      })
+    })
+
+    describe('#successHandler', function () {
+      const mockMoveId = 'c756d3fb-d5c0-4cf4-9416-6691a89570f2'
+      let req, res
+
+      beforeEach(function () {
+        req = {
+          move: {
+            id: mockMoveId,
+          },
+          sessionModel: {
+            reset: sinon.stub(),
+          },
+          journeyModel: {
+            reset: sinon.stub(),
+          },
+        }
+        res = {
+          redirect: sinon.stub(),
+        }
+
+        controller.successHandler(req, res)
+      })
+
+      it('should reset the journey', function () {
+        expect(req.journeyModel.reset).to.have.been.calledOnceWithExactly()
+      })
+
+      it('should reset the session', function () {
+        expect(req.sessionModel.reset).to.have.been.calledOnceWithExactly()
+      })
+
+      it('should redirect correctly', function () {
+        expect(res.redirect).to.have.been.calledOnceWithExactly(
+          `/move/${mockMoveId}`
+        )
+      })
+    })
+  })
+})

--- a/app/person-escort-record/app/confirm/fields.js
+++ b/app/person-escort-record/app/confirm/fields.js
@@ -1,0 +1,15 @@
+const confirmPersonEscortRecord = {
+  name: 'confirm_person_escort_record',
+  component: 'govukCheckboxes',
+  items: [
+    {
+      text: 'fields::confirm_person_escort_record.label',
+      value: 'yes',
+    },
+  ],
+  validate: 'required',
+}
+
+module.exports = {
+  confirm_person_escort_record: confirmPersonEscortRecord,
+}

--- a/app/person-escort-record/app/confirm/index.js
+++ b/app/person-escort-record/app/confirm/index.js
@@ -1,0 +1,16 @@
+// NPM dependencies
+const router = require('express').Router()
+const wizard = require('hmpo-form-wizard')
+
+const config = require('./config')
+const fields = require('./fields')
+const steps = require('./steps')
+
+// Define routes
+router.use(wizard(steps, fields, config))
+
+// Export
+module.exports = {
+  router,
+  mountpath: '/confirm',
+}

--- a/app/person-escort-record/app/confirm/steps.js
+++ b/app/person-escort-record/app/confirm/steps.js
@@ -1,0 +1,19 @@
+const { ConfirmPersonEscortRecordController } = require('./controllers')
+
+module.exports = {
+  '/': {
+    entryPoint: true,
+    reset: true,
+    resetJourney: true,
+    skip: true,
+    next: 'provide-confirmation',
+  },
+  '/provide-confirmation': {
+    controller: ConfirmPersonEscortRecordController,
+    fields: ['confirm_person_escort_record'],
+    buttonText: 'actions::confirm_and_complete_record',
+    pageTitle: 'person-escort-record::journeys.confirm.heading',
+    beforeFieldsContent: 'person-escort-record::journeys.confirm.content',
+    template: 'provide-confirmation',
+  },
+}

--- a/app/person-escort-record/app/confirm/views/provide-confirmation.njk
+++ b/app/person-escort-record/app/confirm/views/provide-confirmation.njk
@@ -1,0 +1,10 @@
+{% extends "form-wizard.njk" %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+    text: t("actions::back_to_move"),
+    href: "/move/" + moveId
+  }) }}
+
+  {{ super() }}
+{% endblock %}

--- a/app/person-escort-record/index.js
+++ b/app/person-escort-record/index.js
@@ -5,6 +5,7 @@ const router = require('express').Router({ mergeParams: true })
 const { uuidRegex } = require('../../common/helpers/url')
 const frameworksService = require('../../common/services/frameworks')
 
+const confirmApp = require('./app/confirm')
 const newApp = require('./app/new')
 const { frameworkOverviewController } = require('./controllers')
 const { setFramework, setPersonEscortRecord } = require('./middleware')
@@ -20,6 +21,7 @@ router.use(frameworkWizard)
 
 // Define sub-apps
 router.use(newApp.mountpath, newApp.router)
+router.use(confirmApp.mountpath, confirmApp.router)
 
 // Define routes
 router.get('/', frameworkOverviewController)

--- a/common/services/person-escort-record.js
+++ b/common/services/person-escort-record.js
@@ -21,6 +21,19 @@ const personEscortRecordService = {
       .then(response => response.data)
   },
 
+  confirm(id) {
+    if (!id) {
+      return Promise.reject(new Error(noIdMessage))
+    }
+
+    return apiClient
+      .update('person_escort_record', {
+        id,
+        status: 'confirmed',
+      })
+      .then(this.transformResponse)
+  },
+
   getById(id) {
     if (!id) {
       return Promise.reject(new Error(noIdMessage))

--- a/common/services/person-escort-record.test.js
+++ b/common/services/person-escort-record.test.js
@@ -85,6 +85,56 @@ describe('Services', function () {
       })
     })
 
+    describe('#confirm', function () {
+      let output
+      const mockId = '8567f1a5-2201-4bc2-b655-f6526401303a'
+
+      beforeEach(async function () {
+        sinon.stub(personEscortRecordService, 'transformResponse').returnsArg(0)
+        sinon.stub(apiClient, 'update').resolves({
+          data: mockRecord,
+        })
+      })
+
+      context('without ID', function () {
+        it('should reject with error', function () {
+          return expect(personEscortRecordService.confirm()).to.be.rejectedWith(
+            'No resource ID supplied'
+          )
+        })
+      })
+
+      context('with ID', function () {
+        beforeEach(async function () {
+          output = await personEscortRecordService.confirm(mockId)
+        })
+
+        it('calls the api service', function () {
+          expect(apiClient.update).to.have.been.calledOnceWithExactly(
+            'person_escort_record',
+            {
+              id: mockId,
+              status: 'confirmed',
+            }
+          )
+        })
+
+        it('should call move transformer with response data', function () {
+          expect(
+            personEscortRecordService.transformResponse
+          ).to.be.calledOnceWithExactly({
+            data: mockRecord,
+          })
+        })
+
+        it('returns the output of transformer', function () {
+          expect(output).to.deep.equal({
+            data: mockRecord,
+          })
+        })
+      })
+    })
+
     describe('#getById', function () {
       let output
       const mockId = '8567f1a5-2201-4bc2-b655-f6526401303a'
@@ -96,7 +146,7 @@ describe('Services', function () {
         })
       })
 
-      context('without move ID', function () {
+      context('without ID', function () {
         it('should reject with error', function () {
           return expect(personEscortRecordService.getById()).to.be.rejectedWith(
             'No resource ID supplied'
@@ -104,7 +154,7 @@ describe('Services', function () {
         })
       })
 
-      context('with move ID', function () {
+      context('with ID', function () {
         beforeEach(async function () {
           output = await personEscortRecordService.getById(mockId)
         })

--- a/common/templates/form-wizard.njk
+++ b/common/templates/form-wizard.njk
@@ -64,7 +64,7 @@
     {% block beforeFields %}
       {% if options.beforeFieldsContent %}
         <div class="markdown govuk-!-margin-bottom-6">
-          {% markdown %}{{ options.beforeFieldsContent }}{% endmarkdown %}
+          {% markdown %}{{ t(options.beforeFieldsContent) }}{% endmarkdown %}
         </div>
       {% endif %}
     {% endblock %}
@@ -80,7 +80,7 @@
     {% block afterFields %}
       {% if options.afterFieldsContent %}
         <div class="markdown govuk-!-margin-bottom-6">
-          {% markdown %}{{ options.afterFieldsContent }}{% endmarkdown %}
+          {% markdown %}{{ t(options.afterFieldsContent) }}{% endmarkdown %}
         </div>
       {% endif %}
     {% endblock %}

--- a/locales/en/actions.json
+++ b/locales/en/actions.json
@@ -41,6 +41,7 @@
   "view_more_information": "View more information",
   "review": "Review",
   "start_person_escort_record": "Start Person Escort Record",
+  "provide_confirmation": "Provide confirmation",
   "confirm_and_complete_record": "Confirm and complete record",
   "continue_person_escort_record": "Continue record",
   "view_person_escort_record": "View Person Escort Record"

--- a/locales/en/actions.json
+++ b/locales/en/actions.json
@@ -41,6 +41,7 @@
   "view_more_information": "View more information",
   "review": "Review",
   "start_person_escort_record": "Start Person Escort Record",
+  "confirm_and_complete_record": "Confirm and complete record",
   "continue_person_escort_record": "Continue record",
   "view_person_escort_record": "View Person Escort Record"
 }

--- a/locales/en/fields.json
+++ b/locales/en/fields.json
@@ -329,5 +329,9 @@
       },
       "details": "Give details"
     }
+  },
+  "confirm_person_escort_record": {
+    "label": "Check this box to confirm that, to the best your knowledge, all information provided in this Person Escort Record is correct",
+    "error_message": "You must provide confirmation"
   }
 }

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -18,12 +18,16 @@
     "heading": "Awaiting a person to be added",
     "content": "$t(moves::allocation_relationship) and is waiting for a person to be added."
   },
-  "pending_person_escort_record": {
+  "person_escort_record_pending": {
     "heading": "Start the Person Escort Record",
     "content": "Once the Person Escort Record has been started you can’t edit the risk and health information provided below, but you can amend them when you complete the risk and health sections in the Person Escort Record."
   },
-  "incomplete_person_escort_record": {
+  "person_escort_record_incomplete": {
     "heading": "Incomplete Person Escort Record"
+  },
+  "person_escort_record_complete": {
+    "heading": "Person Escort Record has been completed",
+    "content": "Once you are confident the information provided is correct and won’t change, provide your confirmation that this record is correct in order to print it."
   },
   "cancel_allocation_move": {
     "content": "$t(moves::allocation_relationship). It can only be cancelled from the allocations page by a member of the Population Management Unit (PMU)."

--- a/locales/en/person-escort-record.json
+++ b/locales/en/person-escort-record.json
@@ -5,7 +5,7 @@
   "statuses": {
     "not_started": "Not started",
     "in_progress": "In progress",
-    "completed": "Complete"
+    "completed": "Completed"
   },
   "journeys": {
     "confirm": {

--- a/locales/en/person-escort-record.json
+++ b/locales/en/person-escort-record.json
@@ -6,5 +6,11 @@
     "not_started": "Not started",
     "in_progress": "In progress",
     "completed": "Complete"
+  },
+  "journeys": {
+    "confirm": {
+      "heading":"Confirm and complete this Person Escort Record",
+      "content":"Once you are confident the information below is correct and won’t change, provide your confirmation that this record is correct in order to complete it.\n\n!!! warning\nOnce you confirm and complete the Person Escort Record you will no longer be able to update the information.\n!!!"
+    }
   }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Adds a new sub-app to handle the journey for "confirming" a Person Escort Record. 

#### TODO

- [ ] ~Prevent access to edit routes once confirmed~ - going to do as separate change
- [ ] ~Prevent access to editing anything else?~ - going to do as separate change
- [x] Prevent access to confirm journey unless PER is `completed`

### Why did it change

Once a PER has been confirmed it should no longer be edited so that it can be printed in that final state.

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

- [P4-1710](https://dsdmoj.atlassian.net/browse/P4-1710)

## Screenshots
<!--- (Optional) Include screenshots if changes update interfaces or components -->
<!--- Delete/copy as appropriate --->

### Move detail when all sections have been completed

<kbd><img src="https://user-images.githubusercontent.com/3327997/87724760-e992b200-c7b3-11ea-94dc-e9565d5576c5.png">

### Journey to confirm

<kbd><img src="https://user-images.githubusercontent.com/3327997/87724832-05965380-c7b4-11ea-8f8e-c08c4472f72c.png">

### When submitted unchecked

<kbd><img src="https://user-images.githubusercontent.com/3327997/87725073-7dfd1480-c7b4-11ea-88fa-5f6ba79ac053.png"></kbd>

## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [x] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed

### Other considerations

Commit messages with a `fix` or `feat` type are automatically used to generate the [changelog](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/CHANGELOG.md) and
[GitHub release notes](https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/releases) during the release task. Please make sure they will read well on their own in a
summary of changes and that the commit body gives a more detailed description of those changes if necessary.

- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
- [x] Update [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md) with any new instructions or tasks
