### PR TITLE
Disable prison transfer move creation for SCH and STC user

### DIFF
--- a/common/lib/permissions.js
+++ b/common/lib/permissions.js
@@ -21,7 +21,6 @@ const secureChildrensHomePermissions = [
   'move:create',
   'move:create:court_appearance',
   'move:create:hospital',
-  'move:create:prison_transfer',
   'move:cancel',
   'move:update',
 ]
@@ -33,7 +32,6 @@ const secureTrainingCentrePermissions = [
   'move:create',
   'move:create:court_appearance',
   'move:create:hospital',
-  'move:create:prison_transfer',
   'move:cancel',
   'move:update',
 ]

--- a/common/lib/user.test.js
+++ b/common/lib/user.test.js
@@ -176,7 +176,6 @@ describe('User class', function () {
           'move:create',
           'move:create:court_appearance',
           'move:create:hospital',
-          'move:create:prison_transfer',
           'move:cancel',
           'move:update',
         ]
@@ -199,7 +198,6 @@ describe('User class', function () {
           'move:create',
           'move:create:court_appearance',
           'move:create:hospital',
-          'move:create:prison_transfer',
           'move:cancel',
           'move:update',
         ])


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes


### What changed

Disable prison transfer move creation for SCH and STC user


### Why did it change

Feature is not ready yet

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

n/a

## Screenshots
<!--- (Optional) Include screenshots if changes update interfaces or components -->
<!--- Delete/copy as appropriate --->

n/a

## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed



### Other considerations


- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics

