### PR TITLE
fix: Allow users with PER editor role to see moves

### DIFF
--- a/common/lib/permissions.js
+++ b/common/lib/permissions.js
@@ -108,6 +108,9 @@ const personEscortRecordAuthorPermissions = [
   'person_escort_record:create',
   'person_escort_record:update',
   'person_escort_record:confirm',
+  'dashboard:view',
+  'moves:view:outgoing',
+  'move:view',
 ]
 
 const permissionsByRole = {

--- a/common/lib/user.test.js
+++ b/common/lib/user.test.js
@@ -327,6 +327,9 @@ describe('User class', function () {
           'person_escort_record:create',
           'person_escort_record:update',
           'person_escort_record:confirm',
+          'dashboard:view',
+          'moves:view:outgoing',
+          'move:view',
         ])
       })
     })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Add move permissions to users who have a PER_AUTHOR role.

### Why did it change

If users only have the PER_AUTHOR role they currently can't see any
dashboards or move details because this role only adds the Person
Escort Record permissions.

This was an oversight initially and a user with this role should still
be able to view a move so that they can complete Person Escort Records.

## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [x] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed

### Other considerations

Commit messages with a `fix` or `feat` type are automatically used to generate the [changelog](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/CHANGELOG.md) and
[GitHub release notes](https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/releases) during the release task. Please make sure they will read well on their own in a
summary of changes and that the commit body gives a more detailed description of those changes if necessary.

- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
- [x] Update [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md) with any new instructions or tasks
