### PR TITLE
build: Wait for master to be deployed before running e2e tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -226,8 +226,9 @@ jobs:
               --label build.git.branch=${CIRCLE_BRANCH} \
               --label build.date=${BUILD_DATE} \
               --build-arg APP_BUILD_DATE=${BUILD_DATE} \
-              --build-arg APP_BUILD_TAG=${CIRCLE_BRANCH} \
+              --build-arg APP_BUILD_TAG=${CIRCLE_BUILD_NUM} \
               --build-arg APP_GIT_COMMIT=${CIRCLE_SHA1} \
+              --build-arg APP_BUILD_BRANCH=${CIRCLE_BRANCH} \
               -t app .
       - run:
           name: Login to ECR

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,9 @@ ENV APP_BUILD_TAG ${APP_BUILD_TAG}
 ARG APP_GIT_COMMIT
 ENV APP_GIT_COMMIT ${APP_GIT_COMMIT}
 
+ARG APP_BUILD_BRANCH
+ENV APP_BUILD_BRANCH ${APP_BUILD_BRANCH}
+
 COPY --chown=node:node start.js .
 COPY --chown=node:node server.js .
 COPY --chown=node:node locales locales

--- a/app/healthcheck/controllers.js
+++ b/app/healthcheck/controllers.js
@@ -1,7 +1,23 @@
 const { some } = require('lodash')
 
-const { BUILD_DATE, BUILD_BRANCH, GIT_SHA } = require('../../config')
+const {
+  API,
+  APP_BUILD_DATE,
+  APP_BUILD_TAG,
+  APP_BUILD_BRANCH,
+  APP_GIT_SHA,
+} = require('../../config')
 const { version } = require('../../package.json')
