### PR TITLE
fix: Correct the contrast of links on light blue banner

### DIFF
--- a/common/components/message/_message.scss
+++ b/common/components/message/_message.scss
@@ -123,6 +123,25 @@ $_message-border-width: 5px;
     margin-top: govuk-spacing(4);
   }
 
+  a {
+    &:link {
+      color: govuk-shade($govuk-link-colour, 9);
+    }
+
+    &:hover {
+      color: $govuk-link-hover-colour;
+    }
+
+    &:focus,
+    &:active {
+      color: $govuk-link-active-colour;
+    }
+
+    &:visited {
+      color: $govuk-link-visited-colour;
+    }
+  }
+
   * + * {
     margin-top: govuk-spacing(3);
   }


### PR DESCRIPTION




<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Update the link colour within the instructional banner so it passed
accessibility contrast standards.

This uses the shade mixin to inject a bit of black to the link colour
when links appear on the instructional banner that has the light blue
background.

The new colour is only marginally different but now passed with WCAG AA
on normal size text with a contrast of 4.55:1, from a previous value
of 3.99:1.

### Why did it change

The previous contrast failed WCAG AA standards which is the minimum which should
be achieving where possible.

## Screenshots
<!--- (Optional) Include screenshots if changes update interfaces or components -->
<!--- Delete/copy as appropriate --->

| Before | After |
| ------ | ----- |
| <kbd><img src="https://user-images.githubusercontent.com/3327997/87769055-f5629080-c814-11ea-9949-eadff4a18e80.png"></kbd> | <kbd><img src="https://user-images.githubusercontent.com/3327997/87769029-e7ad0b00-c814-11ea-9feb-daa64a323795.png"></kbd> |
| <kbd><img src="https://user-images.githubusercontent.com/3327997/87768652-605f9780-c814-11ea-93e1-8740ba1aa3cf.png"></kbd> | <kbd><img src="https://user-images.githubusercontent.com/3327997/87768601-4c1b9a80-c814-11ea-80f6-9cc8e0da2802.png"></kbd> |

## Checklists

### Testing

#### Automated testing

- [ ] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [x] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed

### Other considerations

Commit messages with a `fix` or `feat` type are automatically used to generate the [changelog](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/CHANGELOG.md) and
[GitHub release notes](https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/releases) during the release task. Please make sure they will read well on their own in a
summary of changes and that the commit body gives a more detailed description of those changes if necessary.

- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
- [x] Update [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md) with any new instructions or tasks
