### PR TITLE
refactor: Refactor moves to use api cancel method

### DIFF
--- a/app/allocation/controllers/cancel.js
+++ b/app/allocation/controllers/cancel.js
@@ -13,10 +13,12 @@ class CancelController extends FormWizardController {
     ])
 
     data.cancellation_reason_comment = data.cancellation_reason_other_comment
-    delete data.cancellation_reason_other_comment
 
     try {
-      await allocationService.cancel(id, data)
+      await allocationService.cancel(id, {
+        reason: data.cancellation_reason,
+        comment: data.cancellation_reason_comment,
+      })
 
       req.journeyModel.reset()
       req.sessionModel.reset()

--- a/app/allocation/controllers/cancel.test.js
+++ b/app/allocation/controllers/cancel.test.js
@@ -48,8 +48,8 @@ describe('Cancel controller', function () {
         expect(allocationService.cancel).to.have.been.calledWithExactly(
           mockAllocation.id,
           {
-            cancellation_reason: 'other',
-            cancellation_reason_comment: 'Comment',
+            reason: 'other',
+            comment: 'Comment',
           }
         )
       })

--- a/common/services/allocation.js
+++ b/common/services/allocation.js
@@ -52,11 +52,15 @@ const allocationService = {
 
     const timestamp = dateFunctions.formatISO(new Date())
 
-    return apiClient.one('allocation', id).all('cancel').post({
-      timestamp,
-      cancellation_reason: reason,
-      cancellation_reason_comment: comment,
-    })
+    return apiClient
+      .one('allocation', id)
+      .all('cancel')
+      .post({
+        timestamp,
+        cancellation_reason: reason,
+        cancellation_reason_comment: comment,
+      })
+      .then(response => response.data)
   },
 
   format(data) {

--- a/common/services/allocation.js
+++ b/common/services/allocation.js
@@ -45,21 +45,20 @@ function getAll({
 }
 
 const allocationService = {
-  cancel(id, data) {
+  cancel(id, { reason, comment } = {}) {
     if (!id) {
       return Promise.reject(new Error('No allocation id supplied'))
     }
 
     const timestamp = dateFunctions.formatISO(new Date())
 
-    return apiClient
-      .one('allocation', id)
-      .all('cancel')
-      .post({
-        timestamp,
-        ...data,
-      })
+    return apiClient.one('allocation', id).all('cancel').post({
+      timestamp,
+      cancellation_reason: reason,
+      cancellation_reason_comment: comment,
+    })
   },
+
   format(data) {
     const booleansAndNulls = ['complete_in_full', 'sentence_length']
     const relationships = ['to_location', 'from_location']

--- a/common/services/allocation.test.js
+++ b/common/services/allocation.test.js
@@ -82,26 +82,6 @@ const mockAllocations = [
 
 describe('Allocation service', function () {
   describe('cancel', function () {
-    context.skip('without data args', function () {
-      let move
-
-      beforeEach(async function () {
-        move = await allocationService.cancel(123)
-      })
-
-      it('should call update method with data', function () {
-        expect(apiClient.post).to.be.calledOnceWithExactly({
-          id: 123,
-          cancellation_reason: undefined,
-          cancellation_reason_comment: undefined,
-        })
-      })
-
-      it('should return move', function () {
-        expect(move).to.deep.equal({})
-      })
-    })
-
     context('with correct data supplied', function () {
       let outcome
       beforeEach(async function () {

--- a/common/services/allocation.test.js
+++ b/common/services/allocation.test.js
@@ -106,7 +106,7 @@ describe('Allocation service', function () {
       let outcome
       beforeEach(async function () {
         sinon.stub(apiClient, 'post').resolves({
-          data: {},
+          data: mockAllocations[0],
         })
         sinon.spy(apiClient, 'one')
         sinon.spy(apiClient, 'all')
@@ -115,6 +115,7 @@ describe('Allocation service', function () {
           comment: 'Flood at receiving establishment',
         })
       })
+
       it('calls the service to post a cancel', function () {
         expect(apiClient.post).to.have.been.calledOnceWithExactly({
           cancellation_reason: 'other',
@@ -123,9 +124,7 @@ describe('Allocation service', function () {
         })
       })
       it('returns the data', function () {
-        expect(outcome).to.deep.equal({
-          data: {},
-        })
+        expect(outcome).to.deep.equal(mockAllocations[0])
       })
     })
     context('without id supplied', function () {

--- a/common/services/move.js
+++ b/common/services/move.js
@@ -267,11 +267,15 @@ const moveService = {
 
     const timestamp = dateFunctions.formatISO(new Date())
 
-    return apiClient.one('move', id).all('cancel').post({
-      timestamp,
-      cancellation_reason: reason,
-      cancellation_reason_comment: comment,
-    })
+    return apiClient
+      .one('move', id)
+      .all('cancel')
+      .post({
+        timestamp,
+        cancellation_reason: reason,
+        cancellation_reason_comment: comment,
+      })
+      .then(response => response.data)
   },
 }
 

--- a/common/services/move.js
+++ b/common/services/move.js
@@ -265,14 +265,13 @@ const moveService = {
       return Promise.reject(new Error(noMoveIdMessage))
     }
 
-    return apiClient
-      .update('move', {
-        id,
-        status: 'cancelled',
-        cancellation_reason: reason,
-        cancellation_reason_comment: comment,
-      })
-      .then(response => response.data)
+    const timestamp = dateFunctions.formatISO(new Date())
+
+    return apiClient.one('move', id).all('cancel').post({
+      timestamp,
+      cancellation_reason: reason,
+      cancellation_reason_comment: comment,
+    })
   },
 }
 

--- a/common/services/move.test.js
+++ b/common/services/move.test.js
@@ -1062,7 +1062,7 @@ describe('Move Service', function () {
         })
 
         it('should return move', function () {
-          expect(move).to.deep.equal(mockResponse)
+          expect(move).to.deep.equal(mockResponse.data)
         })
       })
 
@@ -1085,7 +1085,7 @@ describe('Move Service', function () {
         })
 
         it('should return move', function () {
-          expect(move).to.deep.equal(mockResponse)
+          expect(move).to.deep.equal(mockResponse.data)
         })
       })
     })

--- a/common/services/move.test.js
+++ b/common/services/move.test.js
@@ -1045,31 +1045,12 @@ describe('Move Service', function () {
 
       beforeEach(async function () {
         sinon.stub(apiClient, 'post').resolves(mockResponse)
-      })
-
-      context.skip('without data args', function () {
-        beforeEach(async function () {
-          move = await moveService.cancel(mockId)
-        })
-
-        it('should call update method with data', function () {
-          expect(apiClient.post).to.be.calledOnceWithExactly({
-            id: mockId,
-            timestamp: '#timestamp',
-            cancellation_reason: undefined,
-            cancellation_reason_comment: undefined,
-          })
-        })
-
-        it('should return move', function () {
-          expect(move).to.deep.equal(mockResponse.data)
-        })
+        sinon.spy(apiClient, 'one')
+        sinon.spy(apiClient, 'all')
       })
 
       context('with correct data supplied', function () {
         beforeEach(async function () {
-          sinon.spy(apiClient, 'one')
-          sinon.spy(apiClient, 'all')
           move = await moveService.cancel(mockId, {
             reason: 'other',
             comment: 'Reason for cancelling',

--- a/common/services/move.test.js
+++ b/common/services/move.test.js
@@ -1039,53 +1039,53 @@ describe('Move Service', function () {
       const mockResponse = {
         data: {
           ...mockMove,
-          status: 'cancelled',
         },
       }
       let move
 
       beforeEach(async function () {
-        sinon.stub(apiClient, 'update').resolves(mockResponse)
+        sinon.stub(apiClient, 'post').resolves(mockResponse)
       })
 
-      context('without data args', function () {
+      context.skip('without data args', function () {
         beforeEach(async function () {
           move = await moveService.cancel(mockId)
         })
 
         it('should call update method with data', function () {
-          expect(apiClient.update).to.be.calledOnceWithExactly('move', {
+          expect(apiClient.post).to.be.calledOnceWithExactly({
             id: mockId,
-            status: 'cancelled',
+            timestamp: '#timestamp',
             cancellation_reason: undefined,
             cancellation_reason_comment: undefined,
           })
         })
 
         it('should return move', function () {
-          expect(move).to.deep.equal(mockResponse.data)
+          expect(move).to.deep.equal(mockResponse)
         })
       })
 
-      context('with data args', function () {
+      context('with correct data supplied', function () {
         beforeEach(async function () {
+          sinon.spy(apiClient, 'one')
+          sinon.spy(apiClient, 'all')
           move = await moveService.cancel(mockId, {
             reason: 'other',
             comment: 'Reason for cancelling',
           })
         })
 
-        it('should call update method with data', function () {
-          expect(apiClient.update).to.be.calledOnceWithExactly('move', {
-            id: mockId,
-            status: 'cancelled',
+        it('should call the service to post a cancel', function () {
+          expect(apiClient.post).to.be.calledOnceWithExactly({
             cancellation_reason: 'other',
             cancellation_reason_comment: 'Reason for cancelling',
+            timestamp: sinon.match.string,
           })
         })
 
         it('should return move', function () {
-          expect(move).to.deep.equal(mockResponse.data)
+          expect(move).to.deep.equal(mockResponse)
         })
       })
     })


### PR DESCRIPTION
Cancelling moves and cancelling allocations were developed at different times by different people. This PR brings them both up to date with the current approach for making requests.


<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

- Refactor services.move to use api cancel rather than api update
- Explicitly pass reason and comment parameters to service

### What changed

<!--- Describe the changes in detail - the "what"-->

### Why did it change

Code that performs the same task, but is approached differently, makes further work more complicated than it needs to be.

<!--- Describe the reason these changes were made - the "why" -->


## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed

### Other considerations

Commit messages with a `fix` or `feat` type are automatically used to generate the [changelog](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/CHANGELOG.md) and
[GitHub release notes](https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/releases) during the release task. Please make sure they will read well on their own in a
summary of changes and that the commit body gives a more detailed description of those changes if necessary.

- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
- [ ] Update [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md) with any new instructions or tasks
