### PR TITLE
fix(per): Prevent error when record already exists

### DIFF
--- a/app/person-escort-record/app/new/controllers.js
+++ b/app/person-escort-record/app/new/controllers.js
@@ -1,3 +1,5 @@
+const { get } = require('lodash')
+
 const FormWizardController = require('../../../../common/controllers/form-wizard')
 const personEscortRecordService = require('../../../../common/services/person-escort-record')
 
@@ -23,6 +25,12 @@ class NewPersonEscortRecordController extends FormWizardController {
       req.record = await personEscortRecordService.create(req.move.profile.id)
       next()
     } catch (err) {
+      const apiErrorCode = get(err, 'errors[0].code')
+
+      if (err.statusCode === 422 && apiErrorCode === 'taken') {
+        return this.successHandler(req, res)
+      }
+
       next(err)
     }
   }

--- a/app/person-escort-record/app/new/controllers.test.js
+++ b/app/person-escort-record/app/new/controllers.test.js
@@ -114,15 +114,46 @@ describe('Person Escort Record controllers', function () {
       })
 
       context('when save fails', function () {
-        const errorMock = new Error('Problem')
+        context('with existing record error', function () {
+          const errorMock = new Error('Existing record')
 
-        beforeEach(async function () {
-          personEscortRecordService.create.throws(errorMock)
-          await controller.saveValues(req, {}, nextSpy)
+          beforeEach(async function () {
+            errorMock.statusCode = 422
+            errorMock.errors = [
+              {
+                code: 'taken',
+              },
+            ]
+
+            sinon.stub(controller, 'successHandler')
+
+            personEscortRecordService.create.throws(errorMock)
+            await controller.saveValues(req, {}, nextSpy)
+          })
+
+          it('should not call next', function () {
+            expect(nextSpy).not.to.be.called
+          })
+
+          it('should call success handler', function () {
+            expect(controller.successHandler).to.be.calledOnceWithExactly(
+              req,
+              {}
+            )
+          })
         })
 
-        it('should call next with the error', function () {
-          expect(nextSpy).to.be.calledOnceWithExactly(errorMock)
+        context('with any other error', function () {
+          const errorMock = new Error('Problem')
+
+          beforeEach(async function () {
+            personEscortRecordService.create.throws(errorMock)
+            await controller.saveValues(req, {}, nextSpy)
+          })
+
+          it('should call next with the error', function () {
+            expect(nextSpy).to.be.calledOnceWithExactly(errorMock)
+          })
         })
       })
     })


### PR DESCRIPTION
## Proposed changes

### What changed

This change will look for that error and then handle it more appropriately
by redirecting back to the move.

### Why did it change

An [issue was recorded in sentry](https://sentry.service.dsd.io/mojds/book-a-secure-move-frontend/issues/38714/) which returned an API error when the
frontend was attempting to create a new Person Escort Record when
one had already been created for this move.

This scenario could occur when:
- two users open a move without a record and see the start button
- first user clicks to start a new PER
- second user clicks to start a new PER but will receive an error
because one had already been created

## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [x] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed

### Other considerations

Commit messages with a `fix` or `feat` type are automatically used to generate the [changelog](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/CHANGELOG.md) and
[GitHub release notes](https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/releases) during the release task. Please make sure they will read well on their own in a
summary of changes and that the commit body gives a more detailed description of those changes if necessary.

- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
- [x] Update [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md) with any new instructions or tasks
