### PR TITLE
[P4-1800] Prevent access to framework steps once a Person Escort Record has been confirmed

### DIFF
--- a/app/person-escort-record/controllers/framework-section.js
+++ b/app/person-escort-record/controllers/framework-section.js
@@ -8,12 +8,22 @@ class FrameworkSectionController extends FormWizardController {
     super.middlewareLocals()
     this.use(this.setSectionSummary)
     this.use(this.setMoveId)
+    this.use(this.setEditableStatus)
   }
 
   setMoveId(req, res, next) {
     // TODO: Make available when accessing PER without a move based URLs
     res.locals.moveId = req.move?.id
 
+    next()
+  }
+
+  setEditableStatus(req, res, next) {
+    const personEscortRecordIsConfirmed = ['confirmed'].includes(
+      req.personEscortRecord?.status
+    )
+
+    res.locals.isEditable = !personEscortRecordIsConfirmed
     next()
   }
 

--- a/app/person-escort-record/controllers/framework-section.js
+++ b/app/person-escort-record/controllers/framework-section.js
@@ -11,10 +11,8 @@ class FrameworkSectionController extends FormWizardController {
   }
 
   setMoveId(req, res, next) {
-    const { move } = req
-
-    // TODO: Need to make sure this is available if accessing the PER directly
-    res.locals.moveId = move.id
+    // TODO: Make available when accessing PER without a move based URLs
+    res.locals.moveId = req.move?.id
 
     next()
   }

