### PR TITLE
Customise what includes we need for API requests

### DIFF
--- a/app/moves/controllers/download.js
+++ b/app/moves/controllers/download.js
@@ -5,7 +5,6 @@ const presenters = require('../../../common/presenters')
 module.exports = function download(req, res, next) {
   const { results } = req
   const { dateRange, extension } = req.params
-  const moves = [...results.active, ...results.cancelled]
   const currentTimestamp = format(new Date(), 'yyyy-MM-dd HH:mm:ss')
   const filename = req.t('moves::download_filename', {
     date: dateRange.toString().replace(/,/g, 'to'),
@@ -22,12 +21,12 @@ module.exports = function download(req, res, next) {
   )
 
   if (extension === 'json') {
-    return res.json(moves)
+    return res.json(results)
   }
 
   if (extension === 'csv') {
     return presenters
-      .movesToCSV(moves)
+      .movesToCSV(results)
       .then(csv => {
         res.setHeader('Content-Type', 'text/csv')
         res.send(csv)

--- a/app/moves/controllers/download.test.js
+++ b/app/moves/controllers/download.test.js
@@ -7,13 +7,9 @@ const controller = require('./download')
 const mockDateRange = ['2018-10-10', '2018-10-17']
 const mockUTCDate = Date.UTC(2019, 10, 10, 15, 30, 15)
 const mockDownloadDate = new Date(mockUTCDate)
-const activeMovesStub = [
+const resultsStub = [
   { foo: 'bar', status: 'requested' },
   { fizz: 'buzz', status: 'requested' },
-]
-const cancelledMovesStub = [
-  { foo: 'bar', status: 'cancelled' },
-  { fizz: 'buzz', status: 'cancelled' },
 ]
 const csvStub = `
 "Col 1","Col 2"
@@ -31,10 +27,7 @@ describe('Moves controllers', function () {
           period: 'week',
           dateRange: mockDateRange,
         },
-        results: {
-          active: activeMovesStub,
-          cancelled: cancelledMovesStub,
-        },
+        results: resultsStub,
         t: sinon.stub().returnsArg(0),
       }
       res = {
@@ -106,10 +99,7 @@ describe('Moves controllers', function () {
       })
 
       it('should render moves as JSON', function () {
-        expect(res.json).to.be.calledOnceWithExactly([
-          ...activeMovesStub,
-          ...cancelledMovesStub,
-        ])
+        expect(res.json).to.be.calledOnceWithExactly(resultsStub)
       })
 
       it('should not call next', function () {
@@ -151,10 +141,7 @@ describe('Moves controllers', function () {
         })
 
         it('should call CSV presenter with combined moves', function () {
-          expect(presenters.movesToCSV).to.be.calledOnceWithExactly([
-            ...activeMovesStub,
-            ...cancelledMovesStub,
-          ])
+          expect(presenters.movesToCSV).to.be.calledOnceWithExactly(resultsStub)
         })
 
         it('should send moves as CSV', function () {

--- a/app/moves/index.js
+++ b/app/moves/index.js
@@ -29,6 +29,8 @@ const {
   redirectBaseUrl,
   saveUrl,
   setFromLocation,
+  setDownloadResultsMoves,
+  setDownloadResultsSingleRequests,
   setBodyMoves,
   setBodySingleRequests,
   setFilterSingleRequests,
@@ -61,7 +63,7 @@ viewRouter.get(
   '/:view(requested)/download.:extension(csv|json)',
   protectRoute('moves:download'),
   protectRoute('moves:view:proposed'),
-  [setBodySingleRequests, setResultsSingleRequests],
+  [setBodySingleRequests, setDownloadResultsSingleRequests],
   download
 )
 viewRouter.get(
@@ -83,7 +85,10 @@ viewRouter.get(
   '/:view(outgoing)/download.:extension(csv|json)',
   protectRoute('moves:download'),
   protectRoute('moves:view:outgoing'),
-  [setBodyMoves('outgoing', 'fromLocationId'), setResultsMoves('outgoing')],
+  [
+    setBodyMoves('outgoing', 'fromLocationId'),
+    setDownloadResultsMoves('outgoing'),
+  ],
   download
 )
 viewRouter.get(
@@ -107,7 +112,7 @@ viewRouter.get(
   protectRoute('moves:view:incoming'),
   [
     setBodyMoves('incoming', 'toLocationId'),
-    setResultsMoves('incoming', 'from_location'),
+    setDownloadResultsMoves('incoming'),
   ],
   download
 )

--- a/app/moves/middleware/index.js
+++ b/app/moves/middleware/index.js
@@ -2,6 +2,8 @@ const redirectBaseUrl = require('./redirect-base-url')
 const saveUrl = require('./save-url')
 const setBodyMoves = require('./set-body.moves')
 const setBodySingleRequests = require('./set-body.single-requests')
+const setDownloadResultsMoves = require('./set-download-results.moves')
+const setDownloadResultsSingleRequests = require('./set-download-results.single-requests')
 const setFilterMoves = require('./set-filter.moves')
 const setFilterSingleRequests = require('./set-filter.single-requests')
 const setFromLocation = require('./set-from-location')
@@ -13,6 +15,8 @@ module.exports = {
   saveUrl,
   setBodyMoves,
   setBodySingleRequests,
+  setDownloadResultsMoves,
+  setDownloadResultsSingleRequests,
   setFromLocation,
   setFilterMoves,
   setFilterSingleRequests,

--- a/app/moves/middleware/set-download-results.moves.js
+++ b/app/moves/middleware/set-download-results.moves.js
@@ -1,0 +1,14 @@
+const moveService = require('../../../common/services/move')
+
+function setDownloadResultsMoves(bodyKey) {
+  return async function handleResults(req, res, next) {
+    try {
+      req.results = await moveService.getDownload(req.body[bodyKey])
+      next()
+    } catch (error) {
+      next(error)
+    }
+  }
+}
+
+module.exports = setDownloadResultsMoves

--- a/app/moves/middleware/set-download-results.moves.test.js
+++ b/app/moves/middleware/set-download-results.moves.test.js
@@ -1,0 +1,74 @@
+const moveService = require('../../../common/services/move')
+
+const middleware = require('./set-download-results.moves')
+
+const mockMoves = [
+  { id: '1', foo: 'bar', status: 'requested' },
+  { id: '2', fizz: 'buzz', status: 'requested' },
+  { id: '3', foo: 'bar', status: 'completed' },
+  { id: '4', fizz: 'buzz', status: 'completed' },
+]
+const mockBodyKey = 'outgoing'
+const errorStub = new Error('Problem')
+
+describe('Moves middleware', function () {
+  describe('#setDownloadResultsMoves()', function () {
+    let req, res, nextSpy
+
+    beforeEach(async function () {
+      sinon.stub(moveService, 'getDownload')
+      nextSpy = sinon.spy()
+      res = {}
+      req = {
+        body: {
+          [mockBodyKey]: {
+            dateRange: ['2010-10-10', '2010-10-11'],
+            locationId: '5555',
+          },
+        },
+      }
+    })
+
+    context('when API call returns successfully', function () {
+      beforeEach(function () {
+        moveService.getDownload.resolves(mockMoves)
+      })
+
+      context('without `locationKey`', function () {
+        beforeEach(async function () {
+          await middleware(mockBodyKey)(req, res, nextSpy)
+        })
+
+        it('should call API with move date and location ID', function () {
+          expect(moveService.getDownload).to.be.calledOnceWithExactly(
+            req.body[mockBodyKey]
+          )
+        })
+
+        it('should set results on req', function () {
+          expect(req).to.have.property('results')
+          expect(req.results).to.deep.equal(mockMoves)
+        })
+
+        it('should call next with no argument', function () {
+          expect(nextSpy).to.be.calledOnceWithExactly()
+        })
+      })
+    })
+
+    context('when API call returns an error', function () {
+      beforeEach(async function () {
+        moveService.getDownload.throws(errorStub)
+        await middleware(mockBodyKey)(req, res, nextSpy)
+      })
+
+      it('should not request properties', function () {
+        expect(req).not.to.have.property('results')
+      })
+
+      it('should send error to next function', function () {
+        expect(nextSpy).to.be.calledOnceWithExactly(errorStub)
+      })
+    })
+  })
+})

--- a/app/moves/middleware/set-download-results.single-requests.js
+++ b/app/moves/middleware/set-download-results.single-requests.js
@@ -1,0 +1,12 @@
+const singleRequestService = require('../../../common/services/single-request')
+
+async function setDownloadResultsSingleRequests(req, res, next) {
+  try {
+    req.results = await singleRequestService.getDownload(req.body.requested)
+    next()
+  } catch (error) {
+    next(error)
+  }
+}
+
+module.exports = setDownloadResultsSingleRequests

--- a/app/moves/middleware/set-results.moves.js
+++ b/app/moves/middleware/set-results.moves.js
@@ -17,10 +17,6 @@ function setResultsMoves(bodyKey, locationKey, personEscortRecordFeature) {
         ? 'personEscortRecord'
         : undefined
 
-      req.results = {
-        active: activeMoves,
-        cancelled: cancelledMoves,
-      }
       req.resultsAsCards = {
         active: presenters.movesByLocation(
           activeMoves,

--- a/app/moves/middleware/set-results.moves.test.js
+++ b/app/moves/middleware/set-results.moves.test.js
@@ -63,14 +63,6 @@ describe('Moves middleware', function () {
           )
         })
 
-        it('should set results on req', function () {
-          expect(req).to.have.property('results')
-          expect(req.results).to.deep.equal({
-            active: mockActiveMoves,
-            cancelled: mockCancelledMoves,
-          })
-        })
-
         it('should set resultsAsCards on req', function () {
           expect(req).to.have.property('resultsAsCards')
           expect(req.resultsAsCards).to.deep.equal({

--- a/app/moves/middleware/set-results.single-requests.js
+++ b/app/moves/middleware/set-results.single-requests.js
@@ -5,10 +5,6 @@ async function setResultsSingleRequests(req, res, next) {
   try {
     const singleRequests = await singleRequestService.getAll(req.body.requested)
 
-    req.results = {
-      active: singleRequests,
-      cancelled: [],
-    }
     req.resultsAsTable = {
       active: presenters.singleRequestsToTableComponent(singleRequests),
       cancelled: [],

--- a/common/services/allocation.js
+++ b/common/services/allocation.js
@@ -19,7 +19,7 @@ function getAll({
       ...filter,
       page,
       per_page: isAggregation ? 1 : 100,
-      include,
+      include: isAggregation ? [] : include,
     })
     .then(response => {
       const { data, links, meta } = response
@@ -101,6 +101,7 @@ const allocationService = {
     fromLocations = [],
     toLocations = [],
     locations = [],
+    include,
     includeCancelled = false,
     isAggregation = false,
     status,
@@ -111,6 +112,7 @@ const allocationService = {
 
     return allocationService.getAll({
       isAggregation,
+      include,
       includeCancelled,
       filter: pickBy({
         'filter[status]': status,
@@ -128,12 +130,14 @@ const allocationService = {
     return allocationService.getByDateAndLocation({
       ...args,
       status: args.status || 'filled,unfilled',
+      include: ['from_location', 'moves', 'to_location'],
     })
   },
   getCancelled(args) {
     return allocationService.getByDateAndLocation({
       ...args,
       includeCancelled: true,
+      include: ['from_location', 'moves', 'to_location'],
       status: 'cancelled',
     })
   },

--- a/common/services/allocation.test.js
+++ b/common/services/allocation.test.js
@@ -447,7 +447,7 @@ describe('Allocation service', function () {
             ...mockFilter,
             page: 1,
             per_page: 1,
-            include: undefined,
+            include: [],
           })
         })
 
@@ -584,7 +584,7 @@ describe('Allocation service', function () {
             ...mockFilter,
             page: 1,
             per_page: 1,
-            include: undefined,
+            include: [],
           })
         })
 
@@ -646,6 +646,7 @@ describe('Allocation service', function () {
         expect(allocationService.getAll).to.be.calledOnceWithExactly({
           isAggregation: false,
           includeCancelled: false,
+          include: undefined,
           filter: {},
         })
       })
@@ -667,6 +668,7 @@ describe('Allocation service', function () {
             fromLocations: [mockFromLocationId],
             toLocations: [mockToLocationId],
             locations: [mockFromLocationId, mockToLocationId],
+            include: ['foo', 'bar'],
           })
         })
 
@@ -674,6 +676,7 @@ describe('Allocation service', function () {
           expect(allocationService.getAll).to.be.calledOnceWithExactly({
             isAggregation: false,
             includeCancelled: false,
+            include: ['foo', 'bar'],
             filter: {
               'filter[date_from]': mockMoveDateRange[0],
               'filter[date_to]': mockMoveDateRange[1],
@@ -700,6 +703,7 @@ describe('Allocation service', function () {
           expect(allocationService.getAll).to.be.calledOnceWithExactly({
             isAggregation: false,
             includeCancelled: false,
+            include: undefined,
             filter: {
               'filter[locations]': mockFromLocationId,
             },
@@ -723,6 +727,31 @@ describe('Allocation service', function () {
           expect(allocationService.getAll).to.be.calledOnceWithExactly({
             isAggregation: true,
             includeCancelled: false,
+            include: undefined,
+            filter: {
+              'filter[locations]': mockFromLocationId,
+            },
+          })
+        })
+
+        it('should return results', function () {
+          expect(results).to.deep.equal(mockAllocations)
+        })
+      })
+
+      context('with include ', function () {
+        beforeEach(async function () {
+          results = await allocationService.getByDateAndLocation({
+            include: ['fizz', 'buzz'],
+            locations: [mockFromLocationId],
+          })
+        })
+
+        it('should call moves.getAll with correct args', function () {
+          expect(allocationService.getAll).to.be.calledOnceWithExactly({
+            isAggregation: false,
+            includeCancelled: false,
+            include: ['fizz', 'buzz'],
             filter: {
               'filter[locations]': mockFromLocationId,
             },
@@ -746,6 +775,7 @@ describe('Allocation service', function () {
           expect(allocationService.getAll).to.be.calledOnceWithExactly({
             isAggregation: false,
             includeCancelled: true,
+            include: undefined,
             filter: {
               'filter[locations]': mockFromLocationId,
             },
@@ -777,6 +807,7 @@ describe('Allocation service', function () {
           allocationService.getByDateAndLocation
         ).to.have.been.calledWithExactly({
           additionalParams: {},
+          include: ['from_location', 'moves', 'to_location'],
           status: 'custom',
         })
       })
@@ -794,6 +825,7 @@ describe('Allocation service', function () {
           allocationService.getByDateAndLocation
         ).to.have.been.calledWithExactly({
           additionalParams: {},
+          include: ['from_location', 'moves', 'to_location'],
           status: 'filled,unfilled',
         })
       })
@@ -814,6 +846,7 @@ describe('Allocation service', function () {
       ).to.have.been.calledWithExactly({
         additionalParams: {},
         includeCancelled: true,
+        include: ['from_location', 'moves', 'to_location'],
         status: 'cancelled',
       })
     })

--- a/common/services/move.js
+++ b/common/services/move.js
@@ -17,7 +17,7 @@ function getAll({
   return apiClient
     .findAll('move', {
       ...filter,
-      include,
+      include: isAggregation ? [] : include,
       page,
       per_page: isAggregation ? 1 : 100,
     })
@@ -99,6 +99,13 @@ const moveService = {
     const [startDate, endDate] = dateRange
     return moveService.getAll({
       isAggregation,
+      include: [
+        'profile',
+        'profile.person_escort_record.flags',
+        'profile.person',
+        'profile.person.gender',
+        'to_location',
+      ],
       filter: {
         'filter[status]': 'requested,accepted,booked,in_transit,completed',
         'filter[date_from]': startDate,
@@ -118,6 +125,7 @@ const moveService = {
     const [startDate, endDate] = dateRange
     return moveService.getAll({
       isAggregation,
+      include: ['profile.person'],
       filter: {
         'filter[status]': 'cancelled',
         'filter[date_from]': startDate,

--- a/common/services/move.js
+++ b/common/services/move.js
@@ -136,6 +136,20 @@ const moveService = {
     })
   },
 
+  getDownload({ dateRange = [], fromLocationId, toLocationId } = {}) {
+    const [startDate, endDate] = dateRange
+    return moveService.getAll({
+      filter: {
+        'filter[status]':
+          'requested,accepted,booked,in_transit,completed,cancelled',
+        'filter[date_from]': startDate,
+        'filter[date_to]': endDate,
+        'filter[from_location_id]': fromLocationId,
+        'filter[to_location_id]': toLocationId,
+      },
+    })
+  },
+
   getById(id, { include } = {}) {
     if (!id) {
       return Promise.reject(new Error(noMoveIdMessage))

--- a/common/services/move.test.js
+++ b/common/services/move.test.js
@@ -427,7 +427,7 @@ describe('Move Service', function () {
             ...mockFilter,
             page: 1,
             per_page: 1,
-            include: undefined,
+            include: [],
           })
         })
 
@@ -519,7 +519,7 @@ describe('Move Service', function () {
             ...mockFilter,
             page: 1,
             per_page: 1,
-            include: undefined,
+            include: [],
           })
         })
 
@@ -634,6 +634,13 @@ describe('Move Service', function () {
       it('should call getAll with active statuses', function () {
         expect(moveService.getAll).to.be.calledOnceWithExactly({
           isAggregation: false,
+          include: [
+            'profile',
+            'profile.person_escort_record.flags',
+            'profile.person',
+            'profile.person.gender',
+            'to_location',
+          ],
           filter: {
             'filter[status]': 'requested,accepted,booked,in_transit,completed',
             'filter[date_from]': undefined,
@@ -665,6 +672,13 @@ describe('Move Service', function () {
       it('should call getAll with active statuses', function () {
         expect(moveService.getAll).to.be.calledOnceWithExactly({
           isAggregation: false,
+          include: [
+            'profile',
+            'profile.person_escort_record.flags',
+            'profile.person',
+            'profile.person.gender',
+            'to_location',
+          ],
           filter: {
             'filter[status]': 'requested,accepted,booked,in_transit,completed',
             'filter[date_from]': mockDateRange[0],
@@ -693,6 +707,13 @@ describe('Move Service', function () {
       it('should call getAll with active statuses', function () {
         expect(moveService.getAll).to.be.calledOnceWithExactly({
           isAggregation: true,
+          include: [
+            'profile',
+            'profile.person_escort_record.flags',
+            'profile.person',
+            'profile.person.gender',
+            'to_location',
+          ],
           filter: {
             'filter[status]': 'requested,accepted,booked,in_transit,completed',
             'filter[date_from]': undefined,
@@ -725,6 +746,7 @@ describe('Move Service', function () {
       it('should call getAll methods', function () {
         expect(moveService.getAll).to.be.calledOnceWithExactly({
           isAggregation: false,
+          include: ['profile.person'],
           filter: {
             'filter[status]': 'cancelled',
             'filter[date_from]': undefined,
@@ -756,6 +778,7 @@ describe('Move Service', function () {
       it('should call getAll methods', function () {
         expect(moveService.getAll).to.be.calledOnceWithExactly({
           isAggregation: false,
+          include: ['profile.person'],
           filter: {
             'filter[status]': 'cancelled',
             'filter[date_from]': mockDateRange[0],
@@ -784,6 +807,7 @@ describe('Move Service', function () {
       it('should call getAll with active statuses', function () {
         expect(moveService.getAll).to.be.calledOnceWithExactly({
           isAggregation: true,
+          include: ['profile.person'],
           filter: {
             'filter[status]': 'cancelled',
             'filter[date_from]': undefined,

--- a/common/services/single-request.js
+++ b/common/services/single-request.js
@@ -47,6 +47,12 @@ const singleRequestService = {
 
     return moveService.getAll({
       isAggregation,
+      include: [
+        'from_location',
+        'to_location',
+        'profile.person',
+        'prison_transfer_reason',
+      ],
       filter: omitBy(
         {
           ...statusFilter,

--- a/common/services/single-request.js
+++ b/common/services/single-request.js
@@ -13,6 +13,7 @@ const singleRequestService = {
     createdAtDate = [],
     fromLocationId,
     toLocationId,
+    include,
     isAggregation = false,
     sortBy = 'created_at',
     sortDirection = 'desc',
@@ -47,7 +48,7 @@ const singleRequestService = {
 
     return moveService.getAll({
       isAggregation,
-      include: [
+      include: include || [
         'from_location',
         'to_location',
         'profile.person',
@@ -69,6 +70,22 @@ const singleRequestService = {
         },
         isNil
       ),
+    })
+  },
+
+  getDownload(args) {
+    return singleRequestService.getAll({
+      ...args,
+      include: [
+        'from_location',
+        'prison_transfer_reason',
+        'profile',
+        'profile.documents',
+        'profile.person',
+        'profile.person.ethnicity',
+        'profile.person.gender',
+        'to_location',
+      ],
     })
   },
 

--- a/common/services/single-request.test.js
+++ b/common/services/single-request.test.js
@@ -179,14 +179,13 @@ describe('Single request service', function () {
       context('with sort direction', function () {
         beforeEach(async function () {
           moves = await singleRequestService.getAll({
-            isAggregation: true,
             sortDirection: 'asc',
           })
         })
 
         it('should call moves.getAll with correct args', function () {
           expect(moveService.getAll).to.be.calledOnceWithExactly({
-            isAggregation: true,
+            isAggregation: false,
             include: [
               'from_location',
               'to_location',
@@ -198,6 +197,31 @@ describe('Single request service', function () {
               'filter[move_type]': 'prison_transfer',
               'sort[by]': 'created_at',
               'sort[direction]': 'asc',
+            },
+          })
+        })
+
+        it('should return moves', function () {
+          expect(moves).to.deep.equal(mockMoves)
+        })
+      })
+
+      context('with include', function () {
+        beforeEach(async function () {
+          moves = await singleRequestService.getAll({
+            include: ['foo', 'bar'],
+          })
+        })
+
+        it('should call moves.getAll with defined include', function () {
+          expect(moveService.getAll).to.be.calledOnceWithExactly({
+            isAggregation: false,
+            include: ['foo', 'bar'],
+            filter: {
+              'filter[has_relationship_to_allocation]': false,
+              'filter[move_type]': 'prison_transfer',
+              'sort[by]': 'created_at',
+              'sort[direction]': 'desc',
             },
           })
         })
@@ -393,6 +417,67 @@ describe('Single request service', function () {
             expect(moves).to.deep.equal(mockMoves)
           })
         })
+      })
+    })
+  })
+
+  describe('#getDownload()', function () {
+    let moves
+
+    beforeEach(async function () {
+      sinon.stub(singleRequestService, 'getAll').resolves(mockMoves)
+    })
+
+    context('without arguments', function () {
+      beforeEach(async function () {
+        moves = await singleRequestService.getDownload()
+      })
+
+      it('should call getAll with include', function () {
+        expect(singleRequestService.getAll).to.be.calledOnceWithExactly({
+          include: [
+            'from_location',
+            'prison_transfer_reason',
+            'profile',
+            'profile.documents',
+            'profile.person',
+            'profile.person.ethnicity',
+            'profile.person.gender',
+            'to_location',
+          ],
+        })
+      })
+
+      it('should return moves', function () {
+        expect(moves).to.deep.equal(mockMoves)
+      })
+    })
+
+    context('with arguments', function () {
+      beforeEach(async function () {
+        moves = await singleRequestService.getDownload({
+          foo: 'bar',
+        })
+      })
+
+      it('should call getAll with existing args and include', function () {
+        expect(singleRequestService.getAll).to.be.calledOnceWithExactly({
+          foo: 'bar',
+          include: [
+            'from_location',
+            'prison_transfer_reason',
+            'profile',
+            'profile.documents',
+            'profile.person',
+            'profile.person.ethnicity',
+            'profile.person.gender',
+            'to_location',
+          ],
+        })
+      })
+
+      it('should return moves', function () {
+        expect(moves).to.deep.equal(mockMoves)
       })
     })
   })

--- a/common/services/single-request.test.js
+++ b/common/services/single-request.test.js
@@ -45,6 +45,12 @@ describe('Single request service', function () {
       it('should call moves.getAll with default filter', function () {
         expect(moveService.getAll).to.be.calledOnceWithExactly({
           isAggregation: false,
+          include: [
+            'from_location',
+            'to_location',
+            'profile.person',
+            'prison_transfer_reason',
+          ],
           filter: {
             'filter[has_relationship_to_allocation]': false,
             'filter[move_type]': 'prison_transfer',
@@ -79,6 +85,12 @@ describe('Single request service', function () {
         it('should call moves.getAll with correct args', function () {
           expect(moveService.getAll).to.be.calledOnceWithExactly({
             isAggregation: false,
+            include: [
+              'from_location',
+              'to_location',
+              'profile.person',
+              'prison_transfer_reason',
+            ],
             filter: {
               'filter[status]': 'proposed',
               'filter[has_relationship_to_allocation]': false,
@@ -111,6 +123,12 @@ describe('Single request service', function () {
         it('should call moves.getAll with correct args', function () {
           expect(moveService.getAll).to.be.calledOnceWithExactly({
             isAggregation: false,
+            include: [
+              'from_location',
+              'to_location',
+              'profile.person',
+              'prison_transfer_reason',
+            ],
             filter: {
               'filter[has_relationship_to_allocation]': false,
               'filter[created_at_from]': mockCreatedDateRange[0],
@@ -138,6 +156,12 @@ describe('Single request service', function () {
         it('should call moves.getAll with correct args', function () {
           expect(moveService.getAll).to.be.calledOnceWithExactly({
             isAggregation: false,
+            include: [
+              'from_location',
+              'to_location',
+              'profile.person',
+              'prison_transfer_reason',
+            ],
             filter: {
               'filter[has_relationship_to_allocation]': false,
               'filter[move_type]': 'prison_transfer',
@@ -163,6 +187,12 @@ describe('Single request service', function () {
         it('should call moves.getAll with correct args', function () {
           expect(moveService.getAll).to.be.calledOnceWithExactly({
             isAggregation: true,
+            include: [
+              'from_location',
+              'to_location',
+              'profile.person',
+              'prison_transfer_reason',
+            ],
             filter: {
               'filter[has_relationship_to_allocation]': false,
               'filter[move_type]': 'prison_transfer',
@@ -188,6 +218,12 @@ describe('Single request service', function () {
         it('should call moves.getAll with correct args', function () {
           expect(moveService.getAll).to.be.calledOnceWithExactly({
             isAggregation: true,
+            include: [
+              'from_location',
+              'to_location',
+              'profile.person',
+              'prison_transfer_reason',
+            ],
             filter: {
               'filter[has_relationship_to_allocation]': false,
               'filter[from_location_id]': mockFromLocationId,
@@ -212,6 +248,12 @@ describe('Single request service', function () {
           it('should call moves.getAll without status', function () {
             expect(moveService.getAll).to.be.calledOnceWithExactly({
               isAggregation: false,
+              include: [
+                'from_location',
+                'to_location',
+                'profile.person',
+                'prison_transfer_reason',
+              ],
               filter: {
                 'filter[has_relationship_to_allocation]': false,
                 'filter[move_type]': 'prison_transfer',
@@ -236,6 +278,12 @@ describe('Single request service', function () {
           it('should call moves.getAll with correct statuses', function () {
             expect(moveService.getAll).to.be.calledOnceWithExactly({
               isAggregation: false,
+              include: [
+                'from_location',
+                'to_location',
+                'profile.person',
+                'prison_transfer_reason',
+              ],
               filter: {
                 'filter[status]': 'proposed',
                 'filter[has_relationship_to_allocation]': false,
@@ -261,6 +309,12 @@ describe('Single request service', function () {
           it('should call moves.getAll with correct statuses', function () {
             expect(moveService.getAll).to.be.calledOnceWithExactly({
               isAggregation: false,
+              include: [
+                'from_location',
+                'to_location',
+                'profile.person',
+                'prison_transfer_reason',
+              ],
               filter: {
                 'filter[status]':
                   'requested,accepted,booked,in_transit,completed',
@@ -287,6 +341,12 @@ describe('Single request service', function () {
           it('should call moves.getAll with correct statuses', function () {
             expect(moveService.getAll).to.be.calledOnceWithExactly({
               isAggregation: false,
+              include: [
+                'from_location',
+                'to_location',
+                'profile.person',
+                'prison_transfer_reason',
+              ],
               filter: {
                 'filter[status]': 'cancelled',
                 'filter[has_relationship_to_allocation]': false,
@@ -313,6 +373,12 @@ describe('Single request service', function () {
           it('should call moves.getAll with correct filter', function () {
             expect(moveService.getAll).to.be.calledOnceWithExactly({
               isAggregation: false,
+              include: [
+                'from_location',
+                'to_location',
+                'profile.person',
+                'prison_transfer_reason',
+              ],
               filter: {
                 'filter[status]': 'other',
                 'filter[has_relationship_to_allocation]': false,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

This change tailors the current includes used to ask for a list of
resources to only require the minimum to build that view.

#### Todo

- [x] Find way to still use all includes for download service calls

### Why did it change

Currently we use a default include, specified on the model, that
asks for **every** include when making requests to the API for a
particular model.

This has started to make performance quite slow as certain requests,
like loading a list of moves or allocations, don't require the same
detail as when viewing a single resource.

## Screenshots
<!--- (Optional) Include screenshots if changes update interfaces or components -->
<!--- Delete/copy as appropriate --->

### Outgoing dashboard

The example for these benchmarks included 25 active moves and 30 cancelled moves.

| Before | After |
| ------ | ----- |
| <kbd><img src="https://user-images.githubusercontent.com/3327997/89270064-1a3f6c00-d63b-11ea-960e-310294eda27f.png"></kbd> | <kbd><img src="https://user-images.githubusercontent.com/3327997/89270728-0e07de80-d63c-11ea-916d-84af81882b11.png"></kbd> |

### Single requests dashboard

The page used for this benchmark included ~115 single requests.

| Before | After |
| ------ | ----- |
| <kbd><img src="https://user-images.githubusercontent.com/3327997/89270643-ec0e5c00-d63b-11ea-8479-80b499125a2e.png"></kbd> | <kbd><img src="https://user-images.githubusercontent.com/3327997/89270587-d305ab00-d63b-11ea-96c3-4770e5b32739.png"></kbd> |

## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [x] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed

<!--- Delete if changes DO NOT include new environment variables -->
- [ ] Documented in the [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md)
- [ ] Added to [continous integration](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-book-secure-move-frontend)
- [ ] Added to staging environment (deployment repository)
- [ ] Added to preproduction environment (deployment repository)
- [ ] Added to production environment (deployment repository)

### Other considerations

Commit messages with a `fix` or `feat` type are automatically used to generate the [changelog](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/CHANGELOG.md) and
[GitHub release notes](https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/releases) during the release task. Please make sure they will read well on their own in a
summary of changes and that the commit body gives a more detailed description of those changes if necessary.

- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
- [x] Update [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md) with any new instructions or tasks
