### PR TITLE
Fix issue with shifting dates periodically failing date tests

### DIFF
--- a/app/moves/middleware/set-results.single-requests.js
+++ b/app/moves/middleware/set-results.single-requests.js
@@ -13,6 +13,7 @@ async function setResultsSingleRequests(req, res, next) {
     let cancelledMoves
 
     const status = req?.body?.requested?.status
+
     switch (status) {
       case 'pending': {
         cancelledMoves = cancelledRequests.filter(it => !isString(it.date))

--- a/common/parsers/index.test.js
+++ b/common/parsers/index.test.js
@@ -15,9 +15,21 @@ const marchCurrentYear = getExpectedDate()
 const octoberCurrentYear = getExpectedDate(undefined, '3 October')
 const march2019 = getExpectedDate(2019)
 const october2019 = getExpectedDate(2019, '3 October')
+const currentYear = new Date(2020, 5, 1)
+let clock
 
 describe('Parsers', function () {
   describe('#date', function () {
+    beforeEach(function () {
+      clock = sinon.useFakeTimers({
+        now: currentYear,
+      })
+    })
+
+    afterEach(function () {
+      clock.restore()
+    })
+
     context('When passed non-string value', function () {
       it('should return undefined values as is', function () {
         expect(parse.date(undefined)).to.be.undefined

--- a/common/parsers/index.test.js
+++ b/common/parsers/index.test.js
@@ -15,19 +15,16 @@ const marchCurrentYear = getExpectedDate()
 const octoberCurrentYear = getExpectedDate(undefined, '3 October')
 const march2019 = getExpectedDate(2019)
 const october2019 = getExpectedDate(2019, '3 October')
-const currentYear = new Date(2020, 5, 1)
-let clock
 
 describe('Parsers', function () {
   describe('#date', function () {
     beforeEach(function () {
-      clock = sinon.useFakeTimers({
-        now: currentYear,
-      })
+      const mockDate = new Date('2020-06-01')
+      this.clock = sinon.useFakeTimers(mockDate.getTime())
     })
 
     afterEach(function () {
-      clock.restore()
+      this.clock.restore()
     })
 
     context('When passed non-string value', function () {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

- Fix issues with shifting dates periodically failing tests
- Fix unrelated linting issues

### What changed

<!--- Describe the changes in detail - the "what"-->

- Use sinon fake timers to set date to middle of year to avoid shifting dates periodically failing date tests

### Why did it change

<!--- Describe the reason these changes were made - the "why" -->

## Checklists

### Testing

#### Automated testing

- [ ] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed

### Other considerations

Commit messages with a `fix` or `feat` type are automatically used to generate the [changelog](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/CHANGELOG.md) and
[GitHub release notes](https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/releases) during the release task. Please make sure they will read well on their own in a
summary of changes and that the commit body gives a more detailed description of those changes if necessary.

- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
- [ ] Update [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md) with any new instructions or tasks
