### PR TITLE
Pass all arguments to i18n function

### DIFF
--- a/config/nunjucks/globals.js
+++ b/config/nunjucks/globals.js
@@ -21,7 +21,7 @@ module.exports = {
   SUPPORT_EMAIL,
   SERVICE_NAME: 'Book a secure move',
   GA_ID: ANALYTICS.GA_ID,
-  t: key => i18n.t(key),
+  t: (...args) => i18n.t(...args),
   callAsMacro(name) {
     const macro = this.ctx[name]
 

--- a/config/nunjucks/globals.test.js
+++ b/config/nunjucks/globals.test.js
@@ -13,15 +13,42 @@ describe('Nunjucks globals', function () {
 
     beforeEach(function () {
       sinon.stub(i18n, 't').returns('__translated__')
-      translation = t(mockKey)
     })
 
-    it('should call translation with key', function () {
-      expect(i18n.t).to.be.calledOnceWithExactly(mockKey)
+    context('with one argument', function () {
+      beforeEach(function () {
+        translation = t(mockKey)
+      })
+
+      it('should call translation with key', function () {
+        expect(i18n.t).to.be.calledOnceWithExactly(mockKey)
+      })
+
+      it('should return translation', function () {
+        expect(translation).to.equal('__translated__')
+      })
     })
 
-    it('should return translation', function () {
-      expect(translation).to.equal('__translated__')
+    context('with multiple arguments', function () {
+      const args = [
+        mockKey,
+        {
+          context: 'foo',
+        },
+        'bar',
+      ]
+
+      beforeEach(function () {
+        translation = t(...args)
+      })
+
+      it('should call translation with all args', function () {
+        expect(i18n.t).to.be.calledOnceWithExactly(...args)
+      })
+
+      it('should return translation', function () {
+        expect(translation).to.equal('__translated__')
+      })
     })
   })
 


### PR DESCRIPTION
# Proposed changes

### What changed

This fix now passes through all arguments to the i18n library.

### Why did it change

The nunjucks global that added i18n support was only passing through
the key. This meant that if a context was set it wasn't registered
by the i18n function.

This method is used in components and a component coming soon needs to access
contexts.

## Checklists

### Testing

#### Automated testing

- [ ] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [ ] No environment variables were added or changed

### Other considerations

Commit messages with a `fix` or `feat` type are automatically used to generate the [changelog](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/CHANGELOG.md) and
[GitHub release notes](https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/releases) during the release task. Please make sure they will read well on their own in a
summary of changes and that the commit body gives a more detailed description of those changes if necessary.

- [ ] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
- [ ] Update [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md) with any new instructions or tasks
