### PR TITLE
Prevent last property bag from being removed [P4-2071]

### DIFF
--- a/common/components/add-another/add-another.yaml
+++ b/common/components/add-another/add-another.yaml
@@ -20,6 +20,13 @@ params:
   type: string
   required: false
   description: Name to use for each item heading and "Add another {name}" button. Defaults to `item`.
+- name: minItems
+  type: number
+  default: 1
+  description: Minimum number of items
+- name: maxItems
+  type: number
+  description: Maximum number of items
 
 examples:
   - name: default
@@ -40,3 +47,29 @@ examples:
       items:
         -
           text: Person 1 content
+  - name: with minItems
+    data:
+      name: add-another-field
+      minItems: 1
+      itemName: Person
+      items:
+        -
+          text: Person 1 content
+  - name: with minItems set to zero
+    data:
+      name: add-another-field
+      minItems: 0
+      itemName: Person
+      items:
+        -
+          text: Person 1 content
+  - name: with maxItems
+    data:
+      name: add-another-field
+      maxItems: 2
+      itemName: Person
+      items:
+        -
+          text: Person 1 content
+        -
+          text: Person 2 content

--- a/common/components/add-another/add-another.yaml
+++ b/common/components/add-another/add-another.yaml
@@ -63,13 +63,3 @@ examples:
       items:
         -
           text: Person 1 content
-  - name: with maxItems
-    data:
-      name: add-another-field
-      maxItems: 2
-      itemName: Person
-      items:
-        -
-          text: Person 1 content
-        -
-          text: Person 2 content

--- a/common/components/add-another/template.njk
+++ b/common/components/add-another/template.njk
@@ -36,16 +36,14 @@
   {% endcall %}
 {% endfor %}
 
-{% if not params.maxItems or items.length < params.maxItems %}
-  <div class="app-add-another__add-item {{ 'app-border-top-1 govuk-!-padding-top-5' if items.length > 0 }}">
-    {{ govukButton({
-      text: t("actions::add_item", {
-        context: "with_items" if items.length > 0,
-        name: itemName | lower
-      }),
-      classes: "govuk-button--secondary",
-      name: "multiple-action",
-      value: "add::" + params.name
-    }) }}
-  </div>
-{% endif %}
+<div class="app-add-another__add-item {{ 'app-border-top-1 govuk-!-padding-top-5' if items.length > 0 }}">
+  {{ govukButton({
+    text: t("actions::add_item", {
+      context: "with_items" if items.length > 0,
+      name: itemName | lower
+    }),
+    classes: "govuk-button--secondary",
+    name: "multiple-action",
+    value: "add::" + params.name
+  }) }}
+</div>

--- a/common/components/add-another/template.njk
+++ b/common/components/add-another/template.njk
@@ -18,30 +18,34 @@
       isPageHeading: false
     }
   }) %}
-    <div>
-      {{ govukButton({
-        html: t("actions::remove_item", {
-          name: itemName | lower,
-          index: loop.index
-        }),
-        classes: "govuk-button--secondary app-!-position-top-right",
-        name: "multiple-action",
-        value: "remove::" + params.name + "::" + loop.index0
-      }) }}
-    </div>
+    {% if not params.minItems or items.length > params.minItems %}
+      <div class="app-add-another__remove-item">
+        {{ govukButton({
+          html: t("actions::remove_item", {
+            name: itemName | lower,
+            index: loop.index
+          }),
+          classes: "govuk-button--secondary app-!-position-top-right",
+          name: "multiple-action",
+          value: "remove::" + params.name + "::" + loop.index0
+        }) }}
+      </div>
+    {% endif %}
 
     {{ item.html | safe if item.html else item.text }}
   {% endcall %}
 {% endfor %}
 
