### PR TITLE
Disable supplier e2e tests

### DIFF
--- a/test/e2e/move.update.forbidden.test.js
+++ b/test/e2e/move.update.forbidden.test.js
@@ -3,9 +3,10 @@ import {
   checkNoUpdateLinks,
   checkUpdatePagesForbidden,
 } from './_move'
-import { prisonUser, ocaUser, supplierUser } from './_roles'
+import { prisonUser, ocaUser } from './_roles'
 import { home } from './_routes'
 
+// TODO: Reenable supplier tests
 const users = [
   {
     name: 'prison user',
@@ -14,10 +15,6 @@ const users = [
   {
     name: 'OCA user',
     role: ocaUser,
-  },
-  {
-    name: 'supplier user',
-    role: supplierUser,
   },
 ]
 

--- a/test/e2e/moves.download.test.js
+++ b/test/e2e/moves.download.test.js
@@ -3,10 +3,11 @@ import { readFileSync } from 'fs'
 import { every } from 'lodash'
 
 import { deleteCsvDownloads, waitForCsvDownloadFilePaths } from './_helpers'
-import { policeUser, prisonUser, stcUser, supplierUser } from './_roles'
+import { policeUser, prisonUser, stcUser } from './_roles'
 import { movesByDay } from './_routes'
 import { movesDashboardPage } from './pages'
 
+// TODO: Reenable supplier tests
 const users = [
   {
     name: 'Police user',
@@ -19,10 +20,6 @@ const users = [
   {
     name: 'STC user',
     role: stcUser,
-  },
-  {
-    name: 'Supplier user',
-    role: supplierUser,
   },
 ]
 

--- a/test/e2e/smoke.test.js
+++ b/test/e2e/smoke.test.js
@@ -1,13 +1,8 @@
-import {
-  policeUser,
-  stcUser,
-  prisonUser,
-  supplierUser,
-  ocaUser,
-} from './_roles'
+import { policeUser, stcUser, prisonUser, ocaUser } from './_roles'
 import { home, movesByDay } from './_routes'
 import { dashboardPage, page, movesDashboardPage } from './pages'
 
+// TODO: Reenable supplier tests
 const users = [
   {
     name: 'Police user',
@@ -26,12 +21,6 @@ const users = [
     role: prisonUser,
     username: 'End-to-End Test Prison',
     homeButton: movesDashboardPage.nodes.createMoveButton,
-  },
-  {
-    name: 'Supplier user',
-    role: supplierUser,
-    username: 'End-to-End Test Supplier',
-    homeButton: movesDashboardPage.nodes.downloadMovesLink,
   },
 ]
 


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Removes tests relying on the `E2E_SUPPLIER` user

### Why did it change

Supplier users now need to login with 2FA

Until we have a proper fix for handling that step, any tests relying on
the E2E_SUPPLIER user need to be disabled.

When fixed, this commit should be reverted.

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

n/a

## Screenshots
<!--- (Optional) Include screenshots if changes update interfaces or components -->
<!--- Delete/copy as appropriate --->

n/a

## Checklists

### Testing

#### Automated testing

- [ ] Added unit tests to cover changes
- [x] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed

### Other considerations


- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics

