### PR TITLE
[P4-1726] Support ordering of framework sections

### DIFF
--- a/common/presenters/framework-to-task-list-component.js
+++ b/common/presenters/framework-to-task-list-component.js
@@ -1,3 +1,5 @@
+const { sortBy } = require('lodash')
+
 const i18n = require('../../config/i18n')
 
 const tagClasses = {
@@ -13,12 +15,11 @@ function frameworkToTaskListComponent({
 } = {}) {
   const tasks = sectionProgress
     .filter(section => frameworkSections[section.key])
-    .map(section => ({
-      ...section,
-      ...frameworkSections[section.key],
-    }))
-    .map(({ key, name, status }) => {
+    .map(({ key, status }) => {
+      const { name, order } = frameworkSections[key]
+
       return {
+        order,
         text: name,
         href: baseUrl + key,
         tag: {
@@ -29,7 +30,7 @@ function frameworkToTaskListComponent({
     })
 
   return {
-    items: tasks,
+    items: sortBy(tasks, ['order', 'text']),
   }
 }
 

--- a/common/presenters/framework-to-task-list-component.test.js
+++ b/common/presenters/framework-to-task-list-component.test.js
@@ -49,6 +49,10 @@ describe('Presenters', function () {
       it('should return section', function () {
         expect(output.items).to.have.length(1)
       })
+
+      it('should return correct number of keys for item', function () {
+        expect(Object.keys(output.items[0])).to.have.length(4)
+      })
     })
 
     context('with sections that does not exist', function () {
@@ -79,28 +83,28 @@ describe('Presenters', function () {
     context('with different statuses', function () {
       const mockProgress = [
         {
-          key: 'incompleteSection',
+          key: 'incomplete-section',
           status: 'in_progress',
         },
         {
-          key: 'completeSection',
+          key: 'complete-section',
           status: 'completed',
         },
         {
-          key: 'notStartedSection',
+          key: 'not-started-section',
           status: 'not_started',
         },
       ]
       const mockSections = {
-        incompleteSection: {
+        'incomplete-section': {
           name: 'Incomplete section',
           key: 'incomplete-section',
         },
-        completeSection: {
+        'complete-section': {
           name: 'Complete section',
           key: 'complete-section',
         },
-        notStartedSection: {
+        'not-started-section': {
           name: 'Not started section',
           key: 'not-started-section',
         },
@@ -118,44 +122,13 @@ describe('Presenters', function () {
       })
 
       describe('items', function () {
-        describe('incomplete section', function () {
-          it('should return correct number of keys', function () {
-            expect(Object.keys(output.items[0])).to.have.length(3)
-          })
-
-          it('should return text', function () {
-            expect(output.items[0].text).to.equal('Incomplete section')
-          })
-
-          it('should return href', function () {
-            expect(output.items[0].href).to.equal('incomplete-section')
-          })
-
-          it('should translate status', function () {
-            expect(i18n.t).to.be.calledWithExactly(
-              'person-escort-record::statuses.in_progress'
-            )
-          })
-
-          it('should return correct tag class', function () {
-            expect(output.items[0].tag).to.deep.equal({
-              text: 'person-escort-record::statuses.in_progress',
-              classes: 'govuk-tag--blue',
-            })
-          })
-        })
-
         describe('complete section', function () {
-          it('should return correct number of keys', function () {
-            expect(Object.keys(output.items[1])).to.have.length(3)
-          })
-
           it('should return text', function () {
-            expect(output.items[1].text).to.equal('Complete section')
+            expect(output.items[0].text).to.equal('Complete section')
           })
 
           it('should return href', function () {
-            expect(output.items[1].href).to.equal('complete-section')
+            expect(output.items[0].href).to.equal('complete-section')
           })
 
           it('should translate status', function () {
@@ -165,18 +138,37 @@ describe('Presenters', function () {
           })
 
           it('should return correct tag class', function () {
-            expect(output.items[1].tag).to.deep.equal({
+            expect(output.items[0].tag).to.deep.equal({
               text: 'person-escort-record::statuses.completed',
               classes: '',
             })
           })
         })
 
-        describe('not started section', function () {
-          it('should return correct number of keys', function () {
-            expect(Object.keys(output.items[2])).to.have.length(3)
+        describe('incomplete section', function () {
+          it('should return text', function () {
+            expect(output.items[1].text).to.equal('Incomplete section')
           })
 
+          it('should return href', function () {
+            expect(output.items[1].href).to.equal('incomplete-section')
+          })
+
+          it('should translate status', function () {
+            expect(i18n.t).to.be.calledWithExactly(
+              'person-escort-record::statuses.in_progress'
+            )
+          })
+
+          it('should return correct tag class', function () {
+            expect(output.items[1].tag).to.deep.equal({
+              text: 'person-escort-record::statuses.in_progress',
+              classes: 'govuk-tag--blue',
+            })
+          })
+        })
+
+        describe('not started section', function () {
           it('should return text', function () {
             expect(output.items[2].text).to.equal('Not started section')
           })
@@ -204,12 +196,12 @@ describe('Presenters', function () {
     context('with base URL', function () {
       const mockProgress = [
         {
-          key: 'sectionKey',
+          key: 'incomplete-section',
           status: 'in_progress',
         },
       ]
       const mockSections = {
-        sectionKey: {
+        'incomplete-section': {
           name: 'Incomplete section',
           key: 'incomplete-section',
         },
@@ -226,6 +218,131 @@ describe('Presenters', function () {
       describe('items', function () {
         it('should return href with base url', function () {
           expect(output.items[0].href).to.equal('/base-url/incomplete-section')
+        })
+      })
+    })
+
+    describe('item order', function () {
+      const mockProgress = [
+        {
+          key: 'foo',
+          status: 'in_progress',
+        },
+        {
+          key: 'baz',
+          status: 'completed',
+        },
+        {
+          key: 'bar',
+          status: 'not_started',
+        },
+        {
+          key: 'fizz',
+          status: 'completed',
+        },
+      ]
+
+      context('without order', function () {
+        const mockSections = {
+          foo: {
+            name: 'Foo',
+            key: 'foo',
+          },
+          bar: {
+            name: 'Bar',
+            key: 'bar',
+          },
+          baz: {
+            name: 'Baz',
+            key: 'baz',
+          },
+          fizz: {
+            name: 'Fizz',
+            key: 'fizz',
+          },
+        }
+
+        beforeEach(function () {
+          output = presenter({
+            sectionProgress: mockProgress,
+            frameworkSections: mockSections,
+          })
+        })
+
+        it('should order alphabetically', function () {
+          const keys = output.items.map(item => item.text)
+          expect(keys).to.deep.equal(['Bar', 'Baz', 'Fizz', 'Foo'])
+        })
+      })
+
+      context('with order', function () {
+        const mockSections = {
+          foo: {
+            name: 'Foo',
+            key: 'foo',
+            order: 1,
+          },
+          bar: {
+            name: 'Bar',
+            key: 'bar',
+            order: 3,
+          },
+          baz: {
+            name: 'Baz',
+            key: 'baz',
+            order: 4,
+          },
+          fizz: {
+            name: 'Fizz',
+            key: 'fizz',
+            order: 2,
+          },
+        }
+
+        beforeEach(function () {
+          output = presenter({
+            sectionProgress: mockProgress,
+            frameworkSections: mockSections,
+          })
+        })
+
+        it('should order by order', function () {
+          const keys = output.items.map(item => item.text)
+          expect(keys).to.deep.equal(['Foo', 'Fizz', 'Bar', 'Baz'])
+        })
+      })
+
+      context('with partial order', function () {
+        const mockSections = {
+          foo: {
+            name: 'Foo',
+            key: 'foo',
+          },
+          bar: {
+            name: 'Bar',
+            key: 'bar',
+          },
+          baz: {
+            name: 'Baz',
+            key: 'baz',
+          },
+          fizz: {
+            name: 'Fizz',
+            key: 'fizz',
+            order: 1,
+          },
+        }
+
+        beforeEach(function () {
+          output = presenter({
+            sectionProgress: mockProgress,
+            frameworkSections: mockSections,
+          })
+        })
+
+        it('should order by order and then alphabetically', function () {
+          const keys = output.items.map(item => item.text)
+          expect(keys).to.deep.equal(['Fizz', 'Bar', 'Baz', 'Foo'])
         })
       })
     })

--- a/common/services/frameworks.js
+++ b/common/services/frameworks.js
@@ -176,6 +176,7 @@ function transformManifest(key, manifest) {
   return {
     key,
     name: manifest.name,
+    order: manifest.order,
     steps: keyBy(steps, 'key'),
   }
 }

--- a/common/services/frameworks.test.js
+++ b/common/services/frameworks.test.js
@@ -488,6 +488,7 @@ describe('Frameworks service', function () {
           expect(transformed).to.deep.equal({
             key: 'key',
             name: 'Manifest name',
+            order: undefined,
             steps: {},
           })
         })
@@ -522,13 +523,14 @@ describe('Frameworks service', function () {
         })
 
         it('should contain correct number of manifest keys', function () {
-          expect(Object.keys(transformed)).to.have.length(3)
+          expect(Object.keys(transformed)).to.have.length(4)
         })
 
         it('should contain correct manifest key', function () {
           expect(Object.keys(transformed)).to.deep.equal([
             'key',
             'name',
+            'order',
             'steps',
           ])
         })
@@ -539,6 +541,10 @@ describe('Frameworks service', function () {
 
         it('should set name', function () {
           expect(transformed.name).to.equal('Manifest name')
+        })
+
+        it('should not set order', function () {
+          expect(transformed.order).to.equal(undefined)
         })
 
         it('should transform steps correctly', function () {
@@ -724,13 +730,14 @@ describe('Frameworks service', function () {
         })
 
         it('should contain correct number of manifest keys', function () {
-          expect(Object.keys(transformed)).to.have.length(3)
+          expect(Object.keys(transformed)).to.have.length(4)
         })
 
         it('should contain correct manifest key', function () {
           expect(Object.keys(transformed)).to.deep.equal([
             'key',
             'name',
+            'order',
             'steps',
           ])
         })
@@ -802,13 +809,14 @@ describe('Frameworks service', function () {
         })
 
         it('should contain correct number of manifest keys', function () {
-          expect(Object.keys(transformed)).to.have.length(3)
+          expect(Object.keys(transformed)).to.have.length(4)
         })
 
         it('should contain correct manifest key', function () {
           expect(Object.keys(transformed)).to.deep.equal([
             'key',
             'name',
+            'order',
             'steps',
           ])
         })
@@ -877,13 +885,14 @@ describe('Frameworks service', function () {
         })
 
         it('should contain correct number of manifest keys', function () {
-          expect(Object.keys(transformed)).to.have.length(3)
+          expect(Object.keys(transformed)).to.have.length(4)
         })
 
         it('should contain correct manifest key', function () {
           expect(Object.keys(transformed)).to.deep.equal([
             'key',
             'name',
+            'order',
             'steps',
           ])
         })
@@ -926,6 +935,25 @@ describe('Frameworks service', function () {
         it('should set empty values for fields', function () {
           expect(transformed.steps['/step-1'].fields).to.deep.equal([])
           expect(transformed.steps['/step-2'].fields).to.deep.equal([])
+        })
+      })
+
+      context('with order', function () {
+        let transformed
+
+        beforeEach(function () {
+          transformed = frameworksService.transformManifest('key', {
+            name: 'Manifest name',
+            order: 2,
+          })
+        })
+
+        it('should contain correct number of manifest keys', function () {
+          expect(Object.keys(transformed)).to.have.length(4)
+        })
+
+        it('should set order', function () {
+          expect(transformed.order).to.equal(2)
         })
       })
     })


### PR DESCRIPTION
## Proposed changes

### What changed

This adds support to use an order property for a section to order
them when they are displayed in summaries or task lists.

### Why did it change

The order in which users should complete steps has an order that has been established during
lots of user research so we need a way to be able to control that order from the framework.

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

- [P4-1726](https://dsdmoj.atlassian.net/browse/P4-1726)

## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [x] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed

### Other considerations

Commit messages with a `fix` or `feat` type are automatically used to generate the [changelog](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/CHANGELOG.md) and
[GitHub release notes](https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/releases) during the release task. Please make sure they will read well on their own in a
summary of changes and that the commit body gives a more detailed description of those changes if necessary.

- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
- [x] Update [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md) with any new instructions or tasks