-<div class="{{ 'app-border-top-1 govuk-!-padding-top-5' if items.length > 0 }}">
-  {{ govukButton({
-    text: t("actions::add_item", {
-      context: "with_items" if items.length > 0,
-      name: itemName | lower
-    }),
-    classes: "govuk-button--secondary",
-    name: "multiple-action",
-    value: "add::" + params.name
-  }) }}
-</div>
+{% if not params.maxItems or items.length < params.maxItems %}
+  <div class="app-add-another__add-item {{ 'app-border-top-1 govuk-!-padding-top-5' if items.length > 0 }}">
+    {{ govukButton({
+      text: t("actions::add_item", {
+        context: "with_items" if items.length > 0,
+        name: itemName | lower
+      }),
+      classes: "govuk-button--secondary",
+      name: "multiple-action",
+      value: "add::" + params.name
+    }) }}
+  </div>
+{% endif %}

--- a/common/components/add-another/template.test.js
+++ b/common/components/add-another/template.test.js
@@ -19,11 +19,11 @@ describe('Add another component', function () {
     })
 
     it('should render a button element last', function () {
-      const $div = $component.children().last()
-      const $button = $div.find('button')
+      const $addItem = $component.find('.app-add-another__add-item')
+      const $button = $addItem.find('button')
 
-      expect($div.get(0).tagName).to.equal('div')
-      expect($div.hasClass('app-border-top-1')).to.be.false
+      expect($addItem.get(0).tagName).to.equal('div')
+      expect($addItem.hasClass('app-border-top-1')).to.be.false
 
       expect($button.text().trim()).to.equal('Add item')
       expect($button.attr('value')).to.equal('add::add-another-field')
@@ -76,11 +76,11 @@ describe('Add another component', function () {
     })
 
     it('should render a button element last', function () {
-      const $div = $component.children().last()
-      const $button = $div.find('button')
+      const $addItem = $component.find('.app-add-another__add-item')
+      const $button = $addItem.find('button')
 
-      expect($div.get(0).tagName).to.equal('div')
-      expect($div.hasClass('app-border-top-1')).to.be.true
+      expect($addItem.get(0).tagName).to.equal('div')
+      expect($addItem.hasClass('app-border-top-1')).to.be.true
 
       expect($button.text().trim()).to.equal('Add another item')
       expect($button.attr('value')).to.equal('add::add-another-field')
@@ -127,10 +127,72 @@ describe('Add another component', function () {
     })
 
     it('should render a button element last', function () {
-      const $div = $component.children().last()
-      const $button = $div.find('button')
+      const $addItem = $component.find('.app-add-another__add-item')
+      const $button = $addItem.find('button')
 
       expect($button.text().trim()).to.equal('Add another person')
+    })
+  })
+
+  context('with minItems', function () {
+    let $, $component
+
+    beforeEach(function () {
+      $ = renderComponentHtmlToCheerio('add-another', examples['with minItems'])
+      $component = $('body')
+    })
+
+    describe('fieldsets', function () {
+      let $fieldsets, $item1
+
+      beforeEach(function () {
+        $fieldsets = $component.find('fieldset')
+        $item1 = $($fieldsets[0])
+      })
+
+      it('should not render remove buttons', function () {
+        expect($item1.find('button').length).to.equal(0)
+      })
+    })
+  })
+
+  context('with minItems set to zero', function () {
+    let $, $component
+
+    beforeEach(function () {
+      $ = renderComponentHtmlToCheerio(
+        'add-another',
+        examples['with minItems set to zero']
+      )
+      $component = $('body')
+    })
+
+    describe('fieldsets', function () {
+      let $fieldsets, $item1
+
+      beforeEach(function () {
+        $fieldsets = $component.find('fieldset')
+        $item1 = $($fieldsets[0])
+      })
+
+      it('should render remove buttons', function () {
+        expect($item1.find('button').length).to.equal(1)
+      })
+    })
+  })
+
+  context('with maxItems', function () {
+    let $, $component
+
+    beforeEach(function () {
+      $ = renderComponentHtmlToCheerio('add-another', examples['with maxItems'])
+      $component = $('body')
+    })
+
+    it('should not render an add item button', function () {
+      const $addItem = $component.find('.app-add-another__add-item')
+
+      expect($addItem.length).to.equal(0)
     })
   })
 })