--- a/app/person-escort-record/controllers/framework-section.test.js
+++ b/app/person-escort-record/controllers/framework-section.test.js
@@ -44,24 +44,42 @@ describe('Person Escort Record controllers', function () {
 
       beforeEach(function () {
         nextSpy = sinon.spy()
-        mockReq = {
-          move: {
-            id: '12345',
-          },
-        }
+        mockReq = {}
         mockRes = {
           locals: {},
         }
-
-        controller.setMoveId(mockReq, mockRes, nextSpy)
       })
 
-      it('should set move ID', function () {
-        expect(mockRes.locals.moveId).to.equal('12345')
+      context('without a move', function () {
+        beforeEach(function () {
+          controller.setMoveId(mockReq, mockRes, nextSpy)
+        })
+
+        it('should not set move ID', function () {
+          expect(mockRes.locals.moveId).to.be.undefined
+        })
+
+        it('should call next without error', function () {
+          expect(nextSpy).to.be.calledOnceWithExactly()
+        })
       })
 
-      it('should call next without error', function () {
-        expect(nextSpy).to.be.calledOnceWithExactly()
+      context('with a move', function () {
+        beforeEach(function () {
+          mockReq.move = {
+            id: '12345',
+          }
+
+          controller.setMoveId(mockReq, mockRes, nextSpy)
+        })
+
+        it('should set move ID', function () {
+          expect(mockRes.locals.moveId).to.equal('12345')
+        })
+
+        it('should call next without error', function () {
+          expect(nextSpy).to.be.calledOnceWithExactly()
+        })
       })
     })
 

--- a/app/person-escort-record/controllers/framework-section.test.js
+++ b/app/person-escort-record/controllers/framework-section.test.js
@@ -12,6 +12,9 @@ describe('Person Escort Record controllers', function () {
     describe('#middlewareLocals()', function () {
       beforeEach(function () {
         sinon.stub(FormWizardController.prototype, 'middlewareLocals')
+        sinon.stub(controller, 'setSectionSummary')
+        sinon.stub(controller, 'setMoveId')
+        sinon.stub(controller, 'setEditableStatus')
         sinon.stub(controller, 'use')
 
         controller.middlewareLocals()
@@ -23,19 +26,25 @@ describe('Person Escort Record controllers', function () {
       })
 
       it('should call set section summary method', function () {
-        expect(controller.use.getCall(0)).to.have.been.calledWithExactly(
+        expect(controller.use).to.have.been.calledWithExactly(
           controller.setSectionSummary
         )
       })
 
       it('should call set move ID method', function () {
-        expect(controller.use.getCall(1)).to.have.been.calledWithExactly(
+        expect(controller.use).to.have.been.calledWithExactly(
+          controller.setMoveId
+        )
+      })
+
+      it('should call set editable status', function () {
+        expect(controller.use).to.have.been.calledWithExactly(
           controller.setMoveId
         )
       })
 
       it('should call correct number of middleware', function () {
-        expect(controller.use).to.be.callCount(2)
+        expect(controller.use).to.be.callCount(3)
       })
     })
 
@@ -75,6 +84,54 @@ describe('Person Escort Record controllers', function () {
 
         it('should set move ID', function () {
           expect(mockRes.locals.moveId).to.equal('12345')
+        })
+
+        it('should call next without error', function () {
+          expect(nextSpy).to.be.calledOnceWithExactly()
+        })
+      })
+    })
+
+    describe('#setEditableStatus', function () {
+      let mockReq, mockRes, nextSpy
+
+      beforeEach(function () {
+        nextSpy = sinon.spy()
+        mockReq = {
+          personEscortRecord: {
+            id: '12345',
+          },
+        }
+        mockRes = {
+          locals: {},
+        }
+      })
+
+      context('when Person Escort Record is confirmed', function () {
+        beforeEach(function () {
+          mockReq.personEscortRecord.status = 'confirmed'
+
+          controller.setEditableStatus(mockReq, mockRes, nextSpy)
+        })
+
+        it('should set isEditable to false', function () {
+          expect(mockRes.locals.isEditable).to.equal(false)
+        })
+
+        it('should call next without error', function () {
+          expect(nextSpy).to.be.calledOnceWithExactly()
+        })
+      })
+
+      context('when Person Escort Record is not confirmed', function () {
+        beforeEach(function () {
+          mockReq.personEscortRecord.status = 'not_started'
+
+          controller.setEditableStatus(mockReq, mockRes, nextSpy)
+        })
+
+        it('should set isEditable to true', function () {
+          expect(mockRes.locals.isEditable).to.equal(true)
         })
 
         it('should call next without error', function () {

--- a/app/person-escort-record/controllers/framework-step.js
+++ b/app/person-escort-record/controllers/framework-step.js
@@ -12,11 +12,27 @@ class FrameworkStepController extends FormWizardController {
     // TODO: Exist this logic to redirect to the overview path if
     // user does not have permission to update
     this.use(permissionsControllers.protectRoute('person_escort_record:update'))
+    this.use(this.checkEditable)
   }
 
   middlewareSetup() {
     super.middlewareSetup()
     this.use(this.setButtonText)
+  }
+
+  checkEditable(req, res, next) {
+    const { steps: wizardSteps = {} } = req?.form?.options || {}
+    const steps = Object.keys(wizardSteps)
+    const overviewStepPath = steps[steps.length - 1]
+    const personEscortRecordIsConfirmed = ['confirmed'].includes(
+      req.personEscortRecord?.status
+    )
+
+    if (personEscortRecordIsConfirmed) {
+      return res.redirect(req.baseUrl + overviewStepPath)
+    }
+
+    next()
   }
 
   setButtonText(req, res, next) {

--- a/app/person-escort-record/index.js
+++ b/app/person-escort-record/index.js
@@ -18,15 +18,18 @@ const { defineFormWizards } = require('./router')
 const framework = frameworksService.getPersonEscortRecord()
 const frameworkWizard = defineFormWizards(framework)
 
+// Define middlewares used by all routes and sub-apps
+router.use(setFramework(framework))
+
+// Define "create" sub-app before ID sepcific middleware
+router.use(newApp.mountpath, newApp.router)
+
 // Define shared middleware
 router.use(protectRoute('person_escort_record:view'))
-router.use(setFramework(framework))
+router.use(setPersonEscortRecord)
 router.use(frameworkWizard)
 
 // Define sub-apps
-router.use(newApp.mountpath, newApp.router)
-
-router.use(setPersonEscortRecord)
 router.use(confirmApp.mountpath, confirmApp.router)
 
 // Define routes

--- a/app/person-escort-record/views/framework-section.njk
+++ b/app/person-escort-record/views/framework-section.njk
@@ -34,7 +34,7 @@
             {{ step.pageTitle }}
           </h2>
 
-          {% if canAccess('person_escort_record:update') %}
+          {% if canAccess('person_escort_record:update') and isEditable %}
             <p class="app-!-position-top-right">
               <a href="{{ step.stepUrl }}" class="govuk-link">
                 <strong>{{ t("actions::change", {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

This prevents a user from accessing the edit steps once a Person Escort Record has been confirmed.

If I user has the URL stored and tries to access it, they will be redirected back to the section overview.

### Why did it change

The API already won't allow this so this just handles that journey
better on the frontend so that the user won't end up seeing API
error messages.

It also hides the actions from the overview if is has been completed.

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

- [P4-1800](https://dsdmoj.atlassian.net/browse/P4-1800)

## Screenshots
<!--- (Optional) Include screenshots if changes update interfaces or components -->
<!--- Delete/copy as appropriate --->

| Before | After |
| ------ | ----- |
| <kbd><img src="https://user-images.githubusercontent.com/3327997/89098842-5086ac80-d3eb-11ea-9b9e-aaa513377159.png"></kbd> | <kbd><img src="https://user-images.githubusercontent.com/3327997/89098831-3a78ec00-d3eb-11ea-83a1-5ecea2a2dfc9.png"></kbd> |


## Checklists

### Testing

#### Automated testing

- [ ] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed

<!--- Delete if changes DO NOT include new environment variables -->
- [ ] Documented in the [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md)
- [ ] Added to [continous integration](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-book-secure-move-frontend)
- [ ] Added to staging environment (deployment repository)
- [ ] Added to preproduction environment (deployment repository)
- [ ] Added to production environment (deployment repository)

### Other considerations

Commit messages with a `fix` or `feat` type are automatically used to generate the [changelog](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/CHANGELOG.md) and
[GitHub release notes](https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/releases) during the release task. Please make sure they will read well on their own in a
summary of changes and that the commit body gives a more detailed description of those changes if necessary.

- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
- [x] Update [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md) with any new instructions or tasks
