### PR TITLE
P4 2105 prevent moves being created from courts

### DIFF
--- a/app/allocation/controllers/view.js
+++ b/app/allocation/controllers/view.js
@@ -4,26 +4,26 @@ const presenters = require('../../../common/presenters')
 
 function viewAllocation(personEscortRecordFeature = false) {
   return (req, res) => {
-    const { allocation, checkPermissions } = req
+    const { allocation, canAccess } = req
     const { moves, status } = allocation
     const bannerStatuses = ['cancelled']
     const movesWithoutProfile = moves.filter(move => !move.profile)
     const movesWithProfile = moves.filter(move => move.profile)
     const personEscortRecordIsEnabled =
-      personEscortRecordFeature && checkPermissions('person_escort_record:view')
+      personEscortRecordFeature && canAccess('person_escort_record:view')
     const moveToCardComponent = presenters.moveToCardComponent({
       showStatus: false,
       tagSource: personEscortRecordIsEnabled ? 'personEscortRecord' : '',
     })
 
     const removeUnassignedMoves = move => {
-      return !(checkPermissions('allocation:person:assign') && !move.profile)
+      return !(canAccess('allocation:person:assign') && !move.profile)
     }
 
     const removeMoveLink = move => {
       if (
         move.profile ||
-        !checkPermissions('allocation:cancel') ||
+        !canAccess('allocation:cancel') ||
         moves.length === 1
       ) {
         return

--- a/app/allocation/controllers/view.js
+++ b/app/allocation/controllers/view.js
@@ -1,35 +1,29 @@
 const { sortBy } = require('lodash')
 
-const permissions = require('../../../common/middleware/permissions')
 const presenters = require('../../../common/presenters')
 
 function viewAllocation(personEscortRecordFeature = false) {
   return (req, res) => {
-    const { allocation } = req
+    const { allocation, checkPermissions } = req
     const { moves, status } = allocation
-    const userPermissions = req.session?.user?.permissions
     const bannerStatuses = ['cancelled']
     const movesWithoutProfile = moves.filter(move => !move.profile)
     const movesWithProfile = moves.filter(move => move.profile)
     const personEscortRecordIsEnabled =
-      personEscortRecordFeature &&
-      permissions.check('person_escort_record:view', userPermissions)
+      personEscortRecordFeature && checkPermissions('person_escort_record:view')
     const moveToCardComponent = presenters.moveToCardComponent({
       showStatus: false,
       tagSource: personEscortRecordIsEnabled ? 'personEscortRecord' : '',
     })
 
     const removeUnassignedMoves = move => {
-      return !(
-        permissions.check('allocation:person:assign', userPermissions) &&
-        !move.profile
-      )
+      return !(checkPermissions('allocation:person:assign') && !move.profile)
     }
 
     const removeMoveLink = move => {
       if (
         move.profile ||
-        !permissions.check('allocation:cancel', userPermissions) ||
+        !checkPermissions('allocation:cancel') ||
         moves.length === 1
       ) {
         return

--- a/app/allocation/controllers/view.test.js
+++ b/app/allocation/controllers/view.test.js
@@ -84,7 +84,7 @@ describe('Allocation controllers', function () {
 
       mockReq = {
         t: sinon.stub().returnsArg(0),
-        checkPermissions: sinon.stub().returns(false),
+        canAccess: sinon.stub().returns(false),
         allocation: { ...allocationExample },
       }
       mockRes = {
@@ -97,7 +97,7 @@ describe('Allocation controllers', function () {
       'the creation of the link to remove a move from an allocation',
       function () {
         beforeEach(function () {
-          mockReq.checkPermissions.callsFake(arg => arg === 'allocation:cancel')
+          mockReq.canAccess.callsFake(arg => arg === 'allocation:cancel')
           moveToCardComponentStub = sinon.stub()
         })
 
@@ -109,7 +109,7 @@ describe('Allocation controllers', function () {
         })
 
         it('does not create removeMoveHref if the user has no permission to cancel allocations', function () {
-          mockReq.checkPermissions.callsFake(() => false)
+          mockReq.canAccess.callsFake(() => false)
           handler()(mockReq, mockRes)
           const { moves } = mockRes.render.firstCall.lastArg
 
@@ -126,7 +126,7 @@ describe('Allocation controllers', function () {
         })
 
         it('does otherwise create removeMoveHref', function () {
-          mockReq.checkPermissions.callsFake(arg => arg === 'allocation:cancel')
+          mockReq.canAccess.callsFake(arg => arg === 'allocation:cancel')
           handler()(mockReq, mockRes)
           const { moves } = mockRes.render.firstCall.lastArg
           expect(moves[0].removeMoveHref).to.equal(
@@ -278,7 +278,7 @@ describe('Allocation controllers', function () {
       let locals
 
       beforeEach(function () {
-        mockReq.checkPermissions.returns(true)
+        mockReq.canAccess.returns(true)
         handler()(mockReq, mockRes)
         locals = mockRes.render.firstCall.lastArg
       })

--- a/app/allocations/middleware/set-body.allocations.js
+++ b/app/allocations/middleware/set-body.allocations.js
@@ -1,16 +1,11 @@
 const { set } = require('lodash')
 
 const dateHelpers = require('../../../common/helpers/date')
-const permissions = require('../../../common/middleware/permissions')
 
 function setBodyAllocations(req, res, next) {
   const { status, sortBy, sortDirection } = req.query
   const { dateRange } = req.params
-  const userPermissions = req.session?.user?.permissions
-  const hasAssignerPermission = permissions.check(
-    'allocation:person:assign',
-    userPermissions
-  )
+  const hasAssignerPermission = req.checkPermissions('allocation:person:assign')
   const locationType = hasAssignerPermission ? 'fromLocations' : 'locations'
   const locations = req.locations
 

--- a/app/allocations/middleware/set-body.allocations.js
+++ b/app/allocations/middleware/set-body.allocations.js
@@ -5,7 +5,7 @@ const dateHelpers = require('../../../common/helpers/date')
 function setBodyAllocations(req, res, next) {
   const { status, sortBy, sortDirection } = req.query
   const { dateRange } = req.params
-  const hasAssignerPermission = req.checkPermissions('allocation:person:assign')
+  const hasAssignerPermission = req.canAccess('allocation:person:assign')
   const locationType = hasAssignerPermission ? 'fromLocations' : 'locations'
   const locations = req.locations
 

--- a/app/allocations/middleware/set-body.allocations.test.js
+++ b/app/allocations/middleware/set-body.allocations.test.js
@@ -1,5 +1,4 @@
 const dateHelpers = require('../../../common/helpers/date')
-const permissions = require('../../../common/middleware/permissions')
 
 const middleware = require('./set-body.allocations')
 
@@ -21,6 +20,7 @@ describe('Allocations middleware', function () {
           sortBy: 'moves_count',
           sortDirection: 'asc',
         },
+        checkPermissions: sinon.stub().returns(false),
       }
     })
 
@@ -67,7 +67,7 @@ describe('Allocations middleware', function () {
 
     context('when user has assign role', function () {
       beforeEach(function () {
-        sinon.stub(permissions, 'check').returns(true)
+        mockReq.checkPermissions.returns(true)
         middleware(mockReq, mockRes, nextSpy)
       })
 

--- a/app/allocations/middleware/set-body.allocations.test.js
+++ b/app/allocations/middleware/set-body.allocations.test.js
@@ -20,7 +20,7 @@ describe('Allocations middleware', function () {
           sortBy: 'moves_count',
           sortDirection: 'asc',
         },
-        checkPermissions: sinon.stub().returns(false),
+        canAccess: sinon.stub().returns(false),
       }
     })
 
@@ -67,7 +67,7 @@ describe('Allocations middleware', function () {
 
     context('when user has assign role', function () {
       beforeEach(function () {
-        mockReq.checkPermissions.returns(true)
+        mockReq.canAccess.returns(true)
         middleware(mockReq, mockRes, nextSpy)
       })
 

--- a/app/allocations/middleware/set-results.allocations.js
+++ b/app/allocations/middleware/set-results.allocations.js
@@ -2,7 +2,7 @@ const presenters = require('../../../common/presenters')
 const allocationService = require('../../../common/services/allocation')
 
 async function setResultsAllocations(req, res, next) {
-  const hasAssignerPermission = req.checkPermissions('allocation:person:assign')
+  const hasAssignerPermission = req.canAccess('allocation:person:assign')
   const query = req.query
 
   const displayConfig = {

--- a/app/allocations/middleware/set-results.allocations.js
+++ b/app/allocations/middleware/set-results.allocations.js
@@ -1,15 +1,8 @@
-const { get } = require('lodash')
-
-const permissions = require('../../../common/middleware/permissions')
 const presenters = require('../../../common/presenters')
 const allocationService = require('../../../common/services/allocation')
 
 async function setResultsAllocations(req, res, next) {
-  const userPermissions = get(req.session, 'user.permissions')
-  const hasAssignerPermission = permissions.check(
-    'allocation:person:assign',
-    userPermissions
-  )
+  const hasAssignerPermission = req.checkPermissions('allocation:person:assign')
   const query = req.query
 
   const displayConfig = {

--- a/app/allocations/middleware/set-results.allocations.test.js
+++ b/app/allocations/middleware/set-results.allocations.test.js
@@ -32,7 +32,7 @@ describe('Allocations middleware', function () {
       res = {}
       req = {
         session: {},
-        checkPermissions: sinon.stub().callsFake(permission => {
+        canAccess: sinon.stub().callsFake(permission => {
           if (Array.isArray(permission)) {
             permission = permission[0]
           }
@@ -54,7 +54,7 @@ describe('Allocations middleware', function () {
 
     context('when services resolve', function () {
       beforeEach(function () {
-        req.checkPermissions.returns(false)
+        req.canAccess.returns(false)
         allocationService.getActive.resolves(mockActiveMoves)
         allocationService.getCancelled.resolves(mockCancelledMoves)
       })
@@ -154,9 +154,7 @@ describe('Allocations middleware', function () {
         'when user has permissions to assign a person to a move',
         function () {
           beforeEach(async function () {
-            req.checkPermissions
-              .withArgs('allocation:person:assign')
-              .returns(true)
+            req.canAccess.withArgs('allocation:person:assign').returns(true)
             await middleware(req, res, next)
           })
 

--- a/app/home/middleware.js
+++ b/app/home/middleware.js
@@ -1,11 +1,8 @@
-const permissions = require('../../common/middleware/permissions')
-
 function movesRedirect(req, res, next) {
   // TODO: Remove this once we enable the dashboard for all users
   // Moves will then likely always redirect to the dashboard
-  const userPermissions = req.session?.user?.permissions
 
-  if (!permissions.check('dashboard:view', userPermissions)) {
+  if (!req.checkPermissions('dashboard:view')) {
     return res.redirect('/moves')
   }
 

--- a/app/home/middleware.js
+++ b/app/home/middleware.js
@@ -2,7 +2,7 @@ function movesRedirect(req, res, next) {
   // TODO: Remove this once we enable the dashboard for all users
   // Moves will then likely always redirect to the dashboard
 
-  if (!req.checkPermissions('dashboard:view')) {
+  if (!req.canAccess('dashboard:view')) {
     return res.redirect('/moves')
   }
 

--- a/app/home/middleware.test.js
+++ b/app/home/middleware.test.js
@@ -6,7 +6,7 @@ describe('Home middleware', function () {
 
     beforeEach(function () {
       req = {
-        checkPermissions: sinon.stub().returns(false),
+        canAccess: sinon.stub().returns(false),
       }
       res = {
         redirect: sinon.spy(),
@@ -30,7 +30,7 @@ describe('Home middleware', function () {
 
     context('with correct permission', function () {
       beforeEach(function () {
-        req.checkPermissions.withArgs('dashboard:view').returns(true)
+        req.canAccess.withArgs('dashboard:view').returns(true)
         controllers.movesRedirect(req, res, next)
       })
 

--- a/app/home/middleware.test.js
+++ b/app/home/middleware.test.js
@@ -6,11 +6,7 @@ describe('Home middleware', function () {
 
     beforeEach(function () {
       req = {
-        session: {
-          user: {
-            permissions: [],
-          },
-        },
+        checkPermissions: sinon.stub().returns(false),
       }
       res = {
         redirect: sinon.spy(),
@@ -34,8 +30,7 @@ describe('Home middleware', function () {
 
     context('with correct permission', function () {
       beforeEach(function () {
-        req.session.user.permissions = ['dashboard:view']
-
+        req.checkPermissions.withArgs('dashboard:view').returns(true)
         controllers.movesRedirect(req, res, next)
       })
 

--- a/app/move/controllers/view.js
+++ b/app/move/controllers/view.js
@@ -36,7 +36,7 @@ module.exports = function view(req, res) {
   } = profile || {}
   const personEscortRecordIsEnabled =
     FEATURE_FLAGS.PERSON_ESCORT_RECORD &&
-    req.checkPermissions('person_escort_record:view')
+    req.canAccess('person_escort_record:view')
   const personEscortRecordIsCompleted =
     !isEmpty(personEscortRecord) &&
     !['not_started', 'in_progress'].includes(personEscortRecord?.status)

--- a/app/move/controllers/view.js
+++ b/app/move/controllers/view.js
@@ -1,6 +1,5 @@
 const { isEmpty, find, sortBy } = require('lodash')
 
-const permissionsMiddleware = require('../../../common/middleware/permissions')
 const presenters = require('../../../common/presenters')
 const { FEATURE_FLAGS } = require('../../../config')
 const updateSteps = require('../steps/update')
@@ -28,8 +27,7 @@ module.exports = function view(req, res) {
   }
 
   const bannerStatuses = ['cancelled']
-  const userPermissions = req.session?.user?.permissions
-  const updateUrls = getUpdateUrls(updateSteps, move, userPermissions)
+  const updateUrls = getUpdateUrls(updateSteps, move, req)
   const updateActions = getUpdateLinks(updateSteps, updateUrls)
   const {
     person,
@@ -38,7 +36,7 @@ module.exports = function view(req, res) {
   } = profile || {}
   const personEscortRecordIsEnabled =
     FEATURE_FLAGS.PERSON_ESCORT_RECORD &&
-    permissionsMiddleware.check('person_escort_record:view', userPermissions)
+    req.checkPermissions('person_escort_record:view')
   const personEscortRecordIsCompleted =
     !isEmpty(personEscortRecord) &&
     !['not_started', 'in_progress'].includes(personEscortRecord?.status)
@@ -96,6 +94,7 @@ module.exports = function view(req, res) {
       }
     })
 
+  const userPermissions = req.session?.user?.permissions
   const locals = {
     move,
     assessment,

--- a/app/move/controllers/view.test.js
+++ b/app/move/controllers/view.test.js
@@ -124,7 +124,7 @@ describe('Move controllers', function () {
 
       req = {
         t: sinon.stub().returnsArg(0),
-        checkPermissions: sinon.stub().returns(true),
+        canAccess: sinon.stub().returns(true),
         session: {
           user: {
             permissions: userPermissions,
@@ -764,7 +764,7 @@ describe('Move controllers', function () {
 
       context('when user does not have permission', function () {
         beforeEach(function () {
-          req.checkPermissions.returns(false)
+          req.canAccess.returns(false)
           controller(req, res)
           params = res.render.args[0][1]
         })

--- a/app/move/controllers/view.test.js
+++ b/app/move/controllers/view.test.js
@@ -1,6 +1,5 @@
 const proxyquire = require('proxyquire').noCallThru()
 
-const permissionsMiddleware = require('../../../common/middleware/permissions')
 const presenters = require('../../../common/presenters')
 
 const getUpdateUrls = sinon.stub()
@@ -100,7 +99,6 @@ describe('Move controllers', function () {
     beforeEach(function () {
       getUpdateUrls.resetHistory()
       getUpdateLinks.resetHistory()
-      sinon.stub(permissionsMiddleware, 'check').returns(true)
       sinon
         .stub(presenters, 'moveToMetaListComponent')
         .returns('__moveToMetaListComponent__')
@@ -126,6 +124,7 @@ describe('Move controllers', function () {
 
       req = {
         t: sinon.stub().returnsArg(0),
+        checkPermissions: sinon.stub().returns(true),
         session: {
           user: {
             permissions: userPermissions,
@@ -385,7 +384,7 @@ describe('Move controllers', function () {
           expect(getUpdateUrls).to.be.calledOnceWithExactly(
             updateSteps,
             mockMove,
-            userPermissions
+            req
           )
         })
 
@@ -428,7 +427,7 @@ describe('Move controllers', function () {
           expect(getUpdateUrls).to.be.calledOnceWithExactly(
             updateSteps,
             { ...youthTransferMove, move_type: youthTransferType },
-            userPermissions
+            req
           )
         })
       })
@@ -765,7 +764,7 @@ describe('Move controllers', function () {
 
       context('when user does not have permission', function () {
         beforeEach(function () {
-          permissionsMiddleware.check.returns(false)
+          req.checkPermissions.returns(false)
           controller(req, res)
           params = res.render.args[0][1]
         })
@@ -813,7 +812,6 @@ describe('Move controllers', function () {
           ...mockMove,
           person: undefined,
         }
-        req.session.user.permissions = []
       })
 
       context('with proposed state', function () {

--- a/app/move/controllers/view/view.update.urls.js
+++ b/app/move/controllers/view/view.update.urls.js
@@ -1,14 +1,12 @@
-const { check } = require('../../../../common/middleware/permissions')
-
-const getUpdateUrls = (updateSteps, move, userPermissions) => {
+const getUpdateUrls = (updateSteps, move, req) => {
   const updateUrls = {}
 
-  if (!check(`move:update:${move.move_type}`, userPermissions)) {
+  if (!req.checkPermissions(`move:update:${move.move_type}`)) {
     return updateUrls
   }
 
   updateSteps.forEach(updateJourney => {
-    if (!check(updateJourney.permission, userPermissions)) {
+    if (!req.checkPermissions(updateJourney.permission)) {
       return
     }
 

--- a/app/move/controllers/view/view.update.urls.js
+++ b/app/move/controllers/view/view.update.urls.js
@@ -1,12 +1,12 @@
 const getUpdateUrls = (updateSteps, move, req) => {
   const updateUrls = {}
 
-  if (!req.checkPermissions(`move:update:${move.move_type}`)) {
+  if (!req.canAccess(`move:update:${move.move_type}`)) {
     return updateUrls
   }
 
   updateSteps.forEach(updateJourney => {
-    if (!req.checkPermissions(updateJourney.permission)) {
+    if (!req.canAccess(updateJourney.permission)) {
       return
     }
 

--- a/app/move/controllers/view/view.update.urls.test.js
+++ b/app/move/controllers/view/view.update.urls.test.js
@@ -23,10 +23,10 @@ describe('Move controllers', function () {
     describe('#getUpdateUrls', function () {
       let updateUrls
       const req = {
-        checkPermissions: sinon.stub().returns(false),
+        canAccess: sinon.stub().returns(false),
       }
       beforeEach(function () {
-        req.checkPermissions
+        req.canAccess
           .withArgs('move:update:prison_transfer')
           .returns(true)
           .withArgs('move:allowed')

--- a/app/move/controllers/view/view.update.urls.test.js
+++ b/app/move/controllers/view/view.update.urls.test.js
@@ -22,12 +22,19 @@ describe('Move controllers', function () {
   describe('#view()', function () {
     describe('#getUpdateUrls', function () {
       let updateUrls
-      const userPermissions = ['move:allowed', 'move:update:prison_transfer']
+      const req = {
+        checkPermissions: sinon.stub().returns(false),
+      }
       beforeEach(function () {
+        req.checkPermissions
+          .withArgs('move:update:prison_transfer')
+          .returns(true)
+          .withArgs('move:allowed')
+          .returns(true)
         updateUrls = getUpdateUrls(
           updateSteps,
           { id: 'moveId', move_type: 'prison_transfer' },
-          userPermissions
+          req
         )
       })
 
@@ -47,7 +54,7 @@ describe('Move controllers', function () {
         updateUrls = getUpdateUrls(
           updateSteps,
           { id: 'moveId', move_type: 'hospital' },
-          userPermissions
+          req
         )
         expect(updateUrls).to.deep.equal({})
       })

--- a/app/moves/middleware/redirect-base-url.js
+++ b/app/moves/middleware/redirect-base-url.js
@@ -8,7 +8,7 @@ function redirectBaseUrl(req, res) {
   const currentLocation = get(req.session, 'currentLocation')
 
   if (currentLocation) {
-    const canViewProposedMoves = req.checkPermissions('moves:view:proposed')
+    const canViewProposedMoves = req.canAccess('moves:view:proposed')
     const url =
       canViewProposedMoves && currentLocation.location_type === 'prison'
         ? `${req.baseUrl}/week/${today}/${currentLocation.id}/requested`

--- a/app/moves/middleware/redirect-base-url.js
+++ b/app/moves/middleware/redirect-base-url.js
@@ -1,7 +1,6 @@
 const { format } = require('date-fns')
 const { get } = require('lodash')
 
-const permissions = require('../../../common/middleware/permissions')
 const { DATE_FORMATS } = require('../../../config/index')
 
 function redirectBaseUrl(req, res) {
@@ -9,11 +8,7 @@ function redirectBaseUrl(req, res) {
   const currentLocation = get(req.session, 'currentLocation')
 
   if (currentLocation) {
-    const userPermissions = get(req.session, 'user.permissions')
-    const canViewProposedMoves = permissions.check(
-      'moves:view:proposed',
-      userPermissions
-    )
+    const canViewProposedMoves = req.checkPermissions('moves:view:proposed')
     const url =
       canViewProposedMoves && currentLocation.location_type === 'prison'
         ? `${req.baseUrl}/week/${today}/${currentLocation.id}/requested`

--- a/app/moves/middleware/redirect-base-url.test.js
+++ b/app/moves/middleware/redirect-base-url.test.js
@@ -9,7 +9,7 @@ describe('Moves middleware', function () {
       this.clock = sinon.useFakeTimers(new Date(mockMoveDate).getTime())
       req = {
         baseUrl: '/moves',
-        session: {},
+        checkPermissions: sinon.stub().returns(false),
       }
       res = {
         redirect: sinon.stub(),
@@ -33,9 +33,6 @@ describe('Moves middleware', function () {
             beforeEach(function () {
               req.session = {
                 currentLocation: mockLocation,
-                user: {
-                  permissions: [],
-                },
               }
 
               middleware(req, res)
@@ -56,9 +53,6 @@ describe('Moves middleware', function () {
             beforeEach(function () {
               req.session = {
                 currentLocation: mockLocation,
-                user: {
-                  permissions: [],
-                },
               }
 
               middleware(req, res)
@@ -82,11 +76,9 @@ describe('Moves middleware', function () {
             }
 
             beforeEach(function () {
+              req.checkPermissions.withArgs('moves:view:proposed').returns(true)
               req.session = {
                 currentLocation: mockLocation,
-                user: {
-                  permissions: ['moves:view:proposed'],
-                },
               }
 
               middleware(req, res)
@@ -104,11 +96,9 @@ describe('Moves middleware', function () {
             }
 
             beforeEach(function () {
+              req.checkPermissions.withArgs('moves:view:proposed').returns(true)
               req.session = {
                 currentLocation: mockLocation,
-                user: {
-                  permissions: ['moves:view:proposed'],
-                },
               }
 
               middleware(req, res)
@@ -140,11 +130,7 @@ describe('Moves middleware', function () {
         'when user has permission to see the proposed moves',
         function () {
           beforeEach(function () {
-            req.session = {
-              user: {
-                permissions: ['move:proposed:view'],
-              },
-            }
+            req.checkPermissions.withArgs('move:proposed:view').returns(true)
             res.redirect.resetHistory()
             middleware(req, res)
           })

--- a/app/moves/middleware/redirect-base-url.test.js
+++ b/app/moves/middleware/redirect-base-url.test.js
@@ -9,7 +9,7 @@ describe('Moves middleware', function () {
       this.clock = sinon.useFakeTimers(new Date(mockMoveDate).getTime())
       req = {
         baseUrl: '/moves',
-        checkPermissions: sinon.stub().returns(false),
+        canAccess: sinon.stub().returns(false),
       }
       res = {
         redirect: sinon.stub(),
@@ -76,7 +76,7 @@ describe('Moves middleware', function () {
             }
 
             beforeEach(function () {
-              req.checkPermissions.withArgs('moves:view:proposed').returns(true)
+              req.canAccess.withArgs('moves:view:proposed').returns(true)
               req.session = {
                 currentLocation: mockLocation,
               }
@@ -96,7 +96,7 @@ describe('Moves middleware', function () {
             }
 
             beforeEach(function () {
-              req.checkPermissions.withArgs('moves:view:proposed').returns(true)
+              req.canAccess.withArgs('moves:view:proposed').returns(true)
               req.session = {
                 currentLocation: mockLocation,
               }
@@ -130,7 +130,7 @@ describe('Moves middleware', function () {
         'when user has permission to see the proposed moves',
         function () {
           beforeEach(function () {
-            req.checkPermissions.withArgs('move:proposed:view').returns(true)
+            req.canAccess.withArgs('move:proposed:view').returns(true)
             res.redirect.resetHistory()
             middleware(req, res)
           })

--- a/app/moves/middleware/set-results.moves.js
+++ b/app/moves/middleware/set-results.moves.js
@@ -1,6 +1,5 @@
 const { omitBy, isUndefined } = require('lodash')
 
-const permissions = require('../../../common/middleware/permissions')
 const presenters = require('../../../common/presenters')
 const moveService = require('../../../common/services/move')
 
@@ -16,10 +15,9 @@ function setResultsMoves(bodyKey, locationKey, personEscortRecordFeature) {
         moveService.getActive(args),
         moveService.getCancelled(args),
       ])
-      const userPermissions = req.session?.user?.permissions
       const personEscortRecordIsEnabled =
         personEscortRecordFeature &&
-        permissions.check('person_escort_record:view', userPermissions)
+        req.checkPermissions('person_escort_record:view')
       const cardTagSource = personEscortRecordIsEnabled
         ? 'personEscortRecord'
         : undefined

--- a/app/moves/middleware/set-results.moves.js
+++ b/app/moves/middleware/set-results.moves.js
@@ -16,8 +16,7 @@ function setResultsMoves(bodyKey, locationKey, personEscortRecordFeature) {
         moveService.getCancelled(args),
       ])
       const personEscortRecordIsEnabled =
-        personEscortRecordFeature &&
-        req.checkPermissions('person_escort_record:view')
+        personEscortRecordFeature && req.canAccess('person_escort_record:view')
       const cardTagSource = personEscortRecordIsEnabled
         ? 'personEscortRecord'
         : undefined

--- a/app/moves/middleware/set-results.moves.test.js
+++ b/app/moves/middleware/set-results.moves.test.js
@@ -1,4 +1,3 @@
-const permissions = require('../../../common/middleware/permissions')
 const presenters = require('../../../common/presenters')
 const moveService = require('../../../common/services/move')
 
@@ -27,13 +26,13 @@ describe('Moves middleware', function () {
       sinon.stub(moveService, 'getCancelled')
       moveToCardComponentMapStub = sinon.stub().returnsArg(0)
       sinon.stub(presenters, 'movesByLocation').returnsArg(0)
-      sinon.stub(permissions, 'check').returns(false)
       sinon
         .stub(presenters, 'moveToCardComponent')
         .returns(moveToCardComponentMapStub)
       nextSpy = sinon.spy()
       res = {}
       req = {
+        checkPermissions: sinon.stub().returns(false),
         body: {
           [mockBodyKey]: {
             dateRange: ['2010-10-10', '2010-10-11'],
@@ -138,14 +137,9 @@ describe('Moves middleware', function () {
       context('with `personEscortRecordFeature`', function () {
         context('with correct user permission', function () {
           beforeEach(async function () {
-            permissions.check
-              .withArgs('person_escort_record:view', [
-                'person_escort_record:view',
-              ])
+            req.checkPermissions
+              .withArgs('person_escort_record:view')
               .returns(true)
-            req.session.user = {
-              permissions: ['person_escort_record:view'],
-            }
             await middleware(mockBodyKey, mockLocationKey, true)(
               req,
               res,

--- a/app/moves/middleware/set-results.moves.test.js
+++ b/app/moves/middleware/set-results.moves.test.js
@@ -32,7 +32,7 @@ describe('Moves middleware', function () {
       nextSpy = sinon.spy()
       res = {}
       req = {
-        checkPermissions: sinon.stub().returns(false),
+        canAccess: sinon.stub().returns(false),
         body: {
           [mockBodyKey]: {
             dateRange: ['2010-10-10', '2010-10-11'],
@@ -137,9 +137,7 @@ describe('Moves middleware', function () {
       context('with `personEscortRecordFeature`', function () {
         context('with correct user permission', function () {
           beforeEach(async function () {
-            req.checkPermissions
-              .withArgs('person_escort_record:view')
-              .returns(true)
+            req.canAccess.withArgs('person_escort_record:view').returns(true)
             await middleware(mockBodyKey, mockLocationKey, true)(
               req,
               res,

--- a/common/controllers/collection/render-as-cards.js
+++ b/common/controllers/collection/render-as-cards.js
@@ -1,10 +1,7 @@
-const permissions = require('../../middleware/permissions')
-
 module.exports = function listAsCards(req, res) {
-  const { actions, context, pagination, params, resultsAsCards, session } = req
+  const { actions, context, pagination, params, resultsAsCards } = req
   const { dateRange, locationId, period } = params
-  const userPermissions = session?.user?.permissions ?? []
-  const canViewMove = permissions.check('move:view', userPermissions)
+  const canViewMove = req.checkPermissions('move:view')
   const template =
     canViewMove && locationId ? 'collection-as-cards' : 'moves/views/download'
   const locals = {

--- a/common/controllers/collection/render-as-cards.js
+++ b/common/controllers/collection/render-as-cards.js
@@ -1,7 +1,7 @@
 module.exports = function listAsCards(req, res) {
   const { actions, context, pagination, params, resultsAsCards } = req
   const { dateRange, locationId, period } = params
-  const canViewMove = req.checkPermissions('move:view')
+  const canViewMove = req.canAccess('move:view')
   const template =
     canViewMove && locationId ? 'collection-as-cards' : 'moves/views/download'
   const locals = {

--- a/common/controllers/collection/render-as-cards.test.js
+++ b/common/controllers/collection/render-as-cards.test.js
@@ -19,7 +19,7 @@ describe('Collection controllers', function () {
 
     beforeEach(function () {
       req = {
-        checkPermissions: sinon.stub().returns(false),
+        canAccess: sinon.stub().returns(false),
         actions: ['1', '2'],
         context: 'listContext',
         pagination: mockPagination,
@@ -91,7 +91,7 @@ describe('Collection controllers', function () {
               locationId: '83a4208b-21a5-4b1d-a576-5d9513e0b910',
               dateRange: ['2020-10-01', '2020-10-10'],
             }
-            req.checkPermissions.withArgs('move:view').returns(true)
+            req.canAccess.withArgs('move:view').returns(true)
 
             controller(req, res)
           })
@@ -107,7 +107,7 @@ describe('Collection controllers', function () {
 
       context('if user can view move and all locations requested', function () {
         beforeEach(function () {
-          req.checkPermissions.withArgs('move:view').returns(true)
+          req.canAccess.withArgs('move:view').returns(true)
 
           controller(req, res)
         })

--- a/common/controllers/collection/render-as-cards.test.js
+++ b/common/controllers/collection/render-as-cards.test.js
@@ -1,5 +1,3 @@
-const permissions = require('../../middleware/permissions')
-
 const controller = require('./render-as-cards')
 
 const mockActiveMovesByDate = [
@@ -21,6 +19,7 @@ describe('Collection controllers', function () {
 
     beforeEach(function () {
       req = {
+        checkPermissions: sinon.stub().returns(false),
         actions: ['1', '2'],
         context: 'listContext',
         pagination: mockPagination,
@@ -84,24 +83,15 @@ describe('Collection controllers', function () {
     })
 
     describe('template', function () {
-      beforeEach(function () {
-        sinon.stub(permissions, 'check')
-      })
-
       context(
         'if user can view move and individual location requested',
         function () {
           beforeEach(function () {
-            req.session = {
-              user: {
-                permissions: ['move:view'],
-              },
-            }
             req.params = {
               locationId: '83a4208b-21a5-4b1d-a576-5d9513e0b910',
               dateRange: ['2020-10-01', '2020-10-10'],
             }
-            permissions.check.withArgs('move:view', ['move:view']).returns(true)
+            req.checkPermissions.withArgs('move:view').returns(true)
 
             controller(req, res)
           })
@@ -117,13 +107,7 @@ describe('Collection controllers', function () {
 
       context('if user can view move and all locations requested', function () {
         beforeEach(function () {
-          req.session = {
-            user: {
-              permissions: ['move:view'],
-            },
-          }
-
-          permissions.check.withArgs('move:view', ['move:view']).returns(true)
+          req.checkPermissions.withArgs('move:view').returns(true)
 
           controller(req, res)
         })
@@ -138,7 +122,6 @@ describe('Collection controllers', function () {
 
       context('if user cannot view move', function () {
         beforeEach(function () {
-          permissions.check.returns(false)
           controller(req, res)
         })
 

--- a/common/lib/prohibitions.js
+++ b/common/lib/prohibitions.js
@@ -1,0 +1,7 @@
+const prohibitionsByLocationType = {
+  court: ['move:create'],
+}
+
+module.exports = {
+  prohibitionsByLocationType,
+}

--- a/common/lib/prohibitions.test.js
+++ b/common/lib/prohibitions.test.js
@@ -1,0 +1,10 @@
+const { prohibitionsByLocationType } = require('./prohibitions')
+
+describe('Prohibitions', function () {
+  describe('When location type is court', function () {
+    it('should prohibit creation of moves', function () {
+      expect(prohibitionsByLocationType.court.includes('move:create')).to.be
+        .true
+    })
+  })
+})

--- a/common/middleware/locals.js
+++ b/common/middleware/locals.js
@@ -17,11 +17,11 @@ module.exports = function setLocals(req, res, next) {
     getLocal: key => res.locals[key],
     getMessages: () => req.flash(),
     canAccess: permission => {
-      if (!req.checkPermissions) {
+      if (!req.canAccess) {
         return false
       }
 
-      return req.checkPermissions(permission)
+      return req.canAccess(permission)
     },
   }
 

--- a/common/middleware/locals.js
+++ b/common/middleware/locals.js
@@ -1,9 +1,6 @@
 const { startOfTomorrow } = require('date-fns')
-const { get } = require('lodash')
 
 const movesApp = require('../../app/moves')
-
-const { check } = require('./permissions')
 
 module.exports = function setLocals(req, res, next) {
   const protocol = req.encrypted ? 'https' : req.protocol
@@ -20,8 +17,11 @@ module.exports = function setLocals(req, res, next) {
     getLocal: key => res.locals[key],
     getMessages: () => req.flash(),
     canAccess: permission => {
-      const userPermissions = get(req.session, 'user.permissions')
-      return check(permission, userPermissions)
+      if (!req.checkPermissions) {
+        return false
+      }
+
+      return req.checkPermissions(permission)
     },
   }
 

--- a/common/middleware/locals.test.js
+++ b/common/middleware/locals.test.js
@@ -106,21 +106,21 @@ describe('Locals', function () {
     })
 
     context('When invoking canAccess', function () {
-      it('should return false if no checkPermissions on the req object', function () {
+      it('should return false if no canAccess on the req object', function () {
         setLocals(req, res, next)
         expect(res.locals.canAccess('required_permission')).to.be.false
       })
 
-      context('and checkPermissions exists on the req object', function () {
+      context('and canAccess exists on the req object', function () {
         let checked
         beforeEach(function () {
-          req.checkPermissions = sinon.stub().returns('checked-permission')
+          req.canAccess = sinon.stub().returns('checked-permission')
           setLocals(req, res, next)
           checked = res.locals.canAccess('required_permission')
         })
 
-        it('should call checkPermissions with the permission', function () {
-          expect(req.checkPermissions).to.be.calledOnceWithExactly(
+        it('should call canAccess with the permission', function () {
+          expect(req.canAccess).to.be.calledOnceWithExactly(
             'required_permission'
           )
         })

--- a/common/middleware/locals.test.js
+++ b/common/middleware/locals.test.js
@@ -104,5 +104,31 @@ describe('Locals', function () {
         expect(res.locals.CANONICAL_URL).to.equal('gopher://hostname/foo')
       })
     })
+
+    context('When invoking canAccess', function () {
+      it('should return false if no checkPermissions on the req object', function () {
+        setLocals(req, res, next)
+        expect(res.locals.canAccess('required_permission')).to.be.false
+      })
+
+      context('and checkPermissions exists on the req object', function () {
+        let checked
+        beforeEach(function () {
+          req.checkPermissions = sinon.stub().returns('checked-permission')
+          setLocals(req, res, next)
+          checked = res.locals.canAccess('required_permission')
+        })
+
+        it('should call checkPermissions with the permission', function () {
+          expect(req.checkPermissions).to.be.calledOnceWithExactly(
+            'required_permission'
+          )
+        })
+
+        it('should return the expected result', function () {
+          expect(checked).to.equal('checked-permission')
+        })
+      })
+    })
   })
 })

--- a/common/middleware/locals.test.js
+++ b/common/middleware/locals.test.js
@@ -1,0 +1,108 @@
+const proxyquire = require('proxyquire')
+
+const setLocals = proxyquire('./locals', {
+  'date-fns': {
+    startOfTomorrow: sinon.stub().returns('tomorrow'),
+  },
+})
+
+const now = new Date()
+
+describe('Locals', function () {
+  describe('#setLocals', function () {
+    let clock
+    let req
+    let res
+    let next
+    beforeEach(function () {
+      clock = sinon.useFakeTimers(now.getTime())
+      req = {
+        encrypted: 'true',
+        protocol: 'gopher',
+        path: '/foo',
+        get: sinon.stub().withArgs('host').returns('hostname'),
+        user: 'USER',
+        session: {
+          currentLocation: 'current-location',
+          currentRegion: 'current-region',
+          movesUrl: 'moves-url',
+        },
+        flash: sinon.stub().returns('flash-messages'),
+      }
+      res = {
+        locals: {
+          foo: 'bar',
+        },
+      }
+      next = sinon.spy()
+    })
+    afterEach(function () {
+      clock.restore()
+    })
+
+    context('When invoked', function () {
+      beforeEach(function () {
+        setLocals(req, res, next)
+      })
+
+      it('should call next', function () {
+        expect(next).to.be.calledOnceWithExactly()
+      })
+
+      it('should set CANONICAL_URL', function () {
+        expect(res.locals.CANONICAL_URL).to.equal('https://hostname/foo')
+      })
+
+      it('should set TODAY', function () {
+        expect(res.locals.TODAY.getTime()).to.equal(now.getTime())
+      })
+
+      it('should set TOMORROW', function () {
+        expect(res.locals.TOMORROW).to.equal('tomorrow')
+      })
+
+      it('should set REQUEST_PATH', function () {
+        expect(res.locals.REQUEST_PATH).to.equal('/foo')
+      })
+
+      it('should set USER', function () {
+        expect(res.locals.USER).to.equal('USER')
+      })
+
+      it('should set CURRENT_LOCATION', function () {
+        expect(res.locals.CURRENT_LOCATION).to.equal('current-location')
+      })
+
+      it('should set CURRENT_REGION', function () {
+        expect(res.locals.CURRENT_REGION).to.equal('current-region')
+      })
+
+      it('should set MOVES_URL', function () {
+        expect(res.locals.MOVES_URL).to.equal('moves-url')
+      })
+
+      it('should create getLocal method', function () {
+        expect(res.locals.getLocal('foo')).to.equal('bar')
+      })
+
+      it('should create getMessages method', function () {
+        expect(res.locals.getMessages()).to.equal('flash-messages')
+      })
+
+      it('should maintain existing properties on res.locals', function () {
+        expect(res.locals.foo).to.equal('bar')
+      })
+    })
+
+    context('When request not encrypted', function () {
+      beforeEach(function () {
+        req.encrypted = false
+        setLocals(req, res, next)
+      })
+
+      it('should set CANONICAL_URL', function () {
+        expect(res.locals.CANONICAL_URL).to.equal('gopher://hostname/foo')
+      })
+    })
+  })
+})

--- a/common/middleware/permissions.js
+++ b/common/middleware/permissions.js
@@ -1,8 +1,21 @@
 const { get } = require('lodash')
 
-function check(permissions, userPermissions = []) {
+const { prohibitionsByLocationType } = require('../lib/prohibitions')
+
+function check(permissions, userPermissions = [], locationType) {
   if (!Array.isArray(permissions)) {
     permissions = [permissions]
+  }
+
+  const locationTypeProhibitions = prohibitionsByLocationType[locationType]
+
+  if (
+    locationTypeProhibitions &&
+    permissions.some(permission =>
+      locationTypeProhibitions.includes(permission)
+    )
+  ) {
+    return false
   }
 
   return permissions.some(permission => userPermissions.includes(permission))

--- a/common/middleware/permissions.js
+++ b/common/middleware/permissions.js
@@ -21,11 +21,10 @@ function check(permissions, userPermissions = [], locationType) {
   return permissions.some(permission => userPermissions.includes(permission))
 }
 
-function setCheckPermissions(req, res, next) {
+function setCanAccess(req, res, next) {
   const userPermissions = req.session.user?.permissions
   const locationType = req.session.currentLocation?.location_type
-  req.checkPermissions = permission =>
-    check(permission, userPermissions, locationType)
+  req.canAccess = permission => check(permission, userPermissions, locationType)
 
   next()
 }
@@ -47,6 +46,6 @@ function protectRoute(permission) {
 
 module.exports = {
   check,
-  setCheckPermissions,
+  setCanAccess,
   protectRoute,
 }

--- a/common/middleware/permissions.js
+++ b/common/middleware/permissions.js
@@ -21,6 +21,15 @@ function check(permissions, userPermissions = [], locationType) {
   return permissions.some(permission => userPermissions.includes(permission))
 }
 
+function setCheckPermissions(req, res, next) {
+  const userPermissions = req.session.user?.permissions
+  const locationType = req.session.currentLocation?.location_type
+  req.checkPermissions = permission =>
+    check(permission, userPermissions, locationType)
+
+  next()
+}
+
 function protectRoute(permission) {
   return (req, res, next) => {
     const userPermissions = get(req.session, 'user.permissions')
@@ -38,5 +47,6 @@ function protectRoute(permission) {
 
 module.exports = {
   check,
+  setCheckPermissions,
   protectRoute,
 }

--- a/common/middleware/permissions.test.js
+++ b/common/middleware/permissions.test.js
@@ -92,7 +92,7 @@ describe('Permissions middleware', function () {
     })
   })
 
-  describe('#setCheckPermissions()', function () {
+  describe('#setCanAccess()', function () {
     let req, next, allowed
 
     beforeEach(function () {
@@ -111,7 +111,7 @@ describe('Permissions middleware', function () {
 
     context('when invoked', function () {
       beforeEach(function () {
-        middleware.setCheckPermissions(req, {}, next)
+        middleware.setCanAccess(req, {}, next)
       })
 
       it('should call next', function () {
@@ -122,8 +122,8 @@ describe('Permissions middleware', function () {
     context('when the method on the request object is invoked', function () {
       context('and the user does not have the permission', function () {
         beforeEach(function () {
-          middleware.setCheckPermissions(req, {}, next)
-          allowed = req.checkPermissions('missing_permission')
+          middleware.setCanAccess(req, {}, next)
+          allowed = req.canAccess('missing_permission')
         })
 
         it('should return false', function () {
@@ -133,8 +133,8 @@ describe('Permissions middleware', function () {
 
       context('and the user has the permission', function () {
         beforeEach(function () {
-          middleware.setCheckPermissions(req, {}, next)
-          allowed = req.checkPermissions('required_permission')
+          middleware.setCanAccess(req, {}, next)
+          allowed = req.canAccess('required_permission')
         })
 
         it('should return true', function () {
@@ -147,8 +147,8 @@ describe('Permissions middleware', function () {
         function () {
           beforeEach(function () {
             req.session.currentLocation.location_type = 'forbidden_planet'
-            middleware.setCheckPermissions(req, {}, next)
-            allowed = req.checkPermissions('required_permission')
+            middleware.setCanAccess(req, {}, next)
+            allowed = req.canAccess('required_permission')
           })
 
           it('should return false', function () {

--- a/common/middleware/permissions.test.js
+++ b/common/middleware/permissions.test.js
@@ -92,6 +92,73 @@ describe('Permissions middleware', function () {
     })
   })
 
+  describe('#setCheckPermissions()', function () {
+    let req, next, allowed
+
+    beforeEach(function () {
+      next = sinon.spy()
+      req = {
+        session: {
+          currentLocation: {
+            location_type: 'somewhere',
+          },
+          user: {
+            permissions: ['required_permission'],
+          },
+        },
+      }
+    })
+
+    context('when invoked', function () {
+      beforeEach(function () {
+        middleware.setCheckPermissions(req, {}, next)
+      })
+
+      it('should call next', function () {
+        expect(next).to.be.calledOnceWithExactly()
+      })
+    })
+
+    context('when the method on the request object is invoked', function () {
+      context('and the user does not have the permission', function () {
+        beforeEach(function () {
+          middleware.setCheckPermissions(req, {}, next)
+          allowed = req.checkPermissions('missing_permission')
+        })
+
+        it('should return false', function () {
+          expect(allowed).to.be.false
+        })
+      })
+
+      context('and the user has the permission', function () {
+        beforeEach(function () {
+          middleware.setCheckPermissions(req, {}, next)
+          allowed = req.checkPermissions('required_permission')
+        })
+
+        it('should return true', function () {
+          expect(allowed).to.be.true
+        })
+      })
+
+      context(
+        'and the user has the permission but the location prohibits the action',
+        function () {
+          beforeEach(function () {
+            req.session.currentLocation.location_type = 'forbidden_planet'
+            middleware.setCheckPermissions(req, {}, next)
+            allowed = req.checkPermissions('required_permission')
+          })
+
+          it('should return false', function () {
+            expect(allowed).to.be.false
+          })
+        }
+      )
+    })
+  })
+
   describe('#protectRoute()', function () {
     let req, nextSpy
 

--- a/common/middleware/permissions.test.js
+++ b/common/middleware/permissions.test.js
@@ -1,4 +1,13 @@
-const middleware = require('./permissions')
+const proxyquire = require('proxyquire')
+const prohibitions = {
+  prohibitionsByLocationType: {
+    forbidden_planet: ['required_permission'],
+  },
+}
+
+const middleware = proxyquire('./permissions', {
+  '../lib/prohibitions': prohibitions,
+})
 
 describe('Permissions middleware', function () {
   describe('#check()', function () {
@@ -16,17 +25,34 @@ describe('Permissions middleware', function () {
 
     context('when required permission exists', function () {
       beforeEach(function () {
-        permit = middleware.check('required_permission', [
-          'user_permission_1',
-          'user_permission_2',
+        permit = middleware.check(
           'required_permission',
-        ])
+          ['user_permission_1', 'user_permission_2', 'required_permission'],
+          'somewhere'
+        )
       })
 
       it('should return true', function () {
         expect(permit).to.be.true
       })
     })
+
+    context(
+      'when required permission exists but location type prohibits it',
+      function () {
+        beforeEach(function () {
+          permit = middleware.check(
+            'required_permission',
+            ['required_permission'],
+            'forbidden_planet'
+          )
+        })
+
+        it('should return false', function () {
+          expect(permit).to.be.false
+        })
+      }
+    )
 
     describe('when multiple permissions are possible', function () {
       let permit

--- a/common/middleware/set-primary-navigation.js
+++ b/common/middleware/set-primary-navigation.js
@@ -36,7 +36,7 @@ function setPrimaryNavigation(req, res, next) {
   ]
 
   res.locals.primaryNavigation = items
-    .filter(item => req.checkPermissions(item.permission))
+    .filter(item => req.canAccess(item.permission))
     .map(item => omit(item, 'permission'))
 
   next()

--- a/common/middleware/set-primary-navigation.js
+++ b/common/middleware/set-primary-navigation.js
@@ -1,9 +1,6 @@
-const { get, omit } = require('lodash')
-
-const permissions = require('./permissions')
+const { omit } = require('lodash')
 
 function setPrimaryNavigation(req, res, next) {
-  const userPermissions = get(req.session, 'user.permissions')
   const items = [
     {
       permission: 'dashboard:view',
@@ -39,7 +36,7 @@ function setPrimaryNavigation(req, res, next) {
   ]
 
   res.locals.primaryNavigation = items
-    .filter(item => permissions.check(item.permission, userPermissions))
+    .filter(item => req.checkPermissions(item.permission))
     .map(item => omit(item, 'permission'))
 
   next()

--- a/common/middleware/set-primary-navigation.test.js
+++ b/common/middleware/set-primary-navigation.test.js
@@ -1,4 +1,3 @@
-const permissions = require('./permissions')
 const middleware = require('./set-primary-navigation')
 
 describe('#setPrimaryNavigation()', function () {
@@ -7,17 +6,8 @@ describe('#setPrimaryNavigation()', function () {
   beforeEach(function () {
     nextSpy = sinon.spy()
     req = {
+      checkPermissions: sinon.stub().returns(false),
       path: '',
-      session: {
-        user: {
-          permissions: [
-            'dashboard:view',
-            'allocations:view',
-            'moves:view:proposed',
-            'moves:view:outgoing',
-          ],
-        },
-      },
       t: sinon.stub().returnsArg(0),
     }
     res = {
@@ -27,7 +17,6 @@ describe('#setPrimaryNavigation()', function () {
 
   context('with no permissions', function () {
     beforeEach(function () {
-      sinon.stub(permissions, 'check').returns(false)
       middleware(req, res, nextSpy)
     })
 
@@ -42,7 +31,7 @@ describe('#setPrimaryNavigation()', function () {
 
   context('with all permissions', function () {
     beforeEach(function () {
-      sinon.stub(permissions, 'check').returns(true)
+      req.checkPermissions.returns(true)
     })
 
     describe('navigation items', function () {
@@ -236,47 +225,38 @@ describe('#setPrimaryNavigation()', function () {
 
   describe('permissions', function () {
     beforeEach(function () {
-      sinon.stub(permissions, 'check').returns(true)
+      req.checkPermissions.returns(true)
       middleware(req, res, nextSpy)
     })
 
     it('should check for dashboard permission', function () {
-      expect(permissions.check).to.be.calledWithExactly(
-        'dashboard:view',
-        req.session.user.permissions
-      )
+      expect(req.checkPermissions).to.be.calledWithExactly('dashboard:view')
     })
 
     it('should check for single request permission', function () {
-      expect(permissions.check).to.be.calledWithExactly(
-        'moves:view:proposed',
-        req.session.user.permissions
+      expect(req.checkPermissions).to.be.calledWithExactly(
+        'moves:view:proposed'
       )
     })
 
     it('should check for allocation permission', function () {
-      expect(permissions.check).to.be.calledWithExactly(
-        'allocations:view',
-        req.session.user.permissions
-      )
+      expect(req.checkPermissions).to.be.calledWithExactly('allocations:view')
     })
 
     it('should check for outgoing moves permission', function () {
-      expect(permissions.check).to.be.calledWithExactly(
-        'moves:view:outgoing',
-        req.session.user.permissions
+      expect(req.checkPermissions).to.be.calledWithExactly(
+        'moves:view:outgoing'
       )
     })
 
     it('should check for incoming moves permission', function () {
-      expect(permissions.check).to.be.calledWithExactly(
-        'moves:view:incoming',
-        req.session.user.permissions
+      expect(req.checkPermissions).to.be.calledWithExactly(
+        'moves:view:incoming'
       )
     })
 
     it('should check for permissions correct number of times', function () {
-      expect(permissions.check.callCount).to.equal(5)
+      expect(req.checkPermissions.callCount).to.equal(5)
     })
   })
 })

--- a/common/middleware/set-primary-navigation.test.js
+++ b/common/middleware/set-primary-navigation.test.js
@@ -6,7 +6,7 @@ describe('#setPrimaryNavigation()', function () {
   beforeEach(function () {
     nextSpy = sinon.spy()
     req = {
-      checkPermissions: sinon.stub().returns(false),
+      canAccess: sinon.stub().returns(false),
       path: '',
       t: sinon.stub().returnsArg(0),
     }
@@ -31,7 +31,7 @@ describe('#setPrimaryNavigation()', function () {
 
   context('with all permissions', function () {
     beforeEach(function () {
-      req.checkPermissions.returns(true)
+      req.canAccess.returns(true)
     })
 
     describe('navigation items', function () {
@@ -225,38 +225,32 @@ describe('#setPrimaryNavigation()', function () {
 
   describe('permissions', function () {
     beforeEach(function () {
-      req.checkPermissions.returns(true)
+      req.canAccess.returns(true)
       middleware(req, res, nextSpy)
     })
 
     it('should check for dashboard permission', function () {
-      expect(req.checkPermissions).to.be.calledWithExactly('dashboard:view')
+      expect(req.canAccess).to.be.calledWithExactly('dashboard:view')
     })
 
     it('should check for single request permission', function () {
-      expect(req.checkPermissions).to.be.calledWithExactly(
-        'moves:view:proposed'
-      )
+      expect(req.canAccess).to.be.calledWithExactly('moves:view:proposed')
     })
 
     it('should check for allocation permission', function () {
-      expect(req.checkPermissions).to.be.calledWithExactly('allocations:view')
+      expect(req.canAccess).to.be.calledWithExactly('allocations:view')
     })
 
     it('should check for outgoing moves permission', function () {
-      expect(req.checkPermissions).to.be.calledWithExactly(
-        'moves:view:outgoing'
-      )
+      expect(req.canAccess).to.be.calledWithExactly('moves:view:outgoing')
     })
 
     it('should check for incoming moves permission', function () {
-      expect(req.checkPermissions).to.be.calledWithExactly(
-        'moves:view:incoming'
-      )
+      expect(req.canAccess).to.be.calledWithExactly('moves:view:incoming')
     })
 
     it('should check for permissions correct number of times', function () {
-      expect(req.checkPermissions.callCount).to.equal(5)
+      expect(req.canAccess.callCount).to.equal(5)
     })
   })
 })

--- a/server.js
+++ b/server.js
@@ -25,6 +25,7 @@ const ensureAuthenticated = require('./common/middleware/ensure-authenticated')
 const ensureSelectedLocation = require('./common/middleware/ensure-selected-location')
 const errorHandlers = require('./common/middleware/errors')
 const locals = require('./common/middleware/locals')
+const { setCheckPermissions } = require('./common/middleware/permissions')
 const processOriginalRequestBody = require('./common/middleware/process-original-request-body')
 const sentryEnrichScope = require('./common/middleware/sentry-enrich-scope')
 const sentryRequestId = require('./common/middleware/sentry-request-id')
@@ -183,6 +184,9 @@ app.use(
 
 // Ensure body processed after reauthentication
 app.use(processOriginalRequestBody())
+
+// Add permission checker
+app.use(setCheckPermissions)
 
 // Routing
 app.use(setPrimaryNavigation)

--- a/server.js
+++ b/server.js
@@ -25,7 +25,7 @@ const ensureAuthenticated = require('./common/middleware/ensure-authenticated')
 const ensureSelectedLocation = require('./common/middleware/ensure-selected-location')
 const errorHandlers = require('./common/middleware/errors')
 const locals = require('./common/middleware/locals')
-const { setCheckPermissions } = require('./common/middleware/permissions')
+const { setCanAccess } = require('./common/middleware/permissions')
 const processOriginalRequestBody = require('./common/middleware/process-original-request-body')
 const sentryEnrichScope = require('./common/middleware/sentry-enrich-scope')
 const sentryRequestId = require('./common/middleware/sentry-request-id')
@@ -186,7 +186,7 @@ app.use(
 app.use(processOriginalRequestBody())
 
 // Add permission checker
-app.use(setCheckPermissions)
+app.use(setCanAccess)
 
 // Routing
 app.use(setPrimaryNavigation)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Adds the ability for permissions to be prohibited by location type.

Prohibits `move:create` when the location_type is `court`.

Refactors calls to check permissions to use a method attached to the request object.

### Why did it change

We have users that can access court locations and also have the `move:create` permission. This led to the unwanted outcome of being able to create a move through the frontend from a court.


### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

- [P4-2105 - Prevent moves being created from courts](https://dsdmoj.atlassian.net/browse/P4-2105)

## Screenshots
<!--- (Optional) Include screenshots if changes update interfaces or components -->
<!--- Delete/copy as appropriate --->

n/a

## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed


### Other considerations

- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics

