### PR TITLE
chore: Support v1 and v2 person differences

### DIFF
--- a/common/lib/api-client/models.js
+++ b/common/lib/api-client/models.js
@@ -83,6 +83,9 @@ module.exports = {
         jsonApi: 'hasOne',
         type: 'ethnicities',
       },
+      prison_number: '',
+      criminal_records_office: '',
+      police_national_computer: '',
       profiles: {
         jsonApi: 'hasMany',
         type: 'profiles',

--- a/common/presenters/person-to-summary-list-component.js
+++ b/common/presenters/person-to-summary-list-component.js
@@ -1,6 +1,8 @@
+const { API } = require('../../config')
 const i18n = require('../../config/i18n')
 const filters = require('../../config/nunjucks/filters')
 
+// TODO: when V2, props will be splatted and no need for identifier_type prop
 function mapIdentifier({ value, identifier_type: type }) {
   return {
     key: {
@@ -20,7 +22,6 @@ module.exports = function personToSummaryListComponent(props) {
   const {
     gender,
     ethnicity,
-    identifiers = [],
     date_of_birth: dateOfBirth,
     gender_additional_information: genderAdditionalInformation,
   } = props
@@ -28,6 +29,21 @@ module.exports = function personToSummaryListComponent(props) {
   const genderExtra = genderAdditionalInformation
     ? ` — ${genderAdditionalInformation}`
     : ''
+
+  let { identifiers = [] } = props
+
+  if (API.VERSION !== 1) {
+    identifiers = [
+      'police_national_computer',
+      'prison_number',
+      'criminal_records_office',
+    ]
+      .filter(identifier => props[identifier])
+      .map(identifier => ({
+        value: props[identifier],
+        identifier_type: identifier,
+      }))
+  }
 
   const rows = [
     ...identifiers.map(mapIdentifier),

--- a/common/presenters/person-to-summary-list-component.test.js
+++ b/common/presenters/person-to-summary-list-component.test.js
@@ -1,3 +1,4 @@
+const { API } = require('../../config')
 const i18n = require('../../config/i18n')
 const filters = require('../../config/nunjucks/filters')
 
@@ -7,7 +8,19 @@ const mockPerson = {
   id: '12345',
   date_of_birth: '1948-04-24',
   gender_additional_information: 'Additional gender information',
-  identifiers: [
+  police_national_computer: '11009922',
+  prison_number: 'AA/183716',
+  criminal_records_office: 'JS901873',
+  ethnicity: {
+    title: 'Mixed (White and Black Caribbean)',
+  },
+  gender: {
+    title: 'Transexual',
+  },
+}
+
+if (API.VERSION === 1) {
+  mockPerson.identifiers = [
     {
       identifier_type: 'police_national_computer',
       value: '11009922',
@@ -20,13 +33,7 @@ const mockPerson = {
       identifier_type: 'criminal_records_office',
       value: 'JS901873',
     },
-  ],
-  ethnicity: {
-    title: 'Mixed (White and Black Caribbean)',
-  },
-  gender: {
-    title: 'Transexual',
-  },
+  ]
 }
 
 describe('Presenters', function () {
@@ -55,18 +62,33 @@ describe('Presenters', function () {
           const row2 = transformedResponse.rows[1]
           const row3 = transformedResponse.rows[2]
 
-          expect(row1).to.deep.equal({
-            key: { html: '__translated__' },
-            value: { text: mockPerson.identifiers[0].value },
-          })
-          expect(row2).to.deep.equal({
-            key: { html: '__translated__' },
-            value: { text: mockPerson.identifiers[1].value },
-          })
-          expect(row3).to.deep.equal({
-            key: { html: '__translated__' },
-            value: { text: mockPerson.identifiers[2].value },
-          })
+          if (API.VERSION === 1) {
+            expect(row1).to.deep.equal({
+              key: { html: '__translated__' },
+              value: { text: mockPerson.identifiers[0].value },
+            })
+            expect(row2).to.deep.equal({
+              key: { html: '__translated__' },
+              value: { text: mockPerson.identifiers[1].value },
+            })
+            expect(row3).to.deep.equal({
+              key: { html: '__translated__' },
+              value: { text: mockPerson.identifiers[2].value },
+            })
+          } else {
+            expect(row1).to.deep.equal({
+              key: { html: '__translated__' },
+              value: { text: mockPerson.police_national_computer },
+            })
+            expect(row2).to.deep.equal({
+              key: { html: '__translated__' },
+              value: { text: mockPerson.prison_number },
+            })
+            expect(row3).to.deep.equal({
+              key: { html: '__translated__' },
+              value: { text: mockPerson.criminal_records_office },
+            })
+          }
         })
 
         it('should contain date of birth', function () {

--- a/common/services/person.js
+++ b/common/services/person.js
@@ -1,17 +1,21 @@
 const { mapKeys, mapValues, uniqBy, omitBy, isNil } = require('lodash')
 
+const { API } = require('../../config')
 const apiClient = require('../lib/api-client')()
 
 const unformat = require('./person/person.unformat')
 
 const relationshipKeys = ['gender', 'ethnicity']
-const identifierKeys = [
+
+const identifierKeysV1 = [
   'police_national_computer',
   'criminal_records_office',
   'prison_number',
   'niche_reference',
   'athena_reference',
 ]
+
+const identifierKeys = API.VERSION === 1 ? identifierKeysV1 : []
 const dateKeys = ['date_of_birth']
 
 const personService = {

--- a/config/index.js
+++ b/config/index.js
@@ -60,7 +60,7 @@ module.exports = {
   BUILD_BRANCH: process.env.APP_BUILD_TAG,
   GIT_SHA: process.env.APP_GIT_COMMIT,
   API: {
-    VERSION: API_VERSION,
+    VERSION: Number(API_VERSION),
     BASE_URL: API_BASE_URL + process.env.API_PATH,
     AUTH_URL: API_BASE_URL + process.env.API_AUTH_PATH,
     HEALTHCHECK_URL: API_BASE_URL + process.env.API_HEALTHCHECK_PATH,

--- a/test/e2e/_helpers.js
+++ b/test/e2e/_helpers.js
@@ -15,6 +15,8 @@ import profileService from '../../common/services/profile'
 import referenceDataService from '../../common/services/reference-data'
 import { formatDate } from '../../config/nunjucks/filters'
 
+const { API } = require('../../config')
+
 export const scrollToTop = ClientFunction(() => {
   window.scrollTo(0, 0)
 })
@@ -108,6 +110,10 @@ export async function createPersonFixture(overrides = {}) {
   })
 
   const getIdentifierValue = type => {
+    if (API.VERSION !== 1) {
+      return person[type]
+    }
+
     return get(
       find(person.identifiers, {
         identifier_type: type,

--- a/test/fixtures/api-client/person.create.json
+++ b/test/fixtures/api-client/person.create.json
@@ -7,6 +7,9 @@
       "last_name": "Roberts",
       "date_of_birth": "1965-10-24",
       "gender_additional_information": "Additional information",
+      "prison_number": "AA/BBBBBB",
+      "police_national_computer": "xxxxxx",
+      "criminal_records_office": "ZZZZZZ",
       "assessment_answers": [
         {
           "title": "Violent",


### PR DESCRIPTION


Implemnents P4-1911

<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

- Flatten identifier properties in model
- Update personService transform, format and unformat methods to match
- Update personToSummaryList presenter to use flattened props

### Why did it change

Enables move from v1 -> v2 of API

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

- [P4-1911](https://dsdmoj.atlassian.net/browse/P4-1911)

## Screenshots

Functionally identical

## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed

### Other considerations



- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics

