### PR TITLE
chore: Add original_move relationship to move model

### DIFF
--- a/common/lib/api-client/models.js
+++ b/common/lib/api-client/models.js
@@ -44,6 +44,10 @@ module.exports = {
         jsonApi: 'hasOne',
         type: 'allocations',
       },
+      original_move: {
+        jsonApi: 'hasOne',
+        type: 'moves',
+      },
     },
     options: {
       defaultInclude: [


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Add `original_move` to `moves` model

### Why did it change

Prevent devour client complaining about missing field

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

n/a



## Checklists


### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed


### Other considerations


- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics

