### PR TITLE
[P4-1997 bis] SHC and STC transfer moves

### DIFF
--- a/app/move/controllers/view.js
+++ b/app/move/controllers/view.js
@@ -19,7 +19,7 @@ module.exports = function view(req, res) {
   } = move
   const bannerStatuses = ['cancelled']
   const userPermissions = req.session?.user?.permissions
-  const updateUrls = getUpdateUrls(updateSteps, move.id, userPermissions)
+  const updateUrls = getUpdateUrls(updateSteps, move, userPermissions)
   const updateActions = getUpdateLinks(updateSteps, updateUrls)
   const {
     person,

--- a/app/move/controllers/view.js
+++ b/app/move/controllers/view.js
@@ -17,6 +17,16 @@ module.exports = function view(req, res) {
     cancellation_reason_comment: cancellationComments,
     rejection_reason: rejectionReason,
   } = move
+
+  // We have to pretend that 'secure_childrens_home', 'secure_training_centre' are valid `move_type`s
+  const youthTransfer = ['secure_childrens_home', 'secure_training_centre']
+  const toLocationType = move?.to_location?.location_type
+  const fromLocationType = move?.from_location?.location_type
+
+  if (toLocationType === 'prison' && youthTransfer.includes(fromLocationType)) {
+    move.move_type = fromLocationType
+  }
+
   const bannerStatuses = ['cancelled']
   const userPermissions = req.session?.user?.permissions
   const updateUrls = getUpdateUrls(updateSteps, move, userPermissions)

--- a/app/move/controllers/view.test.js
+++ b/app/move/controllers/view.test.js
@@ -397,6 +397,32 @@ describe('Move controllers', function () {
       })
     })
 
