### PR TITLE
fix(single-requests): Make single request download work again

### DIFF
--- a/common/services/move.js
+++ b/common/services/move.js
@@ -164,17 +164,24 @@ const moveService = {
   },
 
   async getDownload({
+    status = 'requested,accepted,booked,in_transit,completed,cancelled',
     dateRange = [],
+    createdAtDate = [],
     fromLocationId,
     toLocationId,
     supplierId = undefined,
+    dateOfBirthFrom,
+    dateOfBirthTo,
   } = {}) {
     const [startDate, endDate] = dateRange
+    const [createdAtFrom, createdAtTo] = createdAtDate
     const filter = omitBy(
       {
-        status: 'requested,accepted,booked,in_transit,completed,cancelled',
+        status,
         date_from: startDate,
         date_to: endDate,
+        created_at_from: createdAtFrom,
+        created_at_to: createdAtTo,
         from_location_id: Array.isArray(fromLocationId)
           ? fromLocationId.join(',')
           : fromLocationId,
@@ -182,6 +189,8 @@ const moveService = {
           ? toLocationId.join(',')
           : toLocationId,
         supplier_id: supplierId,
+        date_of_birth_from: dateOfBirthFrom,
+        date_of_birth_to: dateOfBirthTo,
       },
       isEmpty
     )

--- a/common/services/move.test.js
+++ b/common/services/move.test.js
@@ -894,12 +894,14 @@ describe('Move Service', function () {
 
     context('with arguments', function () {
       const mockDateRange = ['2019-10-10', '2019-10-11']
+      const mockCreatedRange = ['2019-10-01', '2019-10-21']
       const mockFromLocationId = 'b695d0f0-af8e-4b97-891e-92020d6820b9'
       const mockToLocationId = 'b195d0f0-df8e-4b97-891e-92020d6820b9'
 
       beforeEach(async function () {
         moves = await moveService.getDownload({
           dateRange: mockDateRange,
+          createdAtDate: mockCreatedRange,
           fromLocationId: mockFromLocationId,
           toLocationId: mockToLocationId,
         })
@@ -914,6 +916,8 @@ describe('Move Service', function () {
                 'requested,accepted,booked,in_transit,completed,cancelled',
               date_from: mockDateRange[0],
               date_to: mockDateRange[1],
+              created_at_from: mockCreatedRange[0],
+              created_at_to: mockCreatedRange[1],
               from_location_id: mockFromLocationId,
               to_location_id: mockToLocationId,
             },

--- a/common/services/single-request.js
+++ b/common/services/single-request.js
@@ -77,20 +77,8 @@ const singleRequestService = {
     })
   },
 
-  getDownload(args) {
-    return singleRequestService.getAll({
-      ...args,
-      include: [
-        'from_location',
-        'prison_transfer_reason',
-        'profile',
-        'profile.documents',
-        'profile.person',
-        'profile.person.ethnicity',
-        'profile.person.gender',
-        'to_location',
-      ],
-    })
+  async getDownload(args) {
+    return moveService.getDownload(args)
   },
 
   approve(id, { date } = {}) {

--- a/common/services/single-request.test.js
+++ b/common/services/single-request.test.js
@@ -431,32 +431,7 @@ describe('Single request service', function () {
     let moves
 
     beforeEach(async function () {
-      sinon.stub(singleRequestService, 'getAll').resolves(mockMoves)
-    })
-
-    context('without arguments', function () {
-      beforeEach(async function () {
-        moves = await singleRequestService.getDownload()
-      })
-
-      it('should call getAll with include', function () {
-        expect(singleRequestService.getAll).to.be.calledOnceWithExactly({
-          include: [
-            'from_location',
-            'prison_transfer_reason',
-            'profile',
-            'profile.documents',
-            'profile.person',
-            'profile.person.ethnicity',
-            'profile.person.gender',
-            'to_location',
-          ],
-        })
-      })
-
-      it('should return moves', function () {
-        expect(moves).to.deep.equal(mockMoves)
-      })
+      sinon.stub(moveService, 'getDownload').resolves('#download')
     })
 
     context('with arguments', function () {
@@ -467,23 +442,13 @@ describe('Single request service', function () {
       })
 
       it('should call getAll with existing args and include', function () {
-        expect(singleRequestService.getAll).to.be.calledOnceWithExactly({
+        expect(moveService.getDownload).to.be.calledOnceWithExactly({
           foo: 'bar',
-          include: [
-            'from_location',
-            'prison_transfer_reason',
-            'profile',
-            'profile.documents',
-            'profile.person',
-            'profile.person.ethnicity',
-            'profile.person.gender',
-            'to_location',
-          ],
         })
       })
 
       it('should return moves', function () {
-        expect(moves).to.deep.equal(mockMoves)
+        expect(moves).to.deep.equal('#download')
       })
     })
   })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

This fix gets the single requests download data from the BE endpoint as csv.

### Why did it change

Single request downloads were still fetching the download data from the BE as JSON but then attempted to send that data as if it were already in csv format but without processing it, resulting in an inadvertent conversion circularity error.

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

n/a

## Screenshots
<!--- (Optional) Include screenshots if changes update interfaces or components -->
<!--- Delete/copy as appropriate --->

n/a

## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed


### Other considerations


- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
