### PR TITLE
[P4-2126] fix: Add validation to prison number field

### DIFF
--- a/app/move/fields/filter.prison-number.js
+++ b/app/move/fields/filter.prison-number.js
@@ -12,6 +12,9 @@ const filterPrisonNumber = {
     html: 'fields::filter.prison_number.label',
     classes: 'govuk-label--s',
   },
+  hint: {
+    text: 'fields::filter.prison_number.hint',
+  },
   validate: ['required', validators.prisonNumber],
 }
 

--- a/app/move/fields/filter.prison-number.js
+++ b/app/move/fields/filter.prison-number.js
@@ -1,5 +1,7 @@
 const { cloneDeep } = require('lodash')
 
+const validators = require('../validators')
+
 const filter = require('./common.filter')
 
 const filterPrisonNumber = {
@@ -10,6 +12,7 @@ const filterPrisonNumber = {
     html: 'fields::filter.prison_number.label',
     classes: 'govuk-label--s',
   },
+  validate: ['required', validators.prisonNumber],
 }
 
 module.exports = filterPrisonNumber

--- a/app/move/validators.js
+++ b/app/move/validators.js
@@ -27,4 +27,10 @@ module.exports = {
       (Controller.validators.date(value) && isAfter(test, comparator))
     )
   },
+  prisonNumber(value) {
+    return (
+      value === '' ||
+      Controller.validators.regex(value, /^[A-Z][0-9]{5}[A-Z]{2}$/)
+    )
+  },
 }

--- a/app/move/validators.js
+++ b/app/move/validators.js
@@ -30,7 +30,7 @@ module.exports = {
   prisonNumber(value) {
     return (
       value === '' ||
-      Controller.validators.regex(value, /^[A-Z][0-9]{5}[A-Z]{2}$/)
+      Controller.validators.regex(value, /^[A-Z][0-9]{4}[A-Z]{2}$/)
     )
   },
 }

--- a/app/move/validators.test.js
+++ b/app/move/validators.test.js
@@ -134,3 +134,33 @@ describe('Validators', function () {
     })
   })
 })
+
+describe('#prisonNumber()', function () {
+  describe('invalid values', function () {
+    const inputs = [
+      796507,
+      '796507',
+      null,
+      'AA/BBBBBB',
+      'AA/183716',
+      'ABCDEF',
+      'A12345BC',
+    ]
+
+    inputs.forEach(i => {
+      it(`test for: "${i}"`, function () {
+        expect(validators.prisonNumber(i)).not.to.be.ok
+      })
+    })
+  })
+
+  describe('valid values', function () {
+    const inputs = ['', 'A1234BC']
+
+    inputs.forEach(i => {
+      it(`test for: "${i}"`, function () {
+        expect(validators.prisonNumber(i)).to.be.ok
+      })
+    })
+  })
+})

--- a/locales/en/fields.json
+++ b/locales/en/fields.json
@@ -8,7 +8,8 @@
       "label": "Police National Computer (PNC) number"
     },
     "prison_number": {
-      "label": "Prison number"
+      "label": "Prison number",
+      "hint": "For example, 'A1234AB'"
     }
   },
   "people": {

--- a/locales/en/validation.json
+++ b/locales/en/validation.json
@@ -22,6 +22,7 @@
   "default": "is required",
   "default_with_label": "{{label}} is required",
   "generic": "something went wrong",
+  "prisonNumber_with_label": "{{label}} must be of the format A1234AB",
   "move_conflict": {
     "heading": "This move cannot be created",
     "message": "A move <a href=\"{{href}}\">already exists</a> for <strong>{{name}}</strong> to <strong>{{location}}</strong> on <strong>{{date}}</strong>.",

--- a/locales/en/validation.json
+++ b/locales/en/validation.json
@@ -22,7 +22,7 @@
   "default": "is required",
   "default_with_label": "{{label}} is required",
   "generic": "something went wrong",
-  "prisonNumber_with_label": "{{label}} must be of the format A1234AB",
+  "prisonNumber": "Enter a prison number in the correct format",
   "move_conflict": {
     "heading": "This move cannot be created",
     "message": "A move <a href=\"{{href}}\">already exists</a> for <strong>{{name}}</strong> to <strong>{{location}}</strong> on <strong>{{date}}</strong>.",

--- a/test/e2e/_helpers.js
+++ b/test/e2e/_helpers.js
@@ -70,9 +70,7 @@ export async function generatePerson(overrides = {}) {
     policeNationalComputer: faker
       .fake('{{random.alphaNumeric(6)}}/{{random.alphaNumeric(2)}}')
       .toUpperCase(),
-    prisonNumber: faker.fake(
-      '{{helpers.replaceSymbols("?")}}{{random.number}}{{helpers.replaceSymbols("??")}}'
-    ),
+    prisonNumber: faker.fake('{{helpers.replaceSymbols("?####??")}}'),
     criminalRecordsOffice: faker.fake('CRO/{{random.number}}'),
     nicheReference: faker.fake('NI/{{random.number}}'),
     athenaReference: faker.fake('AT/{{random.number}}'),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes
Add form-wizard validation to the prison number field

### What changed
A validator was added to the prison number field

### Why did it change

There is an existing issue with "Prison number containing colon character - e.g. 08:00 returns nasty exception" [P4-2124](https://dsdmoj.atlassian.net/browse/P4-2124).

Recently a downstream service made some changes, and these errors were being surfaced in the `frontend` application as 5xx errors. These errors were also being thrown while running the E2E tests.

#763 works around the issue for the E2E tests, but the underlying bug is still present.

This fix applies validation to the field to ensure that only correctly formatted prison numbers are sent downstream.

### Issue tracking

- [P4-2126](https://dsdmoj.atlassian.net/browse/P4-2126)

## Screenshots
<!--- (Optional) Include screenshots if changes update interfaces or components -->

![Screenshot from 2020-09-04 16-11-10](https://user-images.githubusercontent.com/196695/92255444-3cdad400-eeca-11ea-990a-aa2b3eb6f0c5.png)
----
![Screenshot from 2020-09-04 16-11-23](https://user-images.githubusercontent.com/196695/92255449-3f3d2e00-eeca-11ea-9606-5c3929d32966.png)
----

![Screenshot from 2020-09-29 17-00-17](https://user-images.githubusercontent.com/196695/94584001-ffbdf380-0275-11eb-9639-089e3a54f887.png)

----

| Before | After |
| ------ | ----- |
| <kbd><img src=""></kbd> | <kbd><img src=""></kbd> |

## Checklists

### Testing

#### Automated testing

- [ ] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [ ] No environment variables were added or changed

### Other considerations

Commit messages with a `fix` or `feat` type are automatically used to generate the [changelog](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/CHANGELOG.md) and
[GitHub release notes](https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/releases) during the release task. Please make sure they will read well on their own in a
summary of changes and that the commit body gives a more detailed description of those changes if necessary.

- [ ] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
- [ ] Update [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md) with any new instructions or tasks
