### PR TITLE
Enable dependencies check to work in absence of redis

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -162,6 +162,9 @@ jobs:
       - *restore_cache
       - *install_dependencies
       - *save_cache
+      - run:
+          name: Build assets and frameworks
+          command: npm run build
       - when:
           condition: <<parameters.use_same_instance>>
           steps:

--- a/.circleci/e2e-pre-flight.sh
+++ b/.circleci/e2e-pre-flight.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 
-npm run build
 node start.js 1>/dev/null &
 
 if [ -n "$E2E_MOCK_AUTH" ]; then

--- a/app/healthcheck/dependencies.js
+++ b/app/healthcheck/dependencies.js
@@ -5,8 +5,14 @@ const {
   DEFAULT_AUTH_PROVIDER,
   API,
   NOMIS_ELITE2_API,
+  REDIS,
 } = require('../../config')
-const redisStore = require('../../config/redis-store')
+
+let redisStore
+
+if (REDIS.SESSION) {
+  redisStore = require('../../config/redis-store')
+}
 
 const timeout = 5000
 
@@ -43,15 +49,19 @@ module.exports = [
   {
     name: 'redis',
     healthcheck: () => {
-      return new Promise((resolve, reject) => {
-        const result = redisStore().client.ping()
+      if (redisStore) {
+        return new Promise((resolve, reject) => {
+          const result = redisStore().client.ping()
 
-        if (!result) {
-          reject(new Error('No connection'))
-        }
+          if (!result) {
+            reject(new Error('No connection'))
+          }
 
-        resolve('OK')
-      })
+          resolve('OK')
+        })
+      } else {
+        return Promise.resolve('NOT RUNNING')
+      }
     },
   },
 ]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Skip redis check if not running and return 'NOT RUNNING' instead

### Why did it change

Healthcheck endpoint would fail if redis not running otherwise

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

n/a

## Screenshots
<!--- (Optional) Include screenshots if changes update interfaces or components -->
<!--- Delete/copy as appropriate --->

n/a

## Checklists

### Testing

#### Automated testing

- [ ] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed


### Other considerations



- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics

