### PR TITLE
fix: Remove circular dependency when loading routers

### DIFF
--- a/app/router.js
+++ b/app/router.js
@@ -1,21 +1,29 @@
 const fs = require('fs')
 
+const debug = require('debug')('app:router')
 const router = require('express').Router()
 
-const subApps = fs.readdirSync(__dirname)
+const subApps = fs.readdirSync(__dirname, { withFileTypes: true })
 
-const appRouters = subApps.map(subAppDir => {
-  const subApp = require(`./${subAppDir}`)
+const appRouters = subApps
+  .filter(dirent => dirent.isDirectory())
+  .map(({ name }) => {
+    const subApp = require(`./${name}`)
+    debug('Loading app:', name)
 
-  if (subApp.router && !subApp.skip) {
-    if (subApp.mountpath) {
-      return router.use(subApp.mountpath, subApp.router)
+    if (subApp.router && !subApp.skip) {
+      debug('Loading router:', name)
+
+      if (subApp.mountpath) {
+        return router.use(subApp.mountpath, subApp.router)
+      }
+
+      return router.use(subApp.router)
     }
 
-    return router.use(subApp.router)
-  }
+    debug('Skipping router:', name)
 
-  return (req, res, next) => next()
-})
+    return (req, res, next) => next()
+  })
 
 module.exports = appRouters


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

This change ensures we only run the map to load routers for directories.

This will remove the warning that appears each time the app is started.

It also adds extra uses of the debug module to see which sub-apps are
loaded and in which order for debugging purposes.

### Why did it change

The file that loads the routers for the sub-apps was trying to
load itself which was causing a circular dependency warning.

## Screenshots
<!--- (Optional) Include screenshots if changes update interfaces or components -->
<!--- Delete/copy as appropriate --->

This fix will remove the following warning:

<kbd><img src="https://user-images.githubusercontent.com/3327997/89630045-114ed480-d89f-11ea-8dfc-d23ee8d3a532.png"></kbd>


## Checklists

### Testing

#### Automated testing

- [ ] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed

### Other considerations

Commit messages with a `fix` or `feat` type are automatically used to generate the [changelog](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/CHANGELOG.md) and
[GitHub release notes](https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/releases) during the release task. Please make sure they will read well on their own in a
summary of changes and that the commit body gives a more detailed description of those changes if necessary.

- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
- [x] Update [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md) with any new instructions or tasks
