### PR TITLE
fix: Add actual move dates to single-request getCancelled method

### DIFF
--- a/common/services/single-request.js
+++ b/common/services/single-request.js
@@ -1,5 +1,5 @@
 const dateFunctions = require('date-fns')
-const { isNil, mapValues, omitBy, pick } = require('lodash')
+const { isNil, isUndefined, mapValues, omitBy, pick } = require('lodash')
 
 const apiClient = require('../lib/api-client')()
 
@@ -82,13 +82,25 @@ const singleRequestService = {
   },
 
   getCancelled({
+    moveDate = [],
     createdAtDate = [],
     fromLocationId,
     include,
     sortBy = 'created_at',
     sortDirection = 'desc',
   } = {}) {
+    const [moveDateFrom, moveDateTo] = moveDate
     const [createdAtFrom, createdAtTo] = createdAtDate
+    const dateRanges = omitBy(
+      {
+        'filter[date_from]': moveDateFrom,
+        'filter[date_to]': moveDateTo,
+        'filter[created_at_from]': createdAtFrom,
+        'filter[created_at_to]': createdAtTo,
+      },
+      isUndefined
+    )
+
     return moveService.getAll({
       isAggregation: false,
       include: include || [
@@ -106,8 +118,7 @@ const singleRequestService = {
         'filter[rejection_reason]': undefined,
         'sort[by]': sortBy,
         'sort[direction]': sortDirection,
-        'filter[created_at_from]': createdAtFrom,
-        'filter[created_at_to]': createdAtTo,
+        ...dateRanges,
       },
     })
   },

--- a/common/services/single-request.test.js
+++ b/common/services/single-request.test.js
@@ -466,6 +466,7 @@ describe('Single request service', function () {
         moves = await singleRequestService.getCancelled({
           fromLocationId: 'fromLocationId',
           createdAtDate: ['2019-01-01', '2019-01-07'],
+          moveDate: ['2020-01-01', '2020-01-07'],
         })
       })
 
@@ -476,12 +477,14 @@ describe('Single request service', function () {
             'filter[from_location_id]': 'fromLocationId',
             'filter[allocation]': false,
             'filter[move_type]': 'prison_transfer',
-            'filter[rejection_reason]': undefined,
             'filter[status]': 'cancelled',
+            'filter[rejection_reason]': undefined,
             'sort[by]': 'created_at',
             'sort[direction]': 'desc',
             'filter[created_at_from]': '2019-01-01',
             'filter[created_at_to]': '2019-01-07',
+            'filter[date_from]': '2020-01-01',
+            'filter[date_to]': '2020-01-07',
           },
           include: [
             'from_location',


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Adds move dates to single-request getCancelled method

### Why did it change

Absence of move date handling resulted in cancelled moves not having any date filter applied

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->
n/a

## Screenshots
<!--- (Optional) Include screenshots if changes update interfaces or components -->
<!--- Delete/copy as appropriate --->

n/a

## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed


### Other considerations

- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
