### PR TITLE
Display supplier for move rather than location when updating

### DIFF
--- a/app/move/controllers/update/base.js
+++ b/app/move/controllers/update/base.js
@@ -1,8 +1,7 @@
-const { isEqual, keys, map, pick } = require('lodash')
+const { isEqual, keys, pick } = require('lodash')
 
 const moveService = require('../../../../common/services/move')
 const personService = require('../../../../common/services/person')
-const filters = require('../../../../config/nunjucks/filters')
 const CreateBaseController = require('../create/base')
 
 class UpdateBaseController extends CreateBaseController {
@@ -129,12 +128,7 @@ class UpdateBaseController extends CreateBaseController {
 
   setFlash(req, category) {
     const move = req.getMove()
-    const suppliers = move?.from_location?.suppliers
-    const supplierNames =
-      suppliers && suppliers.length
-        ? map(suppliers, 'name')
-        : [req.t('supplier_fallback')]
-    const supplier = filters.oxfordJoin(supplierNames)
+    const supplier = move.supplier?.name || req.t('supplier_fallback')
     category = category || this.flashKey || req.form.options.key
     req.flash('success', {
       title: req.t(`moves::update_flash.categories.${category}.heading`),

--- a/app/move/controllers/update/base.test.js
+++ b/app/move/controllers/update/base.test.js
@@ -3,7 +3,6 @@ const { cloneDeep } = require('lodash')
 
 const moveService = require('../../../../common/services/move')
 const personService = require('../../../../common/services/person')
-const filters = require('../../../../config/nunjucks/filters')
 const CreateBaseController = require('../create/base')
 const BaseProto = CreateBaseController.prototype
 
@@ -658,9 +657,6 @@ describe('Move controllers', function () {
   describe('#setFlash', function () {
     let req
     beforeEach(async function () {
-      sinon.stub(filters, 'oxfordJoin').callsFake((...arr) => {
-        return arr.join(',')
-      })
       req = {
         t: sinon.stub().returnsArg(0),
         flash: sinon.spy(),
@@ -670,15 +666,8 @@ describe('Move controllers', function () {
           },
         },
         getMove: sinon.stub().returns({
-          from_location: {
-            suppliers: [
-              {
-                name: 'Supplier A',
-              },
-              {
-                name: 'Supplier B',
-              },
-            ],
+          supplier: {
+            name: 'Supplier A',
           },
         }),
       }
@@ -690,31 +679,24 @@ describe('Move controllers', function () {
       })
 
       it('should output localised strings containing the suppliers', function () {
-        expect(filters.oxfordJoin).to.be.calledOnceWithExactly([
-          'Supplier A',
-          'Supplier B',
-        ])
         expect(req.t).to.be.callCount(2)
         expect(req.t.getCall(0).args).to.deep.equal([
           'moves::update_flash.categories.categoryKey.heading',
         ])
         expect(req.t.getCall(1).args).to.deep.equal([
           'moves::update_flash.categories.categoryKey.message',
-          { supplier: 'Supplier A,Supplier B' },
+          { supplier: 'Supplier A' },
         ])
       })
     })
 
     context('when the supplier is not known', function () {
       beforeEach(async function () {
-        req.getMove = sinon.stub().returns()
+        req.getMove = sinon.stub().returns({})
         await controller.setFlash(req, 'categoryKey')
       })
 
       it('should output localised strings containing generic supplier info', function () {
-        expect(filters.oxfordJoin).to.be.calledOnceWithExactly([
-          'supplier_fallback',
-        ])
         expect(req.t).to.be.callCount(3)
         expect(req.t.getCall(0).args).to.deep.equal(['supplier_fallback'])
         expect(req.t.getCall(1).args).to.deep.equal([


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Display supplier for move rather than location when updating

### Why did it change

Missed it in the previous golive work.

We now get the supplier from the move itself. There will either be one or there won't - but there definitely will not be potentially multiple suppliers for the move any more.

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

n/a

## Screenshots
<!--- (Optional) Include screenshots if changes update interfaces or components -->
<!--- Delete/copy as appropriate --->

n/a (simply displays the correct string)

## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed



### Other considerations



- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
