### PR TITLE
build: Update Content Security Policy (CSP)

### DIFF
--- a/server.js
+++ b/server.js
@@ -155,7 +155,14 @@ app.use(
     contentSecurityPolicy: {
       directives: {
         defaultSrc: ["'self'"],
-        scriptSrc: ["'self'", "'unsafe-inline'"],
+        scriptSrc: [
+          "'self'",
+          "'unsafe-inline'",
+          'www.googletagmanager.com',
+          'www.google-analytics.com',
+        ],
+        imgSrc: ["'self'", 'www.google-analytics.com'],
+        fontSrc: ["'self'", 'fonts.googleapis.com'],
       },
     },
   })


### PR DESCRIPTION
## Proposed changes

### What changed

This change updates the CSP to include the domains we load some
assets from as trusted sources, like Google Analytics and Fonts.

### Why did it change

[Helmet v4 introduced CSP](https://github.com/helmetjs/helmet/wiki/Helmet-4-upgrade-guide) by default
which means we need to explicitly define the sources of our assets. This adds the remaining definitions for
analytics and fonts.

## Checklists

### Testing

#### Automated testing

- [ ] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed

### Other considerations

Commit messages with a `fix` or `feat` type are automatically used to generate the [changelog](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/CHANGELOG.md) and
[GitHub release notes](https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/releases) during the release task. Please make sure they will read well on their own in a
summary of changes and that the commit body gives a more detailed description of those changes if necessary.

- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
- [x] Update [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md) with any new instructions or tasks
