### PR TITLE
refactor: Set optional field label dynamically

### DIFF
--- a/common/controllers/form-wizard.js
+++ b/common/controllers/form-wizard.js
@@ -88,6 +88,7 @@ class FormController extends Controller {
       .map(fieldHelpers.setFieldValue(req.form.values))
       .map(fieldHelpers.setFieldError(req.form.errors))
       .map(fieldHelpers.translateField)
+      .map(fieldHelpers.setOptionalLabel)
       .map(fieldHelpers.renderConditionalFields)
 
     req.form.options.fields = fromPairs(fields)

--- a/common/helpers/field/index.js
+++ b/common/helpers/field/index.js
@@ -18,6 +18,7 @@ const getFieldErrorMessage = require('./get-field-error-message')
 const isAllowedDependent = require('./is-allowed-dependent')
 const reduceDependentFields = require('./reduce-dependent-fields')
 const setFieldError = require('./set-field-error')
+const setOptionalLabel = require('./set-optional-label')
 
 function mapReferenceDataToOption({
   id,
@@ -248,6 +249,7 @@ module.exports = {
   isAllowedDependent,
   setFieldValue,
   setFieldError,
+  setOptionalLabel,
   translateField,
   insertInitialOption,
   insertItemConditional,

--- a/common/helpers/field/set-optional-label.js
+++ b/common/helpers/field/set-optional-label.js
@@ -1,0 +1,31 @@
+const { cloneDeep, get, set, flatten } = require('lodash')
+
+const i18n = require('../../../config/i18n')
+
+function setOptionalLabel([key, field]) {
+  const translated = cloneDeep(field)
+  const validations = flatten([translated.validate])
+  const isOptional =
+    validations.filter(v => v?.type === 'required' || v === 'required').length <
+    1
+  const labelPaths = [
+    'label.text',
+    'label.html',
+    'fieldset.legend.text',
+    'fieldset.legend.html',
+  ]
+
+  if (isOptional) {
+    labelPaths.forEach(path => {
+      const key = get(translated, path)
+
+      if (key) {
+        set(translated, path, `${key} (${i18n.t('optional')})`)
+      }
+    })
+  }
+
+  return [key, translated]
+}
+
+module.exports = setOptionalLabel

--- a/locales/en/default.json
+++ b/locales/en/default.json
@@ -1,6 +1,7 @@
 {
   "feedback_link": "Give us feedback",
   "age": "Age",
+  "optional": "optional",
   "name": "Name",
   "from": "From",
   "date": "Date",

--- a/locales/en/fields.json
+++ b/locales/en/fields.json
@@ -100,7 +100,7 @@
     "label": "Name of hospital"
   },
   "additional_information": {
-    "label": "Additional information (optional)",
+    "label": "Additional information",
     "hint": "",
     "label_hospital": "Details of contact in hospital",
     "hint_hospital": "Provide name and contact information",
@@ -164,7 +164,7 @@
     "hint": "The case must exist in NOMIS to appear here"
   },
   "court_hearing__comments": {
-    "label": "Give details (optional)"
+    "label": "Give details"
   },
   "should_save_court_hearings": {
     "label": "Would you like to add this court date to NOMIS?",
@@ -191,7 +191,7 @@
   },
   "assessment_comment": {
     "required": "Give details",
-    "optional": "Give details (optional)"
+    "optional": "Give details"
   },
   "review_decision": {
     "label": "Can this move be requested with the supplier?",
@@ -220,7 +220,7 @@
   },
   "cancellation_reason_comment": {
     "label": "Additional information",
-    "label_optional": "Additional information (optional)",
+    "label_optional": "Additional information",
     "label_with_error": "Additional information"
   },
   "rebook": {
@@ -287,7 +287,7 @@
   },
   "documents": {
     "heading": "Only include documents that will help plan the move.",
-    "label": "Upload a file (optional)",
+    "label": "Upload a file",
     "hint": "You can upload Word, Excel, PDF and JPEG documents up to 50 megabytes"
   },
   "prison_transfer_type": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

This adds another field helper to determine whether a field is optional
or not and set the label suffix (`(optional)`) dynamically.

### Why did it change

The majority of our fields are required so the pattern is to mark any non-required fields as _optional_.

To accommodate the framework this has been added to the form wizard logic.

This change started in the framework but I moved it to the form wizard
to reduce the complexity of the importer and to share the logic across
all areas where we use the form wizard.

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

- [P4-XXXX]()

## Screenshots
<!--- (Optional) Include screenshots if changes update interfaces or components -->
<!--- Delete/copy as appropriate --->

| Before | After |
| ------ | ----- |
| <kbd><img src=""></kbd> | <kbd><img src=""></kbd> |

## Checklists

### Testing

#### Automated testing

- [ ] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [ ] No environment variables were added or changed

<!--- Delete if changes DO NOT include new environment variables -->
- [ ] Documented in the [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md)
- [ ] Added to [continous integration](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-book-secure-move-frontend)
- [ ] Added to staging environment (deployment repository)
- [ ] Added to preproduction environment (deployment repository)
- [ ] Added to production environment (deployment repository)

### Other considerations

Commit messages with a `fix` or `feat` type are automatically used to generate the [changelog](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/CHANGELOG.md) and
[GitHub release notes](https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/releases) during the release task. Please make sure they will read well on their own in a
summary of changes and that the commit body gives a more detailed description of those changes if necessary.

- [ ] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
- [ ] Update [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md) with any new instructions or tasks
