### PR TITLE
Set variables on req instead of res.locals

### DIFF
--- a/app/allocation/controllers/cancel.js
+++ b/app/allocation/controllers/cancel.js
@@ -5,7 +5,7 @@ const allocationService = require('../../../common/services/allocation')
 
 class CancelController extends FormWizardController {
   async successHandler(req, res, next) {
-    const { id } = res.locals.allocation
+    const { id } = req.allocation
     const data = omit(req.sessionModel.toJSON(), [
       'csrf-secret',
       'errors',

--- a/app/allocation/controllers/cancel.test.js
+++ b/app/allocation/controllers/cancel.test.js
@@ -31,12 +31,10 @@ describe('Cancel controller', function () {
         journeyModel: {
           reset: sinon.stub(),
         },
+        allocation: mockAllocation,
       }
       res = {
         redirect: sinon.stub(),
-        locals: {
-          allocation: mockAllocation,
-        },
       }
     })
 

--- a/app/allocation/controllers/create/confirmation.js
+++ b/app/allocation/controllers/create/confirmation.js
@@ -1,5 +1,5 @@
-function Confirmation(req, res) {
-  res.render('allocation/views/confirmation', res.locals)
+function confirmation(req, res) {
+  res.render('allocation/views/confirmation')
 }
 
-module.exports = Confirmation
+module.exports = confirmation

--- a/app/allocation/controllers/create/confirmation.js
+++ b/app/allocation/controllers/create/confirmation.js
@@ -1,5 +1,9 @@
 function confirmation(req, res) {
-  res.render('allocation/views/confirmation')
+  const allocation = req.allocation
+
+  res.render('allocation/views/confirmation', {
+    allocation,
+  })
 }
 
 module.exports = confirmation

--- a/app/allocation/controllers/create/confirmation.test.js
+++ b/app/allocation/controllers/create/confirmation.test.js
@@ -1,23 +1,21 @@
-const handler = require('./confirmation')
+const controller = require('./confirmation')
 
-describe('the confirmation handler', function () {
-  const render = sinon.stub()
-  const locals = {
-    local1: 123,
-  }
-  beforeEach(function () {
-    handler(
-      {},
-      {
-        render,
-        locals,
+describe('Allocation controllers', function () {
+  describe('confirmation controller', function () {
+    let mockRes
+
+    beforeEach(function () {
+      mockRes = {
+        render: sinon.stub(),
       }
-    )
-  })
-  it('renders the confirmation template with the locals', function () {
-    expect(render).to.have.been.calledOnceWithExactly(
-      'allocation/views/confirmation',
-      locals
-    )
+
+      controller({}, mockRes)
+    })
+
+    it('renders the confirmation template', function () {
+      expect(mockRes.render).to.have.been.calledOnceWithExactly(
+        'allocation/views/confirmation'
+      )
+    })
   })
 })

--- a/app/allocation/controllers/create/confirmation.test.js
+++ b/app/allocation/controllers/create/confirmation.test.js
@@ -2,20 +2,38 @@ const controller = require('./confirmation')
 
 describe('Allocation controllers', function () {
   describe('confirmation controller', function () {
-    let mockRes
+    let mockReq, mockRes, params
+    const mockAllocation = {
+      id: '1',
+    }
 
     beforeEach(function () {
+      mockReq = {
+        allocation: mockAllocation,
+      }
       mockRes = {
         render: sinon.stub(),
       }
 
-      controller({}, mockRes)
+      controller(mockReq, mockRes)
+
+      params = mockRes.render.args[0][1]
     })
 
     it('renders the confirmation template', function () {
-      expect(mockRes.render).to.have.been.calledOnceWithExactly(
+      expect(mockRes.render).to.have.been.calledOnce
+      expect(mockRes.render.args[0][0]).to.equal(
         'allocation/views/confirmation'
       )
+    })
+
+    it('should pass correct number of locals to template', function () {
+      expect(Object.keys(mockRes.render.args[0][1])).to.have.length(1)
+    })
+
+    it('should contain an allocation param', function () {
+      expect(params).to.have.property('allocation')
+      expect(params.allocation).to.deep.equal(mockAllocation)
     })
   })
 })

--- a/app/allocation/controllers/remove-move.js
+++ b/app/allocation/controllers/remove-move.js
@@ -9,21 +9,21 @@ class RemoveMoveController extends FormWizardController {
   }
 
   setAdditionalLocals(req, res, next) {
-    const movesCount = res.locals.allocation.moves.length
-    res.locals.moveSummary = presenters.moveToMetaListComponent(
-      res.locals.allocation
-    )
+    const movesCount = req.allocation.moves.length
+
+    res.locals.moveSummary = presenters.moveToMetaListComponent(req.allocation)
     res.locals.sidebarHeading = req.t('allocation::view.summary.heading')
     res.locals.pageText = req.t('moves::remove_from_allocation.message', {
       movesCount,
       newMovesCount: movesCount - 1,
     })
+
     next()
   }
 
   async successHandler(req, res, next) {
     const { id: moveId } = req.move
-    const { id: allocationId } = res.locals.allocation
+    const { id: allocationId } = req.allocation
 
     try {
       // TODO remove reason and comment once the backend supplies them as default

--- a/app/allocation/controllers/remove-move.js
+++ b/app/allocation/controllers/remove-move.js
@@ -22,7 +22,7 @@ class RemoveMoveController extends FormWizardController {
   }
 
   async successHandler(req, res, next) {
-    const { id: moveId } = res.locals.move
+    const { id: moveId } = req.move
     const { id: allocationId } = res.locals.allocation
 
     try {

--- a/app/allocation/controllers/view.js
+++ b/app/allocation/controllers/view.js
@@ -4,7 +4,7 @@ const permissions = require('../../../common/middleware/permissions')
 const presenters = require('../../../common/presenters')
 
 module.exports = function view(req, res) {
-  const { allocation } = res.locals
+  const { allocation } = req
   const { moves, status } = allocation
   const userPermissions = get(req.session, 'user.permissions')
   const bannerStatuses = ['cancelled']
@@ -34,6 +34,7 @@ module.exports = function view(req, res) {
   }
 
   const locals = {
+    allocation,
     // TODO: Find way to store the actual URL they came from: See similar solution within moves app
     dashboardUrl: '/allocations',
     criteria: presenters.allocationToSummaryListComponent(allocation),

--- a/app/allocation/middleware.js
+++ b/app/allocation/middleware.js
@@ -6,7 +6,7 @@ async function setAllocation(req, res, next, allocationId) {
   }
 
   try {
-    res.locals.allocation = await allocationService.getById(allocationId)
+    req.allocation = await allocationService.getById(allocationId)
     next()
   } catch (error) {
     next(error)

--- a/app/move/controllers/assign/base.js
+++ b/app/move/controllers/assign/base.js
@@ -9,13 +9,13 @@ class AssignBaseController extends CreateBaseController {
   }
 
   setCancelUrl(req, res, next) {
-    const allocationId = res.locals.move.allocation.id
+    const allocationId = req.move.allocation.id
     res.locals.cancelUrl = `/allocation/${allocationId}`
     next()
   }
 
   setMoveSummary(req, res, next) {
-    res.locals.moveSummary = presenters.moveToMetaListComponent(res.locals.move)
+    res.locals.moveSummary = presenters.moveToMetaListComponent(req.move)
     next()
   }
 
@@ -23,7 +23,7 @@ class AssignBaseController extends CreateBaseController {
     const person = req.sessionModel.get('person')
     res.locals.person = person
 
-    const move = req.sessionModel.get('move') || res.locals.move
+    const move = req.sessionModel.get('move') || req.move
     req.sessionModel.set('move', move)
 
     // TODO: when req.getMove et al are removed these can be zapped

--- a/app/move/controllers/assign/base.test.js
+++ b/app/move/controllers/assign/base.test.js
@@ -34,42 +34,34 @@ describe('Assign controllers', function () {
     })
 
     describe('#setMoveSummary()', function () {
-      let locals
-      let next
+      let req, res, next
 
       beforeEach(function () {
         next = sinon.stub()
         sinon
           .stub(presenters, 'moveToMetaListComponent')
           .returns({ summary: {} })
-        locals = {
+        req = {
           move: {
             to_location: 'b',
             other_prop: 'c',
           },
         }
-        controller.setMoveSummary(
-          {
-            session: {
-              currentLocation: 'a',
-            },
-          },
-          {
-            locals,
-          },
-          next
-        )
+        res = {
+          locals: {},
+        }
+        controller.setMoveSummary(req, res, next)
       })
 
       it('creates moveSummary on the locals', function () {
-        expect(locals.moveSummary).to.exist
-        expect(locals.moveSummary).to.deep.equal({ summary: {} })
+        expect(res.locals.moveSummary).to.exist
+        expect(res.locals.moveSummary).to.deep.equal({ summary: {} })
       })
 
       it('invokes moveToMetaListComponent with move', function () {
         expect(
           presenters.moveToMetaListComponent
-        ).to.have.been.calledWithExactly(locals.move)
+        ).to.have.been.calledWithExactly(req.move)
       })
     })
 
@@ -125,15 +117,15 @@ describe('Assign controllers', function () {
 
     beforeEach(function () {
       nextSpy = sinon.spy()
-      req = {}
-      res = {
-        locals: {
-          move: {
-            allocation: {
-              id: '__allocationId__',
-            },
+      req = {
+        move: {
+          allocation: {
+            id: '__allocationId__',
           },
         },
+      }
+      res = {
+        locals: {},
       }
       controller.setCancelUrl(req, res, nextSpy)
     })
@@ -170,11 +162,10 @@ describe('Assign controllers', function () {
           set: sinon.stub(),
         },
         models: {},
+        move: moveFilled,
       }
       res = {
-        locals: {
-          move: moveFilled,
-        },
+        locals: {},
       }
       req.sessionModel.get.withArgs('person').returnsArg(0)
     })

--- a/app/move/controllers/cancel.js
+++ b/app/move/controllers/cancel.js
@@ -12,25 +12,26 @@ class CancelController extends FormWizardController {
   }
 
   setAdditionalInfo(req, res, next) {
-    const { move } = res.locals
+    const { move } = req
     res.locals.moveSummary = presenters.moveToMetaListComponent(move)
     res.locals.person = move.profile.person || {}
+    res.locals.move = move
 
     next()
   }
 
   checkAllocation(req, res, next) {
-    const { allocation, id } = res.locals.move
+    const { allocation, id: moveId } = req.move
 
     if (allocation) {
-      return res.redirect(`/move/${id}`)
+      return res.redirect(`/move/${moveId}`)
     }
 
     next()
   }
 
   async successHandler(req, res, next) {
-    const { id: moveId } = res.locals.move
+    const { id: moveId } = req.move
 
     try {
       const data = pick(

--- a/app/move/controllers/cancel.test.js
+++ b/app/move/controllers/cancel.test.js
@@ -53,18 +53,20 @@ describe('Move controllers', function () {
     })
 
     describe('setAdditionalInfo', function () {
-      let res
-      let next
+      let req, res, next
+
       beforeEach(function () {
+        req = {
+          move: { id: 123, profile: { person: { name: 'John Doe' } } },
+        }
         res = {
-          locals: {
-            move: { id: 123, profile: { person: { name: 'John Doe' } } },
-          },
+          locals: {},
         }
         sinon.stub(presenters, 'moveToMetaListComponent').returnsArg(0)
         next = sinon.stub()
-        controller.setAdditionalInfo({}, res, next)
+        controller.setAdditionalInfo(req, res, next)
       })
+
       it('passes the move to moveToMetaListComponent', function () {
         expect(
           presenters.moveToMetaListComponent
@@ -73,6 +75,7 @@ describe('Move controllers', function () {
           profile: { person: { name: 'John Doe' } },
         })
       })
+
       it('sets moveSummary on the locals', function () {
         expect(res.locals.moveSummary).to.exist
         expect(res.locals.moveSummary).to.deep.equal({
@@ -80,33 +83,35 @@ describe('Move controllers', function () {
           profile: { person: { name: 'John Doe' } },
         })
       })
+
       it('sets person on the locals', function () {
         expect(res.locals.person).to.exist
         expect(res.locals.person).to.deep.equal({ name: 'John Doe' })
       })
+
       it('calls next', function () {
         expect(next).to.have.been.calledWithExactly()
       })
     })
 
     describe('#checkAllocation()', function () {
-      let mockRes, nextSpy
+      let mockReq, mockRes, nextSpy
 
       beforeEach(function () {
         nextSpy = sinon.spy()
-        mockRes = {
-          locals: {
-            move: {
-              id: '12345',
-            },
+        mockReq = {
+          move: {
+            id: '12345',
           },
+        }
+        mockRes = {
           redirect: sinon.spy(),
         }
       })
 
       context('with non allocation move', function () {
         beforeEach(function () {
-          controller.checkAllocation({}, mockRes, nextSpy)
+          controller.checkAllocation(mockReq, mockRes, nextSpy)
         })
 
         it('should not redirect', function () {
@@ -120,10 +125,10 @@ describe('Move controllers', function () {
 
       context('with allocation move', function () {
         beforeEach(function () {
-          mockRes.locals.move.allocation = {
+          mockReq.move.allocation = {
             id: '123',
           }
-          controller.checkAllocation({}, mockRes, nextSpy)
+          controller.checkAllocation(mockReq, mockRes, nextSpy)
         })
 
         it('should redirect to move', function () {
@@ -157,12 +162,10 @@ describe('Move controllers', function () {
           journeyModel: {
             reset: sinon.stub(),
           },
+          move: mockMove,
         }
         res = {
           redirect: sinon.stub(),
-          locals: {
-            move: mockMove,
-          },
         }
       })
 

--- a/app/move/controllers/confirmation.js
+++ b/app/move/controllers/confirmation.js
@@ -1,13 +1,14 @@
-const { filter, get, map, reject } = require('lodash')
+const { filter, map, reject } = require('lodash')
 
 function confirmation(req, res) {
+  const move = req.move
   const {
     court_hearings: courtHearings,
     move_type: moveType,
     to_location: toLocation,
-  } = res.locals.move
+  } = move
   const { moves: allocationMoves = [] } = req.allocation || {}
-  const suppliers = get(res.locals, 'move.from_location.suppliers')
+  const suppliers = move?.from_location?.suppliers
   const supplierNames =
     suppliers && suppliers.length
       ? map(suppliers, 'name')
@@ -21,11 +22,11 @@ function confirmation(req, res) {
     'case_number'
   )
   const unassignedMoves = allocationMoves.filter(move => !move.profile)
-  const unassignedMoveId = unassignedMoves.length
-    ? unassignedMoves[0].id
-    : undefined
+  const unassignedMoveId =
+    unassignedMoves.length !== 0 ? unassignedMoves[0].id : undefined
 
   const locals = {
+    move,
     unassignedMoveId,
     supplierNames,
     savedHearings,

--- a/app/move/controllers/confirmation.test.js
+++ b/app/move/controllers/confirmation.test.js
@@ -14,12 +14,10 @@ describe('Move controllers', function () {
     beforeEach(function () {
       req = {
         t: sinon.stub().returnsArg(0),
+        move: mockMove,
       }
       res = {
         render: sinon.spy(),
-        locals: {
-          move: mockMove,
-        },
       }
     })
 
@@ -33,6 +31,12 @@ describe('Move controllers', function () {
 
         expect(res.render.calledOnce).to.be.true
         expect(template).to.equal('move/views/confirmation')
+      })
+
+      it('should pass move to template locals', function () {
+        const params = res.render.args[0][1]
+        expect(params).to.have.property('move')
+        expect(params.move).to.deep.equal(mockMove)
       })
 
       it('should use to location title as location', function () {
@@ -71,13 +75,13 @@ describe('Move controllers', function () {
 
       it('should contain correct number of locals', function () {
         const locals = res.render.args[0][1]
-        expect(Object.keys(locals)).to.have.length(5)
+        expect(Object.keys(locals)).to.have.length(6)
       })
     })
 
     describe('with move_type "prison_recall"', function () {
       beforeEach(function () {
-        res.locals.move = {
+        req.move = {
           ...mockMove,
           move_type: 'prison_recall',
         }
@@ -99,7 +103,7 @@ describe('Move controllers', function () {
 
     describe('with empty supplier', function () {
       beforeEach(function () {
-        res.locals.move = {
+        req.move = {
           ...mockMove,
           from_location: {
             suppliers: [],
@@ -122,7 +126,7 @@ describe('Move controllers', function () {
 
     describe('with one supplier', function () {
       beforeEach(function () {
-        res.locals.move = {
+        req.move = {
           ...mockMove,
           from_location: {
             suppliers: [
@@ -145,7 +149,7 @@ describe('Move controllers', function () {
 
     describe('with multiple suppliers', function () {
       beforeEach(function () {
-        res.locals.move = {
+        req.move = {
           ...mockMove,
           from_location: {
             suppliers: [
@@ -174,7 +178,7 @@ describe('Move controllers', function () {
 
     describe('with hearings', function () {
       beforeEach(function () {
-        res.locals.move = {
+        req.move = {
           ...mockMove,
           court_hearings: [
             {

--- a/app/move/controllers/review.js
+++ b/app/move/controllers/review.js
@@ -26,7 +26,7 @@ class ReviewController extends FormWizardController {
 
   setRebookOptions(req, res, next) {
     const existingItems = req.form.options.fields.rebook.items
-    const maxDate = res.locals.move.date_to
+    const maxDate = req.move.date_to
     const isAboutToExpire =
       maxDate && differenceInCalendarDays(parseISO(maxDate), new Date()) <= 7
 
@@ -45,7 +45,7 @@ class ReviewController extends FormWizardController {
   }
 
   checkStatus(req, res, next) {
-    const { id, status } = res.locals.move
+    const { id, status } = req.move
 
     if (status !== 'proposed') {
       return res.redirect(`/move/${id}`)
@@ -55,18 +55,19 @@ class ReviewController extends FormWizardController {
   }
 
   canAccess(req, res, next) {
-    const { canAccess, move } = res.locals
+    const { canAccess } = res.locals
+    const { id: moveId } = req.move
 
     if (canAccess('move:review', req.session.user.permissions)) {
       return next()
     }
 
-    res.redirect(`/move/${move.id}`)
+    res.redirect(`/move/${moveId}`)
   }
 
   updateDateHint(req, res, next) {
     const { move_date: moveDate } = req.form.options.fields
-    const { date_to: dateTo, date_from: dateFrom } = res.locals.move
+    const { date_to: dateTo, date_from: dateFrom } = req.move
 
     moveDate.hint.text = req.t(moveDate.hint.text, {
       context: dateTo ? 'with_date_range' : 'with_date',
@@ -77,8 +78,9 @@ class ReviewController extends FormWizardController {
   }
 
   setMoveSummary(req, res, next) {
-    const { move } = res.locals
+    const { move } = req
 
+    res.locals.move = move
     res.locals.person = move.profile.person
     res.locals.moveSummary = presenters.moveToMetaListComponent(move)
 
@@ -86,7 +88,7 @@ class ReviewController extends FormWizardController {
   }
 
   async successHandler(req, res, next) {
-    const { id: moveId } = res.locals.move
+    const { id: moveId } = req.move
     const data = pick(
       req.sessionModel.toJSON(),
       Object.keys(req.form.options.allFields)

--- a/app/move/controllers/unassign.js
+++ b/app/move/controllers/unassign.js
@@ -8,7 +8,7 @@ class UnassignController extends FormWizardController {
   }
 
   checkAllocation(req, res, next) {
-    const { move } = res.locals
+    const { move } = req
 
     if (!move.allocation) {
       return res.redirect(`/move/${move.id}`)
@@ -27,17 +27,20 @@ class UnassignController extends FormWizardController {
   }
 
   setMoveRelationships(req, res, next) {
-    const { move } = res.locals
-    res.locals.person = move.profile.person
-    res.locals.allocation = move.allocation
+    const { allocation, profile } = req.move
+    res.locals.move = req.move
+    res.locals.person = profile.person
+    res.locals.allocation = allocation
 
     next()
   }
 
   async saveValues(req, res, next) {
     try {
-      const { id } = res.locals.move
-      await moveService.unassign(id)
+      const { id: moveId } = req.move
+
+      await moveService.unassign(moveId)
+
       super.saveValues(req, res, next)
     } catch (err) {
       next(err)
@@ -45,7 +48,7 @@ class UnassignController extends FormWizardController {
   }
 
   successHandler(req, res) {
-    const { id: allocationId } = res.locals.move.allocation
+    const { id: allocationId } = req.move.allocation
 
     req.journeyModel.reset()
     req.sessionModel.reset()

--- a/app/move/controllers/unassign.test.js
+++ b/app/move/controllers/unassign.test.js
@@ -52,23 +52,24 @@ describe('Move controllers', function () {
     })
 
     describe('#checkAllocation()', function () {
-      let res, next
+      let req, res, next
 
       beforeEach(function () {
         next = sinon.stub()
+        req = {
+          move: {},
+        }
+        res = {
+          redirect: sinon.stub(),
+        }
       })
 
       context('with no allocation', function () {
         beforeEach(function () {
-          res = {
-            locals: {
-              move: {
-                id: '12345',
-              },
-            },
-            redirect: sinon.stub(),
+          req.move = {
+            id: '12345',
           }
-          controller.checkAllocation({}, res, next)
+          controller.checkAllocation(req, res, next)
         })
 
         it('should redirect to allocation', function () {
@@ -82,16 +83,11 @@ describe('Move controllers', function () {
 
       context('with allocation but not person', function () {
         beforeEach(function () {
-          res = {
-            locals: {
-              move: {
-                id: '12345',
-                allocation: { id: '6789' },
-              },
-            },
-            redirect: sinon.stub(),
+          req.move = {
+            id: '12345',
+            allocation: { id: '6789' },
           }
-          controller.checkAllocation({}, res, next)
+          controller.checkAllocation(req, res, next)
         })
 
         it('should redirect to allocation', function () {
@@ -105,18 +101,13 @@ describe('Move controllers', function () {
 
       context('with allocation and person', function () {
         beforeEach(function () {
-          res = {
-            locals: {
-              move: {
-                id: '12345',
-                allocation: { id: '6789' },
-                profile: { person: { id: '__person__' } },
-              },
-            },
-            redirect: sinon.stub(),
+          req.move = {
+            id: '12345',
+            allocation: { id: '6789' },
+            profile: { person: { id: '__person__' } },
           }
 
-          controller.checkAllocation({}, res, next)
+          controller.checkAllocation(req, res, next)
         })
 
         it('should not redirect', function () {
@@ -130,21 +121,30 @@ describe('Move controllers', function () {
     })
 
     describe('#setMoveRelationships()', function () {
-      let res, next
+      let req, res, next
 
       beforeEach(function () {
         next = sinon.stub()
-        res = {
-          locals: {
-            move: {
-              id: '12345',
-              allocation: { id: '__allocation__' },
-              profile: { person: { id: '__person__' } },
-            },
+        req = {
+          move: {
+            id: '12345',
+            allocation: { id: '__allocation__' },
+            profile: { person: { id: '__person__' } },
           },
+        }
+        res = {
+          locals: {},
           redirect: sinon.stub(),
         }
-        controller.setMoveRelationships({}, res, next)
+        controller.setMoveRelationships(req, res, next)
+      })
+
+      it('should set move on locals', function () {
+        expect(res.locals.move).to.deep.equal({
+          id: '12345',
+          allocation: { id: '__allocation__' },
+          profile: { person: { id: '__person__' } },
+        })
       })
 
       it('should set allocation on locals', function () {
@@ -162,12 +162,10 @@ describe('Move controllers', function () {
 
     describe('#saveValues()', function () {
       const move = { id: '__move__' }
-      const req = {}
-      const res = {
-        locals: {
-          move,
-        },
+      const req = {
+        move,
       }
+      const res = {}
       let next
 
       beforeEach(function () {
@@ -226,16 +224,14 @@ describe('Move controllers', function () {
           journeyModel: {
             reset: sinon.stub(),
           },
+          move: {
+            allocation: {
+              id: '__allocation__',
+            },
+          },
         }
         res = {
           redirect: sinon.stub(),
-          locals: {
-            move: {
-              allocation: {
-                id: '__allocation__',
-              },
-            },
-          },
         }
       })
 

--- a/app/move/controllers/update/assessment.js
+++ b/app/move/controllers/update/assessment.js
@@ -1,4 +1,4 @@
-const { isEqual, pick, keys, get } = require('lodash')
+const { isEqual, pick, keys } = require('lodash')
 
 const profileService = require('../../../../common/services/profile')
 const Assessment = require('../create/assessment')
@@ -31,7 +31,7 @@ class UpdateAssessmentController extends UpdateBase {
 
   getUpdateValues(req, res) {
     const profile = req.getProfile()
-    const fields = keys(get(req, 'form.options.fields'))
+    const fields = keys(req.form?.options?.fields)
     return profileService.unformat(profile, fields)
   }
 

--- a/app/move/controllers/update/base.js
+++ b/app/move/controllers/update/base.js
@@ -1,4 +1,4 @@
-const { get, isEqual, keys, map, pick } = require('lodash')
+const { isEqual, keys, map, pick } = require('lodash')
 
 const moveService = require('../../../../common/services/move')
 const personService = require('../../../../common/services/person')
@@ -13,8 +13,7 @@ class UpdateBaseController extends CreateBaseController {
   }
 
   _setModels(req) {
-    const res = req.res
-    const move = res.locals.move
+    const move = req.move
     req.models.move = move
     req.models.profile = move.profile
     req.models.person = move.profile.person
@@ -101,7 +100,7 @@ class UpdateBaseController extends CreateBaseController {
 
   getUpdateValues(req, res) {
     const person = req.getPerson()
-    const fields = keys(get(req, 'form.options.fields'))
+    const fields = keys(req.form?.options?.fields)
     return personService.unformat(person, fields)
   }
 
@@ -129,7 +128,8 @@ class UpdateBaseController extends CreateBaseController {
   }
 
   setFlash(req, category) {
-    const suppliers = get(req.getMove(), 'from_location.suppliers')
+    const move = req.getMove()
+    const suppliers = move?.from_location?.suppliers
     const supplierNames =
       suppliers && suppliers.length
         ? map(suppliers, 'name')

--- a/app/move/controllers/update/base.test.js
+++ b/app/move/controllers/update/base.test.js
@@ -234,11 +234,7 @@ describe('Move controllers', function () {
       beforeEach(function () {
         req = {
           models: {},
-          res: {
-            locals: {
-              move: mockSession,
-            },
-          },
+          move: mockSession,
         }
         controller._setModels(req)
       })
@@ -711,7 +707,7 @@ describe('Move controllers', function () {
 
     context('when the supplier is not known', function () {
       beforeEach(async function () {
-        req.getMove = sinon.stub().returns({})
+        req.getMove = sinon.stub().returns()
         await controller.setFlash(req, 'categoryKey')
       })
 

--- a/app/move/controllers/update/court.js
+++ b/app/move/controllers/update/court.js
@@ -1,12 +1,9 @@
-const { get } = require('lodash')
-
 const AssessmentController = require('./assessment')
 
 class UpdateCourtController extends AssessmentController {
   // TODO: replace this with a centralised more form-wizard-based protection
   configure(req, res, next) {
-    const isCourt =
-      get(res, 'locals.move.to_location.location_type') === 'court'
+    const isCourt = req.move?.to_location?.location_type === 'court'
 
     if (!isCourt) {
       const error = new Error(

--- a/app/move/controllers/update/court.test.js
+++ b/app/move/controllers/update/court.test.js
@@ -5,11 +5,11 @@ const controller = new CourtController({ route: '/' })
 const ownProto = Object.getPrototypeOf(controller)
 
 describe('Move controllers', function () {
-  const req = {}
-  let res
+  const res = {}
+  let req
   let nextSpy
   beforeEach(function () {
-    res = {}
+    req = {}
     nextSpy = sinon.spy()
     sinon.stub(AssessmentController.prototype, 'configure')
   })
@@ -53,12 +53,10 @@ describe('Move controllers', function () {
 
       context('when the move is to a court', function () {
         beforeEach(function () {
-          res = {
-            locals: {
-              move: {
-                to_location: {
-                  location_type: 'court',
-                },
+          req = {
+            move: {
+              to_location: {
+                location_type: 'court',
               },
             },
           }

--- a/app/move/controllers/update/document.js
+++ b/app/move/controllers/update/document.js
@@ -1,4 +1,4 @@
-const { get, pick } = require('lodash')
+const { pick } = require('lodash')
 
 const profileService = require('../../../../common/services/profile')
 const DocumentUploadController = require('../create/document')
@@ -7,10 +7,8 @@ const UpdateBase = require('./base')
 
 class UpdateDocumentUploadController extends UpdateBase {
   configure(req, res, next) {
-    const canUploadDocuments = get(
-      req,
-      'session.currentLocation.can_upload_documents'
-    )
+    const canUploadDocuments =
+      req.session?.currentLocation?.can_upload_documents
 
     if (!canUploadDocuments) {
       const error = new Error(

--- a/app/move/controllers/update/move-details.js
+++ b/app/move/controllers/update/move-details.js
@@ -1,4 +1,4 @@
-const { get, pick } = require('lodash')
+const { pick } = require('lodash')
 
 const moveService = require('../../../../common/services/move')
 const CreateMoveDetailsController = require('../create/move-details')
@@ -26,7 +26,7 @@ class UpdateMoveDetailsController extends UpdateBase {
       values[`${moveType}_comments`] = values.additional_information
     }
 
-    const toLocation = get(move, 'to_location.id')
+    const toLocation = move.to_location?.id
 
     if (toLocation) {
       values[`to_location_${moveType}`] = toLocation
@@ -38,7 +38,7 @@ class UpdateMoveDetailsController extends UpdateBase {
   filterMoveTypes(req, res, next) {
     const move = req.getMove()
     const moveType = move.move_type
-    const moveTypeField = get(req, 'form.options.fields.move_type')
+    const moveTypeField = req.form.options.fields?.move_type
     moveTypeField.items = moveTypeField.items.filter(
       item => item.value === moveType
     )
@@ -54,7 +54,7 @@ class UpdateMoveDetailsController extends UpdateBase {
       const toLocation = values[`to_location_${moveType}`]
       const additionalInformation = values[`${moveType}_comments`]
 
-      if (toLocation !== get(move, 'to_location.id')) {
+      if (toLocation !== move.to_location?.id) {
         const notes = req.t('moves::redirect_notes', req.session.user)
 
         await moveService.redirect({

--- a/app/move/middleware.js
+++ b/app/move/middleware.js
@@ -8,12 +8,7 @@ module.exports = {
     }
 
     try {
-      const move = await moveService.getById(moveId)
-
-      // TODO: Remove `res.locals` in favour of `req.move`. See issue #451
-      res.locals.move = move
-      req.move = move
-
+      req.move = await moveService.getById(moveId)
       next()
     } catch (error) {
       next(error)
@@ -31,7 +26,7 @@ module.exports = {
   },
 
   setAllocation: async (req, res, next) => {
-    const { allocation } = res.locals.move || {}
+    const { allocation } = req.move || {}
 
     if (!allocation) {
       return next()

--- a/app/move/middleware.test.js
+++ b/app/move/middleware.test.js
@@ -18,7 +18,7 @@ describe('Move middleware', function () {
 
     beforeEach(function () {
       req = {}
-      res = { locals: {} }
+      res = {}
       nextSpy = sinon.spy()
     })
 
@@ -35,10 +35,6 @@ describe('Move middleware', function () {
 
       it('should not call API with move ID', function () {
         expect(moveService.getById).not.to.be.called
-      })
-
-      it('should not set response data to locals object', function () {
-        expect(res.locals).not.to.have.property('move')
       })
 
       it('should not set response data to request object', function () {
@@ -58,11 +54,6 @@ describe('Move middleware', function () {
           expect(moveService.getById).to.be.calledWith(mockMoveId)
         })
 
-        it('should set response data to locals object', function () {
-          expect(res.locals).to.have.property('move')
-          expect(res.locals.move).to.equal(moveStub)
-        })
-
         it('should set response data to request object', function () {
           expect(req).to.have.property('move')
           expect(req.move).to.equal(moveStub)
@@ -78,10 +69,6 @@ describe('Move middleware', function () {
           sinon.stub(moveService, 'getById').throws(errorStub)
 
           await middleware.setMove({}, res, nextSpy, mockMoveId)
-        })
-
-        it('should not set a value on the locals object', function () {
-          expect(res.locals).not.to.have.property('move')
         })
 
         it('should not set response data to request object', function () {
@@ -151,7 +138,7 @@ describe('Move middleware', function () {
       sinon.stub(allocationService, 'getById')
 
       req = {}
-      res = { locals: {} }
+      res = {}
       nextSpy = sinon.spy()
     })
 
@@ -175,7 +162,7 @@ describe('Move middleware', function () {
 
     context('when move exists', function () {
       beforeEach(function () {
-        res.locals.move = moveStub
+        req.move = moveStub
       })
 
       context('when move does not contain allocation', function () {
@@ -198,7 +185,7 @@ describe('Move middleware', function () {
 
       context('when move contains allocation', function () {
         beforeEach(function () {
-          res.locals.move = moveWithAllocationStub
+          req.move = moveWithAllocationStub
         })
 
         context('when API call returns succesfully', function () {

--- a/locales/en/allocations.json
+++ b/locales/en/allocations.json
@@ -3,7 +3,7 @@
   "total_plural": "total allocations",
   "confirmation": {
     "page_title": "Allocation requested",
-    "detail": "The request for <a href=\"{{href}}\">{{moves_count}} {{people}}</a> from {{from_location}} to {{to_location}} on {{date}} has been sent",
+    "detail": "The request for <strong><a href=\"{{href}}\">{{moves_count}} {{people}}</a></strong> from <strong>{{from_location}}</strong> to <strong>{{to_location}}</strong> on <strong>{{date}}</strong> has been sent.",
     "view_all": "View all allocations",
     "view_by_from_location": "View {{from_location}} overview"
   },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Replaces the use of `res.locals[var]` with `req[var]`.

Part of cleaning out long-lived branches that have been kicked around a while...

Closes #451 

### Why did it change

This helps to reduce the issue we have of things being set to `res.locals`
within middleware and making it a little harder to find where is it being
set.

This moves towards a pattern of setting things on the request object
within middleware if that value needs to be used later on in the request
chain.

Then if that value is required by a view, it is handled within the
controller that calls that template.

## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [x] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed

### Other considerations

Commit messages with a `fix` or `feat` type are automatically used to generate the [changelog](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/CHANGELOG.md) and
[GitHub release notes](https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/releases) during the release task. Please make sure they will read well on their own in a
summary of changes and that the commit body gives a more detailed description of those changes if necessary.

- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
- [x] Update [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md) with any new instructions or tasks
