### PR TITLE
[P4-2193] Correctly show banners/edit states with different move states

### DIFF
--- a/app/move/controllers/view.js
+++ b/app/move/controllers/view.js
@@ -48,8 +48,16 @@ module.exports = function view(req, res) {
   const personEscortRecordUrl = `${originalUrl}/person-escort-record`
   const showPersonEscortRecordBanner =
     personEscortRecordIsEnabled &&
-    ['requested', 'booked'].includes(move?.status) &&
+    !['proposed'].includes(move?.status) &&
     move.profile?.id !== undefined
+  const canStartPersonEscortRecord =
+    showPersonEscortRecordBanner &&
+    ['requested', 'booked'].includes(move?.status) &&
+    !personEscortRecord
+  const canConfirmPersonEscortRecord =
+    showPersonEscortRecordBanner &&
+    personEscortRecordIsCompleted &&
+    ['requested', 'booked'].includes(move?.status)
   const personEscortRecordtaskList = presenters.frameworkToTaskListComponent({
     baseUrl: `${personEscortRecordUrl}/`,
     deepLinkToFirstStep: true,
@@ -99,6 +107,8 @@ module.exports = function view(req, res) {
     personEscortRecordUrl,
     personEscortRecordtaskList,
     showPersonEscortRecordBanner,
+    canStartPersonEscortRecord,
+    canConfirmPersonEscortRecord,
     personEscortRecordTagList,
     assessmentSections,
     moveSummary: presenters.moveToMetaListComponent(move, updateActions),

--- a/app/move/controllers/view.test.js
+++ b/app/move/controllers/view.test.js
@@ -151,7 +151,7 @@ describe('Move controllers', function () {
       })
 
       it('should pass correct number of locals to template', function () {
-        expect(Object.keys(res.render.args[0][1])).to.have.length(22)
+        expect(Object.keys(res.render.args[0][1])).to.have.length(24)
       })
 
       it('should call moveToMetaListComponent presenter with correct args', function () {
@@ -207,6 +207,16 @@ describe('Move controllers', function () {
       it('should contain a showPersonEscortRecordBanner param', function () {
         expect(params).to.have.property('showPersonEscortRecordBanner')
         expect(params.showPersonEscortRecordBanner).to.be.false
+      })
+
+      it('should contain a showPersonEscortRecordBanner param', function () {
+        expect(params).to.have.property('canStartPersonEscortRecord')
+        expect(params.canStartPersonEscortRecord).to.be.false
+      })
+
+      it('should contain a showPersonEscortRecordBanner param', function () {
+        expect(params).to.have.property('canConfirmPersonEscortRecord')
+        expect(params.canConfirmPersonEscortRecord).to.be.false
       })
 
       it('should contain a personEscortRecordtaskList param', function () {
@@ -574,6 +584,11 @@ describe('Move controllers', function () {
           )
         })
 
+        it('should not allow record to be confirmed', function () {
+          expect(params).to.have.property('canConfirmPersonEscortRecord')
+          expect(params.canConfirmPersonEscortRecord).to.be.false
+        })
+
         it('should not show Person Escort Record as confirmed', function () {
           expect(params).to.have.property('personEscortRecordIsConfirmed')
           expect(params.personEscortRecordIsConfirmed).to.be.false
@@ -763,6 +778,29 @@ describe('Move controllers', function () {
         it('should not show Person Escort Record banner', function () {
           expect(params).to.have.property('showPersonEscortRecordBanner')
           expect(params.showPersonEscortRecordBanner).to.be.false
+        })
+      })
+
+      context('when move has started', function () {
+        beforeEach(function () {
+          req.move.status = 'in_transit'
+          controller(req, res)
+          params = res.render.args[0][1]
+        })
+
+        it('should not allow record to be started', function () {
+          expect(params).to.have.property('canStartPersonEscortRecord')
+          expect(params.canStartPersonEscortRecord).to.be.false
+        })
+
+        it('should not allow record to be confirmed', function () {
+          expect(params).to.have.property('canConfirmPersonEscortRecord')
+          expect(params.canConfirmPersonEscortRecord).to.be.false
+        })
+
+        it('should show Person Escort Record banner', function () {
+          expect(params).to.have.property('showPersonEscortRecordBanner')
+          expect(params.showPersonEscortRecordBanner).to.be.true
         })
       })
     })

--- a/app/move/middleware.js
+++ b/app/move/middleware.js
@@ -19,7 +19,14 @@ module.exports = {
     const personEscortRecord = req.move?.profile?.person_escort_record
 
     if (personEscortRecord) {
-      req.personEscortRecord = personEscortRecord
+      const isEditable =
+        ['requested', 'booked'].includes(req.move?.status) &&
+        !['confirmed'].includes(personEscortRecord.status)
+
+      req.personEscortRecord = {
+        ...personEscortRecord,
+        isEditable,
+      }
     }
 
     next()

--- a/app/move/middleware.test.js
+++ b/app/move/middleware.test.js
@@ -111,21 +111,89 @@ describe('Move middleware', function () {
             profile: {
               person_escort_record: {
                 id: '12345',
+                status: 'not_started',
               },
             },
           },
         }
-        middleware.setPersonEscortRecord(mockReq, {}, nextSpy)
       })
 
-      it('should set request property', function () {
-        expect(mockReq).to.contain.property('personEscortRecord')
-        expect(mockReq.personEscortRecord).to.deep.equal({
-          id: '12345',
+      context('with unstarted move', function () {
+        beforeEach(function () {
+          mockReq.move.status = 'requested'
+        })
+
+        context('with unconfirmed Person Escort Record', function () {
+          beforeEach(function () {
+            middleware.setPersonEscortRecord(mockReq, {}, nextSpy)
+          })
+
+          it('should set request property', function () {
+            expect(mockReq).to.contain.property('personEscortRecord')
+            expect(mockReq.personEscortRecord).to.deep.equal({
+              id: '12345',
+              status: 'not_started',
+              isEditable: true,
+            })
+          })
+        })
+
+        context('with confirmed Person Escort Record', function () {
+          beforeEach(function () {
+            mockReq.move.profile.person_escort_record.status = 'confirmed'
+            middleware.setPersonEscortRecord(mockReq, {}, nextSpy)
+          })
+
+          it('should set request property', function () {
+            expect(mockReq).to.contain.property('personEscortRecord')
+            expect(mockReq.personEscortRecord).to.deep.equal({
+              id: '12345',
+              status: 'confirmed',
+              isEditable: false,
+            })
+          })
+        })
+      })
+
+      context('with started move', function () {
+        beforeEach(function () {
+          mockReq.move.status = 'in_transit'
+        })
+
+        context('with unconfirmed Person Escort Record', function () {
+          beforeEach(function () {
+            middleware.setPersonEscortRecord(mockReq, {}, nextSpy)
+          })
+
+          it('should set request property', function () {
+            expect(mockReq).to.contain.property('personEscortRecord')
+            expect(mockReq.personEscortRecord).to.deep.equal({
+              id: '12345',
+              status: 'not_started',
+              isEditable: false,
+            })
+          })
+        })
+
+        context('with confirmed Person Escort Record', function () {
+          beforeEach(function () {
+            mockReq.move.profile.person_escort_record.status = 'confirmed'
+            middleware.setPersonEscortRecord(mockReq, {}, nextSpy)
+          })
+
+          it('should set request property', function () {
+            expect(mockReq).to.contain.property('personEscortRecord')
+            expect(mockReq.personEscortRecord).to.deep.equal({
+              id: '12345',
+              status: 'confirmed',
+              isEditable: false,
+            })
+          })
         })
       })
 
       it('should call next', function () {
+        middleware.setPersonEscortRecord(mockReq, {}, nextSpy)
         expect(nextSpy).to.be.calledOnceWithExactly()
       })
     })

--- a/app/move/views/view.njk
+++ b/app/move/views/view.njk
@@ -93,7 +93,7 @@
     }) }}
   {% endif %}
 
-  {% if showPersonEscortRecordBanner and not personEscortRecord %}
+  {% if canStartPersonEscortRecord %}
     {% set html %}
       <p>{{ t("messages::person_escort_record_pending.content") }}</p>
 
@@ -130,8 +130,17 @@
 
             {{ govukButton({
               href: personEscortRecordUrl + "/confirm",
-              text: t("actions::provide_confirmation")
+              text: t("actions::provide_confirmation"),
+              disabled: not canConfirmPersonEscortRecord
             }) }}
+
+            {% if not canConfirmPersonEscortRecord %}
+              {{ govukWarningText({
+                text: t("person-escort-record::left_custody"),
+                classes: "govuk-!-padding-top-0 govuk-!-margin-top-5",
+                iconFallbackText: "Warning"
+              }) }}
+            {% endif %}
           {% endif %}
         </div>
       </div>

--- a/app/person-escort-record/controllers/framework-section.js
+++ b/app/person-escort-record/controllers/framework-section.js
@@ -19,11 +19,7 @@ class FrameworkSectionController extends FormWizardController {
   }
 
   setEditableStatus(req, res, next) {
-    const personEscortRecordIsConfirmed = ['confirmed'].includes(
-      req.personEscortRecord?.status
-    )
-
-    res.locals.isEditable = !personEscortRecordIsConfirmed
+    res.locals.isEditable = req.personEscortRecord?.isEditable
     next()
   }
 

--- a/app/person-escort-record/controllers/framework-section.test.js
+++ b/app/person-escort-record/controllers/framework-section.test.js
@@ -100,43 +100,22 @@ describe('Person Escort Record controllers', function () {
         mockReq = {
           personEscortRecord: {
             id: '12345',
+            isEditable: true,
           },
         }
         mockRes = {
           locals: {},
         }
+
+        controller.setEditableStatus(mockReq, mockRes, nextSpy)
       })
 
-      context('when Person Escort Record is confirmed', function () {
-        beforeEach(function () {
-          mockReq.personEscortRecord.status = 'confirmed'
-
-          controller.setEditableStatus(mockReq, mockRes, nextSpy)
-        })
-
-        it('should set isEditable to false', function () {
-          expect(mockRes.locals.isEditable).to.equal(false)
-        })
-
-        it('should call next without error', function () {
-          expect(nextSpy).to.be.calledOnceWithExactly()
-        })
+      it('should set isEditable to false', function () {
+        expect(mockRes.locals.isEditable).to.equal(true)
       })
 
-      context('when Person Escort Record is not confirmed', function () {
-        beforeEach(function () {
-          mockReq.personEscortRecord.status = 'not_started'
-
-          controller.setEditableStatus(mockReq, mockRes, nextSpy)
-        })
-
-        it('should set isEditable to true', function () {
-          expect(mockRes.locals.isEditable).to.equal(true)
-        })
-
-        it('should call next without error', function () {
-          expect(nextSpy).to.be.calledOnceWithExactly()
-        })
+      it('should call next without error', function () {
+        expect(nextSpy).to.be.calledOnceWithExactly()
       })
     })
 

--- a/app/person-escort-record/controllers/framework-step.js
+++ b/app/person-escort-record/controllers/framework-step.js
@@ -9,22 +9,19 @@ const responseService = require('../../../common/services/framework-response')
 class FrameworkStepController extends FormWizardController {
   middlewareChecks() {
     super.middlewareChecks()
-    // TODO: Exist this logic to redirect to the overview path if
-    // user does not have permission to update
-    this.use(permissionsControllers.protectRoute('person_escort_record:update'))
     this.use(this.checkEditable)
   }
 
   checkEditable(req, res, next) {
-    const { steps: wizardSteps = {} } = req?.form?.options || {}
-    const steps = Object.keys(wizardSteps)
-    const overviewStepPath = steps[steps.length - 1]
-    const personEscortRecordIsConfirmed = ['confirmed'].includes(
-      req.personEscortRecord?.status
+    const isEditable = req.personEscortRecord?.isEditable
+    const userPermissions = req.user?.permissions
+    const canEdit = permissionsControllers.check(
+      'person_escort_record:update',
+      userPermissions
     )
 
-    if (personEscortRecordIsConfirmed) {
-      return res.redirect(req.baseUrl + overviewStepPath)
+    if (!isEditable || !canEdit) {
+      return res.redirect(req.baseUrl)
     }
 
     next()

--- a/app/person-escort-record/views/framework-section.njk
+++ b/app/person-escort-record/views/framework-section.njk
@@ -36,6 +36,13 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-three-quarters">
+      {% if not isEditable %}
+        {{ govukWarningText({
+          text: t("person-escort-record::locked"),
+          iconFallbackText: "Warning"
+        }) }}
+      {% endif %}
+
       {% for key, step in summarySteps %}
         <section class="app-!-position-relative govuk-!-margin-bottom-8">
           <h2 class="govuk-heading-m govuk-!-margin-bottom-0 govuk-!-padding-bottom-1 govuk-!-padding-right-8 app-border-bottom-1">

--- a/locales/en/person-escort-record.json
+++ b/locales/en/person-escort-record.json
@@ -4,6 +4,8 @@
   "heading": "Person Escort Record",
   "heading_with_name": "Person Escort Record for",
   "section_overview": "{{section}} overview",
+  "locked": "A Person Escort Record cannot be updated once it has been confirmed or once the move has started.",
+  "left_custody": "A Person Escort Record cannot be confirmed once the move has started.",
   "statuses": {
     "not_started": "Not started",
     "in_progress": "In progress",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

This tidys up the logic around when the banner exists and what users
are allowed to do in those states.

### Why did it change

Currently the banners that show the status of the Person Escort Record
and allow it to be started, edited or confirmed don't have any concept
of the status of the move.

This caused issues when some moves were started or completed and the
Person Escort Record banner was no longer visible.

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

- [P4-2193](https://dsdmoj.atlassian.net/browse/P4-2193)

## Screenshots
<!--- (Optional) Include screenshots if changes update interfaces or components -->
<!--- Delete/copy as appropriate --->

### Started move (`in_transit`, `completed`)

| Before | After |
| ------ | ----- |
| <kbd>![image](https://user-images.githubusercontent.com/3327997/93783008-24392080-fc23-11ea-8e6b-0a207672d1d1.png)</kbd> | <kbd>![image](https://user-images.githubusercontent.com/3327997/93782972-197e8b80-fc23-11ea-9b56-7555c3961c17.png)</kbd> |
| <kbd>![image](https://user-images.githubusercontent.com/3327997/93783115-42068580-fc23-11ea-99f2-a934b1c5abb6.png)</kbd> | <kbd>![image](https://user-images.githubusercontent.com/3327997/93783073-35822d00-fc23-11ea-95dd-77001ece42e3.png)</kbd> |
| <kbd>![image](https://user-images.githubusercontent.com/3327997/93782807-e6d49300-fc22-11ea-935a-fba596fcd0c4.png)</kbd> | <kbd>![image](https://user-images.githubusercontent.com/3327997/93783338-7bd78c00-fc23-11ea-8bd5-6204a150dedd.png)</kbd> |

## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [x] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed

<!--- Delete if changes DO NOT include new environment variables -->
- [ ] Documented in the [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md)
- [ ] Added to [continous integration](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-book-secure-move-frontend)
- [ ] Added to staging environment (deployment repository)
- [ ] Added to preproduction environment (deployment repository)
- [ ] Added to production environment (deployment repository)

### Other considerations

Commit messages with a `fix` or `feat` type are automatically used to generate the [changelog](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/CHANGELOG.md) and
[GitHub release notes](https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/releases) during the release task. Please make sure they will read well on their own in a
summary of changes and that the commit body gives a more detailed description of those changes if necessary.

- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
- [x] Update [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md) with any new instructions or tasks
