### PR TITLE
fix(per): Ensure nested fields are populated with initial values

### DIFF
--- a/app/person-escort-record/controllers/framework-step.js
+++ b/app/person-escort-record/controllers/framework-step.js
@@ -31,6 +31,10 @@ class FrameworkStepController extends FormWizardController {
   }
 
   middlewareSetup() {
+    // This also needs to be called before setInitialValues otherwise
+    // the nested conditional fields don't exist and won't get populated
+    // TODO: Find a more efficient way to solve this ordering issue
+    this.use(this.setupConditionalFields)
     super.middlewareSetup()
     this.use(this.setButtonText)
   }

--- a/app/person-escort-record/controllers/framework-step.test.js
+++ b/app/person-escort-record/controllers/framework-step.test.js
@@ -51,6 +51,7 @@ describe('Person Escort Record controllers', function () {
     describe('#middlewareSetup', function () {
       beforeEach(function () {
         sinon.stub(FormWizardController.prototype, 'middlewareSetup')
+        sinon.stub(controller, 'setupConditionalFields')
         sinon.stub(controller, 'use')
         sinon.stub(controller, 'setButtonText')
 
@@ -62,14 +63,20 @@ describe('Person Escort Record controllers', function () {
           .calledOnce
       })
 
-      it('should call set button text method', function () {
+      it('should call set models method', function () {
         expect(controller.use.getCall(0)).to.have.been.calledWithExactly(
+          controller.setupConditionalFields
+        )
+      })
+
+      it('should call set button text method', function () {
+        expect(controller.use.getCall(1)).to.have.been.calledWithExactly(
           controller.setButtonText
         )
       })
 
       it('should call correct number of middleware', function () {
-        expect(controller.use).to.be.callCount(1)
+        expect(controller.use).to.be.callCount(2)
       })
     })
 
@@ -88,7 +95,7 @@ describe('Person Escort Record controllers', function () {
       })
 
       it('should call set models method', function () {
-        expect(controller.use.getCall(0)).to.have.been.calledWithExactly(
+        expect(controller.use).to.have.been.calledWithExactly(
           controller.setPageTitleLocals
         )
       })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Call middleware in correct order to support nested conditional fields, add another fields
and previously saved data for the framework step.

### Why did it change

The works to support add another fields, that can also be include
nested fields, meant re-working the order of some middleware.

This ended up causing a side-effect where nested fields weren't being
repopulated when editing a step.

This was because of the ordering of the middleware. The synthetic nested
fields didn't yet exist in the fields for this step so weren't ever
populated with a value.

## Screenshots
<!--- (Optional) Include screenshots if changes update interfaces or components -->
<!--- Delete/copy as appropriate --->

| Before | After |
| ------ | ----- |
| <kbd><img src="https://user-images.githubusercontent.com/3327997/93453875-22452980-f8d2-11ea-9247-33910b534ca8.png"></kbd> | <kbd><img src="https://user-images.githubusercontent.com/3327997/93453676-e14d1500-f8d1-11ea-81e3-ce32046d0483.png"></kbd> |

## Checklists

### Testing

#### Automated testing

- [ ] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [x] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed

### Other considerations

Commit messages with a `fix` or `feat` type are automatically used to generate the [changelog](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/CHANGELOG.md) and
[GitHub release notes](https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/releases) during the release task. Please make sure they will read well on their own in a
summary of changes and that the commit body gives a more detailed description of those changes if necessary.

- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
- [x] Update [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md) with any new instructions or tasks
