### PR TITLE
fix(move): Prevent undefined additional_info being sent to patch move

### DIFF
--- a/app/move/controllers/update/move-details.js
+++ b/app/move/controllers/update/move-details.js
@@ -64,7 +64,12 @@ class UpdateMoveDetailsController extends UpdateBase {
             id: toLocation,
           },
         })
-      } else if (additionalInformation !== move.additional_information) {
+      } else if (
+        // API can return null or string for additional_information
+        // form value can be string or undefined depending on move type
+        additionalInformation !== undefined &&
+        additionalInformation !== move.additional_information
+      ) {
         await moveService.update({
           id: moveId,
           additional_information: additionalInformation,

--- a/app/move/controllers/update/move-details.test.js
+++ b/app/move/controllers/update/move-details.test.js
@@ -346,6 +346,20 @@ describe('Move controllers', function () {
 
       checkMoveTypeWithAdditionalInfo('prison_recall')
       checkMoveTypeWithAdditionalInfo('video_remand')
+
+      context('when no additional_info field is present', function () {
+        beforeEach(async function () {
+          req.getMove.returns({
+            move_type: 'move-type',
+            additional_information: null,
+          })
+          await controller.saveValues(req, res, nextSpy)
+        })
+
+        it('should not call move service’s update method', async function () {
+          expect(moveService.update).to.not.be.called
+        })
+      })
     })
   })
 })


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

To prevent unnecessary submission of move details, we now check that

- the form value for `additional_information` actually exists
- that it is different from the current value

### Why did it change

- The API can return null or string for additional_information
- The form value can be string or undefined depending on move type

The strict identity comparison by itself meant that we were patching when there
was no need to, and worse were sending an empty body

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

n/a

## Screenshots

n/a

## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed



### Other considerations


- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
