### PR TITLE
fix(per): Group responses correctly under flag summary

### DIFF
--- a/app/move/controllers/view.js
+++ b/app/move/controllers/view.js
@@ -66,7 +66,7 @@ module.exports = function view(req, res) {
     .map(
       presenters.frameworkSectionToPanelList({
         tagList: personEscortRecordTagList,
-        framework,
+        questions: framework.questions,
         personEscortRecord,
         personEscortRecordUrl,
       })

--- a/common/presenters/framework-responses-to-meta-list-component.js
+++ b/common/presenters/framework-responses-to-meta-list-component.js
@@ -7,18 +7,16 @@ function _mapResponse(response) {
     value: isEmpty(response.value) ? undefined : response.value,
     valueType: response.value_type,
   })
+  const description = response.question?.description
 
   return {
     value: {
-      html: `
-        <h4 class="govuk-heading-s govuk-!-margin-0 govuk-!-font-size-16">${response.question.description}</h4>
-        ${responseHtml}
-      `,
+      html: `<h4 class="govuk-heading-s govuk-!-margin-bottom-2 govuk-!-font-size-16">${description}</h4>${responseHtml}`,
     },
   }
 }
 
-function frameworkResponsesToMetaListComponent(responses) {
+function frameworkResponsesToMetaListComponent(responses = []) {
   return {
     classes: 'app-meta-list--divider',
     items: responses.map(_mapResponse),

--- a/common/presenters/framework-responses-to-meta-list-component.test.js
+++ b/common/presenters/framework-responses-to-meta-list-component.test.js
@@ -1,0 +1,170 @@
+const componentService = require('../services/component')
+
+const presenter = require('./framework-responses-to-meta-list-component')
+
+describe('Presenters', function () {
+  describe('#frameworkResponsesToMetaListComponent', function () {
+    let output
+
+    beforeEach(function () {
+      sinon.stub(componentService, 'getComponent').returns('__getComponent__')
+    })
+
+    context('with no responses', function () {
+      beforeEach(function () {
+        output = presenter()
+      })
+
+      it('should return empty items', function () {
+        expect(output).to.deep.equal({
+          classes: 'app-meta-list--divider',
+          items: [],
+        })
+      })
+    })
+
+    context('with responses', function () {
+      const mockResponses = [
+        {
+          value: 'string value',
+          value_type: 'string',
+          question: {
+            description: 'String',
+          },
+        },
+        {
+          value: { option: 'Yes' },
+          value_type: 'object',
+          question: {
+            description: 'Object',
+          },
+        },
+        {
+          value: ['One'],
+          value_type: 'array',
+          question: {
+            description: 'Array',
+          },
+        },
+      ]
+
+      beforeEach(function () {
+        output = presenter(mockResponses)
+      })
+
+      it('should return output', function () {
+        expect(output).to.deep.equal({
+          classes: 'app-meta-list--divider',
+          items: [
+            {
+              value: {
+                html:
+                  '<h4 class="govuk-heading-s govuk-!-margin-bottom-2 govuk-!-font-size-16">String</h4>__getComponent__',
+              },
+            },
+            {
+              value: {
+                html:
+                  '<h4 class="govuk-heading-s govuk-!-margin-bottom-2 govuk-!-font-size-16">Object</h4>__getComponent__',
+              },
+            },
+            {
+              value: {
+                html:
+                  '<h4 class="govuk-heading-s govuk-!-margin-bottom-2 govuk-!-font-size-16">Array</h4>__getComponent__',
+              },
+            },
+          ],
+        })
+      })
+
+      describe('component service', function () {
+        mockResponses.forEach(response => {
+          describe(response.question.description, function () {
+            it('should call component with value', function () {
+              expect(componentService.getComponent).to.have.been.calledWith(
+                'appFrameworkResponse',
+                {
+                  value: response.value,
+                  valueType: response.value_type,
+                }
+              )
+            })
+          })
+        })
+      })
+    })
+
+    context('with empty responses', function () {
+      const mockEmptyResponses = [
+        {
+          value: '',
+          value_type: 'string',
+          question: {
+            description: 'String',
+          },
+        },
+        {
+          value: {},
+          value_type: 'object',
+          question: {
+            description: 'Object',
+          },
+        },
+        {
+          value: [],
+          value_type: 'array',
+          question: {
+            description: 'Array',
+          },
+        },
+      ]
+
+      beforeEach(function () {
+        output = presenter(mockEmptyResponses)
+      })
+
+      it('should return output', function () {
+        expect(output).to.deep.equal({
+          classes: 'app-meta-list--divider',
+          items: [
+            {
+              value: {
+                html:
+                  '<h4 class="govuk-heading-s govuk-!-margin-bottom-2 govuk-!-font-size-16">String</h4>__getComponent__',
+              },
+            },
+            {
+              value: {
+                html:
+                  '<h4 class="govuk-heading-s govuk-!-margin-bottom-2 govuk-!-font-size-16">Object</h4>__getComponent__',
+              },
+            },
+            {
+              value: {
+                html:
+                  '<h4 class="govuk-heading-s govuk-!-margin-bottom-2 govuk-!-font-size-16">Array</h4>__getComponent__',
+              },
+            },
+          ],
+        })
+      })
+
+      describe('component service', function () {
+        mockEmptyResponses.forEach(response => {
+          describe(response.question.description, function () {
+            it('should call component with undefined', function () {
+              expect(componentService.getComponent).to.have.been.calledWith(
+                'appFrameworkResponse',
+                {
+                  value: undefined,
+                  valueType: response.value_type,
+                }
+              )
+            })
+          })
+        })
+      })
+    })
+  })
+})

--- a/common/presenters/framework-section-to-panel-list.js
+++ b/common/presenters/framework-section-to-panel-list.js
@@ -3,66 +3,89 @@ const { kebabCase, omit } = require('lodash')
 const frameworkResponseToMetaListComponent = require('./framework-responses-to-meta-list-component')
 
 function frameworkSectionToPanelList({
-  tagList,
-  framework,
+  tagList = [],
+  questions,
   personEscortRecord,
-  personEscortRecordUrl,
-}) {
+  personEscortRecordUrl = '',
+} = {}) {
   return section => {
     const flagsMap = personEscortRecord?.responses
+      // Remove responses with no flags
       .filter(response => response.flags.length > 0)
+      // Remove responses from other framework sections
       .filter(response => response.question.section === section.key)
+      // Reduce to a map with flag title and responses for that flag
       .reduce((acc, response) => {
-        delete response.person_escort_record
-        delete response.question.framework
         response.flags.forEach(flag => {
-          if (!acc[flag.title]) {
-            acc[flag.title] = []
+          const flagGroup = acc[flag.title] || []
+
+          // handle collections and arrays differently to other types
+          if (
+            response.value_type === 'collection' ||
+            response.value_type === 'array'
+          ) {
+            const existingGroup = flagGroup.find(f => f.id === response.id)
+            const flagValue = response.value.filter(
+              value => value.option === flag.question_value
+            )
+
+            // check to see if response already exists
+            // this is to avoid question being duplicated in panel list
+            if (existingGroup) {
+              existingGroup.value.push(flagValue[0])
+            } else {
+              flagGroup.push({
+                ...response,
+                value: flagValue,
+              })
+            }
+          } else {
+            flagGroup.push(response)
           }
 
-          if (response.value_type === 'collection') {
-            acc[flag.title].push({
-              ...response,
-              value: response.value.filter(value => {
-                return value.option === flag.question_value
-              }),
-            })
-          } else {
-            acc[flag.title].push(response)
-          }
+          acc[flag.title] = flagGroup
         })
 
         return acc
       }, {})
 
-    return {
+    const output = {
       key: section.key,
       name: section.name,
       url: `${personEscortRecordUrl}/${section.key}/overview`,
       panels: tagList
+        // Filter tags to just this section
         .filter(tag => tag.section === section.key)
+        // Return a meta list component for each tag
         .map(tag => {
-          return {
-            attributes: {
-              id: kebabCase(tag.text),
-            },
-            tag: omit(tag, ['href']),
-            metaList: frameworkResponseToMetaListComponent(
-              flagsMap[tag.text].map(response => {
-                const question = framework.questions[response.question.key]
+          // Loop over each item to append question description
+          const flagsWithQuestionDescription = (flagsMap[tag.text] || []).map(
+            response => {
+              const { description } = questions[response.question.key]
 
-                return {
-                  ...response,
-                  question: {
-                    ...response.question,
-                    description: question.description,
-                  },
-                }
-              })
+              return {
+                ...response,
+                question: {
+                  ...response.question,
+                  description,
+                },
+              }
+            }
+          )
+
+          return {
+            // Remove link so that when displayed in the main
+            // body the tag isn't linked
+            tag: omit(tag, ['href']),
+            attributes: { id: kebabCase(tag.text) },
+            metaList: frameworkResponseToMetaListComponent(
+              flagsWithQuestionDescription
             ),
           }
         }),
     }
+
+    return output
   }
 }
 

--- a/common/presenters/framework-section-to-panel-list.test.js
+++ b/common/presenters/framework-section-to-panel-list.test.js
@@ -1,0 +1,432 @@
+const proxyquire = require('proxyquire')
+
+const frameworkResponseToMetaListComponentStub = sinon
+  .stub()
+  .returns('__frameworkResponseToMetaListComponent__')
+const presenter = proxyquire('./framework-section-to-panel-list', {
+  './framework-responses-to-meta-list-component': frameworkResponseToMetaListComponentStub,
+})
+
+const mockArgs = {
+  personEscortRecordUrl:
+    '/move/0568d216-4e1c-4b06-bd22-13c221368384/person-escort-record',
+  tagList: [
+    {
+      text: 'Concealed items',
+      section: 'risk-information',
+      href: '#concealed-items',
+      classes: 'app-tag--destructive',
+      sortOrder: 1,
+    },
+    {
+      text: 'Escape',
+      section: 'risk-information',
+      href: '#escape',
+      classes: 'app-tag--destructive',
+      sortOrder: 1,
+    },
+    {
+      text: 'Hold separately',
+      section: 'risk-information',
+      href: '#hold-separately',
+      classes: 'app-tag--destructive',
+      sortOrder: 1,
+    },
+  ],
+  questions: {
+    'actions-of-self-harm-undertaken': {
+      description: 'Actions taken to keep person safe',
+    },
+    'addiction-dependencies': {
+      description: 'Addictions or dependencies',
+    },
+    'alcohol-withdrawal': {
+      description: 'Alcohol withdrawal',
+    },
+    arsonist: {
+      description: 'Arsonist',
+    },
+    'communication-needs': {
+      description: 'Communication needs',
+    },
+    'concealed-items': {
+      description: 'Items concealed, created or used',
+    },
+    'current-offences': {
+      description: 'Current offences',
+    },
+    'current-or-previous-sex-offender': {
+      description: 'Sex offender',
+    },
+    'escape-risk': {
+      description: 'Escape risk',
+    },
+    'female-hygiene-kit': {
+      description: 'Requires female hygiene kit',
+    },
+    'gang-member-or-organised-crime': {
+      description: 'Gang member or involved in organised crime',
+    },
+    'has-concealed-items': {
+      description: 'Concealed, created or used restricted items',
+    },
+    'health-contact-details': {
+      description: 'Custody contact number for health',
+    },
+    'health-issues': {
+      description: 'Health issues',
+    },
+    'held-separately': {
+      description: 'Hold separately',
+    },
+    'help-with-personal-tasks': {
+      description: 'Help with personal tasks',
+    },
+    'high-public-interest': {
+      description: 'Of high public interest',
+    },
+    'history-of-self-harm-details': {
+      description: 'Self-harm history details',
+    },
+    'history-of-self-harm-method': {
+      description: 'Methods used to self-harm',
+    },
+    'history-of-self-harm-recency': {
+      description: 'Recency of self-harm',
+    },
+    'history-of-self-harm': {
+      description: 'History of self-harm',
+    },
+    'hostage-taker': {
+      description: 'Hostage taker',
+    },
+    'indication-of-self-harm-or-suicide': {
+      description: 'Risk of self-harm or suicide',
+    },
+    'medical-health-professional-referral': {
+      description: 'Referred to a medical professional',
+    },
+    'medication-carrier-while-moving': {
+      description: 'Medication carrier while moving',
+    },
+    'medication-while-moving-details': {
+      description: 'Medication while moving details',
+    },
+    'medication-while-moving': {
+      description: 'Medication while moving',
+    },
+    'mental-health-needs': {
+      description: 'Mental health needs',
+    },
+    'nature-of-self-harm': {
+      description: 'Nature of self-harm',
+    },
+    'observation-level': {
+      description: 'Current observation level',
+    },
+    'other-health-information': {
+      description: 'Other health information',
+    },
+    'other-risk-information': {
+      description: 'Other risk information',
+    },
+    'physical-health-needs': {
+      description: 'Physical health needs',
+    },
+    pregnant: {
+      description: 'Pregnant',
+    },
+    'prescribed-medication-carrier': {
+      description: 'Prescribed medication carrier',
+    },
+    'prescribed-medication-details': {
+      description: 'Prescribed medication details',
+    },
+    'prescribed-medication': {
+      description: 'Prescribed medication',
+    },
+    'release-status': {
+      description: 'Release status',
+    },
+    'requires-special-vehicle': {
+      description: 'May require special vehicle',
+    },
+    'risk-from-other-people': {
+      description: 'Vulnerable — at risk from other people',
+    },
+    'risk-to-other-people': {
+      description: 'Risk to other people',
+    },
+    'sensitive-medication': {
+      description: 'Sensitive medical information',
+    },
+    'special-diet-or-allergies': {
+      description: 'Special diet or allergies',
+    },
+    'stalker-harasser-or-intimidator': {
+      description: 'Stalker, harasser or intimidator',
+    },
+    'terrorism-offences': {
+      description: 'Terrorism related offences',
+    },
+    'violent-or-dangerous': {
+      description: 'Violent or dangerous',
+    },
+    'wheelchair-user': {
+      description: 'Wheelchair user',
+    },
+  },
+  personEscortRecord: {
+    responses: [
+      {
+        id: '1131f451-0434-4e55-833e-d0e269460406',
+        type: 'framework_responses',
+        value: 'Yes',
+        value_type: 'string',
+        flags: [
+          {
+            id: '541dc7de-a8ef-4970-aa80-53487a082f5c',
+            title: 'Hold separately',
+            question_value: 'Yes',
+          },
+        ],
+        question: {
+          id: 'ad3fcd7c-a249-4a53-ab05-b7152c858ec3',
+          key: 'held-separately',
+          section: 'risk-information',
+        },
+      },
+      {
+        id: '7c10a0db-fdbd-40aa-ba05-59dcc579548b',
+        type: 'framework_responses',
+        value: {
+          option: 'Yes',
+          details: 'Lorem',
+        },
+        value_type: 'object',
+        flags: [
+          {
+            id: '2e7a4e98-ba44-4696-891d-b7e6ef021430',
+            title: 'Escape',
+            question_value: 'Yes',
+          },
+        ],
+        question: {
+          id: '7c8f6f25-96fe-453b-970e-fd8212093aa1',
+          key: 'escape-risk',
+          section: 'risk-information',
+        },
+      },
+      {
+        id: '5fc2fb04-f516-4798-bce9-70b03ce7c82a',
+        type: 'framework_responses',
+        value: [
+          {
+            option: 'Staff',
+            details: 'Lorem',
+          },
+          {
+            option: 'Lesbian, gay or bisexual people',
+            details: 'Lorem',
+          },
+        ],
+        value_type: 'collection',
+        flags: [
+          {
+            id: 'cf197679-9b48-4b19-a141-996d6b27eb49',
+            title: 'Hold separately',
+            question_value: 'Staff',
+          },
+          {
+            id: '94f3f854-9062-4d7d-bf90-5a313e106c9c',
+            title: 'Hold separately',
+            question_value: 'Lesbian, gay or bisexual people',
+          },
+        ],
+        question: {
+          id: '81eba694-cbc1-43f3-8c28-aeb3c7271074',
+          key: 'risk-to-other-people',
+          section: 'risk-information',
+        },
+      },
+      {
+        id: '88c041b1-4fb1-4279-9125-97829f075868',
+        type: 'framework_responses',
+        value: {
+          option: 'Yes',
+          details: 'Lorem',
+        },
+        value_type: 'object',
+        flags: [
+          {
+            id: '0015ea23-9a37-469b-b7a6-62dd01bac08f',
+            title: 'Hold separately',
+            question_value: 'Yes',
+          },
+        ],
+        question: {
+          id: 'c12721ff-76f3-4127-917d-3fb5ec1aeb4d',
+          key: 'risk-from-other-people',
+          section: 'risk-information',
+        },
+      },
+    ],
+  },
+}
+const mockSection = {
+  key: 'risk-information',
+  name: 'Risk information',
+}
+const expectedOutput = {
+  key: 'risk-information',
+  name: 'Risk information',
+  url:
+    '/move/0568d216-4e1c-4b06-bd22-13c221368384/person-escort-record/risk-information/overview',
+  panels: [
+    {
+      tag: {
+        text: 'Concealed items',
+        section: 'risk-information',
+        classes: 'app-tag--destructive',
+        sortOrder: 1,
+      },
+      attributes: {
+        id: 'concealed-items',
+      },
+      metaList: '__frameworkResponseToMetaListComponent__',
+    },
+    {
+      tag: {
+        text: 'Escape',
+        section: 'risk-information',
+        classes: 'app-tag--destructive',
+        sortOrder: 1,
+      },
+      attributes: {
+        id: 'escape',
+      },
+      metaList: '__frameworkResponseToMetaListComponent__',
+    },
+    {
+      tag: {
+        text: 'Hold separately',
+        section: 'risk-information',
+        classes: 'app-tag--destructive',
+        sortOrder: 1,
+      },
+      attributes: {
+        id: 'hold-separately',
+      },
+      metaList: '__frameworkResponseToMetaListComponent__',
+    },
+  ],
+}
+
+// TODO: Test this more logically to cover all scenarios
+// Current test just uses a real input/output that contains number of scenarios
+describe('Presenters', function () {
+  describe('#frameworkSectionToPanelList', function () {
+    let output
+
+    beforeEach(function () {
+      frameworkResponseToMetaListComponentStub.resetHistory()
+    })
+
+    context('with no args', function () {
+      beforeEach(function () {
+        output = presenter()(mockSection)
+      })
+
+      it('should return no output', function () {
+        expect(output).to.deep.equal({
+          key: 'risk-information',
+          name: 'Risk information',
+          panels: [],
+          url: '/risk-information/overview',
+        })
+      })
+    })
+
+    context('with mock args', function () {
+      beforeEach(function () {
+        output = presenter(mockArgs)(mockSection)
+      })
+
+      it('should return no output', function () {
+        expect(output).to.deep.equal(expectedOutput)
+      })
+
+      it('should call meta list presenter', function () {
+        expect(
+          frameworkResponseToMetaListComponentStub
+        ).to.have.been.calledWith([
+          {
+            flags: [
+              {
+                id: '541dc7de-a8ef-4970-aa80-53487a082f5c',
+                question_value: 'Yes',
+                title: 'Hold separately',
+              },
+            ],
+            id: '1131f451-0434-4e55-833e-d0e269460406',
+            question: {
+              description: 'Hold separately',
+              id: 'ad3fcd7c-a249-4a53-ab05-b7152c858ec3',
+              key: 'held-separately',
+              section: 'risk-information',
+            },
+            type: 'framework_responses',
+            value: 'Yes',
+            value_type: 'string',
+          },
+          {
+            flags: [
+              {
+                id: 'cf197679-9b48-4b19-a141-996d6b27eb49',
+                question_value: 'Staff',
+                title: 'Hold separately',
+              },
+              {
+                id: '94f3f854-9062-4d7d-bf90-5a313e106c9c',
+                question_value: 'Lesbian, gay or bisexual people',
+                title: 'Hold separately',
+              },
+            ],
+            id: '5fc2fb04-f516-4798-bce9-70b03ce7c82a',
+            question: {
+              description: 'Risk to other people',
+              id: '81eba694-cbc1-43f3-8c28-aeb3c7271074',
+              key: 'risk-to-other-people',
+              section: 'risk-information',
+            },
+            type: 'framework_responses',
+            value: [
+              { details: 'Lorem', option: 'Staff' },
+              { details: 'Lorem', option: 'Lesbian, gay or bisexual people' },
+            ],
+            value_type: 'collection',
+          },
+          {
+            flags: [
+              {
+                id: '0015ea23-9a37-469b-b7a6-62dd01bac08f',
+                question_value: 'Yes',
+                title: 'Hold separately',
+              },
+            ],
+            id: '88c041b1-4fb1-4279-9125-97829f075868',
+            question: {
+              description: 'Vulnerable — at risk from other people',
+              id: 'c12721ff-76f3-4127-917d-3fb5ec1aeb4d',
+              key: 'risk-from-other-people',
+              section: 'risk-information',
+            },
+            type: 'framework_responses',
+            value: { details: 'Lorem', option: 'Yes' },
+            value_type: 'object',
+          },
+        ])
+      })
+    })
+  })
+})


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

This fix checks to see if the response already exists when it's a
collection and appends to that response instead of creating a duplicate question.

This mimics the behaviour used for the overview pages.

It also adds some more high level unit tests to the presenters that control
this behaviour.

### Why did it change

Previously if the response type was `collection` and multiple values
were selected which correlate to a "tag" needing to be shown the
question text was being duplicated.

This was because the response values were being filtered and then
appending separately.

## Screenshots
<!--- (Optional) Include screenshots if changes update interfaces or components -->
<!--- Delete/copy as appropriate --->

| Before | After |
| ------ | ----- |
| <kbd><img src="https://user-images.githubusercontent.com/3327997/89412176-e8a3cf00-d726-11ea-8136-8bf3fd3857f0.png"></kbd> | <kbd><img src="https://user-images.githubusercontent.com/3327997/89412131-d6c22c00-d726-11ea-90ac-2cde97b2b02c.png"></kbd> |

## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [x] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed

### Other considerations

Commit messages with a `fix` or `feat` type are automatically used to generate the [changelog](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/CHANGELOG.md) and
[GitHub release notes](https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/releases) during the release task. Please make sure they will read well on their own in a
summary of changes and that the commit body gives a more detailed description of those changes if necessary.

- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
- [x] Update [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md) with any new instructions or tasks