+
+// https://github.com/ministryofjustice/ping.json
+const buildDetails = {
+  build_date: APP_BUILD_DATE,
+  build_tag: APP_BUILD_TAG,
+  commit_id: APP_GIT_SHA,
+  version_number: version,
+  branch: APP_BUILD_BRANCH,
+  api_version: API.VERSION,
+}
 
 module.exports = {
   get: (req, res) => {
@@ -12,15 +28,12 @@ module.exports = {
     res.setHeader('Cache-Control', 'no-cache, no-store, must-revalidate')
     res.status(errors ? 503 : 200).json({
       status,
-      version,
       dependencies,
-      buildDate: BUILD_DATE,
-      buildTag: BUILD_BRANCH,
-      gitSha: GIT_SHA,
+      ...buildDetails,
     })
   },
   ping: (req, res) => {
     res.setHeader('Cache-Control', 'no-cache, no-store, must-revalidate')
-    res.status(200).send('OK')
+    res.status(200).json(buildDetails)
   },
 }

--- a/app/healthcheck/controllers.test.js
+++ b/app/healthcheck/controllers.test.js
@@ -1,12 +1,16 @@
 const proxyquire = require('proxyquire').noCallThru()
 
 const mockConfig = {
-  BUILD_DATE: '2019-10-10',
-  BUILD_BRANCH: 'master',
-  GIT_SHA: 'gbe34155ae5edfade5107bd5629d0c159dc37d19',
+  API: {
+    VERSION: 7,
+  },
+  APP_BUILD_DATE: '2019-10-10',
+  APP_BUILD_TAG: '5226',
+  APP_BUILD_BRANCH: 'master',
+  APP_GIT_SHA: 'gbe34155ae5edfade5107bd5629d0c159dc37d19',
 }
 const mockManifest = {
-  version: '1.0.0',
+  version_number: '1.0.0',
 }
 const controllers = proxyquire('./controllers', {
   '../../config': mockConfig,
@@ -60,10 +64,12 @@ describe('Healthcheck controllers', function () {
       it('should render JSON', function () {
         expect(res.json.args[0][0]).to.deep.equal({
           status: 'OK',
-          version: mockManifest.version,
-          buildDate: mockConfig.BUILD_DATE,
-          buildTag: mockConfig.BUILD_BRANCH,
-          gitSha: mockConfig.GIT_SHA,
+          api_version: 7,
+          version_number: mockManifest.version,
+          build_date: mockConfig.APP_BUILD_DATE,
+          build_tag: mockConfig.APP_BUILD_TAG,
+          commit_id: mockConfig.APP_GIT_SHA,
+          branch: mockConfig.APP_BUILD_BRANCH,
           dependencies: res.dependencies,
         })
       })
@@ -96,10 +102,12 @@ describe('Healthcheck controllers', function () {
       it('should render JSON', function () {
         expect(res.json.args[0][0]).to.deep.equal({
           status: 'Service unavailable',
-          version: mockManifest.version,
-          buildDate: mockConfig.BUILD_DATE,
-          buildTag: mockConfig.BUILD_BRANCH,
-          gitSha: mockConfig.GIT_SHA,
+          api_version: 7,
+          version_number: mockManifest.version,
+          build_date: mockConfig.APP_BUILD_DATE,
+          build_tag: mockConfig.APP_BUILD_TAG,
+          commit_id: mockConfig.APP_GIT_SHA,
+          branch: mockConfig.APP_BUILD_BRANCH,
           dependencies: res.dependencies,
         })
       })
@@ -113,7 +121,7 @@ describe('Healthcheck controllers', function () {
       res = {
         setHeader: sinon.stub(),
         status: sinon.stub().returnsThis(),
-        send: sinon.stub(),
+        json: sinon.stub(),
       }
       controllers.ping({}, res)
     })
@@ -130,7 +138,14 @@ describe('Healthcheck controllers', function () {
     })
 
     it('should render JSON', function () {
-      expect(res.send).to.be.calledOnceWithExactly('OK')
+      expect(res.json).to.be.calledOnceWithExactly({
+        api_version: 7,
+        version_number: mockManifest.version,
+        build_date: mockConfig.APP_BUILD_DATE,
+        build_tag: mockConfig.APP_BUILD_TAG,
+        commit_id: mockConfig.APP_GIT_SHA,
+        branch: mockConfig.APP_BUILD_BRANCH,
+      })
     })
   })
 })

--- a/config/index.js
+++ b/config/index.js
@@ -56,9 +56,10 @@ module.exports = {
   NO_CACHE: process.env.CACHE_ASSETS ? false : IS_DEV,
   FEEDBACK_URL: process.env.FEEDBACK_URL,
   SUPPORT_EMAIL: process.env.SUPPORT_EMAIL,
-  BUILD_DATE: process.env.APP_BUILD_DATE,
-  BUILD_BRANCH: process.env.APP_BUILD_TAG,
-  GIT_SHA: process.env.APP_GIT_COMMIT,
+  APP_BUILD_DATE: process.env.APP_BUILD_DATE,
+  APP_BUILD_BRANCH: process.env.APP_BUILD_BRANCH,
+  APP_BUILD_TAG: process.env.APP_BUILD_TAG,
+  APP_GIT_SHA: process.env.APP_GIT_COMMIT,
   API: {
     VERSION: Number(API_VERSION),
     BASE_URL: API_BASE_URL + process.env.API_PATH,


### PR DESCRIPTION
## Proposed changes

### What changed

On CircleCI E2E tests run against master branch poll ping endpoint to check same commit has been deployed before running the tests

Update ping endpoint to return build details to enable checking of commit.

### Why did it change

Tests against master on staging were kicked off the moment that the staging deployment task had finished.

This meant that:

a) tests early in the run may have been run against the old pods running the previous deployed commit of the app.
b) tests that ran against the wrong pods were in danger of having requests dropped if they had not been fulfilled by the time the pods were terminated which would cause the test to fail.

This should prevent tests being run against the wrong pods and having the pods switched out from under them.

### Issue tracking

n/a


## Screenshots

n/a

## Checklists

### Testing




### Other considerations

- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics

