### PR TITLE
[P4-1966] Enable permissions for Person Escort Record

### DIFF
--- a/app/move/controllers/view.js
+++ b/app/move/controllers/view.js
@@ -1,5 +1,6 @@
-const { isEmpty, get, sortBy } = require('lodash')
+const { isEmpty, sortBy } = require('lodash')
 
+const permissionsMiddleware = require('../../../common/middleware/permissions')
 const presenters = require('../../../common/presenters')
 const frameworksService = require('../../../common/services/frameworks')
 const { FEATURE_FLAGS } = require('../../../config')
@@ -20,7 +21,7 @@ module.exports = function view(req, res) {
     rejection_reason: rejectionReason,
   } = move
   const bannerStatuses = ['cancelled']
-  const userPermissions = get(req.session, 'user.permissions')
+  const userPermissions = req.session?.user?.permissions
   const updateUrls = getUpdateUrls(updateSteps, move.id, userPermissions)
   const updateActions = getUpdateLinks(updateSteps, updateUrls)
   const {
@@ -28,7 +29,9 @@ module.exports = function view(req, res) {
     assessment_answers: assessmentAnswers = [],
     person_escort_record: personEscortRecord,
   } = profile || {}
-  const personEscortRecordIsEnabled = FEATURE_FLAGS.PERSON_ESCORT_RECORD
+  const personEscortRecordIsEnabled =
+    FEATURE_FLAGS.PERSON_ESCORT_RECORD &&
+    permissionsMiddleware.check('person_escort_record:view', userPermissions)
   const personEscortRecordIsComplete =
     !isEmpty(personEscortRecord) &&
     !['not_started', 'in_progress'].includes(personEscortRecord?.status)

--- a/app/move/controllers/view.test.js
+++ b/app/move/controllers/view.test.js
@@ -1,5 +1,6 @@
 const proxyquire = require('proxyquire').noCallThru()
 
+const permissionsMiddleware = require('../../../common/middleware/permissions')
 const presenters = require('../../../common/presenters')
 
 const getUpdateUrls = sinon.stub()
@@ -102,6 +103,7 @@ describe('Move controllers', function () {
     beforeEach(function () {
       getUpdateUrls.resetHistory()
       getUpdateLinks.resetHistory()
+      sinon.stub(permissionsMiddleware, 'check').returns(true)
       sinon
         .stub(presenters, 'moveToMetaListComponent')
         .returns('__moveToMetaListComponent__')
@@ -677,6 +679,24 @@ describe('Move controllers', function () {
 
         beforeEach(function () {
           controllerWithoutPER(req, res)
+          params = res.render.args[0][1]
+        })
+
+        it('should set personEscortRecordIsEnabled to false', function () {
+          expect(params).to.have.property('personEscortRecordIsEnabled')
+          expect(params.personEscortRecordIsEnabled).to.be.false
+        })
+
+        it('should not show Person Escort Record banner', function () {
+          expect(params).to.have.property('showPersonEscortRecordBanner')
+          expect(params.showPersonEscortRecordBanner).to.be.false
+        })
+      })
+
+      context('when user does not have permission', function () {
+        beforeEach(function () {
+          permissionsMiddleware.check.returns(false)
+          controller(req, res)
           params = res.render.args[0][1]
         })
 

--- a/app/move/views/view.njk
+++ b/app/move/views/view.njk
@@ -98,10 +98,12 @@
     {% set html %}
       <p>{{ t("messages::person_escort_record_pending.content") }}</p>
 
-      {{ govukButton({
-        href: personEscortRecordUrl + "/new",
-        text: t("actions::start_person_escort_record")
-      }) }}
+      {% if canAccess("person_escort_record:create") %}
+        {{ govukButton({
+          href: personEscortRecordUrl + "/new",
+          text: t("actions::start_person_escort_record")
+        }) }}
+      {% endif %}
     {% endset %}
 
     {{ appMessage({
@@ -122,7 +124,7 @@
         <div class="govuk-grid-column-two-thirds">
           {{ appTaskList(personEscortRecordtaskList) }}
 
-          {% if personEscortRecordIsComplete %}
+          {% if personEscortRecordIsComplete and canAccess("person_escort_record:confirm") %}
             <p>
               {{ t("messages::person_escort_record_complete.content") }}
             </p>
@@ -239,14 +241,6 @@
       }),
       classes: "govuk-!-margin-bottom-0"
     }) }}
-  {% endif %}
-
-  {% if personEscortRecordIsComplete %}
-    <p>
-      <a href="{{ personEscortRecordUrl }}">
-        {{ t("actions::view_person_escort_record") }}
-      </a>
-    </p>
   {% endif %}
 
   {% if canCancelMove %}

--- a/app/person-escort-record/app/confirm/index.js
+++ b/app/person-escort-record/app/confirm/index.js
@@ -2,9 +2,14 @@
 const router = require('express').Router()
 const wizard = require('hmpo-form-wizard')
 
+const { protectRoute } = require('../../../../common/middleware/permissions')
+
 const config = require('./config')
 const fields = require('./fields')
 const steps = require('./steps')
+
+// Define shared middleware
+router.use(protectRoute('person_escort_record:confirm'))
 
 // Define routes
 router.use(wizard(steps, fields, config))

--- a/app/person-escort-record/app/new/index.js
+++ b/app/person-escort-record/app/new/index.js
@@ -2,8 +2,13 @@
 const router = require('express').Router()
 const wizard = require('hmpo-form-wizard')
 
+const { protectRoute } = require('../../../../common/middleware/permissions')
+
 const config = require('./config')
 const steps = require('./steps')
+
+// Define shared middleware
+router.use(protectRoute('person_escort_record:create'))
 
 // Define routes
 router.use(wizard(steps, {}, config))

--- a/app/person-escort-record/controllers/framework-section.js
+++ b/app/person-escort-record/controllers/framework-section.js
@@ -1,10 +1,9 @@
 const { filter } = require('lodash')
 
+const FormWizardController = require('../../../common/controllers/form-wizard')
 const presenters = require('../../../common/presenters')
 
-const FrameworksController = require('./frameworks')
-
-class FrameworkSectionController extends FrameworksController {
+class FrameworkSectionController extends FormWizardController {
   middlewareLocals() {
     super.middlewareLocals()
     this.use(this.setSectionSummary)

--- a/app/person-escort-record/controllers/framework-section.test.js
+++ b/app/person-escort-record/controllers/framework-section.test.js
@@ -1,7 +1,7 @@
+const FormWizardController = require('../../../common/controllers/form-wizard')
 const presenters = require('../../../common/presenters')
 
 const Controller = require('./framework-section')
-const FrameworksController = require('./frameworks')
 
 const controller = new Controller({
   route: '/',
@@ -11,14 +11,14 @@ describe('Person Escort Record controllers', function () {
   describe('FrameworkSectionController', function () {
     describe('#middlewareLocals()', function () {
       beforeEach(function () {
-        sinon.stub(FrameworksController.prototype, 'middlewareLocals')
+        sinon.stub(FormWizardController.prototype, 'middlewareLocals')
         sinon.stub(controller, 'use')
 
         controller.middlewareLocals()
       })
 
       it('should call parent method', function () {
-        expect(FrameworksController.prototype.middlewareLocals).to.have.been
+        expect(FormWizardController.prototype.middlewareLocals).to.have.been
           .calledOnce
       })
 

--- a/app/person-escort-record/controllers/framework-step.js
+++ b/app/person-escort-record/controllers/framework-step.js
@@ -3,9 +3,17 @@ const { kebabCase } = require('lodash')
 const FormWizardController = require('../../../common/controllers/form-wizard')
 const fieldHelpers = require('../../../common/helpers/field')
 const frameworksHelpers = require('../../../common/helpers/frameworks')
+const permissionsControllers = require('../../../common/middleware/permissions')
 const responseService = require('../../../common/services/framework-response')
 
-class FrameworksController extends FormWizardController {
+class FrameworkStepController extends FormWizardController {
+  middlewareChecks() {
+    super.middlewareChecks()
+    // TODO: Exist this logic to redirect to the overview path if
+    // user does not have permission to update
+    this.use(permissionsControllers.protectRoute('person_escort_record:update'))
+  }
+
   middlewareSetup() {
     super.middlewareSetup()
     this.use(this.setButtonText)
@@ -108,4 +116,4 @@ class FrameworksController extends FormWizardController {
   }
 }
 
-module.exports = FrameworksController
+module.exports = FrameworkStepController

--- a/app/person-escort-record/controllers/framework-step.test.js
+++ b/app/person-escort-record/controllers/framework-step.test.js
@@ -1,14 +1,46 @@
 const FormWizardController = require('../../../common/controllers/form-wizard')
 const fieldHelpers = require('../../../common/helpers/field')
 const frameworksHelpers = require('../../../common/helpers/frameworks')
+const permissionsControllers = require('../../../common/middleware/permissions')
 const responseService = require('../../../common/services/framework-response')
 
-const Controller = require('./frameworks')
+const Controller = require('./framework-step')
 
 const controller = new Controller({ route: '/' })
 
 describe('Person Escort Record controllers', function () {
-  describe('FrameworksController', function () {
+  describe('FrameworkStepController', function () {
+    describe('#middlewareChecks()', function () {
+      beforeEach(function () {
+        sinon.stub(FormWizardController.prototype, 'middlewareChecks')
+        sinon.stub(controller, 'use')
+        sinon.stub(permissionsControllers, 'protectRoute').returnsArg(0)
+
+        controller.middlewareChecks()
+      })
+
+      it('should call parent method', function () {
+        expect(FormWizardController.prototype.middlewareChecks).to.have.been
+          .calledOnce
+      })
+
+      it('should call use with protect route middleware', function () {
+        expect(controller.use.getCall(0)).to.have.been.calledWithExactly(
+          permissionsControllers.protectRoute('person_escort_record:update')
+        )
+      })
+
+      it('should call protect route middleware', function () {
+        expect(
+          permissionsControllers.protectRoute
+        ).to.have.been.calledOnceWithExactly('person_escort_record:update')
+      })
+
+      it('should call correct number of middleware', function () {
+        expect(controller.use).to.be.callCount(1)
+      })
+    })
+
     describe('#middlewareSetup()', function () {
       beforeEach(function () {
         sinon.stub(FormWizardController.prototype, 'middlewareSetup')

--- a/app/person-escort-record/controllers/index.js
+++ b/app/person-escort-record/controllers/index.js
@@ -1,9 +1,9 @@
 const frameworkOverviewController = require('./framework-overview')
 const FrameworkSectionController = require('./framework-section')
-const FrameworksController = require('./framework-section')
+const FrameworkStepController = require('./framework-step')
 
 module.exports = {
-  FrameworksController,
   frameworkOverviewController,
   FrameworkSectionController,
+  FrameworkStepController,
 }

--- a/app/person-escort-record/index.js
+++ b/app/person-escort-record/index.js
@@ -3,6 +3,7 @@ const router = require('express').Router({ mergeParams: true })
 
 // Local dependencies
 const { uuidRegex } = require('../../common/helpers/url')
+const { protectRoute } = require('../../common/middleware/permissions')
 const frameworksService = require('../../common/services/frameworks')
 
 const confirmApp = require('./app/confirm')
@@ -15,6 +16,7 @@ const framework = frameworksService.getPersonEscortRecord()
 const frameworkWizard = defineFormWizards(framework)
 
 // Define shared middleware
+router.use(protectRoute('person_escort_record:view'))
 router.use(setFramework(framework))
 router.use(setPersonEscortRecord)
 router.use(frameworkWizard)

--- a/app/person-escort-record/router.js
+++ b/app/person-escort-record/router.js
@@ -3,7 +3,7 @@ const wizard = require('hmpo-form-wizard')
 
 const {
   FrameworkSectionController,
-  FrameworksController,
+  FrameworkStepController,
 } = require('./controllers')
 const middleware = require('./middleware')
 
@@ -14,7 +14,7 @@ function defineFormWizards(framework) {
     const section = sections[sectionKey]
     const firstStep = Object.values(section.steps)[0]
     const wizardConfig = {
-      controller: FrameworksController,
+      controller: FrameworkStepController,
       entryPoint: true,
       journeyName: `person-escort-record-${sectionKey}`,
       journeyPageTitle: 'Person escort record',

--- a/app/person-escort-record/router.test.js
+++ b/app/person-escort-record/router.test.js
@@ -2,7 +2,7 @@ const proxyquire = require('proxyquire')
 
 const {
   FrameworkSectionController,
-  FrameworksController,
+  FrameworkStepController,
 } = require('./controllers')
 const middleware = require('./middleware')
 
@@ -92,7 +92,7 @@ describe('Person Escort Record router', function () {
             },
           }
           const config = {
-            controller: FrameworksController,
+            controller: FrameworkStepController,
             entryPoint: true,
             journeyName: `person-escort-record-${key}`,
             journeyPageTitle: 'Person escort record',
@@ -141,7 +141,7 @@ describe('Person Escort Record router', function () {
             },
           }
           const config = {
-            controller: FrameworksController,
+            controller: FrameworkStepController,
             entryPoint: true,
             journeyName: `person-escort-record-${key}`,
             journeyPageTitle: 'Person escort record',

--- a/app/person-escort-record/views/framework-section.njk
+++ b/app/person-escort-record/views/framework-section.njk
@@ -34,14 +34,16 @@
             {{ step.pageTitle }}
           </h2>
 
-          <p class="app-!-position-top-right">
-            <a href="{{ step.stepUrl }}" class="govuk-link">
-              <strong>{{ t("actions::change", {
-                context: "with_visually_hidden_text",
-                text: step.pageTitle
-              }) | safe }}</strong>
-            </a>
-          </p>
+          {% if canAccess('person_escort_record:update') %}
+            <p class="app-!-position-top-right">
+              <a href="{{ step.stepUrl }}" class="govuk-link">
+                <strong>{{ t("actions::change", {
+                  context: "with_visually_hidden_text",
+                  text: step.pageTitle
+                }) | safe }}</strong>
+              </a>
+            </p>
+          {% endif %}
 
           {{ govukSummaryList(step.summaryListComponent) }}
         </section>

--- a/common/lib/permissions.js
+++ b/common/lib/permissions.js
@@ -77,6 +77,12 @@ const courtPermissions = [
   'moves:download',
   'move:view',
 ]
+const personEscortRecordAuthorPermissions = [
+  'person_escort_record:view',
+  'person_escort_record:create',
+  'person_escort_record:update',
+  'person_escort_record:confirm',
+]
 
 const permissionsByRole = {
   ROLE_PECS_POLICE: policePermissions,
@@ -88,6 +94,7 @@ const permissionsByRole = {
   ROLE_PECS_PMU: pmuPermissions,
   ROLE_PECS_SUPPLIER: supplierPermissions,
   ROLE_PECS_COURT: courtPermissions,
+  ROLE_PECS_PER_AUTHOR: personEscortRecordAuthorPermissions,
 }
 
 module.exports = {

--- a/common/lib/user.test.js
+++ b/common/lib/user.test.js
@@ -280,6 +280,21 @@ describe('User class', function () {
       })
     })
 
+    context('when user has ROLE_PECS_PER_AUTHOR role', function () {
+      beforeEach(function () {
+        permissions = user.getPermissions(['ROLE_PECS_PER_AUTHOR'])
+      })
+
+      it('should contain correct permission', function () {
+        expect(permissions).to.deep.equal([
+          'person_escort_record:view',
+          'person_escort_record:create',
+          'person_escort_record:update',
+          'person_escort_record:confirm',
+        ])
+      })
+    })
+
     context('when user has all roles', function () {
       beforeEach(function () {
         permissions = user.getPermissions([
@@ -292,6 +307,7 @@ describe('User class', function () {
           'ROLE_PECS_PMU',
           'ROLE_PECS_HMYOI',
           'ROLE_PECS_COURT',
+          'ROLE_PECS_PER_AUTHOR',
         ])
       })
 
@@ -318,6 +334,10 @@ describe('User class', function () {
           'move:cancel:proposed',
           'moves:view:proposed',
           'move:create:prison_transfer',
+          'person_escort_record:view',
+          'person_escort_record:create',
+          'person_escort_record:update',
+          'person_escort_record:confirm',
         ]
 
         expect(permissions.sort()).to.deep.equal(allPermissions.sort())


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

This creates the necessary permissions needed to access various
journeys within a Person Escort Record.

It uses the existing permissions model approach to assign permissions
based on roles from the Auth Service.

It wraps some pieces of the UI in logic and uses the protectRoute
middleware to prevent access to particular routes if the user
does not have access to those permissions.

### Why did it change

As we have done with other parts of the service, we want to protect certain actions to users
who have permission to do so.

Protecting this feature using permissions also allows us to roll this out incrementally to locations.

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

- [P4-1966](https://dsdmoj.atlassian.net/browse/P4-1966)

## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [x] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed

<!--- Delete if changes DO NOT include new environment variables -->
- [ ] Documented in the [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md)
- [ ] Added to [continous integration](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-book-secure-move-frontend)
- [ ] Added to staging environment (deployment repository)
- [ ] Added to preproduction environment (deployment repository)
- [ ] Added to production environment (deployment repository)

### Other considerations

Commit messages with a `fix` or `feat` type are automatically used to generate the [changelog](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/CHANGELOG.md) and
[GitHub release notes](https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/releases) during the release task. Please make sure they will read well on their own in a
summary of changes and that the commit body gives a more detailed description of those changes if necessary.

- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
- [x] Update [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md) with any new instructions or tasks
