### PR TITLE
Add extra logging around TypeError

### DIFF
--- a/common/services/component.js
+++ b/common/services/component.js
@@ -1,3 +1,4 @@
+const Sentry = require('@sentry/node')
 const { kebabCase } = require('lodash')
 
 const config = require('../../config')
@@ -17,16 +18,30 @@ function _macroNameToFilepath(macroName) {
   return kebabCase(macroName.replace(/^\b(app)/, ''))
 }
 
-function getComponent(macroName, params) {
-  const nunjucksEnv = nunjucksConfig(null, config, configPaths)
-  const macroParams = JSON.stringify(params, null, 2)
-  const filename = _macroNameToFilepath(macroName)
-  const macroString = `
+function getComponent(macroName, params = {}) {
+  try {
+    const nunjucksEnv = nunjucksConfig(null, config, configPaths)
+    const macroParams = JSON.stringify(params, null, 2)
+    const filename = _macroNameToFilepath(macroName)
+    const macroString = `
     {%- from "${filename}/macro.njk" import ${macroName} -%}
     {{- ${macroName}(${macroParams}) -}}
   `
 
-  return nunjucksEnv.renderString(macroString)
+    return nunjucksEnv.renderString(macroString)
+  } catch (error) {
+    Sentry.withScope(scope => {
+      scope.setExtra('macroName', macroName)
+      scope.setExtra('keys', Object.keys(params))
+      scope.setExtra('id', params.id)
+      scope.setExtra('type', params.type)
+      scope.setExtra('version', params.version)
+      scope.setExtra('name', params.name)
+      Sentry.captureException(error)
+    })
+
+    return ''
+  }
 }
 
 module.exports = {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Add more data to the source of the [error in Sentry](https://sentry.service.dsd.io/mojds/book-a-secure-move-frontend/issues/63155/).

### Why did it change

The production instance is currently throwing an error around the
`getComponent` with a circular structure. This error cannot be replicated
locally or any other environment.

This change attempts to provide Sentry with more information of this
error and to fail more silently, hopefully unblocking users who are
seeing this in our production environment.

## Checklists

### Testing

#### Automated testing

- [ ] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed

### Other considerations

Commit messages with a `fix` or `feat` type are automatically used to generate the [changelog](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/CHANGELOG.md) and
[GitHub release notes](https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/releases) during the release task. Please make sure they will read well on their own in a
summary of changes and that the commit body gives a more detailed description of those changes if necessary.

- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
- [x] Update [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md) with any new instructions or tasks