--- a/common/components/add-another/template.test.js
+++ b/common/components/add-another/template.test.js
@@ -180,19 +180,4 @@ describe('Add another component', function () {
       })
     })
   })
-
-  context('with maxItems', function () {
-    let $, $component
-
-    beforeEach(function () {
-      $ = renderComponentHtmlToCheerio('add-another', examples['with maxItems'])
-      $component = $('body')
-    })
-
-    it('should not render an add item button', function () {
-      const $addItem = $component.find('.app-add-another__add-item')
-
-      expect($addItem.length).to.equal(0)
-    })
-  })
 })

--- a/common/services/frameworks.js
+++ b/common/services/frameworks.js
@@ -100,8 +100,6 @@ const frameworksService = {
       questions,
       type,
       validations = [],
-      minItems,
-      maxItems,
     } = {}
   ) {
     if (!key) {
@@ -148,16 +146,7 @@ const frameworksService = {
       field.default = [{}]
 
       // default minimum items based on whether it's required
-      if (minItems === undefined) {
-        minItems = validations.includes('required') ? 1 : 0
-      }
-
-      field.minItems = minItems
-
-      // set maximum items if any
-      if (maxItems) {
-        field.maxItems = maxItems
-      }
+      field.minItems = validations.includes('required') ? 1 : 0
     }
 
     if (options) {

--- a/common/services/frameworks.js
+++ b/common/services/frameworks.js
@@ -100,7 +100,7 @@ const frameworksService = {
       questions,
       type,
       validations = [],
-      minItems = 1,
+      minItems,
       maxItems,
     } = {}
   ) {
@@ -146,7 +146,12 @@ const frameworksService = {
       field['ignore-defaults'] = true
       // use `default` to start with one empty item
       field.default = [{}]
-      // default minimum items to 1
+
+      // default minimum items based on whether it's required
+      if (minItems === undefined) {
+        minItems = validations.includes('required') ? 1 : 0
+      }
+
       field.minItems = minItems
 
       // set maximum items if any

--- a/common/services/frameworks.js
+++ b/common/services/frameworks.js
@@ -100,6 +100,8 @@ const frameworksService = {
       questions,
       type,
       validations = [],
+      minItems = 1,
+      maxItems,
     } = {}
   ) {
     if (!key) {
@@ -144,6 +146,13 @@ const frameworksService = {
       field['ignore-defaults'] = true
       // use `default` to start with one empty item
       field.default = [{}]
+      // default minimum items to 1
+      field.minItems = minItems
+
+      // set maximum items if any
+      if (maxItems) {
+        field.maxItems = maxItems
+      }
     }
 
     if (options) {

--- a/common/services/frameworks.test.js
+++ b/common/services/frameworks.test.js
@@ -561,35 +561,51 @@ describe('Services', function () {
         })
 
         describe('add_multiple_items', function () {
-          it('should format type correctly', function () {
+          const addAnotherMockQuestion = {
+            ...mockQuestion,
+            type: 'add_multiple_items',
+            list_item_name: 'Bag',
+            questions: ['one', 'two', 'three'],
+          }
+          const addAnotherMockResult = {
+            component: 'appAddAnother',
+            question: 'Question text',
+            description: undefined,
+            id: 'question-key',
+            name: 'question-key',
+            label: {
+              text: 'Question text',
+              classes: 'govuk-label--s',
+            },
+            validate: [],
+            classes: '',
+            rows: undefined,
+            descendants: ['one', 'two', 'three'],
+            itemName: 'Bag',
+            'ignore-defaults': true,
+            multiple: true,
+            default: [{}],
+            minItems: 0,
+          }
+
+          it('should set default minItems to 0 when not required', function () {
             const transformed = frameworksService.transformQuestion(
               'question-key',
-              {
-                ...mockQuestion,
-                type: 'add_multiple_items',
-                list_item_name: 'Bag',
-                questions: ['one', 'two', 'three'],
-              }
+              addAnotherMockQuestion
+            )
+
+            expect(transformed).to.deep.equal(addAnotherMockResult)
+          })
+
+          it('should set default minItems to 1 when required', function () {
+            const transformed = frameworksService.transformQuestion(
+              'question-key',
+              { ...addAnotherMockQuestion, validations: ['required'] }
             )
 
             expect(transformed).to.deep.equal({
-              component: 'appAddAnother',
-              question: 'Question text',
-              description: undefined,
-              id: 'question-key',
-              name: 'question-key',
-              label: {
-                text: 'Question text',
-                classes: 'govuk-label--s',
-              },
-              validate: [],
-              classes: '',
-              rows: undefined,
-              descendants: ['one', 'two', 'three'],
-              itemName: 'Bag',
-              'ignore-defaults': true,
-              multiple: true,
-              default: [{}],
+              ...addAnotherMockResult,
+              validate: ['required'],
               minItems: 1,
             })
           })
@@ -598,33 +614,14 @@ describe('Services', function () {
             const transformed = frameworksService.transformQuestion(
               'question-key',
               {
-                ...mockQuestion,
-                type: 'add_multiple_items',
-                list_item_name: 'Bag',
-                questions: ['one', 'two', 'three'],
+                ...addAnotherMockQuestion,
                 minItems: 0,
                 maxItems: 5,
               }
             )
 
             expect(transformed).to.deep.equal({
-              component: 'appAddAnother',
-              question: 'Question text',
-              description: undefined,
-              id: 'question-key',
-              name: 'question-key',
-              label: {
-                text: 'Question text',
-                classes: 'govuk-label--s',
-              },
-              validate: [],
-              classes: '',
-              rows: undefined,
-              descendants: ['one', 'two', 'three'],
-              itemName: 'Bag',
-              'ignore-defaults': true,
-              multiple: true,
-              default: [{}],
+              ...addAnotherMockResult,
               minItems: 0,
               maxItems: 5,
             })

--- a/common/services/frameworks.test.js
+++ b/common/services/frameworks.test.js
@@ -590,6 +590,43 @@ describe('Services', function () {
               'ignore-defaults': true,
               multiple: true,
               default: [{}],
+              minItems: 1,
+            })
+          })
+
+          it('should set minItems and maxItems correctly', function () {
+            const transformed = frameworksService.transformQuestion(
+              'question-key',
+              {
+                ...mockQuestion,
+                type: 'add_multiple_items',
+                list_item_name: 'Bag',
+                questions: ['one', 'two', 'three'],
+                minItems: 0,
+                maxItems: 5,
+              }
+            )
+
+            expect(transformed).to.deep.equal({
+              component: 'appAddAnother',
+              question: 'Question text',
+              description: undefined,
+              id: 'question-key',
+              name: 'question-key',
+              label: {
+                text: 'Question text',
+                classes: 'govuk-label--s',
+              },
+              validate: [],
+              classes: '',
+              rows: undefined,
+              descendants: ['one', 'two', 'three'],
+              itemName: 'Bag',
+              'ignore-defaults': true,
+              multiple: true,
+              default: [{}],
+              minItems: 0,
+              maxItems: 5,
             })
           })
         })

--- a/common/services/frameworks.test.js
+++ b/common/services/frameworks.test.js
@@ -609,23 +609,6 @@ describe('Services', function () {
               minItems: 1,
             })
           })
-
-          it('should set minItems and maxItems correctly', function () {
-            const transformed = frameworksService.transformQuestion(
-              'question-key',
-              {
-                ...addAnotherMockQuestion,
-                minItems: 0,
-                maxItems: 5,
-              }
-            )
-
-            expect(transformed).to.deep.equal({
-              ...addAnotherMockResult,
-              minItems: 0,
-              maxItems: 5,
-            })
-          })
         })
       })
     })


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Adds minItems (defaults to 1) and maxItems to field schema for multiple items fields

- Show remove buttons when items exceeds minItems
- Show add another button unless maxItems exceeds items

### Why did it change

Prevent removal of last item when there should be at least one item

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

- [P4-2071](https://dsdmoj.atlassian.net/browse/P4-2071)

## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed


### Other considerations


- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics

