### PR TITLE
[P4-2054] Ability to sort Single Requests table

### DIFF
--- a/app/moves/middleware/set-body.single-requests.js
+++ b/app/moves/middleware/set-body.single-requests.js
@@ -3,12 +3,14 @@ const { set } = require('lodash')
 const dateHelpers = require('../../../common/helpers/date')
 
 function setBodySingleRequests(req, res, next) {
-  const { status } = req.query
+  const { status, sortBy, sortDirection } = req.query
   const { dateRange } = req.params
   const locations = req.locations
 
   set(req, 'body.requested', {
     status,
+    sortBy,
+    sortDirection,
     createdAtDate: dateRange || dateHelpers.getCurrentWeekAsRange(),
     fromLocationId: locations,
   })

--- a/app/moves/middleware/set-body.single-requests.test.js
+++ b/app/moves/middleware/set-body.single-requests.test.js
@@ -17,6 +17,8 @@ describe('Moves middleware', function () {
         params: {},
         query: {
           status: 'pending',
+          sortBy: 'createdAtDate',
+          sortDirection: 'asc',
         },
       }
     })
@@ -31,6 +33,8 @@ describe('Moves middleware', function () {
           status: 'pending',
           createdAtDate: ['2010-10-10', '2010-10-07'],
           fromLocationId: mockReq.locations,
+          sortBy: 'createdAtDate',
+          sortDirection: 'asc',
         })
       })
 
@@ -50,6 +54,8 @@ describe('Moves middleware', function () {
           status: 'pending',
           createdAtDate: ['2020-10-10', '2020-10-10'],
           fromLocationId: mockReq.locations,
+          sortBy: 'createdAtDate',
+          sortDirection: 'asc',
         })
       })
 

--- a/app/moves/middleware/set-results.single-requests.js
+++ b/app/moves/middleware/set-results.single-requests.js
@@ -10,6 +10,7 @@ async function setResultsSingleRequests(req, res, next) {
       singleRequestService.getCancelled(req.body.requested),
     ])
 
+    const query = req.query
     let cancelledMoves
 
     const status = req?.body?.requested?.status
@@ -32,8 +33,12 @@ async function setResultsSingleRequests(req, res, next) {
     }
 
     req.resultsAsTable = {
-      active: presenters.singleRequestsToTableComponent(singleRequests),
-      cancelled: presenters.singleRequestsToTableComponent(cancelledMoves),
+      active: presenters.singleRequestsToTableComponent({ query })(
+        singleRequests
+      ),
+      cancelled: presenters.singleRequestsToTableComponent({
+        isSortable: false,
+      })(cancelledMoves),
     }
 
     next()

--- a/app/moves/middleware/set-results.single-requests.test.js
+++ b/app/moves/middleware/set-results.single-requests.test.js
@@ -25,11 +25,15 @@ describe('Moves middleware', function () {
     let res
     let req
     let next
+    let singleRequestsToTableStub
 
     beforeEach(function () {
+      singleRequestsToTableStub = sinon.stub().returnsArg(0)
       sinon.stub(singleRequestService, 'getAll')
       sinon.stub(singleRequestService, 'getCancelled')
-      sinon.stub(presenters, 'singleRequestsToTableComponent').returnsArg(0)
+      sinon
+        .stub(presenters, 'singleRequestsToTableComponent')
+        .returns(singleRequestsToTableStub)
       next = sinon.stub()
       res = {}
       req = {

--- a/common/presenters/allocations-to-table-component.test.js
+++ b/common/presenters/allocations-to-table-component.test.js
@@ -84,7 +84,7 @@ describe('#allocationsToTableComponent', function () {
     output = presenter()([])
   })
 
-  it('returns an object with allocationsHeads', function () {
+  it('returns an object with allocations heads', function () {
     expect(output.head).to.exist
     expect(output.head).to.be.an('array')
   })

--- a/common/presenters/single-requests-to-table-component.js
+++ b/common/presenters/single-requests-to-table-component.js
@@ -7,83 +7,95 @@ const componentService = require('../services/component')
 const moveToCardComponent = require('./move-to-card-component')
 const tablePresenters = require('./table')
 
-function singleRequestsToTable(moves) {
-  const tableConfig = [
-    {
-      head: {
-        text: i18n.t('name'),
-        attributes: {
-          width: '220',
+function singleRequestsToTable({ isSortable = true, query } = {}) {
+  return function (moves) {
+    const tableConfig = [
+      {
+        head: {
+          isSortable,
+          sortKey: 'name',
+          html: 'name',
+          attributes: {
+            width: '220',
+          },
+        },
+        row: {
+          html: data => {
+            const card = moveToCardComponent({
+              isCompact: true,
+              hrefSuffix: '/review',
+            })(data)
+            return componentService.getComponent('appCard', card)
+          },
+          attributes: {
+            scope: 'row',
+          },
         },
       },
-      row: {
-        html: data => {
-          const card = moveToCardComponent({
-            isCompact: true,
-            hrefSuffix: '/review',
-          })(data)
-          return componentService.getComponent('appCard', card)
+      {
+        head: {
+          isSortable,
+          sortKey: 'created_at',
+          html: 'collections::labels.created_at',
+          attributes: {
+            width: '120',
+          },
         },
-        attributes: {
-          scope: 'row',
-        },
-      },
-    },
-    {
-      head: {
-        text: i18n.t('collections::labels.created_at'),
-        attributes: {
-          width: '120',
+        row: {
+          text: data => filters.formatDate(data.created_at),
         },
       },
-      row: {
-        text: data => filters.formatDate(data.created_at),
-      },
-    },
-    {
-      head: {
-        text: i18n.t('collections::labels.from_location'),
-      },
-      row: {
-        text: 'from_location.title',
-      },
-    },
-    {
-      head: {
-        text: i18n.t('collections::labels.to_location'),
-      },
-      row: {
-        text: 'to_location.title',
-      },
-    },
-    {
-      head: {
-        text: i18n.t(
-          moves.some(it => !isNil(it.date))
-            ? 'collections::labels.move_date'
-            : 'collections::labels.earliest_move_date'
-        ),
-        attributes: {
-          width: '120',
+      {
+        head: {
+          isSortable,
+          sortKey: 'from_location',
+          html: 'collections::labels.from_location',
+        },
+        row: {
+          text: 'from_location.title',
         },
       },
-      row: {
-        text: data => filters.formatDate(data.date || data.date_from),
+      {
+        head: {
+          isSortable,
+          sortKey: 'to_location',
+          html: 'collections::labels.to_location',
+        },
+        row: {
+          text: 'to_location.title',
+        },
       },
-    },
-    {
-      head: {
-        text: i18n.t('collections::labels.move_type'),
+      {
+        head: {
+          text: i18n.t(
+            moves.some(it => !isNil(it.date))
+              ? 'collections::labels.move_date'
+              : 'collections::labels.earliest_move_date'
+          ),
+          attributes: {
+            width: '120',
+          },
+        },
+        row: {
+          text: data => filters.formatDate(data.date || data.date_from),
+        },
       },
-      row: {
-        text: 'prison_transfer_reason.title',
+      {
+        head: {
+          isSortable,
+          sortKey: 'prison_transfer_reason',
+          html: 'collections::labels.move_type',
+        },
+        row: {
+          text: 'prison_transfer_reason.title',
+        },
       },
-    },
-  ]
+    ]
 
-  return {
-    head: tableConfig.map(row => row.head),
-    rows: moves.map(tablePresenters.objectToTableRow(tableConfig)),
+    return {
+      head: tableConfig.map(tablePresenters.objectToTableHead(query)),
+      rows: moves.map(tablePresenters.objectToTableRow(tableConfig)),
+    }
   }
 }
 

--- a/common/presenters/single-requests-to-table-component.js
+++ b/common/presenters/single-requests-to-table-component.js
@@ -8,7 +8,7 @@ const moveToCardComponent = require('./move-to-card-component')
 const tablePresenters = require('./table')
 
 function singleRequestsToTable({ isSortable = true, query } = {}) {
-  return function (moves) {
+  return function (moves = []) {
     const tableConfig = [
       {
         head: {

--- a/common/presenters/single-requests-to-table-component.test.js
+++ b/common/presenters/single-requests-to-table-component.test.js
@@ -4,6 +4,8 @@ const i18n = require('../../config/i18n')
 const filters = require('../../config/nunjucks/filters')
 const componentService = require('../services/component')
 
+const tablePresenters = require('./table')
+
 const mockMoves = [
   {
     id: 'acba3ad5-a8d3-4b95-9e48-121dafb3babe',
@@ -147,27 +149,35 @@ const mockApprovedMoves = [
   },
 ]
 
-const moveToCardComponentStub = sinon.stub().returnsArg(0)
-const moveToCardComponentOptsStub = sinon
-  .stub()
-  .callsFake(() => moveToCardComponentStub)
-
-const presenter = proxyquire('./single-requests-to-table-component', {
-  './move-to-card-component': moveToCardComponentOptsStub,
-})
-
 describe('#singleRequestsToTableComponent()', function () {
   let output
+  let moveToCardComponentStub
+  let moveToCardComponentOptsStub
+  let presenter
+
+  before(function () {
+    moveToCardComponentStub = sinon.stub().returnsArg(0)
+    moveToCardComponentOptsStub = sinon
+      .stub()
+      .callsFake(() => moveToCardComponentStub)
+
+    presenter = proxyquire('./single-requests-to-table-component', {
+      './move-to-card-component': moveToCardComponentOptsStub,
+    })
+  })
 
   beforeEach(function () {
     sinon.stub(i18n, 't').returnsArg(0)
+    sinon.stub(componentService, 'getComponent').returnsArg(0)
     sinon.stub(filters, 'formatDate').returnsArg(0)
     sinon.stub(filters, 'formatDateRange').returnsArg(0)
-    sinon.stub(componentService, 'getComponent').returnsArg(0)
-    output = presenter([])
+    sinon
+      .stub(tablePresenters, 'objectToTableHead')
+      .returns(sinon.stub().callsFake(arg => arg.head))
+    output = presenter()([])
   })
 
-  it('returns an object with heads', function () {
+  it('returns an object with moves heads', function () {
     expect(output.head).to.exist
     expect(output.head).to.be.an('array')
   })
@@ -179,7 +189,7 @@ describe('#singleRequestsToTableComponent()', function () {
 
   describe('its behaviour', function () {
     beforeEach(function () {
-      output = presenter(mockMoves)
+      output = presenter(mockMoves)(mockMoves)
     })
 
     it('returns html with composite name on the first cell', function () {
@@ -240,22 +250,30 @@ describe('#singleRequestsToTableComponent()', function () {
     it('returns one head row with all the cells', function () {
       expect(output.head).to.deep.equal([
         {
-          text: 'name',
+          html: 'name',
+          isSortable: true,
+          sortKey: 'name',
           attributes: {
             width: '220',
           },
         },
         {
-          text: 'collections::labels.created_at',
+          html: 'collections::labels.created_at',
           attributes: {
             width: '120',
           },
+          isSortable: true,
+          sortKey: 'created_at',
         },
         {
-          text: 'collections::labels.from_location',
+          html: 'collections::labels.from_location',
+          isSortable: true,
+          sortKey: 'from_location',
         },
         {
-          text: 'collections::labels.to_location',
+          html: 'collections::labels.to_location',
+          isSortable: true,
+          sortKey: 'to_location',
         },
         {
           text: 'collections::labels.earliest_move_date',
@@ -264,7 +282,9 @@ describe('#singleRequestsToTableComponent()', function () {
           },
         },
         {
-          text: 'collections::labels.move_type',
+          html: 'collections::labels.move_type',
+          isSortable: true,
+          sortKey: 'prison_transfer_reason',
         },
       ])
     })
@@ -272,7 +292,7 @@ describe('#singleRequestsToTableComponent()', function () {
 
   describe('when the moves are approved', function () {
     beforeEach(function () {
-      output = presenter(mockApprovedMoves)
+      output = presenter(mockApprovedMoves)(mockApprovedMoves)
     })
 
     it('returns the date range on the fifth cell', function () {
@@ -284,22 +304,30 @@ describe('#singleRequestsToTableComponent()', function () {
     it('returns one head row with all the cells', function () {
       expect(output.head).to.deep.equal([
         {
-          text: 'name',
+          html: 'name',
+          isSortable: true,
+          sortKey: 'name',
           attributes: {
             width: '220',
           },
         },
         {
-          text: 'collections::labels.created_at',
+          html: 'collections::labels.created_at',
+          isSortable: true,
+          sortKey: 'created_at',
           attributes: {
             width: '120',
           },
         },
         {
-          text: 'collections::labels.from_location',
+          html: 'collections::labels.from_location',
+          isSortable: true,
+          sortKey: 'from_location',
         },
         {
-          text: 'collections::labels.to_location',
+          html: 'collections::labels.to_location',
+          isSortable: true,
+          sortKey: 'to_location',
         },
         {
           text: 'collections::labels.move_date',
@@ -308,7 +336,9 @@ describe('#singleRequestsToTableComponent()', function () {
           },
         },
         {
-          text: 'collections::labels.move_type',
+          html: 'collections::labels.move_type',
+          isSortable: true,
+          sortKey: 'prison_transfer_reason',
         },
       ])
     })

--- a/common/presenters/single-requests-to-table-component.test.js
+++ b/common/presenters/single-requests-to-table-component.test.js
@@ -187,160 +187,180 @@ describe('#singleRequestsToTableComponent()', function () {
     expect(output.rows).to.be.an('array')
   })
 
+  describe('table headers', function () {
+    context('with no table data', function () {
+      beforeEach(function () {
+        output = presenter()()
+      })
+
+      it('returns html with composite name on the first cell', function () {
+        // console.log(JSON.stringify(output, null, 2)
+        // expect(output.rows.length).to.equal(4)
+        expect(output.rows[0][0]).to.deep.equal({
+          html: 'appCard',
+          attributes: {
+            scope: 'row',
+          },
+        })
+      })
+
+      it('should call card component with correct arguments', function () {
+        expect(moveToCardComponentOptsStub).to.be.calledWithExactly({
+          isCompact: true,
+          hrefSuffix: '/review',
+        })
+        expect(moveToCardComponentStub).to.be.calledWithExactly(mockMoves[0])
+      })
+
+      it('returns html with createdAt on the second cell', function () {
+        expect(output.rows[0][1]).to.deep.equal({
+          text: mockMoves[0].created_at,
+        })
+      })
+
+      it('returns fromLocation on the third cell', function () {
+        expect(output.rows[0][2]).to.deep.equal({
+          text: mockMoves[0].from_location.title,
+        })
+      })
+
+      it('returns toLocation on the forth cell', function () {
+        expect(output.rows[0][3]).to.deep.equal({
+          text: mockMoves[0].to_location.title,
+        })
+      })
+
+      it('returns the date range on the fifth cell', function () {
+        expect(output.rows[0][4]).to.deep.equal({
+          text: mockMoves[0].date_from,
+        })
+      })
+
+      it('returns the move type on the sixth cell', function () {
+        expect(output.rows[0][5]).to.deep.equal({
+          text: mockMoves[0].prison_transfer_reason.title,
+        })
+      })
+
+      it('returns empty object with null prison transfer reason', function () {
+        expect(output.rows[1][5]).to.deep.equal({})
+      })
+
+      it('returns a row per record', function () {
+        expect(output.rows.length).to.equal(2)
+      })
+
+      it('returns one head row with all the cells', function () {
+        expect(output.head).to.deep.equal([
+          {
+            html: 'name',
+            isSortable: true,
+            sortKey: 'name',
+            attributes: {
+              width: '220',
+            },
+          },
+          {
+            html: 'collections::labels.created_at',
+            attributes: {
+              width: '120',
+            },
+            isSortable: true,
+            sortKey: 'created_at',
+          },
+          {
+            html: 'collections::labels.from_location',
+            isSortable: true,
+            sortKey: 'from_location',
+          },
+          {
+            html: 'collections::labels.to_location',
+            isSortable: true,
+            sortKey: 'to_location',
+          },
+          {
+            text: 'collections::labels.earliest_move_date',
+            attributes: {
+              width: '120',
+            },
+          },
+          {
+            html: 'collections::labels.move_type',
+            isSortable: true,
+            sortKey: 'prison_transfer_reason',
+          },
+        ])
+      })
+    })
+
+    context('with only move_date', function () {})
+
+    context('with only date_from', function () {})
+
+    context('with both move_date and date from', function () {
+      beforeEach(function () {
+        output = presenter(mockMoves)(mockMoves)
+      })
+    })
+  })
+
   describe('its behaviour', function () {
     beforeEach(function () {
       output = presenter(mockMoves)(mockMoves)
     })
 
-    it('returns html with composite name on the first cell', function () {
-      expect(output.rows[0][0]).to.deep.equal({
-        html: 'appCard',
-        attributes: {
-          scope: 'row',
-        },
+    describe('when the moves are approved', function () {
+      beforeEach(function () {
+        output = presenter(mockApprovedMoves)(mockApprovedMoves)
       })
-    })
 
-    it('should call card component with correct arguments', function () {
-      expect(moveToCardComponentOptsStub).to.be.calledWithExactly({
-        isCompact: true,
-        hrefSuffix: '/review',
+      it('returns the date range on the fifth cell', function () {
+        expect(output.rows[0][4]).to.deep.equal({
+          text: mockApprovedMoves[0].date,
+        })
       })
-      expect(moveToCardComponentStub).to.be.calledWithExactly(mockMoves[0])
-    })
 
-    it('returns html with createdAt on the second cell', function () {
-      expect(output.rows[0][1]).to.deep.equal({
-        text: mockMoves[0].created_at,
-      })
-    })
-
-    it('returns fromLocation on the third cell', function () {
-      expect(output.rows[0][2]).to.deep.equal({
-        text: mockMoves[0].from_location.title,
-      })
-    })
-
-    it('returns toLocation on the forth cell', function () {
-      expect(output.rows[0][3]).to.deep.equal({
-        text: mockMoves[0].to_location.title,
-      })
-    })
-
-    it('returns the date range on the fifth cell', function () {
-      expect(output.rows[0][4]).to.deep.equal({
-        text: mockMoves[0].date_from,
-      })
-    })
-
-    it('returns the move type on the sixth cell', function () {
-      expect(output.rows[0][5]).to.deep.equal({
-        text: mockMoves[0].prison_transfer_reason.title,
-      })
-    })
-
-    it('returns empty object with null prison transfer reason', function () {
-      expect(output.rows[1][5]).to.deep.equal({})
-    })
-
-    it('returns a row per record', function () {
-      expect(output.rows.length).to.equal(2)
-    })
-
-    it('returns one head row with all the cells', function () {
-      expect(output.head).to.deep.equal([
-        {
-          html: 'name',
-          isSortable: true,
-          sortKey: 'name',
-          attributes: {
-            width: '220',
+      it('returns one head row with all the cells', function () {
+        expect(output.head).to.deep.equal([
+          {
+            html: 'name',
+            isSortable: true,
+            sortKey: 'name',
+            attributes: {
+              width: '220',
+            },
           },
-        },
-        {
-          html: 'collections::labels.created_at',
-          attributes: {
-            width: '120',
+          {
+            html: 'collections::labels.created_at',
+            isSortable: true,
+            sortKey: 'created_at',
+            attributes: {
+              width: '120',
+            },
           },
-          isSortable: true,
-          sortKey: 'created_at',
-        },
-        {
-          html: 'collections::labels.from_location',
-          isSortable: true,
-          sortKey: 'from_location',
-        },
-        {
-          html: 'collections::labels.to_location',
-          isSortable: true,
-          sortKey: 'to_location',
-        },
-        {
-          text: 'collections::labels.earliest_move_date',
-          attributes: {
-            width: '120',
+          {
+            html: 'collections::labels.from_location',
+            isSortable: true,
+            sortKey: 'from_location',
           },
-        },
-        {
-          html: 'collections::labels.move_type',
-          isSortable: true,
-          sortKey: 'prison_transfer_reason',
-        },
-      ])
-    })
-  })
-
-  describe('when the moves are approved', function () {
-    beforeEach(function () {
-      output = presenter(mockApprovedMoves)(mockApprovedMoves)
-    })
-
-    it('returns the date range on the fifth cell', function () {
-      expect(output.rows[0][4]).to.deep.equal({
-        text: mockApprovedMoves[0].date,
+          {
+            html: 'collections::labels.to_location',
+            isSortable: true,
+            sortKey: 'to_location',
+          },
+          {
+            text: 'collections::labels.move_date',
+            attributes: {
+              width: '120',
+            },
+          },
+          {
+            html: 'collections::labels.move_type',
+            isSortable: true,
+            sortKey: 'prison_transfer_reason',
+          },
+        ])
       })
-    })
-
-    it('returns one head row with all the cells', function () {
-      expect(output.head).to.deep.equal([
-        {
-          html: 'name',
-          isSortable: true,
-          sortKey: 'name',
-          attributes: {
-            width: '220',
-          },
-        },
-        {
-          html: 'collections::labels.created_at',
-          isSortable: true,
-          sortKey: 'created_at',
-          attributes: {
-            width: '120',
-          },
-        },
-        {
-          html: 'collections::labels.from_location',
-          isSortable: true,
-          sortKey: 'from_location',
-        },
-        {
-          html: 'collections::labels.to_location',
-          isSortable: true,
-          sortKey: 'to_location',
-        },
-        {
-          text: 'collections::labels.move_date',
-          attributes: {
-            width: '120',
-          },
-        },
-        {
-          html: 'collections::labels.move_type',
-          isSortable: true,
-          sortKey: 'prison_transfer_reason',
-        },
-      ])
     })
   })
 })

--- a/common/presenters/single-requests-to-table-component.test.js
+++ b/common/presenters/single-requests-to-table-component.test.js
@@ -1,3 +1,4 @@
+const _ = require('lodash')
 const proxyquire = require('proxyquire')
 
 const i18n = require('../../config/i18n')
@@ -193,9 +194,97 @@ describe('#singleRequestsToTableComponent()', function () {
         output = presenter()()
       })
 
+      it('should only have table headers', function () {
+        expect(output.rows.length).to.equal(0)
+      })
+
+      it('should have 6 columns', function () {
+        expect(output.head.length).to.equal(6)
+      })
+
+      it('should have a name column', function () {
+        expect(output.head[0]).to.deep.equal({
+          html: 'name',
+          isSortable: true,
+          sortKey: 'name',
+          attributes: { width: '220' },
+        })
+      })
+
+      it('should have a created at column', function () {
+        expect(output.head[1]).to.deep.equal({
+          html: 'collections::labels.created_at',
+          isSortable: true,
+          sortKey: 'created_at',
+          attributes: { width: '120' },
+        })
+      })
+
+      it('should have a from location column', function () {
+        expect(output.head[2]).to.deep.equal({
+          html: 'collections::labels.from_location',
+          isSortable: true,
+          sortKey: 'from_location',
+        })
+      })
+
+      it('should have a to location column', function () {
+        expect(output.head[3]).to.deep.equal({
+          html: 'collections::labels.to_location',
+          isSortable: true,
+          sortKey: 'to_location',
+        })
+      })
+
+      it('should have a move date column', function () {
+        expect(output.head[4]).to.deep.equal({
+          text: 'collections::labels.earliest_move_date',
+          attributes: { width: '120' },
+        })
+      })
+
+      it('should have a move type column', function () {
+        expect(output.head[5]).to.deep.equal({
+          html: 'collections::labels.move_type',
+          isSortable: true,
+          sortKey: 'prison_transfer_reason',
+        })
+      })
+    })
+
+    context('with only moves.date_from', function () {
+      it('should have a earliest_move_date column', function () {
+        output = presenter(mockMoves)(mockMoves)
+
+        expect(output.head[4]).to.deep.equal({
+          text: 'collections::labels.earliest_move_date',
+          attributes: { width: '120' },
+        })
+      })
+    })
+
+    context('with both moves.date and moves.earliest_move_date', function () {
+      it('should have a move_date column', function () {
+        const mockMovesDates = _.cloneDeep(mockMoves)
+        mockMovesDates[0].date = '2020-09-26'
+
+        output = presenter(mockMovesDates)(mockMovesDates)
+
+        expect(output.head[4]).to.deep.equal({
+          text: 'collections::labels.move_date',
+          attributes: { width: '120' },
+        })
+      })
+    })
+  })
+
+  describe('its behaviour', function () {
+    beforeEach(function () {
+      output = presenter(mockMoves)(mockMoves)
+    })
+
+    context('with no options', function () {
       it('returns html with composite name on the first cell', function () {
-        // console.log(JSON.stringify(output, null, 2)
-        // expect(output.rows.length).to.equal(4)
         expect(output.rows[0][0]).to.deep.equal({
           html: 'appCard',
           attributes: {
@@ -250,113 +339,104 @@ describe('#singleRequestsToTableComponent()', function () {
         expect(output.rows.length).to.equal(2)
       })
 
-      it('returns one head row with all the cells', function () {
-        expect(output.head).to.deep.equal([
-          {
-            html: 'name',
-            isSortable: true,
-            sortKey: 'name',
-            attributes: {
-              width: '220',
+      describe('when the moves are approved', function () {
+        beforeEach(function () {
+          output = presenter(mockApprovedMoves)(mockApprovedMoves)
+        })
+
+        it('returns the date range on the fifth cell', function () {
+          expect(output.rows[0][4]).to.deep.equal({
+            text: mockApprovedMoves[0].date,
+          })
+        })
+
+        it('returns one head row with all the cells', function () {
+          expect(output.head).to.deep.equal([
+            {
+              html: 'name',
+              isSortable: true,
+              sortKey: 'name',
+              attributes: {
+                width: '220',
+              },
             },
-          },
-          {
-            html: 'collections::labels.created_at',
-            attributes: {
-              width: '120',
+            {
+              html: 'collections::labels.created_at',
+              isSortable: true,
+              sortKey: 'created_at',
+              attributes: {
+                width: '120',
+              },
             },
-            isSortable: true,
-            sortKey: 'created_at',
-          },
-          {
-            html: 'collections::labels.from_location',
-            isSortable: true,
-            sortKey: 'from_location',
-          },
-          {
-            html: 'collections::labels.to_location',
-            isSortable: true,
-            sortKey: 'to_location',
-          },
-          {
-            text: 'collections::labels.earliest_move_date',
-            attributes: {
-              width: '120',
+            {
+              html: 'collections::labels.from_location',
+              isSortable: true,
+              sortKey: 'from_location',
             },
-          },
-          {
-            html: 'collections::labels.move_type',
-            isSortable: true,
-            sortKey: 'prison_transfer_reason',
-          },
-        ])
-      })
-    })
-
-    context('with only move_date', function () {})
-
-    context('with only date_from', function () {})
-
-    context('with both move_date and date from', function () {
-      beforeEach(function () {
-        output = presenter(mockMoves)(mockMoves)
-      })
-    })
-  })
-
-  describe('its behaviour', function () {
-    beforeEach(function () {
-      output = presenter(mockMoves)(mockMoves)
-    })
-
-    describe('when the moves are approved', function () {
-      beforeEach(function () {
-        output = presenter(mockApprovedMoves)(mockApprovedMoves)
-      })
-
-      it('returns the date range on the fifth cell', function () {
-        expect(output.rows[0][4]).to.deep.equal({
-          text: mockApprovedMoves[0].date,
+            {
+              html: 'collections::labels.to_location',
+              isSortable: true,
+              sortKey: 'to_location',
+            },
+            {
+              text: 'collections::labels.move_date',
+              attributes: {
+                width: '120',
+              },
+            },
+            {
+              html: 'collections::labels.move_type',
+              isSortable: true,
+              sortKey: 'prison_transfer_reason',
+            },
+          ])
         })
       })
+    })
 
-      it('returns one head row with all the cells', function () {
+    context('with isSortable set to false', function () {
+      beforeEach(function () {
+        output = presenter({
+          isSortable: false,
+        })(mockMoves)
+      })
+      it('should return moves without sorting flag', function () {
         expect(output.head).to.deep.equal([
           {
-            html: 'name',
-            isSortable: true,
-            sortKey: 'name',
             attributes: {
               width: '220',
             },
+            html: 'name',
+            isSortable: false,
+            sortKey: 'name',
           },
           {
-            html: 'collections::labels.created_at',
-            isSortable: true,
-            sortKey: 'created_at',
             attributes: {
               width: '120',
             },
+            html: 'collections::labels.created_at',
+            isSortable: false,
+            sortKey: 'created_at',
           },
           {
             html: 'collections::labels.from_location',
-            isSortable: true,
+            isSortable: false,
             sortKey: 'from_location',
           },
           {
             html: 'collections::labels.to_location',
-            isSortable: true,
+            isSortable: false,
             sortKey: 'to_location',
           },
           {
-            text: 'collections::labels.move_date',
             attributes: {
               width: '120',
             },
+            text: 'collections::labels.earliest_move_date',
           },
           {
             html: 'collections::labels.move_type',
-            isSortable: true,
+            isSortable: false,
             sortKey: 'prison_transfer_reason',
           },
         ])

--- a/common/presenters/single-requests-to-table-component.test.js
+++ b/common/presenters/single-requests-to-table-component.test.js
@@ -394,6 +394,25 @@ describe('#singleRequestsToTableComponent()', function () {
       })
     })
 
+    context('with query', function () {
+      beforeEach(function () {
+        output = presenter({
+          query: {
+            sortBy: 'date',
+            status: 'approved',
+          },
+        })(mockMoves)
+      })
+      it('passes the query to objectToTableHead', function () {
+        expect(
+          tablePresenters.objectToTableHead
+        ).to.have.been.calledWithExactly({
+          sortBy: 'date',
+          status: 'approved',
+        })
+      })
+    })
+
     context('with isSortable set to false', function () {
       beforeEach(function () {
         output = presenter({


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

<!--- Describe the changes in detail - the "what"-->

### Why did it change

Ability to sort Single Requests table (follows the same convention as allocations):

- Name - Alphabetical (same as allocations)
- Sent on - Date (same as allocations)
- Move from - Alphabetical (same as allocations)
- Move to - Alphabetical (same as allocations)
- Move type - Alphabetical (same as allocations)

Note: 
- Earliest date of travel (or date of travel) - this is currently a composite of two columns, so is not being sorted as a part of this ticket

### Issue tracking
-  [P4-2054](https://dsdmoj.atlassian.net/browse/P4-2054)

## Screenshots

| Before | After |
| ------ | ----- |
| <kbd><img src=""></kbd> | <kbd><img src=""></kbd> |

## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Internet Explorer
