### PR TITLE
P4-1600 Show allocation is already filled 

### DIFF
--- a/app/allocation/views/view.njk
+++ b/app/allocation/views/view.njk
@@ -83,11 +83,17 @@
     </h2>
 
     <h3 class="govuk-heading-s">
-      {{ t("allocation::view.people.progress", {
-        count: remainingCount if canAccess('allocation:person:assign') else totalCount,
-        addedCount: addedCount,
-        context: "remaining" if canAccess('allocation:person:assign')
-      }) }}
+      {% if canAccess('allocation:person:assign') %}
+        {{ t("allocation::view.people.progress", {
+          count: remainingCount,
+          context: "remaining"
+        }) }}
+      {% else %}
+        {{ t("allocation::view.people.progress", {
+          count: totalCount,
+          addedCount: addedCount,
+        }) }}
+      {% endif %}
     </h3>
 
     {% if canAccess('allocation:person:assign') and remainingCount %}

--- a/app/allocation/views/view.njk
+++ b/app/allocation/views/view.njk
@@ -83,7 +83,9 @@
     </h2>
 
     <h3 class="govuk-heading-s">
-      {% if canAccess('allocation:person:assign') %}
+      {% if remainingCount === 0 %}
+        <span class="app-icon app-icon--tick app-green">{{ t("allocation::view.people.complete") }}</span>
+      {% elif canAccess('allocation:person:assign') %}
         {{ t("allocation::view.people.progress", {
           count: remainingCount,
           context: "remaining"
@@ -91,7 +93,7 @@
       {% else %}
         {{ t("allocation::view.people.progress", {
           count: totalCount,
-          addedCount: addedCount,
+          addedCount: addedCount
         }) }}
       {% endif %}
     </h3>

--- a/common/assets/scss/utilities/_typography.scss
+++ b/common/assets/scss/utilities/_typography.scss
@@ -4,3 +4,6 @@
 .app-font-weight-normal {
   font-weight: normal;
 }
+.app-green {
+  color: govuk-colour("green")
+}

--- a/locales/en/allocation.json
+++ b/locales/en/allocation.json
@@ -8,6 +8,7 @@
     },
     "people": {
       "heading": "People for allocation",
+      "complete": "This allocation is filled",
       "progress": "{{addedCount}} of $t(n_person) added",
       "progress_remaining": "$t(n_person) remaining to add",
       "no_results": "No prisoners added to allocation",


### PR DESCRIPTION
### What changed

A message is displayed when the allocation is full.

### Issue tracking

- P4-1600

## Screenshots

<img width="1115" alt="Screenshot 2020-09-08 at 17 25 40" src="https://user-images.githubusercontent.com/1130499/92458738-62cce500-f1f8-11ea-8c4d-a028f95a0157.png">

## Checklists

### Testing

#### Automated testing

- [ ] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Internet Explorer
