### PR TITLE
Ensure dependent framework responses are filtered correctly

### DIFF
--- a/common/helpers/field/index.js
+++ b/common/helpers/field/index.js
@@ -15,6 +15,7 @@ const componentService = require('../../services/component')
 
 const flattenConditionalFields = require('./flatten-conditional-fields')
 const getFieldErrorMessage = require('./get-field-error-message')
+const isAllowedDependent = require('./is-allowed-dependent')
 const reduceDependentFields = require('./reduce-dependent-fields')
 const setFieldError = require('./set-field-error')
 
@@ -244,6 +245,7 @@ module.exports = {
   mapReferenceDataToOption,
   renderConditionalFields,
   getFieldErrorMessage,
+  isAllowedDependent,
   setFieldValue,
   setFieldError,
   translateField,

--- a/common/helpers/field/is-allowed-dependent.js
+++ b/common/helpers/field/is-allowed-dependent.js
@@ -1,0 +1,40 @@
+const { intersection } = require('lodash')
+
+function isAllowedDependent(fields, key, values) {
+  const field = fields[key]
+
+  if (!field) {
+    return false
+  }
+
+  if (!field.dependent) {
+    return true
+  }
+
+  // set up dependent to an object of field and value
+  if (typeof field.dependent === 'string') {
+    field.dependent = {
+      field: field.dependent,
+      value: true,
+    }
+  }
+
+  if (!fields[field.dependent.field]) {
+    return true
+  }
+
+  // validate if any dependent value matches any field value
+  const dependent = field.dependent
+  const dependentValues = Array.isArray(dependent.value)
+    ? dependent.value
+    : [dependent.value]
+  const fieldValues = Array.isArray(values[dependent.field])
+    ? values[dependent.field]
+    : [values[dependent.field]]
+
+  const matches = intersection(dependentValues, fieldValues)
+
+  return matches.length !== 0
+}
+
+module.exports = isAllowedDependent

--- a/common/helpers/field/is-allowed-dependent.test.js
+++ b/common/helpers/field/is-allowed-dependent.test.js
@@ -1,0 +1,75 @@
+const isAllowedDependent = require('./is-allowed-dependent')
+
+describe('Helpers', function () {
+  describe('Field helpers', function () {
+    describe('#isAllowedDependent', function () {
+      let fields, values, result
+
+      beforeEach(function () {
+        fields = {
+          'field-1': {},
+          'field-2': {},
+          'field-3': {
+            dependent: 'field-2',
+          },
+        }
+        values = {
+          'field-1': 'abc',
+          'field-2': 'def',
+          'field-3': 'hij',
+        }
+      })
+
+      it('returns false if field does not exist', function () {
+        result = isAllowedDependent(fields, 'field-99', values)
+        expect(result).to.be.false
+      })
+
+      it('returns true if there is no dependent field', function () {
+        result = isAllowedDependent(fields, 'field-1', values)
+        expect(result).to.be.true
+      })
+
+      it('returns true if there is a dependent field that matches the value', function () {
+        values['field-2'] = true
+        result = isAllowedDependent(fields, 'field-3', values)
+        expect(result).to.be.true
+      })
+
+      it('returns true if dependent field does not exist', function () {
+        fields['field-3'].dependent = {
+          field: '__non_existent__',
+          value: true,
+        }
+        result = isAllowedDependent(fields, 'field-3', values)
+        expect(result).to.be.true
+      })
+
+      it('returns true if there is a dependent field thatdoes not matches the value', function () {
+        values['field-2'] = false
+        result = isAllowedDependent(fields, 'field-3', values)
+        expect(result).to.be.false
+      })
+
+      it('returns true if one of the field values matches one of the field values', function () {
+        fields['field-3'].dependent = {
+          field: 'field-2',
+          value: ['c', 'd', 'e'],
+        }
+        values['field-2'] = ['a', 'b', 'c']
+        result = isAllowedDependent(fields, 'field-3', values)
+        expect(result).to.be.true
+      })
+
+      it('returns false if none of the field values matches any of the field values', function () {
+        fields['field-3'].dependent = {
+          field: 'field-2',
+          value: ['x', 'y', 'z'],
+        }
+        values['field-2'] = ['a', 'b', 'c']
+        result = isAllowedDependent(fields, 'field-3', values)
+        expect(result).to.be.false
+      })
+    })
+  })
+})

--- a/common/helpers/frameworks/index.js
+++ b/common/helpers/frameworks/index.js
@@ -1,7 +1,9 @@
 const appendResponseToField = require('./append-response-to-field')
 const mapFieldFromName = require('./map-field-from-name')
+const responsesToSaveReducer = require('./responses-to-save-reducer')
 
 module.exports = {
   mapFieldFromName,
   appendResponseToField,
+  responsesToSaveReducer,
 }

--- a/common/helpers/frameworks/responses-to-save-reducer.js
+++ b/common/helpers/frameworks/responses-to-save-reducer.js
@@ -1,0 +1,44 @@
+const { kebabCase, pickBy } = require('lodash')
+
+function responsesToSaveReducer(values = {}) {
+  return (accumulator, { id, question, value_type: valueType }) => {
+    const fieldName = question.key
+    const value = values[fieldName]
+
+    if (valueType === 'object') {
+      accumulator.push({
+        id,
+        value: pickBy({
+          option: value,
+          details: values[`${fieldName}--${kebabCase(value)}`],
+        }),
+      })
+    }
+
+    if (valueType === 'collection') {
+      const collection = value.filter(Boolean).map(option => {
+        return {
+          option,
+          details: values[`${fieldName}--${kebabCase(option)}`],
+        }
+      })
+
+      accumulator.push({
+        id,
+        value: collection,
+      })
+    }
+
+    if (valueType === 'array') {
+      accumulator.push({ id, value: value.filter(Boolean) })
+    }
+
+    if (valueType === 'string') {
+      accumulator.push({ id, value })
+    }
+
+    return accumulator
+  }
+}
+
+module.exports = responsesToSaveReducer

--- a/common/helpers/frameworks/responses-to-save-reducer.test.js
+++ b/common/helpers/frameworks/responses-to-save-reducer.test.js
@@ -1,0 +1,256 @@
+const responsesToSaveReducer = require('./responses-to-save-reducer')
+
+describe('Helpers', function () {
+  describe('Frameworks Helpers', function () {
+    describe('#responsesToSaveReducer', function () {
+      let responses
+      const mockResponses = [
+        {
+          id: '1',
+          question: {
+            key: 'question-1',
+          },
+        },
+        {
+          id: '2',
+          question: {
+            key: 'question-2',
+          },
+        },
+        {
+          id: '3',
+          question: {
+            key: 'question-3',
+          },
+        },
+      ]
+
+      context('with no form values', function () {
+        beforeEach(function () {
+          responses = mockResponses.reduce(responsesToSaveReducer(), [])
+        })
+
+        it('should not return any responses', function () {
+          expect(responses).to.deep.equal([])
+        })
+      })
+
+      context('with form values', function () {
+        const testCases = [
+          {
+            testName: 'with string',
+            formValues: {
+              question: 'Yes',
+            },
+            responses: [
+              {
+                id: '1',
+                value_type: 'string',
+                question: {
+                  key: 'question',
+                },
+              },
+            ],
+            expectedValue: [
+              {
+                id: '1',
+                value: 'Yes',
+              },
+            ],
+          },
+          {
+            testName: 'with array',
+            formValues: {
+              question: ['Yes', 'No'],
+            },
+            responses: [
+              {
+                id: '1',
+                value_type: 'array',
+                question: {
+                  key: 'question',
+                },
+              },
+            ],
+            expectedValue: [
+              {
+                id: '1',
+                value: ['Yes', 'No'],
+              },
+            ],
+          },
+          {
+            testName: 'with array with falsy values',
+            formValues: {
+              question: ['', null, undefined, false],
+            },
+            responses: [
+              {
+                id: '1',
+                value_type: 'array',
+                question: {
+                  key: 'question',
+                },
+              },
+            ],
+            expectedValue: [
+              {
+                id: '1',
+                value: [],
+              },
+            ],
+          },
+          {
+            testName: 'with object without followup comments',
+            formValues: {
+              question: 'Yes',
+            },
+            responses: [
+              {
+                id: '1',
+                value_type: 'object',
+                question: {
+                  key: 'question',
+                },
+              },
+            ],
+            expectedValue: [
+              {
+                id: '1',
+                value: {
+                  option: 'Yes',
+                },
+              },
+            ],
+          },
+          {
+            testName: 'with object with followup comments',
+            formValues: {
+              question: 'Yes',
+              'question--yes': 'Further yes details',
+            },
+            responses: [
+              {
+                id: '1',
+                value_type: 'object',
+                question: {
+                  key: 'question',
+                },
+              },
+            ],
+            expectedValue: [
+              {
+                id: '1',
+                value: {
+                  option: 'Yes',
+                  details: 'Further yes details',
+                },
+              },
+            ],
+          },
+          {
+            testName: 'with collection without followup comments',
+            formValues: {
+              question: ['One', 'Two', 'Three'],
+            },
+            responses: [
+              {
+                id: '1',
+                value_type: 'collection',
+                question: {
+                  key: 'question',
+                },
+              },
+            ],
+            expectedValue: [
+              {
+                id: '1',
+                value: [
+                  {
+                    option: 'One',
+                    details: undefined,
+                  },
+                  {
+                    option: 'Two',
+                    details: undefined,
+                  },
+                  {
+                    option: 'Three',
+                    details: undefined,
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            testName: 'with collection without followup comments',
+            formValues: {
+              question: ['One', 'Two', 'Three'],
+              'question--one': 'Further comments about one',
+              'question--three': 'Further comments about three',
+            },
+            responses: [
+              {
+                id: '1',
+                value_type: 'collection',
+                question: {
+                  key: 'question',
+                },
+              },
+            ],
+            expectedValue: [
+              {
+                id: '1',
+                value: [
+                  {
+                    option: 'One',
+                    details: 'Further comments about one',
+                  },
+                  {
+                    option: 'Two',
+                    details: undefined,
+                  },
+                  {
+                    option: 'Three',
+                    details: 'Further comments about three',
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            testName: 'with any unknown type',
+            formValues: {
+              question: 'Unknown',
+            },
+            responses: [
+              {
+                id: '1',
+                value_type: 'unknkown',
+                question: {
+                  key: 'question',
+                },
+              },
+            ],
+            expectedValue: [],
+          },
+        ]
+
+        testCases.forEach(test => {
+          context(test.testName, function () {
+            beforeEach(function () {
+              responses = test.responses.reduce(
+                responsesToSaveReducer(test.formValues),
+                []
+              )
+            })
+
+            it('should format response correctly', function () {
+              expect(responses).to.deep.equal(test.expectedValue)
+            })
+          })
+        })
+      })
+    })
+  })
+})


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

This change ensures that any dependent responses are not sent to be
saved if the dependent field doesn't match the condition the field
depends on.

This also includes a fix to remove any falsy values from Array like
objects which prevents the API from returning an error when an
array with one empty string is sent when no checkboxes are selected.

### Why did it change

Currently the API would return an error when the frontend would send values for responses that
aren't valid because the condition for a dependent question is not met.

This change ensures that we remove any dependent fields before sending to the API.

## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [x] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed

### Other considerations

Commit messages with a `fix` or `feat` type are automatically used to generate the [changelog](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/CHANGELOG.md) and
[GitHub release notes](https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/releases) during the release task. Please make sure they will read well on their own in a
summary of changes and that the commit body gives a more detailed description of those changes if necessary.

- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
- [x] Update [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md) with any new instructions or tasks
