### PR TITLE
test: Update test prison number to be correct format

### DIFF
--- a/test/e2e/move.new.prison.test.js
+++ b/test/e2e/move.new.prison.test.js
@@ -10,7 +10,7 @@ fixture('New move from Prison to Court').beforeEach(async t => {
 })
 
 test('With unfound person', async t => {
-  const searchTerm = 'UNKNOWN_PRISONER'
+  const searchTerm = 'X9999XX'
 
   // PNC lookup
   await createMovePage.fillInPrisonNumberSearch(searchTerm)


### PR DESCRIPTION
## Proposed changes

### What changed

In order to unblock the e2e pipeline for now, the unknown prison number has been
updated to be in the expected format.

### Why did it change

The downstream Prison API recently merged a change that expected the
search format to be in a pariticular format. If it isn't, it will now
throw an error which has been bubbled up from the API.

This means the frontend now receives a 500 from the API and doesn't
display the expected empty results page which causes the e2e tests to fail.

## Checklists

### Testing

#### Automated testing

- [ ] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed

### Other considerations

Commit messages with a `fix` or `feat` type are automatically used to generate the [changelog](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/CHANGELOG.md) and
[GitHub release notes](https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/releases) during the release task. Please make sure they will read well on their own in a
summary of changes and that the commit body gives a more detailed description of those changes if necessary.

- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
- [x] Update [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md) with any new instructions or tasks
