### PR TITLE
Fix failing allocation e2e test

### DIFF
--- a/test/e2e/pages/allocation-criteria.js
+++ b/test/e2e/pages/allocation-criteria.js
@@ -116,6 +116,7 @@ class AllocationCriteriaPage extends Page {
         prefix: 'Other',
         selector: fields.otherEstate,
         value: faker.lorem.sentence(6),
+        property: 'otherEstate',
       },
     ]
 
@@ -125,7 +126,8 @@ class AllocationCriteriaPage extends Page {
 
     if (conditionalEstateType) {
       const { prefix: omit, ...rest } = conditionalEstateType
-      conditionalFieldsToFill.prisonerCategory = rest
+      const property = rest.property || 'prisonerCategory'
+      conditionalFieldsToFill[property] = rest
     }
 
     const formConditionalAnswers = await fillInForm(conditionalFieldsToFill)

--- a/test/e2e/pages/allocation-details.js
+++ b/test/e2e/pages/allocation-details.js
@@ -1,4 +1,4 @@
-import { format } from 'date-fns'
+import { format, startOfTomorrow } from 'date-fns'
 import faker from 'faker'
 import { Selector, t } from 'testcafe'
 
@@ -47,7 +47,7 @@ class AllocationDetailsPage extends Page {
       },
       date: {
         selector: this.fields.date,
-        value: format(faker.date.future(), 'yyyy-MM-dd'),
+        value: format(faker.date.future(1, startOfTomorrow()), 'yyyy-MM-dd'),
       },
     }
 


### PR DESCRIPTION
## Proposed changes

### What changed

- Ensure allocation date is actually in future
- Ensure otherEstate value set when other selected for estate

### Why did it change

E2E tests would "randomly" fail

### Issue tracking

n/a


## Screenshots
n/a

## Checklists

### Testing

#### Automated testing

- [ ] Added unit tests to cover changes
- [x] Added end-to-end tests to cover any journey changes



### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed



### Other considerations


- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics

