### PR TITLE
fix(framework): Call correct parent method when setting locals

### DIFF
--- a/app/person-escort-record/controllers/framework-step.js
+++ b/app/person-escort-record/controllers/framework-step.js
@@ -48,7 +48,7 @@ class FrameworkStepController extends FormWizardController {
   }
 
   middlewareLocals() {
-    super.middlewareSetup()
+    super.middlewareLocals()
     this.use(this.setPageTitleLocals)
   }
 

--- a/app/person-escort-record/controllers/framework-step.test.js
+++ b/app/person-escort-record/controllers/framework-step.test.js
@@ -72,6 +72,31 @@ describe('Person Escort Record controllers', function () {
       })
     })
 
+    describe('#middlewareLocals()', function () {
+      beforeEach(function () {
+        sinon.stub(FormWizardController.prototype, 'middlewareLocals')
+        sinon.stub(controller, 'setPageTitleLocals')
+        sinon.stub(controller, 'use')
+
+        controller.middlewareLocals()
+      })
+
+      it('should call parent method', function () {
+        expect(FormWizardController.prototype.middlewareLocals).to.have.been
+          .calledOnce
+      })
+
+      it('should call set models method', function () {
+        expect(controller.use.getCall(0)).to.have.been.calledWithExactly(
+          controller.setPageTitleLocals
+        )
+      })
+
+      it('should call correct number of middleware', function () {
+        expect(controller.use).to.be.callCount(1)
+      })
+    })
+
     describe('#checkEditable', function () {
       let mockReq, mockRes, nextSpy
 
@@ -176,6 +201,31 @@ describe('Person Escort Record controllers', function () {
         it('should call next without error', function () {
           expect(nextSpy).to.be.calledOnceWithExactly()
         })
+      })
+    })
+
+    describe('#setPageTitleLocals', function () {
+      let mockReq, mockRes, nextSpy
+
+      beforeEach(function () {
+        nextSpy = sinon.spy()
+        mockReq = {
+          frameworkSection: {
+            name: 'Section one',
+          },
+        }
+        mockRes = {
+          locals: {},
+        }
+        controller.setPageTitleLocals(mockReq, mockRes, nextSpy)
+      })
+
+      it('should use save and continue button text', function () {
+        expect(mockRes.locals.frameworkSection).to.equal('Section one')
+      })
+
+      it('should call next without error', function () {
+        expect(nextSpy).to.be.calledOnceWithExactly()
       })
     })
 


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Fixes the call to `super.middlewareLocals` in the framework step controller.

### Why did it change

A git merge caused the wrong parent method to be called when setting
extra locals in this controller. That meant that the CSRF token wasn't
being set for the form and caused an error when trying to submit an
answer.

## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [x] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed

<!--- Delete if changes DO NOT include new environment variables -->
- [ ] Documented in the [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md)
- [ ] Added to [continous integration](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-book-secure-move-frontend)
- [ ] Added to staging environment (deployment repository)
- [ ] Added to preproduction environment (deployment repository)
- [ ] Added to production environment (deployment repository)

### Other considerations

Commit messages with a `fix` or `feat` type are automatically used to generate the [changelog](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/CHANGELOG.md) and
[GitHub release notes](https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/releases) during the release task. Please make sure they will read well on their own in a
summary of changes and that the commit body gives a more detailed description of those changes if necessary.

- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
- [x] Update [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md) with any new instructions or tasks
