### PR TITLE
chore: Add link back to move on Person Escort Record overview page

### DIFF
--- a/app/person-escort-record/controllers/framework-overview.js
+++ b/app/person-escort-record/controllers/framework-overview.js
@@ -2,6 +2,7 @@ const presenters = require('../../../common/presenters')
 
 function frameworkOverview(req, res) {
   const { originalUrl, framework, personEscortRecord = {}, move } = req
+  const moveId = move?.id
   const profile = move?.profile || personEscortRecord?.profile
   const fullname = profile?.person?.fullname
   const taskList = presenters.frameworkToTaskListComponent({
@@ -11,6 +12,7 @@ function frameworkOverview(req, res) {
   })
 
   res.render('person-escort-record/views/framework-overview', {
+    moveId,
     taskList,
     fullname,
   })

--- a/app/person-escort-record/controllers/framework-overview.test.js
+++ b/app/person-escort-record/controllers/framework-overview.test.js
@@ -50,7 +50,12 @@ describe('Person Escort Record controllers', function () {
         })
 
         it('should pass correct number of params to template', function () {
-          expect(Object.keys(params)).to.have.length(2)
+          expect(Object.keys(params)).to.have.length(3)
+        })
+
+        it('should set moveId', function () {
+          expect(params).to.have.property('moveId')
+          expect(params.moveId).to.be.undefined
         })
 
         it('should set taskList', function () {
@@ -143,6 +148,7 @@ describe('Person Escort Record controllers', function () {
           {
             ...mockReq,
             move: {
+              id: '12345',
               profile: {
                 person: {
                   fullname: 'James Stevens',
@@ -159,6 +165,11 @@ describe('Person Escort Record controllers', function () {
 
         beforeEach(function () {
           params = mockRes.render.args[0][1]
+        })
+
+        it('should set moveId', function () {
+          expect(params).to.have.property('moveId')
+          expect(params.moveId).to.equal('12345')
         })
 
         it('should set fullname', function () {

--- a/app/person-escort-record/controllers/framework-section.js
+++ b/app/person-escort-record/controllers/framework-section.js
@@ -8,6 +8,16 @@ class FrameworkSectionController extends FrameworksController {
   middlewareLocals() {
     super.middlewareLocals()
     this.use(this.setSectionSummary)
+    this.use(this.setMoveId)
+  }
+
+  setMoveId(req, res, next) {
+    const { move } = req
+
+    // TODO: Need to make sure this is available if accessing the PER directly
+    res.locals.moveId = move.id
+
+    next()
   }
 
   setSectionSummary(req, res, next) {

--- a/app/person-escort-record/controllers/framework-section.test.js
+++ b/app/person-escort-record/controllers/framework-section.test.js
@@ -22,14 +22,46 @@ describe('Person Escort Record controllers', function () {
           .calledOnce
       })
 
-      it('should call set models method', function () {
+      it('should call set section summary method', function () {
         expect(controller.use.getCall(0)).to.have.been.calledWithExactly(
           controller.setSectionSummary
         )
       })
 
+      it('should call set move ID method', function () {
+        expect(controller.use.getCall(1)).to.have.been.calledWithExactly(
+          controller.setMoveId
+        )
+      })
+
       it('should call correct number of middleware', function () {
-        expect(controller.use).to.be.callCount(1)
+        expect(controller.use).to.be.callCount(2)
+      })
+    })
+
+    describe('#setMoveId', function () {
+      let mockReq, mockRes, nextSpy
+
+      beforeEach(function () {
+        nextSpy = sinon.spy()
+        mockReq = {
+          move: {
+            id: '12345',
+          },
+        }
+        mockRes = {
+          locals: {},
+        }
+
+        controller.setMoveId(mockReq, mockRes, nextSpy)
+      })
+
+      it('should set move ID', function () {
+        expect(mockRes.locals.moveId).to.equal('12345')
+      })
+
+      it('should call next without error', function () {
+        expect(nextSpy).to.be.calledOnceWithExactly()
       })
     })
 

--- a/app/person-escort-record/views/framework-overview.njk
+++ b/app/person-escort-record/views/framework-overview.njk
@@ -1,5 +1,16 @@
 {% extends "layouts/two-column.njk" %}
 
+{% block beforeContent %}
+  {% if moveId %}
+    {{ govukBackLink({
+      text: t("actions::back_to_move"),
+      href: "/move/" + moveId
+    }) }}
+  {% endif %}
+
+  {{ super() }}
+{% endblock %}
+
 {% block contentHeader %}
   <header class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">

--- a/app/person-escort-record/views/framework-section.njk
+++ b/app/person-escort-record/views/framework-section.njk
@@ -1,5 +1,20 @@
 {% extends "layouts/base.njk" %}
 
+{% macro backLink() %}
+  {% if moveId %}
+    {{ govukBackLink({
+      text: t("actions::back_to_move"),
+      href: "/move/" + moveId
+    }) }}
+  {% endif %}
+{% endmacro %}
+
+{% block beforeContent %}
+  {{ backLink() }}
+
+  {{ super() }}
+{% endblock %}
+
 {% block content %}
   <header class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
@@ -11,22 +26,28 @@
     </div>
   </header>
 
-  {% for key, step in summarySteps %}
-    <section class="app-!-position-relative govuk-!-margin-bottom-8">
-      <h2 class="govuk-heading-m govuk-!-margin-bottom-0 govuk-!-padding-bottom-1 app-border-bottom-1">
-        {{ step.pageTitle }}
-      </h2>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-three-quarters">
+      {% for key, step in summarySteps %}
+        <section class="app-!-position-relative govuk-!-margin-bottom-8">
+          <h2 class="govuk-heading-m govuk-!-margin-bottom-0 govuk-!-padding-bottom-1 govuk-!-padding-right-8 app-border-bottom-1">
+            {{ step.pageTitle }}
+          </h2>
 
-      <p class="app-!-position-top-right">
-        <a href="{{ step.stepUrl }}" class="govuk-link">
-          <strong>{{ t("actions::change", {
-            context: "with_visually_hidden_text",
-            text: step.pageTitle
-          }) | safe }}</strong>
-        </a>
-      </p>
+          <p class="app-!-position-top-right">
+            <a href="{{ step.stepUrl }}" class="govuk-link">
+              <strong>{{ t("actions::change", {
+                context: "with_visually_hidden_text",
+                text: step.pageTitle
+              }) | safe }}</strong>
+            </a>
+          </p>
 
-      {{ govukSummaryList(step.summaryListComponent) }}
-    </section>
-  {% endfor %}
+          {{ govukSummaryList(step.summaryListComponent) }}
+        </section>
+      {% endfor %}
+    </div>
+  </div>
+
+  {{ backLink() }}
 {% endblock %}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Add a link to the overview page of a framework section so that a user
can get back to the move after viewing a section.

### Why did it change

Currently the user would hit a bit of a dead-end when viewing the overview
of a framework section, this allows them to navigate back to the move
detail page.

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

- [P4-XXXX]()

## Screenshots
<!--- (Optional) Include screenshots if changes update interfaces or components -->
<!--- Delete/copy as appropriate --->

| Before | After |
| ------ | ----- |
| <kbd><img src="https://user-images.githubusercontent.com/3327997/88927132-45127480-d277-11ea-89e6-b63b17b31fb5.png"></kbd> | <kbd><img src="https://user-images.githubusercontent.com/3327997/88929317-45603f00-d27a-11ea-8eea-aa459e51a87e.png"></kbd> |
| <kbd><img src="https://user-images.githubusercontent.com/3327997/88927127-4479de00-d277-11ea-8ac3-0953f0b925a1.png"></kbd> | <kbd><img src="https://user-images.githubusercontent.com/3327997/88927125-4348b100-d277-11ea-88b6-333ea94045ac.png"></kbd> |

## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [x] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed

<!--- Delete if changes DO NOT include new environment variables -->
- [ ] Documented in the [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md)
- [ ] Added to [continous integration](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-book-secure-move-frontend)
- [ ] Added to staging environment (deployment repository)
- [ ] Added to preproduction environment (deployment repository)
- [ ] Added to production environment (deployment repository)

### Other considerations

Commit messages with a `fix` or `feat` type are automatically used to generate the [changelog](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/CHANGELOG.md) and
[GitHub release notes](https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/releases) during the release task. Please make sure they will read well on their own in a
summary of changes and that the commit body gives a more detailed description of those changes if necessary.

- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
- [x] Update [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md) with any new instructions or tasks
