### PR TITLE
[P4-1861] Add booked and in transit moves to list of active moves

### DIFF
--- a/app/move/controllers/view.js
+++ b/app/move/controllers/view.js
@@ -74,8 +74,8 @@ module.exports = function view(req, res) {
     tagList: presenters.assessmentToTagList(assessmentAnswers),
     canCancelMove:
       (userPermissions.includes('move:cancel') &&
-        move.status === 'requested' &&
-        !move.allocation) ||
+        !move.allocation &&
+        (move.status === 'requested' || move.status === 'booked')) ||
       (userPermissions.includes('move:cancel:proposed') &&
         move.status === 'proposed'),
     courtHearings: sortBy(move.court_hearings, 'start_time').map(

--- a/app/move/controllers/view.test.js
+++ b/app/move/controllers/view.test.js
@@ -736,69 +736,72 @@ describe('Move controllers', function () {
         })
       })
 
-      context('with requested state', function () {
-        beforeEach(function () {
-          req.move = {
-            ...req.move,
-            status: 'requested',
-          }
-        })
-
-        context('allocation move', function () {
+      const cancellableStates = ['requested', 'booked']
+      cancellableStates.forEach(status => {
+        context(`with ${status} state`, function () {
           beforeEach(function () {
             req.move = {
               ...req.move,
-              allocation: {
-                id: '123',
-              },
+              status,
             }
           })
 
-          context('without permission to cancel move', function () {
+          context('allocation move', function () {
             beforeEach(function () {
-              controller(req, res)
-              params = res.render.args[0][1]
+              req.move = {
+                ...req.move,
+                allocation: {
+                  id: '123',
+                },
+              }
             })
 
-            it('should not be able to cancel move', function () {
-              expect(params.canCancelMove).to.be.false
+            context('without permission to cancel move', function () {
+              beforeEach(function () {
+                controller(req, res)
+                params = res.render.args[0][1]
+              })
+
+              it('should not be able to cancel move', function () {
+                expect(params.canCancelMove).to.be.false
+              })
+            })
+
+            context('with permission to cancel move', function () {
+              beforeEach(function () {
+                req.session.user.permissions = ['move:cancel']
+                controller(req, res)
+                params = res.render.args[0][1]
+              })
+
+              it('should not be able to cancel move', function () {
+                expect(params.canCancelMove).to.be.false
+              })
             })
           })
 
-          context('with permission to cancel move', function () {
-            beforeEach(function () {
-              req.session.user.permissions = ['move:cancel']
-              controller(req, res)
-              params = res.render.args[0][1]
+          context('non-allocation move', function () {
+            context('without permission to cancel move', function () {
+              beforeEach(function () {
+                controller(req, res)
+                params = res.render.args[0][1]
+              })
+
+              it('should not be able to cancel move', function () {
+                expect(params.canCancelMove).to.be.false
+              })
             })
 
-            it('should not be able to cancel move', function () {
-              expect(params.canCancelMove).to.be.false
-            })
-          })
-        })
+            context('with permission to cancel move', function () {
+              beforeEach(function () {
+                req.session.user.permissions = ['move:cancel']
+                controller(req, res)
+                params = res.render.args[0][1]
+              })
 
-        context('non-allocation move', function () {
-          context('without permission to cancel move', function () {
-            beforeEach(function () {
-              controller(req, res)
-              params = res.render.args[0][1]
-            })
-
-            it('should not be able to cancel move', function () {
-              expect(params.canCancelMove).to.be.false
-            })
-          })
-
-          context('with permission to cancel move', function () {
-            beforeEach(function () {
-              req.session.user.permissions = ['move:cancel']
-              controller(req, res)
-              params = res.render.args[0][1]
-            })
-
-            it('should be able to cancel move', function () {
-              expect(params.canCancelMove).to.be.true
+              it('should be able to cancel move', function () {
+                expect(params.canCancelMove).to.be.true
+              })
             })
           })
         })

--- a/common/services/move.js
+++ b/common/services/move.js
@@ -100,7 +100,7 @@ const moveService = {
     return moveService.getAll({
       isAggregation,
       filter: {
-        'filter[status]': 'requested,accepted,completed',
+        'filter[status]': 'requested,accepted,booked,in_transit,completed',
         'filter[date_from]': startDate,
         'filter[date_to]': endDate,
         'filter[from_location_id]': fromLocationId,

--- a/common/services/move.test.js
+++ b/common/services/move.test.js
@@ -635,7 +635,7 @@ describe('Move Service', function () {
         expect(moveService.getAll).to.be.calledOnceWithExactly({
           isAggregation: false,
           filter: {
-            'filter[status]': 'requested,accepted,completed',
+            'filter[status]': 'requested,accepted,booked,in_transit,completed',
             'filter[date_from]': undefined,
             'filter[date_to]': undefined,
             'filter[from_location_id]': undefined,
@@ -666,7 +666,7 @@ describe('Move Service', function () {
         expect(moveService.getAll).to.be.calledOnceWithExactly({
           isAggregation: false,
           filter: {
-            'filter[status]': 'requested,accepted,completed',
+            'filter[status]': 'requested,accepted,booked,in_transit,completed',
             'filter[date_from]': mockDateRange[0],
             'filter[date_to]': mockDateRange[1],
             'filter[from_location_id]': mockFromLocationId,
@@ -694,7 +694,7 @@ describe('Move Service', function () {
         expect(moveService.getAll).to.be.calledOnceWithExactly({
           isAggregation: true,
           filter: {
-            'filter[status]': 'requested,accepted,completed',
+            'filter[status]': 'requested,accepted,booked,in_transit,completed',
             'filter[date_from]': undefined,
             'filter[date_to]': undefined,
             'filter[from_location_id]': undefined,

--- a/common/services/single-request.js
+++ b/common/services/single-request.js
@@ -30,7 +30,7 @@ const singleRequestService = {
         break
       case 'approved':
         statusFilter = {
-          'filter[status]': 'requested,accepted,completed',
+          'filter[status]': 'requested,accepted,booked,in_transit,completed',
         }
         break
       case 'rejected':

--- a/common/services/single-request.test.js
+++ b/common/services/single-request.test.js
@@ -262,7 +262,8 @@ describe('Single request service', function () {
             expect(moveService.getAll).to.be.calledOnceWithExactly({
               isAggregation: false,
               filter: {
-                'filter[status]': 'requested,accepted,completed',
+                'filter[status]':
+                  'requested,accepted,booked,in_transit,completed',
                 'filter[has_relationship_to_allocation]': false,
                 'filter[move_type]': 'prison_transfer',
                 'sort[by]': 'created_at',

--- a/locales/en/statuses.json
+++ b/locales/en/statuses.json
@@ -6,6 +6,8 @@
   "requested": "Move requested",
   "accepted": "Move accepted",
   "completed": "Move completed",
+  "booked": "Move booked",
+  "in_transit": "Move in transit",
   "cancelled": "Move cancelled",
   "filled": "Filled allocation",
   "filled_plural": "Filled allocations",


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Adds `booked` and `in_transit` to list of statuses to filter by when viewing active moves

### Why did it change

There was no way of seeing such moves

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

- [P4-1861](https://dsdmoj.atlassian.net/browse/P4-1861)


## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed



### Other considerations

- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics

