### PR TITLE
Update Person Escort Record framework version

### DIFF
--- a/app/person-escort-record/router.js
+++ b/app/person-escort-record/router.js
@@ -30,6 +30,7 @@ function defineFormWizard(req, res, next) {
     name: `person-escort-record-${key}`,
     template: 'framework-step',
     templatePath: 'person-escort-record/views/',
+    defaultFormatters: ['trim', 'singlespaces', 'apostrophes', 'quotes'],
   }
 
   return wizard(wizardSteps, wizardFields, wizardConfig)(req, res, next)

--- a/app/person-escort-record/router.test.js
+++ b/app/person-escort-record/router.test.js
@@ -100,6 +100,7 @@ describe('Person Escort Record router', function () {
           name: `person-escort-record-${req.frameworkSection.key}`,
           template: 'framework-step',
           templatePath: 'person-escort-record/views/',
+          defaultFormatters: ['trim', 'singlespaces', 'apostrophes', 'quotes'],
         }
 
         expect(wizardStub).to.be.calledWithExactly(

--- a/common/controllers/form-wizard.js
+++ b/common/controllers/form-wizard.js
@@ -115,7 +115,10 @@ class FormController extends Controller {
     const fields = req.form.options.fields
     const errorList = map(errors, error => {
       return {
-        html: fieldHelpers.getFieldErrorMessage(error),
+        html: fieldHelpers.getFieldErrorMessage({
+          ...fields[error.key],
+          ...error,
+        }),
         href: `#${fields[error.key].id}`,
       }
     })

--- a/common/controllers/form-wizard.test.js
+++ b/common/controllers/form-wizard.test.js
@@ -225,12 +225,14 @@ describe('Form wizard', function () {
       })
 
       it('should get error messages', function () {
-        expect(fieldHelpers.getFieldErrorMessage).to.be.calledWithExactly(
-          mockErrors.fieldOne
-        )
-        expect(fieldHelpers.getFieldErrorMessage).to.be.calledWithExactly(
-          mockErrors.fieldTwo
-        )
+        expect(fieldHelpers.getFieldErrorMessage).to.be.calledWithExactly({
+          ...reqMock.form.options.fields.fieldOne,
+          ...mockErrors.fieldOne,
+        })
+        expect(fieldHelpers.getFieldErrorMessage).to.be.calledWithExactly({
+          ...reqMock.form.options.fields.fieldTwo,
+          ...mockErrors.fieldTwo,
+        })
       })
 
       it('should get error messages correct number of times', function () {

--- a/common/helpers/field/get-field-error-message.js
+++ b/common/helpers/field/get-field-error-message.js
@@ -2,6 +2,8 @@ const i18n = require('../../../config/i18n')
 
 function getFieldErrorMessage({
   message,
+  description = '',
+  question = '',
   key: fieldKey,
   type: errorType,
 } = {}) {
@@ -13,12 +15,13 @@ function getFieldErrorMessage({
     return message
   }
 
-  const errorLabel = i18n.t(`fields::${fieldKey}.label`, {
+  const labelFallback = description || question
+  const errorLabel = i18n.t([`fields::${fieldKey}.label`, labelFallback], {
     context: 'with_error',
   })
   const fallback = i18n.t(`validation::${errorType}`, {
     context: 'with_label',
-    label: errorLabel.toLowerCase(),
+    label: errorLabel,
   })
   return i18n.t([`fields::${fieldKey}.error_message`, fallback], {
     context: errorType,

--- a/common/helpers/field/get-field-error-message.test.js
+++ b/common/helpers/field/get-field-error-message.test.js
@@ -47,7 +47,7 @@ describe('Field helpers', function () {
 
       it('should translate label with error context', function () {
         expect(i18n.t).to.be.calledWithExactly(
-          `fields::${mockFieldError.key}.label`,
+          [`fields::${mockFieldError.key}.label`, ''],
           {
             context: 'with_error',
           }
@@ -59,7 +59,7 @@ describe('Field helpers', function () {
           `validation::${mockFieldError.type}`,
           {
             context: 'with_label',
-            label: `fields::${mockFieldError.key}.label`,
+            label: [`fields::${mockFieldError.key}.label`, ''],
           }
         )
       })
@@ -78,6 +78,97 @@ describe('Field helpers', function () {
 
       it('should return error message', function () {
         expect(errorMessage).to.deep.equal('This field is not valid')
+      })
+    })
+
+    context('with missing error message', function () {
+      context('with description', function () {
+        beforeEach(function () {
+          errorMessage = getFieldErrorMessage({
+            ...mockFieldError,
+            description: 'Field name',
+            question: 'What is life?',
+          })
+        })
+
+        it('should translate label with error context', function () {
+          expect(i18n.t).to.be.calledWithExactly(
+            [`fields::${mockFieldError.key}.label`, 'Field name'],
+            {
+              context: 'with_error',
+            }
+          )
+        })
+
+        it('should translate fallback label with label context', function () {
+          expect(i18n.t).to.be.calledWithExactly(
+            `validation::${mockFieldError.type}`,
+            {
+              context: 'with_label',
+              label: [`fields::${mockFieldError.key}.label`, 'Field name'],
+            }
+          )
+        })
+
+        it('should translate with order preference', function () {
+          expect(i18n.t).to.be.calledWithExactly(
+            [
+              `fields::${mockFieldError.key}.error_message`,
+              `validation::${mockFieldError.type}`,
+            ],
+            {
+              context: mockFieldError.type,
+            }
+          )
+        })
+
+        it('should return error message', function () {
+          expect(errorMessage).to.deep.equal('This field is not valid')
+        })
+      })
+
+      context('without description', function () {
+        beforeEach(function () {
+          errorMessage = getFieldErrorMessage({
+            ...mockFieldError,
+            question: 'What is life?',
+          })
+        })
+
+        it('should translate label with error context', function () {
+          expect(i18n.t).to.be.calledWithExactly(
+            [`fields::${mockFieldError.key}.label`, 'What is life?'],
+            {
+              context: 'with_error',
+            }
+          )
+        })
+
+        it('should translate fallback label with label context', function () {
+          expect(i18n.t).to.be.calledWithExactly(
+            `validation::${mockFieldError.type}`,
+            {
+              context: 'with_label',
+              label: [`fields::${mockFieldError.key}.label`, 'What is life?'],
+            }
+          )
+        })
+
+        it('should translate with order preference', function () {
+          expect(i18n.t).to.be.calledWithExactly(
+            [
+              `fields::${mockFieldError.key}.error_message`,
+              `validation::${mockFieldError.type}`,
+            ],
+            {
+              context: mockFieldError.type,
+            }
+          )
+        })
+
+        it('should return error message', function () {
+          expect(errorMessage).to.deep.equal('This field is not valid')
+        })
       })
     })
   })

--- a/common/helpers/field/set-field-error.js
+++ b/common/helpers/field/set-field-error.js
@@ -13,7 +13,10 @@ function setFieldError(errors) {
       {
         ...field,
         errorMessage: {
-          html: getFieldErrorMessage(fieldError),
+          html: getFieldErrorMessage({
+            ...field,
+            ...fieldError,
+          }),
         },
       },
     ]

--- a/common/helpers/field/set-field-error.test.js
+++ b/common/helpers/field/set-field-error.test.js
@@ -39,9 +39,10 @@ describe('Field helpers', function () {
       })
 
       it('should call getFieldErrorMessage with error object', function () {
-        expect(getFieldErrorMessageStub).to.be.calledOnceWithExactly(
-          errors.error_field
-        )
+        expect(getFieldErrorMessageStub).to.be.calledOnceWithExactly({
+          ...field[1],
+          ...errors.error_field,
+        })
       })
 
       it('should return field with error message', function () {

--- a/locales/en/validation.json
+++ b/locales/en/validation.json
@@ -7,6 +7,8 @@
   "required_with_label": "Enter {{label}}",
   "numeric": "can only contain numbers",
   "numeric_with_label": "{{label}} can only contain numbers",
+  "equal": "must be a valid option",
+  "equal_with_label": "{{label}} must be a valid option",
   "date": "must be a valid date",
   "date_with_label": "{{label}} must be a valid date",
   "time": "must be a valid time, for example 12:00 or 12pm",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1698,6 +1698,10 @@
       "version": "git+https://github.com/ministryofjustice/hmpps-book-secure-move-frameworks.git#177e796af623f67738d0f6218df076036796da27",
       "from": "git+https://github.com/ministryofjustice/hmpps-book-secure-move-frameworks.git#v1.1.0"
     },
+    "@hmpps-book-secure-move-frameworks/1.2.0": {
+      "version": "git+https://github.com/ministryofjustice/hmpps-book-secure-move-frameworks.git#6173676a6f5d6915a72bb96692752cc62282449a",
+      "from": "git+https://github.com/ministryofjustice/hmpps-book-secure-move-frameworks.git#v1.2.0"
+    },
     "@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
   "dependencies": {
     "@hmpps-book-secure-move-frameworks/1.0.0": "git+https://github.com/ministryofjustice/hmpps-book-secure-move-frameworks.git#v1.0.0",
     "@hmpps-book-secure-move-frameworks/1.1.0": "git+https://github.com/ministryofjustice/hmpps-book-secure-move-frameworks.git#v1.1.0",
+    "@hmpps-book-secure-move-frameworks/1.2.0": "git+https://github.com/ministryofjustice/hmpps-book-secure-move-frameworks.git#v1.2.0",
     "@ministryofjustice/frontend": "0.0.19-alpha",
     "@sentry/node": "5.22.3",
     "accessible-autocomplete": "2.0.3",


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

This adds support for the latest PER framework version, [v1.2.0](https://github.com/ministryofjustice/hmpps-book-secure-move-frameworks/releases/tag/v1.2.0).

This also includes a fix to support the use of emdashes in the framework which were previously being formatted out and then throwing a validation error as that value was no longer found in the list of available options.

### Why did it change

In order to support the use of the new version, we need to add it to the list of available packages.

The problem cropped up when one of the framework questions contained an emdash (`—`) in the value and the form wizard
[default formatters](https://github.com/UKHomeOffice/passports-form-wizard/blob/c8131187ddaafd220af89e75b8c2a400f4bdd78e/lib/controller/index.js#L31-L37) would [replace emdashes](https://github.com/UKHomeOffice/passports-form-wizard/blob/c8131187ddaafd220af89e75b8c2a400f4bdd78e/lib/formatting/formatters.js#L35-L37) with a hypen. This led to the formatted value not being seen as part of the allowed options and the field failing the [`equal`](https://github.com/UKHomeOffice/passports-form-wizard/blob/c8131187ddaafd220af89e75b8c2a400f4bdd78e/lib/validation/validators.js#L70-L78) validator which is applied by default to fields that contain options.

This also uncovered that there was no support for the `equal` validation code in the translation keys or that if a framework
field failed validation it would use `{key}.label` as the error message text. This meant extending the method to get the error
message to cater for fields that have come from the framework and that contain either `description` or `question`.

## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed

### Other considerations

Commit messages with a `fix` or `feat` type are automatically used to generate the [changelog](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/CHANGELOG.md) and
[GitHub release notes](https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/releases) during the release task. Please make sure they will read well on their own in a
summary of changes and that the commit body gives a more detailed description of those changes if necessary.

- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
- [x] Update [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md) with any new instructions or tasks
