### PR TITLE
feat: Restore cancel moves and proposed moves for STC & SCH roles

### DIFF
--- a/common/lib/permissions.js
+++ b/common/lib/permissions.js
@@ -37,6 +37,7 @@ const secureChildrensHomePermissions = [
   'move:update',
   'move:update:court_appearance',
   'move:update:hospital',
+  'move:cancel',
   'move:cancel:proposed',
 ]
 const secureTrainingCentrePermissions = [
@@ -55,6 +56,7 @@ const secureTrainingCentrePermissions = [
   'move:update',
   'move:update:court_appearance',
   'move:update:hospital',
+  'move:cancel',
   'move:cancel:proposed',
 ]
 

--- a/common/lib/user.test.js
+++ b/common/lib/user.test.js
@@ -192,6 +192,7 @@ describe('User class', function () {
           'move:update',
           'move:update:court_appearance',
           'move:update:hospital',
+          'move:cancel',
           'move:cancel:proposed',
         ]
 
@@ -221,6 +222,7 @@ describe('User class', function () {
           'move:update',
           'move:update:court_appearance',
           'move:update:hospital',
+          'move:cancel',
           'move:cancel:proposed',
         ])
       })

--- a/test/e2e/_helpers.js
+++ b/test/e2e/_helpers.js
@@ -193,12 +193,13 @@ const getRandomLocation = async locationType => {
 export async function generateMove(profile, options = {}, overrides = {}) {
   const fromLocationType = options.from_location_type || 'police'
   const toLocationType = options.to_location_type || 'court'
+  const moveType = options.move_type || 'court_appearance'
 
   const move = {
     profile,
     from_location: await getRandomLocation(fromLocationType),
     to_location: await getRandomLocation(toLocationType),
-    move_type: 'court_appearance',
+    move_type: moveType,
     date: formatDate(new Date(), 'yyyy-MM-dd'),
     ...overrides,
   }

--- a/test/e2e/_move.js
+++ b/test/e2e/_move.js
@@ -150,9 +150,13 @@ const updatePages = [
  *
  * @returns {undefined}
  */
-const filterUpdatePages = (pages = updatePages, exclude = false) => {
-  let show = updatePages.filter(cat => pages.includes(cat))
-  let hide = updatePages.filter(cat => !pages.includes(cat))
+const filterUpdatePages = (pages = updatePages, exclude = false, drop = []) => {
+  let show = updatePages
+    .filter(cat => !drop.includes(cat))
+    .filter(cat => pages.includes(cat))
+  let hide = updatePages
+    .filter(cat => !drop.includes(cat))
+    .filter(cat => !pages.includes(cat))
 
   if (exclude) {
     ;[show, hide] = [hide, show]
@@ -171,10 +175,13 @@ const filterUpdatePages = (pages = updatePages, exclude = false) => {
  *
  * @param {boolean} [exclude] - whether to use list of pages as a blacklist rather than whitelist
  *
+ * @param {string[]} drop - pages to drop from master list of pages
+ *
+ *
  * @returns {undefined}
  */
-export async function checkUpdateLinks(pages, exclude) {
-  const filteredPages = filterUpdatePages(pages, exclude)
+export async function checkUpdateLinks(pages, exclude, drop = []) {
+  const filteredPages = filterUpdatePages(pages, exclude, drop)
 
   for await (const cat of filteredPages.show) {
     await checkUpdateLink(cat)
@@ -226,10 +233,13 @@ export async function checkUpdatePageStatus(page, statusCode) {
  *
  * @param {boolean} [negated] - whether to negate the assertion
  *
+ * @param {string[]} drop - pages to drop from master list of pages
+
+ *
  * @returns {undefined}
  */
-export async function checkUpdatePagesAccessible(pages, negated) {
-  const filteredPages = filterUpdatePages(pages, negated)
+export async function checkUpdatePagesAccessible(pages, negated, drop = []) {
+  const filteredPages = filterUpdatePages(pages, negated, drop)
 
   for await (const page of filteredPages.show) {
     await checkUpdatePageStatus(page, 200)

--- a/test/e2e/_move.js
+++ b/test/e2e/_move.js
@@ -119,8 +119,19 @@ export async function checkNoUpdateLink(page) {
  *
  * @returns {undefined}
  */
-export async function checkCancelLink(page) {
-  return moveDetailPage.checkCancelLink(page)
+export async function checkCancelLink() {
+  return moveDetailPage.checkCancelLink()
+}
+
+/**
+ * Check whether an update link for page is not present
+ *
+ * @param {string} page - page key
+ *
+ * @returns {undefined}
+ */
+export async function checkNoCancelLink() {
+  return moveDetailPage.checkCancelLink(false)
 }
 
 const updatePages = [

--- a/test/e2e/move.update.sch.test.js
+++ b/test/e2e/move.update.sch.test.js
@@ -1,16 +1,16 @@
 import {
-  checkCancelLink,
   checkUpdateLinks,
   checkUpdatePagesAccessible,
   checkUpdateDocuments,
   createMove,
+  checkCancelLink,
 } from './_move'
-import { stcUser } from './_roles'
+import { schUser } from './_roles'
 import { home } from './_routes'
 
-fixture('Existing move from Secure Training Centre (STC) to Court').beforeEach(
+fixture('Existing move from Secure Children Home (SCH) to Court').beforeEach(
   async t => {
-    await t.useRole(stcUser).navigateTo(home)
+    await t.useRole(schUser).navigateTo(home)
     await createMove({
       defaultMoveOptions: {
         to_location_type: 'court',
@@ -51,54 +51,9 @@ test('User should be able to cancel move', async () => {
   await checkCancelLink()
 })
 
-// fixture(
-//   'Existing move from Secure Training Centre (STC) to Hospital'
-// ).beforeEach(async t => {
-//   await t.useRole(stcUser).navigateTo(home)
-//   await createMove({
-//     defaultMoveOptions: {
-//       to_location_type: 'hospital',
-//       move_type: 'hospital',
-//     },
-//   })
-// })
-//
-// test.meta('hasDocument', 'true')(
-//   'User should be able to update move',
-//   async () => {
-//     // await checkUpdateLinks([
-//     //   'personal_details',
-//     //   'risk',
-//     //   'health',
-//     //   'court',
-//     //   'move',
-//     //   'date',
-//     //   'document',
-//     // ])
-//     //
-//     // await checkUpdateDocuments()
-//     //
-//     // await checkUpdatePagesAccessible([
-//     //   'personal_details',
-//     //   'risk',
-//     //   'health',
-//     //   'court',
-//     //   'move',
-//     //   'date',
-//     //   'document',
-//     // ])
-//
-//     await checkCancelLink()
-//   }
-// )
-//
-// test('User should be able to cancel move', async () => {
-//   await checkCancelLink()
-// })
-
-fixture('Existing move from Secure Training Centre (STC) to Prison').beforeEach(
+fixture('Existing move from Secure Children Home (SCH) to Prison').beforeEach(
   async t => {
-    await t.useRole(stcUser).navigateTo(home)
+    await t.useRole(schUser).navigateTo(home)
     await createMove({
       defaultMoveOptions: {
         to_location_type: 'prison',
@@ -131,9 +86,9 @@ test('User should be able to cancel move', async () => {
 })
 
 fixture(
-  'Existing move from Secure Training Centre (STC) to Secure Training Centre (STC)'
+  'Existing move from Secure Children Home (SCH) to Secure Training Centre (STC)'
 ).beforeEach(async t => {
-  await t.useRole(stcUser).navigateTo(home)
+  await t.useRole(schUser).navigateTo(home)
   await createMove({
     defaultMoveOptions: {
       to_location_type: 'secure_training_centre',
@@ -165,9 +120,9 @@ test('User should be able to cancel move', async () => {
 })
 
 fixture(
-  'Existing move from Secure Training Centre (STC) to Secure Children Home (SCH)'
+  'Existing move from Secure Children Home (SCH) to Secure Children Home (SCH)'
 ).beforeEach(async t => {
-  await t.useRole(stcUser).navigateTo(home)
+  await t.useRole(schUser).navigateTo(home)
   await createMove({
     defaultMoveOptions: {
       to_location_type: 'secure_childrens_home',

--- a/test/e2e/move.update.sch.test.js
+++ b/test/e2e/move.update.sch.test.js
@@ -51,6 +51,41 @@ test('User should be able to cancel move', async () => {
   await checkCancelLink()
 })
 
+fixture(
+  'Existing move from Secure Training Centre (STC) to Hospital'
+).beforeEach(async t => {
+  await t.useRole(schUser).navigateTo(home)
+  await createMove({
+    defaultMoveOptions: {
+      to_location_type: 'high_security_hospital',
+      move_type: 'hospital',
+    },
+  })
+})
+
+test.meta('hasDocument', 'true')(
+  'User should be able to update move',
+  async () => {
+    await checkUpdateLinks(
+      ['personal_details', 'risk', 'health', 'move', 'date', 'document'],
+      false,
+      ['court']
+    )
+
+    await checkUpdateDocuments()
+
+    await checkUpdatePagesAccessible(
+      ['personal_details', 'risk', 'health', 'move', 'date', 'document'],
+      false,
+      ['court']
+    )
+  }
+)
+
+test('User should be able to cancel move', async () => {
+  await checkCancelLink()
+})
+
 fixture('Existing move from Secure Children Home (SCH) to Prison').beforeEach(
   async t => {
     await t.useRole(schUser).navigateTo(home)

--- a/test/e2e/move.update.stc.test.js
+++ b/test/e2e/move.update.stc.test.js
@@ -51,50 +51,40 @@ test('User should be able to cancel move', async () => {
   await checkCancelLink()
 })
 
-// fixture(
-//   'Existing move from Secure Training Centre (STC) to Hospital'
-// ).beforeEach(async t => {
-//   await t.useRole(stcUser).navigateTo(home)
-//   await createMove({
-//     defaultMoveOptions: {
-//       to_location_type: 'hospital',
-//       move_type: 'hospital',
-//     },
-//   })
-// })
-//
-// test.meta('hasDocument', 'true')(
-//   'User should be able to update move',
-//   async () => {
-//     // await checkUpdateLinks([
-//     //   'personal_details',
-//     //   'risk',
-//     //   'health',
-//     //   'court',
-//     //   'move',
-//     //   'date',
-//     //   'document',
-//     // ])
-//     //
-//     // await checkUpdateDocuments()
-//     //
-//     // await checkUpdatePagesAccessible([
-//     //   'personal_details',
-//     //   'risk',
-//     //   'health',
-//     //   'court',
-//     //   'move',
-//     //   'date',
-//     //   'document',
-//     // ])
-//
-//     await checkCancelLink()
-//   }
-// )
-//
-// test('User should be able to cancel move', async () => {
-//   await checkCancelLink()
-// })
+fixture(
+  'Existing move from Secure Training Centre (STC) to Hospital'
+).beforeEach(async t => {
+  await t.useRole(stcUser).navigateTo(home)
+  await createMove({
+    defaultMoveOptions: {
+      to_location_type: 'high_security_hospital',
+      move_type: 'hospital',
+    },
+  })
+})
+
+test.meta('hasDocument', 'true')(
+  'User should be able to update move',
+  async () => {
+    await checkUpdateLinks(
+      ['personal_details', 'risk', 'health', 'move', 'date', 'document'],
+      false,
+      ['court']
+    )
+
+    await checkUpdateDocuments()
+
+    await checkUpdatePagesAccessible(
+      ['personal_details', 'risk', 'health', 'move', 'date', 'document'],
+      false,
+      ['court']
+    )
+  }
+)
+
+test('User should be able to cancel move', async () => {
+  await checkCancelLink()
+})
 
 fixture('Existing move from Secure Training Centre (STC) to Prison').beforeEach(
   async t => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

Add `move:cancel` permission for STC & SCH users

### What changed

- changed permissions config
- added SCH E2E test
- added cancel move tests
- added E2E tests for moves to court, prison, stc, sch, hospitals
- added "drop" to checkUpdateLinks as "court" is not a valid update page for a hospital move

### Why did it change

As per the ticket,

> STC & SCH users should NOT be able to edit transfer requests once submitted. They should be able to cancel the request
> STC & SCH should still be able to edit/cancel moves to court moves and hospital moves. This issue is ONLY for transfer moves (moves to Prison, STC & SCH) 

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

- [P4-2106](https://dsdmoj.atlassian.net/browse/P4-2106)

## Checklists

### Testing

#### Automated testing

- [ ] Added unit tests to cover changes
- [x] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [ ] Chrome
- [x] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed

### Other considerations

Commit messages with a `fix` or `feat` type are automatically used to generate the [changelog](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/CHANGELOG.md) and
[GitHub release notes](https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/releases) during the release task. Please make sure they will read well on their own in a
summary of changes and that the commit body gives a more detailed description of those changes if necessary.

- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics