### PR TITLE
[P4-1419] Cancelled moves

### DIFF
--- a/app/moves/middleware/set-results.single-requests.js
+++ b/app/moves/middleware/set-results.single-requests.js
@@ -1,17 +1,41 @@
-const { omitBy, isUndefined } = require('lodash')
+const { omitBy, isUndefined, isString } = require('lodash')
 
 const presenters = require('../../../common/presenters')
 const singleRequestService = require('../../../common/services/single-request')
 
 async function setResultsSingleRequests(req, res, next) {
   try {
-    const singleRequests = await singleRequestService.getAll(
-      omitBy(req.body.requested, isUndefined)
-    )
+    const [singleRequests, cancelledRequests] = await Promise.all([
+      singleRequestService.getAll(omitBy(req.body.requested, isUndefined)),
+      singleRequestService.getCancelled(req.body.requested),
+    ])
+
+    let cancelledMoves
+
+    const status = req?.body?.requested?.status
+    switch (status) {
+      case 'pending': {
+        cancelledMoves = cancelledRequests.filter(it => !isString(it.date))
+        break
+      }
+
+      case 'approved': {
+        cancelledMoves = cancelledRequests.filter(it => isString(it.date))
+        break
+      }
+
+      case 'rejected':
+      default:
+        cancelledMoves = []
+        break
+    }
 
     req.resultsAsTable = {
       active: presenters.singleRequestsToTableComponent(singleRequests),
-      cancelled: [],
+      cancelled:
+        cancelledMoves.length > 0
+          ? presenters.singleRequestsToTableComponent(cancelledMoves)
+          : [],
     }
 
     next()

--- a/common/services/single-request.js
+++ b/common/services/single-request.js
@@ -81,6 +81,37 @@ const singleRequestService = {
     return moveService.getDownload(args)
   },
 
+  getCancelled({
+    createdAtDate = [],
+    fromLocationId,
+    include,
+    sortBy = 'created_at',
+    sortDirection = 'desc',
+  } = {}) {
+    const [createdAtFrom, createdAtTo] = createdAtDate
+    return moveService.getAll({
+      isAggregation: false,
+      include: include || [
+        'from_location',
+        'to_location',
+        'profile.person',
+        'prison_transfer_reason',
+      ],
+      filter: {
+        'filter[has_relationship_to_allocation]': false,
+        'filter[from_location_id]': fromLocationId,
+        'filter[status]': 'cancelled',
+        'filter[allocation]': false,
+        'filter[move_type]': 'prison_transfer',
+        'filter[rejection_reason]': undefined,
+        'sort[by]': sortBy,
+        'sort[direction]': sortDirection,
+        'filter[created_at_from]': createdAtFrom,
+        'filter[created_at_to]': createdAtTo,
+      },
+    })
+  },
+
   approve(id, { date } = {}) {
     if (!id) {
       return Promise.reject(new Error(noMoveIdMessage))

--- a/common/services/single-request.test.js
+++ b/common/services/single-request.test.js
@@ -19,6 +19,7 @@ const mockMoves = [
     person: {
       name: 'Tom Jones',
     },
+    date_from: '2020-08-25',
   },
   {
     id: '67890',
@@ -449,6 +450,51 @@ describe('Single request service', function () {
 
       it('should return moves', function () {
         expect(moves).to.deep.equal('#download')
+      })
+    })
+  })
+
+  describe('#getCancelled()', function () {
+    let moves
+
+    beforeEach(async function () {
+      sinon.stub(moveService, 'getAll').resolves(mockMoves)
+    })
+
+    context('without arguments', function () {
+      beforeEach(async function () {
+        moves = await singleRequestService.getCancelled({
+          fromLocationId: 'fromLocationId',
+          createdAtDate: ['2019-01-01', '2019-01-07'],
+        })
+      })
+
+      it('should call getAll', function () {
+        expect(moveService.getAll).to.be.calledOnceWithExactly({
+          filter: {
+            'filter[has_relationship_to_allocation]': false,
+            'filter[from_location_id]': 'fromLocationId',
+            'filter[allocation]': false,
+            'filter[move_type]': 'prison_transfer',
+            'filter[rejection_reason]': undefined,
+            'filter[status]': 'cancelled',
+            'sort[by]': 'created_at',
+            'sort[direction]': 'desc',
+            'filter[created_at_from]': '2019-01-01',
+            'filter[created_at_to]': '2019-01-07',
+          },
+          include: [
+            'from_location',
+            'to_location',
+            'profile.person',
+            'prison_transfer_reason',
+          ],
+          isAggregation: false,
+        })
+      })
+
+      it('should return moves', function () {
+        expect(moves).to.deep.equal(mockMoves)
       })
     })
   })

--- a/common/templates/collection-as-table.njk
+++ b/common/templates/collection-as-table.njk
@@ -38,11 +38,7 @@
   {% if resultsAsTable.cancelled.rows.length %}
     <div class="govuk-!-margin-top-9">
       {% set html %}
-          {{ govukTable({
-            rows: resultsAsTable.cancelled.rows,
-            head: resultsAsTable.cancelled.head,
-            classes: "app-secondary-text-colour"
-          }) }}
+          {{ govukTable(resultsAsTable.cancelled) }}
       {% endset %}
 
       {{ govukDetails({
@@ -54,5 +50,4 @@
       }) }}
     </div>
   {% endif %}
-
 {% endblock %}


### PR DESCRIPTION
## Proposed changes

### What changed

This PR adds cancelled moves in the single transfer dashboard.

### Issue tracking

- P4-1419

## Screenshots

![2020-09-03 13 51 17](https://user-images.githubusercontent.com/1130499/92076415-16933680-eded-11ea-99c4-6467cda69f69.gif)

## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Internet Explorer
