### PR TITLE
refactor(per): Use move ID instead of profile ID when creating

### DIFF
--- a/app/person-escort-record/app/new/controllers.js
+++ b/app/person-escort-record/app/new/controllers.js
@@ -22,7 +22,7 @@ class NewPersonEscortRecordController extends FormWizardController {
 
   async saveValues(req, res, next) {
     try {
-      req.record = await personEscortRecordService.create(req.move.profile.id)
+      req.record = await personEscortRecordService.create(req.move.id)
       next()
     } catch (err) {
       const apiErrorCode = get(err, 'errors[0].code')

--- a/app/person-escort-record/app/new/controllers.test.js
+++ b/app/person-escort-record/app/new/controllers.test.js
@@ -77,7 +77,7 @@ describe('Person Escort Record controllers', function () {
     })
 
     describe('#saveValues', function () {
-      const mockProfileId = 'c756d3fb-d5c0-4cf4-9416-6691a89570f2'
+      const mockMoveId = 'c756d3fb-d5c0-4cf4-9416-6691a89570f2'
       let req, nextSpy
 
       beforeEach(function () {
@@ -85,9 +85,7 @@ describe('Person Escort Record controllers', function () {
         nextSpy = sinon.spy()
         req = {
           move: {
-            profile: {
-              id: mockProfileId,
-            },
+            id: mockMoveId,
           },
         }
       })
@@ -100,7 +98,7 @@ describe('Person Escort Record controllers', function () {
 
         it('should create person escort record', function () {
           expect(personEscortRecordService.create).to.be.calledOnceWithExactly(
-            mockProfileId
+            mockMoveId
           )
         })
 

--- a/common/presenters/framework-nomis-mappings-to-panel.js
+++ b/common/presenters/framework-nomis-mappings-to-panel.js
@@ -13,7 +13,7 @@ function frameworkNomisMappingsToPanel({
 
   if (heading) {
     html += `
-      <h4 class="govuk-heading-s govuk-!-font-size-16 govuk-!-margin-top-3 govuk-!-padding-top-0 govuk-!-margin-bottom-2">
+      <h4 class="govuk-!-font-size-19 govuk-!-font-weight-regular govuk-!-margin-top-3 govuk-!-padding-top-0 govuk-!-margin-bottom-1">
         ${heading}
       </h4>
     `

--- a/common/presenters/framework-nomis-mappings-to-panel.test.js
+++ b/common/presenters/framework-nomis-mappings-to-panel.test.js
@@ -73,7 +73,7 @@ describe('#frameworkNomisMappingsToPanel', function () {
 
     it('should return HTML', function () {
       expect(output).to.equal(
-        '\n      <h4 class="govuk-heading-s govuk-!-font-size-16 govuk-!-margin-top-3 govuk-!-padding-top-0 govuk-!-margin-bottom-2">\n        Sample heading\n      </h4>\n    \n      <div class="govuk-caption-s govuk-!-margin-top-0 govuk-!-margin-bottom-2 govuk-!-font-size-16">\n        last_updated_at\n      </div>\n    appPanel'
+        '\n      <h4 class="govuk-!-font-size-19 govuk-!-font-weight-regular govuk-!-margin-top-3 govuk-!-padding-top-0 govuk-!-margin-bottom-1">\n        Sample heading\n      </h4>\n    \n      <div class="govuk-caption-s govuk-!-margin-top-0 govuk-!-margin-bottom-2 govuk-!-font-size-16">\n        last_updated_at\n      </div>\n    appPanel'
       )
     })
   })

--- a/common/services/person-escort-record.js
+++ b/common/services/person-escort-record.js
@@ -12,12 +12,12 @@ const personEscortRecordService = {
     }
   },
 
-  create(profileId) {
+  create(moveId) {
     return apiClient
       .create('person_escort_record', {
         version: FRAMEWORKS.CURRENT_VERSION,
-        profile: {
-          id: profileId,
+        move: {
+          id: moveId,
         },
       })
       .then(response => response.data)

--- a/common/services/person-escort-record.test.js
+++ b/common/services/person-escort-record.test.js
@@ -66,7 +66,7 @@ describe('Services', function () {
     })
 
     describe('#create()', function () {
-      const mockProfileId = 'c756d3fb-d5c0-4cf4-9416-6691a89570f2'
+      const mockMoveId = 'c756d3fb-d5c0-4cf4-9416-6691a89570f2'
       const mockResponse = {
         data: mockRecord,
       }
@@ -75,7 +75,7 @@ describe('Services', function () {
       beforeEach(async function () {
         sinon.stub(apiClient, 'create').resolves(mockResponse)
 
-        response = await personEscortRecordService.create(mockProfileId)
+        response = await personEscortRecordService.create(mockMoveId)
       })
 
       it('should call create method with data and current framework version', function () {
@@ -83,8 +83,8 @@ describe('Services', function () {
           'person_escort_record',
           {
             version: mockFrameworksVersion,
-            profile: {
-              id: mockProfileId,
+            move: {
+              id: mockMoveId,
             },
           }
         )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

This updates the creation of a Person Escort Record to use the move ID
instead of the profile ID which is associated to that move.

### Why did it change

The API now needs to accept the move ID to be able to correctly calculate
the logic around adding NOMIS information. This change supports the
new method dictated by the API.

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

- [P4-1888](https://dsdmoj.atlassian.net/browse/P4-1888)

## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [x] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [ ] No environment variables were added or changed

### Other considerations

Commit messages with a `fix` or `feat` type are automatically used to generate the [changelog](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/CHANGELOG.md) and
[GitHub release notes](https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/releases) during the release task. Please make sure they will read well on their own in a
summary of changes and that the commit body gives a more detailed description of those changes if necessary.

- [ ] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
- [ ] Update [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md) with any new instructions or tasks
