### PR TITLE
fix: Allow prison number to be case insensitive

### DIFF
--- a/app/move/validators.js
+++ b/app/move/validators.js
@@ -30,7 +30,7 @@ module.exports = {
   prisonNumber(value) {
     return (
       value === '' ||
-      Controller.validators.regex(value, /^[A-Z][0-9]{4}[A-Z]{2}$/)
+      Controller.validators.regex(value, /^[A-Z][0-9]{4}[A-Z]{2}$/i)
     )
   },
 }

--- a/app/move/validators.test.js
+++ b/app/move/validators.test.js
@@ -155,7 +155,7 @@ describe('#prisonNumber()', function () {
   })
 
   describe('valid values', function () {
-    const inputs = ['', 'A1234BC']
+    const inputs = ['', 'A1234BC', 'a1234bc']
 
     inputs.forEach(i => {
       it(`test for: "${i}"`, function () {

--- a/locales/en/fields.json
+++ b/locales/en/fields.json
@@ -9,7 +9,7 @@
     },
     "prison_number": {
       "label": "Prison number",
-      "hint": "For example, 'A1234AB'"
+      "hint": "For example, ‘A1234AB’"
     }
   },
   "people": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed


This relaxes the validation to allow lowercase letters to be used.

It also updates the hint text to use quotes instead of primes:
https://carsonparkdesign.com/quotation-marks-apostrophes-versus-primes/

### Why did it change

The API supports case insensitive search on prison number so we
shouldn't force uppercase validation on the frontend.

## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [x] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed

### Other considerations

Commit messages with a `fix` or `feat` type are automatically used to generate the [changelog](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/CHANGELOG.md) and
[GitHub release notes](https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/releases) during the release task. Please make sure they will read well on their own in a
summary of changes and that the commit body gives a more detailed description of those changes if necessary.

- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
- [x] Update [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md) with any new instructions or tasks
