### PR TITLE
hotfix(allocations): Add missing include to listing call

### DIFF
--- a/common/services/allocation.js
+++ b/common/services/allocation.js
@@ -130,14 +130,14 @@ const allocationService = {
     return allocationService.getByDateAndLocation({
       ...args,
       status: args.status || 'filled,unfilled',
-      include: ['from_location', 'moves', 'to_location'],
+      include: ['from_location', 'moves', 'moves.profile', 'to_location'],
     })
   },
   getCancelled(args) {
     return allocationService.getByDateAndLocation({
       ...args,
       includeCancelled: true,
-      include: ['from_location', 'moves', 'to_location'],
+      include: ['from_location', 'moves', 'moves.profile', 'to_location'],
       status: 'cancelled',
     })
   },

--- a/common/services/allocation.test.js
+++ b/common/services/allocation.test.js
@@ -807,7 +807,7 @@ describe('Allocation service', function () {
           allocationService.getByDateAndLocation
         ).to.have.been.calledWithExactly({
           additionalParams: {},
-          include: ['from_location', 'moves', 'to_location'],
+          include: ['from_location', 'moves', 'moves.profile', 'to_location'],
           status: 'custom',
         })
       })
@@ -825,7 +825,7 @@ describe('Allocation service', function () {
           allocationService.getByDateAndLocation
         ).to.have.been.calledWithExactly({
           additionalParams: {},
-          include: ['from_location', 'moves', 'to_location'],
+          include: ['from_location', 'moves', 'moves.profile', 'to_location'],
           status: 'filled,unfilled',
         })
       })
@@ -846,7 +846,7 @@ describe('Allocation service', function () {
       ).to.have.been.calledWithExactly({
         additionalParams: {},
         includeCancelled: true,
-        include: ['from_location', 'moves', 'to_location'],
+        include: ['from_location', 'moves', 'moves.profile', 'to_location'],
         status: 'cancelled',
       })
     })


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

The `moves.profile` include was missed when tailoring the requests
for allocations to be more specific.

This change adds that include back in to the call to get active and
cancelled allocations.

### Why did it change

This was needed to be able to build the progress on the dashboard.

## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [x] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed

### Other considerations

Commit messages with a `fix` or `feat` type are automatically used to generate the [changelog](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/CHANGELOG.md) and
[GitHub release notes](https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/releases) during the release task. Please make sure they will read well on their own in a
summary of changes and that the commit body gives a more detailed description of those changes if necessary.

- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
- [x] Update [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md) with any new instructions or tasks
