### PR TITLE
chore: Pass explicit CSP directives to Helmet

### DIFF
--- a/server.js
+++ b/server.js
@@ -149,7 +149,17 @@ app.use(
 )
 app.use(setLocations)
 
-app.use(helmet())
+// unsafe-inline is required as govuk-template injects `js-enabled` class via inline script
+app.use(
+  helmet({
+    contentSecurityPolicy: {
+      directives: {
+        defaultSrc: ["'self'"],
+        scriptSrc: ["'self'", "'unsafe-inline'"],
+      },
+    },
+  })
+)
 
 // Ensure body processed after reauthentication
 app.use(processOriginalRequestBody())


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

As of Helmet 4.0.0, inline-scripts are no longer allowed by default.

`govuk-frontend`’s default template uses an inline script to inject
the `js-enabled` class on the `body` element.

NB. for local dev, browsersync would also be clobbered without this policy change



### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed



### Other considerations


- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics

