### PR TITLE
Restructure framework URLs to be more logical

### DIFF
--- a/app/move/controllers/view.js
+++ b/app/move/controllers/view.js
@@ -52,6 +52,7 @@ module.exports = function view(req, res) {
     move.profile?.id !== undefined
   const personEscortRecordtaskList = presenters.frameworkToTaskListComponent({
     baseUrl: `${personEscortRecordUrl}/`,
+    deepLinkToFirstStep: true,
     frameworkSections: framework.sections,
     sectionProgress: personEscortRecord?.meta?.section_progress,
   })

--- a/app/move/controllers/view.test.js
+++ b/app/move/controllers/view.test.js
@@ -166,6 +166,7 @@ describe('Move controllers', function () {
           presenters.frameworkToTaskListComponent
         ).to.be.calledOnceWithExactly({
           baseUrl: `${mockOriginalUrl}/person-escort-record/`,
+          deepLinkToFirstStep: true,
           frameworkSections: undefined,
           sectionProgress: undefined,
         })
@@ -595,6 +596,7 @@ describe('Move controllers', function () {
             presenters.frameworkToTaskListComponent
           ).to.be.calledOnceWithExactly({
             baseUrl: `${mockOriginalUrl}/person-escort-record/`,
+            deepLinkToFirstStep: true,
             frameworkSections: frameworkStub.sections,
             sectionProgress: mockPersonEscortRecord.meta.section_progress,
           })
@@ -674,6 +676,7 @@ describe('Move controllers', function () {
             presenters.frameworkToTaskListComponent
           ).to.be.calledOnceWithExactly({
             baseUrl: `${mockOriginalUrl}/person-escort-record/`,
+            deepLinkToFirstStep: true,
             frameworkSections: frameworkStub.sections,
             sectionProgress: mockPersonEscortRecord.meta.section_progress,
           })

--- a/app/person-escort-record/controllers/framework-step.js
+++ b/app/person-escort-record/controllers/framework-step.js
@@ -101,16 +101,14 @@ class FrameworkStepController extends FormWizardController {
   }
 
   successHandler(req, res, next) {
-    const { steps: wizardSteps = {}, route } = req?.form?.options || {}
+    const { route } = req?.form?.options || {}
     const goToOverview = req.body.save_and_return_to_overview
-    const steps = Object.keys(wizardSteps)
-    const overviewStepPath = steps[steps.length - 1]
     const nextStep = this.getNextStep(req, res)
     const currentStep = route
     const isLastStep = nextStep.endsWith(currentStep)
 
     if (isLastStep || goToOverview) {
-      return res.redirect(req.baseUrl + overviewStepPath)
+      return res.redirect(req.baseUrl)
     }
 
     super.successHandler(req, res, next)

--- a/app/person-escort-record/controllers/framework-step.test.js
+++ b/app/person-escort-record/controllers/framework-step.test.js
@@ -245,16 +245,7 @@ describe('Person Escort Record controllers', function () {
           body: {},
           baseUrl: '/base-url',
           form: {
-            options: {
-              steps: {
-                '/': {},
-                '/one': {},
-                '/continued': {},
-                '/two': {},
-                '/two-continued': {},
-                '/overview-step': {},
-              },
-            },
+            options: {},
           },
         }
         mockRes = {
@@ -276,7 +267,7 @@ describe('Person Escort Record controllers', function () {
 
         it('should redirect to base URL with last step path', function () {
           expect(mockRes.redirect).to.have.been.calledOnceWithExactly(
-            '/base-url/overview-step'
+            '/base-url'
           )
         })
 
@@ -299,7 +290,7 @@ describe('Person Escort Record controllers', function () {
 
           it('should redirect to base URL with last step path', function () {
             expect(mockRes.redirect).to.have.been.calledOnceWithExactly(
-              '/base-url/overview-step'
+              '/base-url'
             )
           })
 

--- a/app/person-escort-record/router.js
+++ b/app/person-escort-record/router.js
@@ -9,18 +9,18 @@ function defineFormWizard(req, res, next) {
   const wizardFields = req.framework.questions
   const wizardSteps = {
     '/': {
+      controller: FrameworkSectionController,
+      reset: true,
+      resetJourney: true,
+      template: 'framework-section',
+    },
+    '/start': {
       next: firstStep.slug,
       reset: true,
       resetJourney: true,
       skip: true,
     },
     ...steps,
-    '/overview': {
-      controller: FrameworkSectionController,
-      reset: true,
-      resetJourney: true,
-      template: 'framework-section',
-    },
   }
   const wizardConfig = {
     controller: FrameworkStepController,

--- a/app/person-escort-record/router.test.js
+++ b/app/person-escort-record/router.test.js
@@ -79,18 +79,18 @@ describe('Person Escort Record router', function () {
       it('should call form wizard with steps', function () {
         const steps = {
           '/': {
+            controller: FrameworkSectionController,
+            reset: true,
+            resetJourney: true,
+            template: 'framework-section',
+          },
+          '/start': {
             reset: true,
             resetJourney: true,
             skip: true,
             next: Object.values(req.frameworkSection.steps)[0].slug,
           },
           ...req.frameworkSection.steps,
-          '/overview': {
-            controller: FrameworkSectionController,
-            reset: true,
-            resetJourney: true,
-            template: 'framework-section',
-          },
         }
         const config = {
           controller: FrameworkStepController,

--- a/common/presenters/framework-section-to-panel-list.js
+++ b/common/presenters/framework-section-to-panel-list.js
@@ -55,7 +55,7 @@ function frameworkSectionToPanelList({
     const output = {
       key: section.key,
       name: section.name,
-      url: `${personEscortRecordUrl}/${section.key}/overview`,
+      url: `${personEscortRecordUrl}/${section.key}`,
       isCompleted: sectionStatus === 'completed',
       panels: tagList
         // Filter tags to just this section

--- a/common/presenters/framework-section-to-panel-list.test.js
+++ b/common/presenters/framework-section-to-panel-list.test.js
@@ -294,7 +294,7 @@ const expectedOutput = {
   isCompleted: true,
   name: 'Risk information',
   url:
-    '/move/0568d216-4e1c-4b06-bd22-13c221368384/person-escort-record/risk-information/overview',
+    '/move/0568d216-4e1c-4b06-bd22-13c221368384/person-escort-record/risk-information',
   panels: [
     {
       tag: {
@@ -356,7 +356,7 @@ describe('Presenters', function () {
           isCompleted: false,
           name: 'Risk information',
           panels: [],
-          url: '/risk-information/overview',
+          url: '/risk-information',
         })
       })
     })

--- a/common/presenters/framework-to-task-list-component.js
+++ b/common/presenters/framework-to-task-list-component.js
@@ -10,6 +10,7 @@ const tagClasses = {
 
 function frameworkToTaskListComponent({
   baseUrl = '',
+  deepLinkToFirstStep = false,
   sectionProgress = [],
   frameworkSections = {},
 } = {}) {
@@ -21,7 +22,7 @@ function frameworkToTaskListComponent({
       return {
         order,
         text: name,
-        href: baseUrl + key,
+        href: `${baseUrl}${key}${deepLinkToFirstStep ? '/start' : ''}`,
         tag: {
           text: i18n.t(`person-escort-record::statuses.${status}`),
           classes: tagClasses[status] || tagClasses.default,

--- a/common/presenters/framework-to-task-list-component.test.js
+++ b/common/presenters/framework-to-task-list-component.test.js
@@ -222,6 +222,35 @@ describe('Presenters', function () {
       })
     })
 
+    context('with deep link option', function () {
+      const mockProgress = [
+        {
+          key: 'incomplete-section',
+          status: 'in_progress',
+        },
+      ]
+      const mockSections = {
+        'incomplete-section': {
+          name: 'Incomplete section',
+          key: 'incomplete-section',
+        },
+      }
+
+      beforeEach(function () {
+        output = presenter({
+          deepLinkToFirstStep: true,
+          sectionProgress: mockProgress,
+          frameworkSections: mockSections,
+        })
+      })
+
+      describe('items', function () {
+        it('should return href with base url', function () {
+          expect(output.items[0].href).to.equal('incomplete-section/start')
+        })
+      })
+    })
+
     describe('item order', function () {
       const mockProgress = [
         {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Refactor the URLs of framework sections to be more logical.

Before:
```yaml
/person-escort-record/:section # redirects to first step
/person-escort-record/:section/overview # shows overview for section
/person-escort-record/:section/:step # framework step
```

After:
```yaml
/person-escort-record/:section # shows overview for section
/person-escort-record/:section/start # redirects to first step
/person-escort-record/:section/:step # framework step
```

### Why did it change

Currently we use a custom URL as the "overview" for a section and the
root of a section in the URL acts as the starting point, which redirects
to the first step.

This feels like it makes the URL structure less logical. With this change
removing parts of the URL now show higher levels of information.

So a section base URL will show its overview. This has introduced
the custom URL segment to signify wanting to start the user on the first
step and is only required when linking directly from the move.

## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [x] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed

### Other considerations

Commit messages with a `fix` or `feat` type are automatically used to generate the [changelog](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/CHANGELOG.md) and
[GitHub release notes](https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/releases) during the release task. Please make sure they will read well on their own in a
summary of changes and that the commit body gives a more detailed description of those changes if necessary.

- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
- [x] Update [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md) with any new instructions or tasks
