### PR TITLE
[P4 1927] Enable move updates for SCH users

### DIFF
--- a/common/lib/permissions.js
+++ b/common/lib/permissions.js
@@ -19,6 +19,7 @@ const secureChildrensHomePermissions = [
   'move:create',
   'move:create:court_appearance',
   'move:cancel',
+  'move:update',
 ]
 const secureTrainingCentrePermissions = [
   'moves:view:outgoing',

--- a/common/lib/user.test.js
+++ b/common/lib/user.test.js
@@ -185,6 +185,7 @@ describe('User class', function () {
           'move:create',
           'move:create:court_appearance',
           'move:cancel',
+          'move:update',
         ])
       })
     })

--- a/config/index.js
+++ b/config/index.js
@@ -162,6 +162,10 @@ module.exports = {
         username: process.env.E2E_STC_USERNAME,
         password: process.env.E2E_STC_PASSWORD,
       },
+      SCH: {
+        username: process.env.E2E_SCH_USERNAME,
+        password: process.env.E2E_SCH_PASSWORD,
+      },
       PRISON: {
         username: process.env.E2E_PRISON_USERNAME,
         password: process.env.E2E_PRISON_PASSWORD,

--- a/test/e2e/_roles.js
+++ b/test/e2e/_roles.js
@@ -19,6 +19,10 @@ export const stcUser = Role(home, async t => {
   await page.signIn(E2E.ROLES.STC)
 })
 
+export const schUser = Role(home, async t => {
+  await page.signIn(E2E.ROLES.SCH)
+})
+
 export const prisonUser = Role(home, async t => {
   await page.signIn(E2E.ROLES.PRISON)
 })

--- a/test/e2e/move.update.allowed.test.js
+++ b/test/e2e/move.update.allowed.test.js
@@ -1,0 +1,29 @@
+import {
+  createCourtMove,
+  checkUpdateLinks,
+  checkUpdatePagesAccessible,
+} from './_move'
+import { schUser } from './_roles'
+import { home } from './_routes'
+
+const users = [
+  {
+    name: 'SCH user',
+    role: schUser,
+  },
+]
+
+users.forEach(user => {
+  fixture(`Existing move (As ${user.name})`).beforeEach(async t => {
+    await t.useRole(user.role).navigateTo(home)
+    await createCourtMove()
+  })
+
+  test('User should see update links on move page', async () => {
+    await checkUpdateLinks()
+  })
+
+  test('User should be able to access move update pages', async () => {
+    await checkUpdatePagesAccessible()
+  })
+})


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Add `move:update` permission to `SCH` users

### Why did it change

SCH users need to be able to update moves

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

- [P4-1927](https://dsdmoj.atlassian.net/browse/P4-1927)

## Screenshots

n/a

## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [x] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables


<!--- Delete if changes DO NOT include new environment variables -->
- [ ] Documented in the [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md)
- [ ] Added to [continous integration](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-book-secure-move-frontend)
- [ ] Added to staging environment (deployment repository)
- [ ] Added to preproduction environment (deployment repository)
- [ ] Added to production environment (deployment repository)

### Other considerations

- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