+    context('with youth transfer moves', function () {
+      ;['secure_childrens_home', 'secure_training_centre'].forEach(function (
+        youthTransferType
+      ) {
+        const youthTransferMove = {
+          to_location: {
+            location_type: 'prison',
+          },
+          from_location: {
+            location_type: youthTransferType,
+          },
+        }
+        it(`should upgrade the move when ${youthTransferType} to prison`, function () {
+          req.move = {
+            ...youthTransferMove,
+          }
+          controller(req, res)
+          expect(getUpdateUrls).to.be.calledOnceWithExactly(
+            updateSteps,
+            { ...youthTransferMove, move_type: youthTransferType },
+            userPermissions
+          )
+        })
+      })
+    })
+
     context('with null profile (allocation move)', function () {
       beforeEach(function () {
         req.move = {

--- a/app/move/controllers/view.test.js
+++ b/app/move/controllers/view.test.js
@@ -373,7 +373,7 @@ describe('Move controllers', function () {
         it('should call getUpdateUrls with expected args', function () {
           expect(getUpdateUrls).to.be.calledOnceWithExactly(
             updateSteps,
-            'moveId',
+            mockMove,
             userPermissions
           )
         })

--- a/app/move/controllers/view/view.update.urls.js
+++ b/app/move/controllers/view/view.update.urls.js
@@ -1,7 +1,12 @@
 const { check } = require('../../../../common/middleware/permissions')
 
-const getUpdateUrls = (updateSteps, moveId, userPermissions) => {
+const getUpdateUrls = (updateSteps, move, userPermissions) => {
   const updateUrls = {}
+
+  if (!check(`move:update:${move.move_type}`, userPermissions)) {
+    return updateUrls
+  }
+
   updateSteps.forEach(updateJourney => {
     if (!check(updateJourney.permission, userPermissions)) {
       return
@@ -12,7 +17,7 @@ const getUpdateUrls = (updateSteps, moveId, userPermissions) => {
       step => steps[step].entryPoint
     )[0]
     const key = updateJourney.key
-    updateUrls[key] = `/move/${moveId}/edit${entryPointUrl}`
+    updateUrls[key] = `/move/${move.id}/edit${entryPointUrl}`
   })
   return updateUrls
 }

--- a/app/move/controllers/view/view.update.urls.test.js
+++ b/app/move/controllers/view/view.update.urls.test.js
@@ -22,9 +22,13 @@ describe('Move controllers', function () {
   describe('#view()', function () {
     describe('#getUpdateUrls', function () {
       let updateUrls
-      const userPermissions = ['move:allowed']
+      const userPermissions = ['move:allowed', 'move:update:prison_transfer']
       beforeEach(function () {
-        updateUrls = getUpdateUrls(updateSteps, 'moveId', userPermissions)
+        updateUrls = getUpdateUrls(
+          updateSteps,
+          { id: 'moveId', move_type: 'prison_transfer' },
+          userPermissions
+        )
       })
 
       it('should get expected value for key', function () {
@@ -37,6 +41,15 @@ describe('Move controllers', function () {
 
       it('should return undefined if the route is inaccessible', function () {
         expect(updateUrls.baz).to.be.undefined
+      })
+
+      it('should not expose url when the permission do not match', function () {
+        updateUrls = getUpdateUrls(
+          updateSteps,
+          { id: 'moveId', move_type: 'hospital' },
+          userPermissions
+        )
+        expect(updateUrls).to.deep.equal({})
       })
     })
   })

--- a/common/lib/permissions.js
+++ b/common/lib/permissions.js
@@ -21,6 +21,7 @@ const secureChildrensHomePermissions = [
   'move:create',
   'move:create:court_appearance',
   'move:create:hospital',
+  'move:create:prison_transfer',
   'move:cancel',
   'move:update',
 ]
@@ -32,6 +33,7 @@ const secureTrainingCentrePermissions = [
   'move:create',
   'move:create:court_appearance',
   'move:create:hospital',
+  'move:create:prison_transfer',
   'move:cancel',
   'move:update',
 ]

--- a/common/lib/permissions.js
+++ b/common/lib/permissions.js
@@ -11,6 +11,14 @@ const policePermissions = [
   'move:create:video_remand',
   'move:cancel',
   'move:update',
+  'move:update:court_appearance',
+  'move:update:hospital',
+  'move:update:prison_transfer',
+  'move:update:secure_childrens_home',
+  'move:update:secure_training_centre',
+  'move:update:prison_recall',
+  'move:update:police_transfer',
+  'move:update:video_remand',
 ]
 
 const secureChildrensHomePermissions = [
@@ -26,8 +34,10 @@ const secureChildrensHomePermissions = [
   'move:create:prison_transfer',
   'move:create:secure_childrens_home',
   'move:create:secure_training_centre',
-  'move:cancel',
   'move:update',
+  'move:update:court_appearance',
+  'move:update:hospital',
+  'move:cancel:proposed',
 ]
 const secureTrainingCentrePermissions = [
   'dashboard:view',
@@ -42,8 +52,10 @@ const secureTrainingCentrePermissions = [
   'move:create:prison_transfer',
   'move:create:secure_childrens_home',
   'move:create:secure_training_centre',
-  'move:cancel',
   'move:update',
+  'move:update:court_appearance',
+  'move:update:hospital',
+  'move:cancel:proposed',
 ]
 
 const supplierPermissions = [

--- a/common/lib/permissions.js
+++ b/common/lib/permissions.js
@@ -14,8 +14,10 @@ const policePermissions = [
 ]
 
 const secureChildrensHomePermissions = [
+  'dashboard:view',
   'moves:view:outgoing',
   'moves:view:incoming',
+  'moves:view:proposed',
   'moves:download',
   'move:view',
   'move:create',
@@ -28,8 +30,10 @@ const secureChildrensHomePermissions = [
   'move:update',
 ]
 const secureTrainingCentrePermissions = [
+  'dashboard:view',
   'moves:view:outgoing',
   'moves:view:incoming',
+  'moves:view:proposed',
   'moves:download',
   'move:view',
   'move:create',

--- a/common/lib/permissions.js
+++ b/common/lib/permissions.js
@@ -22,6 +22,8 @@ const secureChildrensHomePermissions = [
   'move:create:court_appearance',
   'move:create:hospital',
   'move:create:prison_transfer',
+  'move:create:secure_childrens_home',
+  'move:create:secure_training_centre',
   'move:cancel',
   'move:update',
 ]
@@ -34,6 +36,8 @@ const secureTrainingCentrePermissions = [
   'move:create:court_appearance',
   'move:create:hospital',
   'move:create:prison_transfer',
+  'move:create:secure_childrens_home',
+  'move:create:secure_training_centre',
   'move:cancel',
   'move:update',
 ]

--- a/common/lib/user.test.js
+++ b/common/lib/user.test.js
@@ -176,6 +176,7 @@ describe('User class', function () {
           'move:create',
           'move:create:court_appearance',
           'move:create:hospital',
+          'move:create:prison_transfer',
           'move:cancel',
           'move:update',
         ]
@@ -198,6 +199,7 @@ describe('User class', function () {
           'move:create',
           'move:create:court_appearance',
           'move:create:hospital',
+          'move:create:prison_transfer',
           'move:cancel',
           'move:update',
         ])

--- a/common/lib/user.test.js
+++ b/common/lib/user.test.js
@@ -169,8 +169,10 @@ describe('User class', function () {
 
       it('should contain correct permission', function () {
         const stcPermissions = [
+          'dashboard:view',
           'moves:view:outgoing',
           'moves:view:incoming',
+          'moves:view:proposed',
           'moves:download',
           'move:view',
           'move:create',
@@ -194,8 +196,10 @@ describe('User class', function () {
 
       it('should contain correct permission', function () {
         expect(permissions).to.deep.equal([
+          'dashboard:view',
           'moves:view:outgoing',
           'moves:view:incoming',
+          'moves:view:proposed',
           'moves:download',
           'move:view',
           'move:create',

--- a/common/lib/user.test.js
+++ b/common/lib/user.test.js
@@ -137,6 +137,14 @@ describe('User class', function () {
           'move:create:video_remand',
           'move:cancel',
           'move:update',
+          'move:update:court_appearance',
+          'move:update:hospital',
+          'move:update:prison_transfer',
+          'move:update:secure_childrens_home',
+          'move:update:secure_training_centre',
+          'move:update:prison_recall',
+          'move:update:police_transfer',
+          'move:update:video_remand',
         ]
 
         expect(permissions).to.deep.equal(policePermissions)
@@ -181,8 +189,10 @@ describe('User class', function () {
           'move:create:prison_transfer',
           'move:create:secure_childrens_home',
           'move:create:secure_training_centre',
-          'move:cancel',
           'move:update',
+          'move:update:court_appearance',
+          'move:update:hospital',
+          'move:cancel:proposed',
         ]
 
         expect(permissions).to.deep.equal(stcPermissions)
@@ -208,8 +218,10 @@ describe('User class', function () {
           'move:create:prison_transfer',
           'move:create:secure_childrens_home',
           'move:create:secure_training_centre',
-          'move:cancel',
           'move:update',
+          'move:update:court_appearance',
+          'move:update:hospital',
+          'move:cancel:proposed',
         ])
       })
     })
@@ -356,6 +368,14 @@ describe('User class', function () {
           'move:create:video_remand',
           'move:cancel',
           'move:update',
+          'move:update:court_appearance',
+          'move:update:hospital',
+          'move:update:prison_transfer',
+          'move:update:secure_childrens_home',
+          'move:update:secure_training_centre',
+          'move:update:prison_recall',
+          'move:update:police_transfer',
+          'move:update:video_remand',
           'locations:all',
           'dashboard:view',
           'move:cancel:proposed',

--- a/common/lib/user.test.js
+++ b/common/lib/user.test.js
@@ -177,6 +177,8 @@ describe('User class', function () {
           'move:create:court_appearance',
           'move:create:hospital',
           'move:create:prison_transfer',
+          'move:create:secure_childrens_home',
+          'move:create:secure_training_centre',
           'move:cancel',
           'move:update',
         ]
@@ -200,6 +202,8 @@ describe('User class', function () {
           'move:create:court_appearance',
           'move:create:hospital',
           'move:create:prison_transfer',
+          'move:create:secure_childrens_home',
+          'move:create:secure_training_centre',
           'move:cancel',
           'move:update',
         ])
@@ -343,6 +347,8 @@ describe('User class', function () {
           'move:create:prison_recall',
           'move:create:police_transfer',
           'move:create:hospital',
+          'move:create:secure_childrens_home',
+          'move:create:secure_training_centre',
           'move:create:video_remand',
           'move:cancel',
           'move:update',


### PR DESCRIPTION
This ticket includes the changes in #728 and adds more:

- STC/SCH users should have a dashboard with incoming, outgoing and single requests
- STC/SCH should be able to cancel proposed moves
- STC/SCH should not be able to edit youth transfer moves 

### Issue tracking

- P4-1997
- P4-2107
- P4-2106
- P4-1932

## Screenshots

<img width="1019" alt="Screenshot 2020-08-31 at 17 21 54" src="https://user-images.githubusercontent.com/1130499/91704846-b44cf280-ebae-11ea-976d-3fd7ab2e58c2.png">

## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Internet Explorer
