### PR TITLE
Update to use large rather than xlarge ci instance

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -155,7 +155,7 @@ jobs:
       use_review_app:
         type: string
         default: ""
-    resource_class: xlarge
+    resource_class: large
     steps:
       - checkout
       - *set_package_version


### PR DESCRIPTION
Attempt at saving cost without increasing build time too much. Discussed with Alex Robinson.

## Proposed changes

### What changed

Changed CircleCI config to reduce the build resource type from xlarge to large 

### Why did it change

roughly 50 - 75% cost saving I think

### Issue tracking


## Screenshots
N/A

## Checklists

### Testing

#### Automated testing

N/A

#### Manual testing

Has been tested in the following browsers:

N/A
### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed

### Other considerations

Commit messages with a `fix` or `feat` type are automatically used to generate the [changelog](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/CHANGELOG.md) and
[GitHub release notes](https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/releases) during the release task. Please make sure they will read well on their own in a
summary of changes and that the commit body gives a more detailed description of those changes if necessary.

- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
- [x] Update [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md) with any new instructions or tasks
