### PR TITLE
Add Accept-Encoding: gzip header to API requests

### DIFF
--- a/common/lib/api-client/request-headers.js
+++ b/common/lib/api-client/request-headers.js
@@ -7,6 +7,7 @@ const {
 module.exports = (format = 'application/vnd.api+json') => {
   return {
     Accept: `${format}; version=${VERSION}`,
+    'Accept-Encoding': 'gzip',
     'Idempotency-Key': uuid.v4(),
   }
 }

--- a/common/lib/api-client/request-headers.test.js
+++ b/common/lib/api-client/request-headers.test.js
@@ -29,6 +29,10 @@ describe('API Client', function () {
           )
         })
 
+        it('should return the `Accept-Encoding` header', function () {
+          expect(headers['Accept-Encoding']).to.equal('gzip')
+        })
+
         it('should return the `Idempotency-Key` header', function () {
           expect(headers['Idempotency-Key']).to.equal('#uuid')
         })
@@ -46,6 +50,10 @@ describe('API Client', function () {
         expect(headers.Accept).to.equal(
           `format/foo; version=${config.API.VERSION}`
         )
+      })
+
+      it('should return the `Accept-Encoding` header', function () {
+        expect(headers['Accept-Encoding']).to.equal('gzip')
       })
 
       it('should return the `Idempotency-Key` header', function () {


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Request compressed data from API

NB. axios uncompresses the returned data automagickally

### Why did it change

Backend now supports it

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

- [P4-2175 - Add support for compressed requests](https://dsdmoj.atlassian.net/browse/P4-2175)

## Screenshots
n/a

## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed


### Other considerations



- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics

