### PR TITLE
fix: Remove circular structure when rendering components

### DIFF
--- a/common/presenters/framework-field-summary-list-row.js
+++ b/common/presenters/framework-field-summary-list-row.js
@@ -16,19 +16,20 @@ function frameworkFieldToSummaryListRow(stepUrl) {
       const rows = response.value.map((item, index) => {
         const responsesHtml = descendants
           .map(descendantField => {
-            const question = find(response.question.descendants, {
+            const frameworkQuestion = find(response.question.descendants, {
               key: descendantField.name,
             })
             const descendantResponse = find(item.responses, {
-              framework_question_id: question.id,
+              framework_question_id: frameworkQuestion.id,
             })
 
-            descendantField.response = {
-              ...descendantResponse,
-              question,
+            return {
+              ...descendantField,
+              response: {
+                ...descendantResponse,
+                question: frameworkQuestion,
+              },
             }
-
-            return descendantField
           })
           .map(frameworkFieldToSummaryListRow(stepUrl))
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

This fix removes the chance of mutation by returning a new object.

fixes BOOK-A-SECURE-MOVE-FRONTEND-E

### Why did it change

A recent change to the way dependent fields were rendered introduced
some potential mutation of the field object.

When this field was used further down the chain, like rendering
a component it caused a circular structure to appear from the response
question.

## Checklists

### Testing

#### Automated testing

- [ ] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [x] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed

### Other considerations

Commit messages with a `fix` or `feat` type are automatically used to generate the [changelog](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/CHANGELOG.md) and
[GitHub release notes](https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/releases) during the release task. Please make sure they will read well on their own in a
summary of changes and that the commit body gives a more detailed description of those changes if necessary.

- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
- [x] Update [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md) with any new instructions or tasks
