### PR TITLE
[P4-1760] Render Person Escort Record framework flags on the move detail page

### DIFF
--- a/app/move/controllers/view.js
+++ b/app/move/controllers/view.js
@@ -1,4 +1,4 @@
-const { isEmpty, sortBy } = require('lodash')
+const { isEmpty, find, sortBy } = require('lodash')
 
 const permissionsMiddleware = require('../../../common/middleware/permissions')
 const presenters = require('../../../common/presenters')
@@ -62,6 +62,23 @@ module.exports = function view(req, res) {
     .assessmentAnswersByCategory(assessmentAnswers)
     .filter(category => category.key === 'court')
     .map(presenters.assessmentCategoryToSummaryListComponent)[0]
+  const assessmentSections = sortBy(framework.sections, 'order')
+    .map(
+      presenters.frameworkSectionToPanelList({
+        tagList: personEscortRecordTagList,
+        framework,
+        personEscortRecord,
+        personEscortRecordUrl,
+      })
+    )
+    .map(section => {
+      return {
+        ...section,
+        previousAssessment: find(assessment, {
+          frameworksSection: section.key,
+        }),
+      }
+    })
 
   const locals = {
     move,
@@ -75,6 +92,7 @@ module.exports = function view(req, res) {
     personEscortRecordtaskList,
     showPersonEscortRecordBanner,
     personEscortRecordTagList,
+    assessmentSections,
     moveSummary: presenters.moveToMetaListComponent(move, updateActions),
     personalDetailsSummary: presenters.personToSummaryListComponent(person),
     tagList: presenters.assessmentToTagList(assessmentAnswers),

--- a/app/move/controllers/view.test.js
+++ b/app/move/controllers/view.test.js
@@ -8,7 +8,7 @@ const getUpdateLinks = sinon.stub()
 
 const updateSteps = []
 const frameworkStub = {
-  sections: ['one'],
+  sections: [{ id: 'one' }],
 }
 const pathStubs = {
   '../../../config': {
@@ -113,6 +113,9 @@ describe('Move controllers', function () {
       sinon
         .stub(presenters, 'frameworkFlagsToTagList')
         .returns('__frameworkFlagsToTagList__')
+      sinon
+        .stub(presenters, 'frameworkSectionToPanelList')
+        .returns(sinon.stub().returns({}))
       sinon.stub(presenters, 'personToSummaryListComponent').returnsArg(0)
       sinon.stub(presenters, 'assessmentToTagList').returnsArg(0)
       sinon.stub(presenters, 'assessmentAnswersByCategory').returns([])
@@ -151,7 +154,7 @@ describe('Move controllers', function () {
       })
 
       it('should pass correct number of locals to template', function () {
-        expect(Object.keys(res.render.args[0][1])).to.have.length(20)
+        expect(Object.keys(res.render.args[0][1])).to.have.length(21)
       })
 
       it('should call moveToMetaListComponent presenter with correct args', function () {
@@ -220,6 +223,10 @@ describe('Move controllers', function () {
         expect(params.personEscortRecordTagList).to.equal(
           '__frameworkFlagsToTagList__'
         )
+      })
+
+      it('should contain a assessmentSections param', function () {
+        expect(params).to.have.property('assessmentSections')
       })
 
       it('should contain a move summary param', function () {

--- a/app/move/views/_includes/assessment.njk
+++ b/app/move/views/_includes/assessment.njk
@@ -6,19 +6,7 @@
       }) }}
     </h2>
 
-    {% for panel in assessmentCategory.panels %}
-      {{ appPanel(panel) }}
-    {% else %}
-      {{ appMessage({
-        classes: "app-message--muted govuk-!-margin-top-2",
-        allowDismiss: false,
-        content: {
-          text: t('assessment::no_items.text', {
-            context: assessmentCategory.key
-          })
-        }
-      }) }}
-    {% endfor %}
+    {{ renderAssessmentComponent(assessmentCategory) }}
 
     {% if not personEscortRecord %}
       {{ updateLink(updateLinks[assessmentCategory.key]) }}

--- a/app/move/views/_includes/court-information.njk
+++ b/app/move/views/_includes/court-information.njk
@@ -46,19 +46,7 @@
       }) }}
     </h2>
 
-    {% if courtSummary.rows | length %}
-      {{ govukSummaryList(courtSummary) }}
-    {% else %}
-      {{ appMessage({
-        classes: "app-message--muted",
-        allowDismiss: false,
-        content: {
-          html: t("assessment::no_items.text", {
-            context: "court"
-          })
-        }
-      }) }}
-    {% endif %}
+    {{ renderAssessmentComponent(courtSummary) }}
 
     {{ updateLink(updateLinks.court) }}
   {% endif %}

--- a/app/move/views/_includes/person-escort-record-summary.njk
+++ b/app/move/views/_includes/person-escort-record-summary.njk
@@ -1,0 +1,49 @@
+{% for assessment in assessmentSections %}
+  <section class="app-!-position-relative govuk-!-margin-top-7">
+    <h2 class="govuk-heading-m govuk-!-margin-bottom-2">
+      {{ assessment.name }}
+    </h2>
+
+    {% if personEscortRecordIsCompleted %}
+      {% for panel in assessment.panels %}
+        {% call appPanel(panel) %}
+          {{ appMetaList(panel.metaList) }}
+        {% endcall %}
+      {% else %}
+        {{ appMessage({
+          classes: "app-message--muted govuk-!-margin-top-2",
+          allowDismiss: false,
+          content: {
+            html: t("person-escort-record::flags.empty", {
+              name: assessment.name,
+              url: assessment.url
+            })
+          }
+        }) }}
+      {% endfor %}
+    {% else %}
+      {{ govukInsetText({
+        classes: "govuk-inset-text--compact govuk-!-margin-0",
+        text: t("person-escort-record::flags.incomplete")
+      }) }}
+    {% endif %}
+
+    {% if assessment.previousAssessment %}
+      {% set html %}
+        {{ renderAssessmentComponent(assessment.previousAssessment) }}
+      {% endset %}
+
+      {{ govukDetails({
+        html: html,
+        classes: "govuk-!-font-size-16 govuk-!-margin-top-2",
+        summaryText: t("person-escort-record::flags.information_provided_when_requested")
+      }) }}
+    {% endif %}
+
+    <p class="app-!-position-top-right">
+      <a href="{{ assessment.url }}" class="govuk-link">
+        Review
+      </a>
+    </pre>
+  </section>
+{% endfor %}

--- a/app/move/views/view.njk
+++ b/app/move/views/view.njk
@@ -230,6 +230,28 @@
   {% endif %}
 {% endmacro %}
 
+{% macro renderAssessmentComponent(assessment) %}
+  {% if assessment.count > 0 %}
+    {% if assessment.panels %}
+      {% for panel in assessment.panels %}
+        {{ appPanel(panel) }}
+      {% endfor %}
+    {% else %}
+      {{ govukSummaryList(assessment) }}
+    {% endif %}
+  {% else %}
+    {{ appMessage({
+      classes: "app-message--muted govuk-!-margin-top-2",
+      allowDismiss: false,
+      content: {
+        text: t('assessment::no_items.text', {
+          context: assessment.key
+        })
+      }
+    }) }}
+  {% endif %}
+{% endmacro %}
+
 {% block contentMain %}
   {% if move.profile %}
     <div class="govuk-!-margin-bottom-9">

--- a/app/move/views/view.njk
+++ b/app/move/views/view.njk
@@ -265,7 +265,11 @@
         {{ updateLink(updateLinks.personal_details) }}
       </section>
 
-      {% include "move/views/_includes/assessment.njk" %}
+      {% if personEscortRecord %}
+        {% include "move/views/_includes/person-escort-record-summary.njk" %}
+      {% else %}
+        {% include "move/views/_includes/assessment.njk" %}
+      {% endif %}
 
       {% if move.to_location.location_type == 'court' %}
         {% include "move/views/_includes/court-information.njk" %}

--- a/common/assets/scss/overrides/_govuk-frontend.scss
+++ b/common/assets/scss/overrides/_govuk-frontend.scss
@@ -6,8 +6,11 @@
   display: block;
 }
 
-.govuk-summary-list__value .govuk-list--spaced > li:last-child {
-  margin-bottom: 0;
+.govuk-summary-list__value,
+.app-meta-list__value {
+  .govuk-list--spaced > li:last-child {
+    margin-bottom: 0;
+  }
 }
 
 .govuk-hint * {

--- a/common/components/framework-response/template.njk
+++ b/common/components/framework-response/template.njk
@@ -1,6 +1,8 @@
 {% if params.value and params.valueType %}
   {% if params.valueType === 'object' %}
-    {{ params.value.option }}{{ " — " + params.value.details if params.value.details }}
+    <p class="govuk-!-font-size-16">
+      {{ params.value.option }}{{ " — " + params.value.details if params.value.details }}
+    </p>
   {% endif %}
 
   {% if params.valueType === 'array' %}
@@ -22,7 +24,9 @@
   {% endif %}
 
   {% if params.valueType === 'string' %}
-    {{ params.value }}
+    <p class="govuk-!-font-size-16">
+      {{ params.value }}
+    </p>
   {% endif %}
 {% else %}
   {% if params.responded %}

--- a/common/components/framework-response/template.test.js
+++ b/common/components/framework-response/template.test.js
@@ -18,8 +18,14 @@ describe('Framework Response component', function () {
       $component = $('body')
     })
 
-    it('should not render a parent element', function () {
-      expect($component.children().first().get(0)).to.be.undefined
+    it('should render a parent p', function () {
+      expect($component.children().first().get(0).tagName).to.equal('p')
+    })
+
+    it('should contain correct ul classes', function () {
+      expect($component.children().first().attr('class')).to.equal(
+        'govuk-!-font-size-16'
+      )
     })
 
     it('should render value', function () {
@@ -37,8 +43,14 @@ describe('Framework Response component', function () {
         $component = $('body')
       })
 
-      it('should not render a parent element', function () {
-        expect($component.children().first().get(0)).to.be.undefined
+      it('should render a parent p', function () {
+        expect($component.children().first().get(0).tagName).to.equal('p')
+      })
+
+      it('should contain correct ul classes', function () {
+        expect($component.children().first().attr('class')).to.equal(
+          'govuk-!-font-size-16'
+        )
       })
 
       it('should render value', function () {
@@ -55,8 +67,14 @@ describe('Framework Response component', function () {
         $component = $('body')
       })
 
-      it('should not render a parent element', function () {
-        expect($component.children().first().get(0)).to.be.undefined
+      it('should render a parent p', function () {
+        expect($component.children().first().get(0).tagName).to.equal('p')
+      })
+
+      it('should contain correct ul classes', function () {
+        expect($component.children().first().attr('class')).to.equal(
+          'govuk-!-font-size-16'
+        )
       })
 
       it('should render value', function () {

--- a/common/components/meta-list/_meta-list.scss
+++ b/common/components/meta-list/_meta-list.scss
@@ -31,6 +31,10 @@
 
 .app-meta-list__value {
   margin: 0;
+
+  > :last-child {
+    margin: 0;
+  }
 }
 
 .app-meta-list__action {

--- a/common/presenters/assessment-category-to-panel-component.js
+++ b/common/presenters/assessment-category-to-panel-component.js
@@ -4,7 +4,8 @@ const componentService = require('../services/component')
 
 const assessmentAnswersToMetaListComponent = require('./assessment-answers-to-meta-list-component')
 
-function assessmentCategoryToPanelListComponent({ answers, key, tagClass }) {
+function assessmentCategoryToPanelListComponent(category) {
+  const { answers, tagClass } = category
   const groupedByTitle = groupBy(answers, 'title')
   const panels = map(groupedByTitle, (answers, title) => {
     const metaList = assessmentAnswersToMetaListComponent(answers)
@@ -22,7 +23,8 @@ function assessmentCategoryToPanelListComponent({ answers, key, tagClass }) {
   })
 
   return {
-    key,
+    ...category,
+    count: answers.length,
     panels: sortBy(panels, 'tag.text'),
   }
 }

--- a/common/presenters/assessment-category-to-panel-component.test.js
+++ b/common/presenters/assessment-category-to-panel-component.test.js
@@ -66,8 +66,18 @@ describe('Presenters', function () {
       it('should include correct keys', function () {
         expect(Object.keys(transformedResponse)).to.deep.equal([
           'key',
+          'sortOrder',
+          'tagClass',
+          'answers',
+          'count',
           'panels',
         ])
+      })
+
+      it('should create count of answers', function () {
+        expect(transformedResponse.count).to.equal(
+          mockAssessmentCategory.answers.length
+        )
       })
 
       it('should transform answers by title', function () {

--- a/common/presenters/assessment-category-to-summary-list-component.js
+++ b/common/presenters/assessment-category-to-summary-list-component.js
@@ -4,7 +4,8 @@ const componentService = require('../services/component')
 
 const assessmentAnswersToMetaListComponent = require('./assessment-answers-to-meta-list-component')
 
-function assessmentCategoryToSummaryListComponent({ answers = [], key } = {}) {
+function assessmentCategoryToSummaryListComponent(category = {}) {
+  const { answers = [] } = category
   const groupedByTitle = groupBy(answers, 'title')
   const rows = map(groupedByTitle, (answers, title) => {
     const metaList = assessmentAnswersToMetaListComponent(answers)
@@ -21,7 +22,8 @@ function assessmentCategoryToSummaryListComponent({ answers = [], key } = {}) {
   })
 
   return {
-    key,
+    ...category,
+    count: answers.length,
     rows: sortBy(rows, 'key.text'),
   }
 }

--- a/common/presenters/assessment-category-to-summary-list-component.test.js
+++ b/common/presenters/assessment-category-to-summary-list-component.test.js
@@ -68,8 +68,18 @@ describe('Presenters', function () {
         it('should include correct keys', function () {
           expect(Object.keys(transformedResponse)).to.deep.equal([
             'key',
+            'sortOrder',
+            'tagClass',
+            'answers',
+            'count',
             'rows',
           ])
+        })
+
+        it('should create count of answers', function () {
+          expect(transformedResponse.count).to.equal(
+            mockAssessmentCategory.answers.length
+          )
         })
 
         it('should transform answers by title', function () {

--- a/common/presenters/framework-field-summary-list-row.js
+++ b/common/presenters/framework-field-summary-list-row.js
@@ -12,6 +12,7 @@ function frameworkFieldToSummaryListRow(stepUrl, extraClasses = []) {
       valueType: response.value_type,
       responded: response.responded === true,
       questionUrl: `${stepUrl}#${id}`,
+      classes: 'govuk-!-font-size-16',
     })
 
     const row = {

--- a/common/presenters/framework-field-summary-list-row.test.js
+++ b/common/presenters/framework-field-summary-list-row.test.js
@@ -33,6 +33,7 @@ describe('Presenters', function () {
               valueType: undefined,
               responded: false,
               questionUrl: `${mockStepUrl}#${mockField.id}`,
+              classes: 'govuk-!-font-size-16',
             }
           )
         })
@@ -68,6 +69,7 @@ describe('Presenters', function () {
               valueType: undefined,
               responded: false,
               questionUrl: `${mockStepUrl}#${mockField.id}`,
+              classes: 'govuk-!-font-size-16',
             }
           )
         })
@@ -118,6 +120,7 @@ describe('Presenters', function () {
               valueType: undefined,
               responded: false,
               questionUrl: `${mockStepUrl}#${mockField.id}`,
+              classes: 'govuk-!-font-size-16',
             }
           )
         })
@@ -178,6 +181,7 @@ describe('Presenters', function () {
                 valueType: 'string',
                 responded: false,
                 questionUrl: `${mockStepUrl}#${mockFieldWithFollowup.id}`,
+                classes: 'govuk-!-font-size-16',
               }
             )
             expect(componentService.getComponent).to.be.calledWithExactly(
@@ -187,6 +191,7 @@ describe('Presenters', function () {
                 valueType: undefined,
                 responded: false,
                 questionUrl: `${mockStepUrl}#${mockFieldWithFollowup.items[0].followup[0].id}`,
+                classes: 'govuk-!-font-size-16',
               }
             )
           })
@@ -231,6 +236,7 @@ describe('Presenters', function () {
                 valueType: 'string',
                 responded: false,
                 questionUrl: `${mockStepUrl}#${mockFieldWithFollowup.id}`,
+                classes: 'govuk-!-font-size-16',
               }
             )
           })
@@ -306,6 +312,7 @@ describe('Presenters', function () {
                   valueType: test.valueType,
                   responded: false,
                   questionUrl: `${mockStepUrl}#${mockField.id}`,
+                  classes: 'govuk-!-font-size-16',
                 }
               )
             })
@@ -332,6 +339,7 @@ describe('Presenters', function () {
                   valueType: test.valueType,
                   responded: false,
                   questionUrl: `${mockStepUrl}#${mockField.id}`,
+                  classes: 'govuk-!-font-size-16',
                 }
               )
             })
@@ -361,6 +369,7 @@ describe('Presenters', function () {
               valueType: 'array',
               responded: true,
               questionUrl: `${mockStepUrl}#${mockField.id}`,
+              classes: 'govuk-!-font-size-16',
             }
           )
         })

--- a/common/presenters/framework-flags-to-tag-list.js
+++ b/common/presenters/framework-flags-to-tag-list.js
@@ -3,16 +3,19 @@ const { sortBy, uniqBy, kebabCase } = require('lodash')
 const { FRAMEWORKS } = require('../../config')
 
 function frameworkFlagsToTagList(flags = [], hrefPrefix = '') {
-  const tags = uniqBy(flags, 'title').map(({ flag_type: category, title }) => {
-    const settings = FRAMEWORKS.FLAG_SETTINGS[category] || {}
+  const tags = uniqBy(flags, 'title').map(
+    ({ flag_type: type, title, question } = {}) => {
+      const settings = FRAMEWORKS.FLAG_SETTINGS[type] || {}
 
-    return {
-      text: title,
-      href: `${hrefPrefix}#${kebabCase(title)}`,
-      classes: settings.tagClass || '',
-      sortOrder: settings.sortOrder || null,
+      return {
+        text: title,
+        section: question?.section,
+        href: `${hrefPrefix}#${kebabCase(title)}`,
+        classes: settings.tagClass || '',
+        sortOrder: settings.sortOrder || null,
+      }
     }
-  })
+  )
 
   return sortBy(tags, ['sortOrder', 'text'])
 }

--- a/common/presenters/framework-flags-to-tag-list.test.js
+++ b/common/presenters/framework-flags-to-tag-list.test.js
@@ -24,7 +24,7 @@ const presenter = proxyquire('./framework-flags-to-tag-list', {
 })
 
 describe('Presenters', function () {
-  describe('#assessmentToTagList()', function () {
+  describe('#frameworkFlagsToTagList()', function () {
     let output
 
     context('without args', function () {
@@ -111,9 +111,15 @@ describe('Presenters', function () {
           expect(order).to.deep.equal([1, 1, 2, 2, 3, null])
         })
 
+        it('should not set sections', function () {
+          output.forEach(item => {
+            expect(item.section).to.be.undefined
+          })
+        })
+
         it('should contain correct number of keys', function () {
           output.forEach(item => {
-            expect(Object.keys(item)).to.have.length(4)
+            expect(Object.keys(item)).to.have.length(5)
           })
         })
       })
@@ -133,6 +139,26 @@ describe('Presenters', function () {
 
         it('href should include prefix', function () {
           expect(output[0].href).to.equal('/prefix#escape-risk')
+        })
+      })
+
+      context('with question', function () {
+        const mockFlags = [
+          {
+            title: 'Escape risk',
+            flag_type: 'alert',
+            question: {
+              section: 'section-one',
+            },
+          },
+        ]
+
+        beforeEach(function () {
+          output = presenter(mockFlags)
+        })
+
+        it('href should include prefix', function () {
+          expect(output[0].section).to.equal('section-one')
         })
       })
     })

--- a/common/presenters/framework-responses-to-meta-list-component.js
+++ b/common/presenters/framework-responses-to-meta-list-component.js
@@ -1,0 +1,28 @@
+const { isEmpty } = require('lodash')
+
+const componentService = require('../services/component')
+
+function _mapResponse(response) {
+  const responseHtml = componentService.getComponent('appFrameworkResponse', {
+    value: isEmpty(response.value) ? undefined : response.value,
+    valueType: response.value_type,
+  })
+
+  return {
+    value: {
+      html: `
+        <h4 class="govuk-heading-s govuk-!-margin-0 govuk-!-font-size-16">${response.question.description}</h4>
+        ${responseHtml}
+      `,
+    },
+  }
+}
+
+function frameworkResponsesToMetaListComponent(responses) {
+  return {
+    classes: 'app-meta-list--divider',
+    items: responses.map(_mapResponse),
+  }
+}
+
+module.exports = frameworkResponsesToMetaListComponent

--- a/common/presenters/framework-section-to-panel-list.js
+++ b/common/presenters/framework-section-to-panel-list.js
@@ -1,0 +1,69 @@
+const { kebabCase, omit } = require('lodash')
+
+const frameworkResponseToMetaListComponent = require('./framework-responses-to-meta-list-component')
+
+function frameworkSectionToPanelList({
+  tagList,
+  framework,
+  personEscortRecord,
+  personEscortRecordUrl,
+}) {
+  return section => {
+    const flagsMap = personEscortRecord?.responses
+      .filter(response => response.flags.length > 0)
+      .filter(response => response.question.section === section.key)
+      .reduce((acc, response) => {
+        delete response.person_escort_record
+        delete response.question.framework
+        response.flags.forEach(flag => {
+          if (!acc[flag.title]) {
+            acc[flag.title] = []
+          }
+
+          if (response.value_type === 'collection') {
+            acc[flag.title].push({
+              ...response,
+              value: response.value.filter(value => {
+                return value.option === flag.question_value
+              }),
+            })
+          } else {
+            acc[flag.title].push(response)
+          }
+        })
+
+        return acc
+      }, {})
+
+    return {
+      key: section.key,
+      name: section.name,
+      url: `${personEscortRecordUrl}/${section.key}/overview`,
+      panels: tagList
+        .filter(tag => tag.section === section.key)
+        .map(tag => {
+          return {
+            attributes: {
+              id: kebabCase(tag.text),
+            },
+            tag: omit(tag, ['href']),
+            metaList: frameworkResponseToMetaListComponent(
+              flagsMap[tag.text].map(response => {
+                const question = framework.questions[response.question.key]
+
+                return {
+                  ...response,
+                  question: {
+                    ...response.question,
+                    description: question.description,
+                  },
+                }
+              })
+            ),
+          }
+        }),
+    }
+  }
+}
+
+module.exports = frameworkSectionToPanelList

--- a/common/presenters/index.js
+++ b/common/presenters/index.js
@@ -10,6 +10,7 @@ const courtCaseToCardComponent = require('./court-case-to-card-component')
 const courtHearingToSummaryListComponent = require('./court-hearing-to-summary-list-component')
 const frameworkFieldToSummaryListRow = require('./framework-field-summary-list-row')
 const frameworkFlagsToTagList = require('./framework-flags-to-tag-list')
+const frameworkSectionToPanelList = require('./framework-section-to-panel-list')
 const frameworkStepToSummary = require('./framework-step-to-summary')
 const frameworkToTaskListComponent = require('./framework-to-task-list-component')
 const moveToCardComponent = require('./move-to-card-component')
@@ -37,6 +38,7 @@ module.exports = {
   courtHearingToSummaryListComponent,
   frameworkFieldToSummaryListRow,
   frameworkFlagsToTagList,
+  frameworkSectionToPanelList,
   frameworkStepToSummary,
   frameworkToTaskListComponent,
   moveToCardComponent,

--- a/config/index.js
+++ b/config/index.js
@@ -152,10 +152,12 @@ module.exports = {
   },
   ASSESSMENT_ANSWERS_CATEGORY_SETTINGS: {
     risk: {
+      frameworksSection: 'risk-information',
       tagClass: 'app-tag--destructive',
       sortOrder: 1,
     },
     health: {
+      frameworksSection: 'health-information',
       tagClass: '',
       sortOrder: 2,
     },

--- a/locales/en/person-escort-record.json
+++ b/locales/en/person-escort-record.json
@@ -14,6 +14,8 @@
     }
   },
   "flags": {
-    "incomplete": "Warnings will display once a Person Escort Record has been completed"
+    "incomplete": "Warnings will display once a Person Escort Record has been completed",
+    "empty": "No {{name}} warnings. View <a href=\"{{url}}\">all answers</a>.",
+    "information_provided_when_requested": "View information provided when move was requested"
   }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

This set of changes restructures the move detail page to show the warnings from the Person Escort Record
once it has been completed. Up until that point it will render a message that the warnings cannot be displayed
until all sections have been completed, similar to the summary section.

Once sections have been completed it will render a summary of the tags from the Person Escort Record
answers as well as showing the previous warnings that were collected during the original request.

### Why did it change

The Person Escort Record is a more detailed version of the risk and health information and will soon be
enabled for all moves.

Once this exists we need to restructure the way this information is being displayed on the move detail.

Essentially this information will overrule the information provided during booking so the display of that
information needs to drastically change.

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

- [P4-1760](https://dsdmoj.atlassian.net/browse/P4-1760)

## Screenshots
<!--- (Optional) Include screenshots if changes update interfaces or components -->
<!--- Delete/copy as appropriate --->

<kbd><img src="https://user-images.githubusercontent.com/3327997/88807713-5e9db880-d1b2-11ea-8523-eca5cb537e71.png"></kbd>

## Checklists

### Testing

#### Automated testing

- [ ] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [x] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed

<!--- Delete if changes DO NOT include new environment variables -->
- [ ] Documented in the [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md)
- [ ] Added to [continous integration](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-book-secure-move-frontend)
- [ ] Added to staging environment (deployment repository)
- [ ] Added to preproduction environment (deployment repository)
- [ ] Added to production environment (deployment repository)

### Other considerations

Commit messages with a `fix` or `feat` type are automatically used to generate the [changelog](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/CHANGELOG.md) and
[GitHub release notes](https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/releases) during the release task. Please make sure they will read well on their own in a
summary of changes and that the commit body gives a more detailed description of those changes if necessary.

- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
- [x] Update [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md) with any new instructions or tasks
