### PR TITLE
[P4-2231] Use move rather than created date for approved single requests

### DIFF
--- a/app/moves/middleware/set-body.single-requests.js
+++ b/app/moves/middleware/set-body.single-requests.js
@@ -3,17 +3,23 @@ const { set } = require('lodash')
 const dateHelpers = require('../../../common/helpers/date')
 
 function setBodySingleRequests(req, res, next) {
-  const { status, sortBy, sortDirection } = req.query
+  const { status } = req.query
+  const useMoveDate = status === 'approved'
+  const {
+    sortBy = useMoveDate ? 'date' : undefined,
+    sortDirection = useMoveDate ? 'asc' : undefined,
+  } = req.query
   const { dateRange } = req.params
   const locations = req.locations
-
+  const dateType = useMoveDate ? 'moveDate' : 'createdAtDate'
   const dateTypeRange = dateRange || dateHelpers.getCurrentWeekAsRange()
 
   set(req, 'body.requested', {
     status,
     sortBy,
     sortDirection,
-    createdAtDate: dateTypeRange,
+    [dateType]: dateTypeRange,
+    dateRange: dateTypeRange,
     fromLocationId: locations,
   })
 

--- a/app/moves/middleware/set-body.single-requests.js
+++ b/app/moves/middleware/set-body.single-requests.js
@@ -7,11 +7,13 @@ function setBodySingleRequests(req, res, next) {
   const { dateRange } = req.params
   const locations = req.locations
 
+  const dateTypeRange = dateRange || dateHelpers.getCurrentWeekAsRange()
+
   set(req, 'body.requested', {
     status,
     sortBy,
     sortDirection,
-    createdAtDate: dateRange || dateHelpers.getCurrentWeekAsRange(),
+    createdAtDate: dateTypeRange,
     fromLocationId: locations,
   })
 

--- a/app/moves/middleware/set-body.single-requests.test.js
+++ b/app/moves/middleware/set-body.single-requests.test.js
@@ -23,6 +23,46 @@ describe('Moves middleware', function () {
       }
     })
 
+    context('when status is not approved', function () {
+      beforeEach(function () {
+        mockReq.query = {
+          status: 'foo',
+        }
+        middleware(mockReq, mockRes, nextSpy)
+      })
+
+      it('should not set sort by or direction', function () {
+        expect(mockReq.body.requested).to.deep.equal({
+          status: 'foo',
+          dateRange: ['2010-10-10', '2010-10-07'],
+          createdAtDate: ['2010-10-10', '2010-10-07'],
+          fromLocationId: mockReq.locations,
+          sortBy: undefined,
+          sortDirection: undefined,
+        })
+      })
+    })
+
+    context('when status is approved', function () {
+      beforeEach(function () {
+        mockReq.query = {
+          status: 'approved',
+        }
+        middleware(mockReq, mockRes, nextSpy)
+      })
+
+      it('should set sort by and direction', function () {
+        expect(mockReq.body.requested).to.deep.equal({
+          status: 'approved',
+          dateRange: ['2010-10-10', '2010-10-07'],
+          moveDate: ['2010-10-10', '2010-10-07'],
+          fromLocationId: mockReq.locations,
+          sortBy: 'date',
+          sortDirection: 'asc',
+        })
+      })
+    })
+
     context('without date range', function () {
       beforeEach(function () {
         middleware(mockReq, mockRes, nextSpy)
@@ -31,6 +71,7 @@ describe('Moves middleware', function () {
       it('should assign req.body correctly', function () {
         expect(mockReq.body.requested).to.deep.equal({
           status: 'pending',
+          dateRange: ['2010-10-10', '2010-10-07'],
           createdAtDate: ['2010-10-10', '2010-10-07'],
           fromLocationId: mockReq.locations,
           sortBy: 'createdAtDate',
@@ -52,6 +93,7 @@ describe('Moves middleware', function () {
       it('should assign req.body correctly', function () {
         expect(mockReq.body.requested).to.deep.equal({
           status: 'pending',
+          dateRange: ['2020-10-10', '2020-10-10'],
           createdAtDate: ['2020-10-10', '2020-10-10'],
           fromLocationId: mockReq.locations,
           sortBy: 'createdAtDate',

--- a/app/moves/middleware/set-filter.single-requests.js
+++ b/app/moves/middleware/set-filter.single-requests.js
@@ -4,37 +4,54 @@ const querystring = require('qs')
 const singleRequestService = require('../../../common/services/single-request')
 const i18n = require('../../../config/i18n')
 
+const getItemFilterHref = (req, status, href) => {
+  href = href || `${req.baseUrl}${req.path}`
+  const query = querystring.stringify({
+    ...req.query,
+    status,
+  })
+
+  return `${href}?${query}`
+}
+
 function setfilterSingleRequests(items = []) {
   return async function buildFilter(req, res, next) {
     const requested = req?.body?.requested || {}
     const requestedStatus = requested.status
     const promises = items.map(item => {
-      const { status, label, href } = item
+      const { status, label } = item
+      const href = getItemFilterHref(req, status, item.href)
 
-      return singleRequestService
-        .getAll(
-          omitBy(
-            {
-              ...requested,
-              isAggregation: true,
-              status,
-            },
-            isUndefined
-          )
-        )
-        .then(value => {
-          const query = querystring.stringify({
-            ...req.query,
-            status,
-          })
+      let dateRangeType = 'createdAtDate'
+      let surplusDateRangeType = 'moveDate'
 
-          return {
-            value,
-            label: i18n.t(label).toLowerCase(),
-            active: status === requestedStatus,
-            href: `${href || req.baseUrl + req.path}?${query}`,
-          }
-        })
+      if (status === 'approved') {
+        ;[dateRangeType, surplusDateRangeType] = [
+          surplusDateRangeType,
+          dateRangeType,
+        ]
+      }
+
+      const itemRequested = omitBy(
+        {
+          ...requested,
+          [dateRangeType]: requested.dateRange,
+          [surplusDateRangeType]: undefined,
+          dateRange: undefined,
+          isAggregation: true,
+          status,
+        },
+        isUndefined
+      )
+
+      return singleRequestService.getAll(itemRequested).then(value => {
+        return {
+          value,
+          label: i18n.t(label).toLowerCase(),
+          active: status === requestedStatus,
+          href,
+        }
+      })
     })
 
     try {

--- a/app/moves/middleware/set-filter.single-requests.test.js
+++ b/app/moves/middleware/set-filter.single-requests.test.js
@@ -37,6 +37,7 @@ describe('Moves middleware', function () {
           path: '/week/2010-09-07/123',
           body: {
             requested: {
+              dateRange: mockDateRange,
               createdAtDate: mockDateRange,
               fromLocationId: mockLocationId,
               status: 'pending',
@@ -84,7 +85,7 @@ describe('Moves middleware', function () {
           expect(singleRequestService.getAll).to.have.been.calledWithExactly({
             isAggregation: true,
             status: 'approved',
-            createdAtDate: mockDateRange,
+            moveDate: mockDateRange,
             fromLocationId: mockLocationId,
           })
           expect(singleRequestService.getAll).to.have.been.calledWithExactly({


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

- Sets the correct range type when fetching the single requests depending for the desired status
- Also sets the correct range type for the single request filters depending on the filter status

### Why did it change

Displays the approved moves that are happening in the selected date range rather than those that were created in it.

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

- [P4-2231 - Approved single moves column 'Date of move' contains moves for that week (not moves Booked on that week)](https://dsdmoj.atlassian.net/browse/P4-2231)

## Screenshots
<!--- (Optional) Include screenshots if changes update interfaces or components -->
<!--- Delete/copy as appropriate --->

| Before | After |
| ------ | ----- |
| <kbd>![Single_requests_sent_28_Sep_to_4_Oct_2020__This_week_](https://user-images.githubusercontent.com/4856/94677230-78738d00-0314-11eb-9377-daa4ac2b36e5.png)</kbd> | <kbd>![Single_requests_sent_28_Sep_to_4_Oct_2020__This_week_](https://user-images.githubusercontent.com/4856/94677356-a9ec5880-0314-11eb-9712-9eac051b9584.png)</kbd> |

## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed


### Other considerations

- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics

