### PR TITLE
[P4-2210] Conditionally validate follow up comments based on NOMIS mappings

### DIFF
--- a/app/person-escort-record/controllers/framework-step.js
+++ b/app/person-escort-record/controllers/framework-step.js
@@ -33,7 +33,19 @@ class FrameworkStepController extends FormWizardController {
     // TODO: Find a more efficient way to solve this ordering issue
     this.use(this.setupConditionalFields)
     super.middlewareSetup()
+    this.use(this.setValidationRules)
     this.use(this.setButtonText)
+  }
+
+  setValidationRules(req, res, next) {
+    const { responses } = req.personEscortRecord || {}
+    const fields = Object.entries(req.form.options.fields).map(
+      frameworksHelpers.setValidationRules(responses)
+    )
+
+    req.form.options.fields = fromPairs(fields)
+
+    next()
   }
 
   setInitialValues(req, res, next) {

--- a/app/person-escort-record/controllers/framework-step.test.js
+++ b/app/person-escort-record/controllers/framework-step.test.js
@@ -41,6 +41,7 @@ describe('Person Escort Record controllers', function () {
         sinon.stub(controller, 'setupConditionalFields')
         sinon.stub(controller, 'use')
         sinon.stub(controller, 'setButtonText')
+        sinon.stub(controller, 'setValidationRules')
 
         controller.middlewareSetup()
       })
@@ -58,12 +59,18 @@ describe('Person Escort Record controllers', function () {
 
       it('should call set button text method', function () {
         expect(controller.use.getCall(1)).to.have.been.calledWithExactly(
+          controller.setValidationRules
+        )
+      })
+
+      it('should call set button text method', function () {
+        expect(controller.use.getCall(2)).to.have.been.calledWithExactly(
           controller.setButtonText
         )
       })
 
       it('should call correct number of middleware', function () {
-        expect(controller.use).to.be.callCount(2)
+        expect(controller.use).to.be.callCount(3)
       })
     })
 

--- a/common/helpers/frameworks/index.js
+++ b/common/helpers/frameworks/index.js
@@ -3,6 +3,7 @@ const mapFieldFromName = require('./map-field-from-name')
 const reduceResponsesToFormValues = require('./reduce-responses-to-form-values')
 const renderNomisMappingsToField = require('./render-nomis-mappings-to-field')
 const responsesToSaveReducer = require('./responses-to-save-reducer')
+const setValidationRules = require('./set-validation-rules')
 
 module.exports = {
   mapFieldFromName,
@@ -10,4 +11,5 @@ module.exports = {
   reduceResponsesToFormValues,
   renderNomisMappingsToField,
   responsesToSaveReducer,
+  setValidationRules,
 }

--- a/common/helpers/frameworks/set-validation-rules.js
+++ b/common/helpers/frameworks/set-validation-rules.js
@@ -1,0 +1,39 @@
+const { cloneDeep, find, set } = require('lodash')
+
+function setValidationRules(responses = []) {
+  return ([key, field]) => {
+    const response = find(responses, [
+      'question.key',
+      field.dependentQuestionKey,
+    ])
+
+    if (!response) {
+      return [key, field]
+    }
+
+    const { nomis_mappings: nomisMappings = [] } = response
+    const clonedField = cloneDeep(field)
+
+    clonedField.validate = clonedField.validate.map(validation => {
+      return {
+        ...validation,
+        type: validation.type.replace(
+          'required_unless_nomis_mappings',
+          'required'
+        ),
+      }
+    })
+
+    if (nomisMappings.length > 0) {
+      set(clonedField, 'label.text', `${clonedField.label.text} (optional)`)
+
+      clonedField.validate = clonedField.validate.filter(
+        validation => validation.type !== 'required'
+      )
+    }
+
+    return [key, clonedField]
+  }
+}
+
+module.exports = setValidationRules

--- a/common/helpers/frameworks/set-validation-rules.test.js
+++ b/common/helpers/frameworks/set-validation-rules.test.js
@@ -1,0 +1,159 @@
+const helper = require('./set-validation-rules')
+
+describe('Framework helpers', function () {
+  describe('#setValidationRules', function () {
+    context('with no responses', function () {
+      it('should return original item', function () {
+        const mockField = ['mock-field', { foo: 'bar' }]
+        const output = helper()(mockField)
+
+        expect(output).to.deep.equal(['mock-field', { foo: 'bar' }])
+      })
+    })
+
+    context('with responses', function () {
+      let output
+      const mockResponses = [
+        {
+          id: '1',
+          question: {
+            key: 'violent-or-dangerous',
+          },
+        },
+      ]
+
+      context('without parent response', function () {
+        const mockField = ['mock-field', { foo: 'bar' }]
+
+        beforeEach(function () {
+          output = helper(mockResponses)(mockField)
+        })
+
+        it('should return original field', function () {
+          expect(output).to.deep.equal(['mock-field', { foo: 'bar' }])
+        })
+      })
+
+      context('with parent response', function () {
+        const mockField = [
+          'mock-field',
+          {
+            label: {
+              text: 'Please answer this question',
+            },
+            dependentQuestionKey: 'violent-or-dangerous',
+            validate: [
+              {
+                type: 'custom_validation',
+                message: 'Fix custom validation',
+              },
+              {
+                type: 'required_unless_nomis_mappings',
+                message: 'Fix required validation',
+              },
+            ],
+          },
+        ]
+
+        context('without NOMIS mappings', function () {
+          beforeEach(function () {
+            output = helper(mockResponses)(mockField)
+          })
+
+          it('should update validation', function () {
+            expect(output).to.deep.equal([
+              'mock-field',
+              {
+                label: {
+                  text: 'Please answer this question',
+                },
+                dependentQuestionKey: 'violent-or-dangerous',
+                validate: [
+                  {
+                    type: 'custom_validation',
+                    message: 'Fix custom validation',
+                  },
+                  {
+                    type: 'required',
+                    message: 'Fix required validation',
+                  },
+                ],
+              },
+            ])
+          })
+        })
+
+        context('with empty NOMIS mappings', function () {
+          beforeEach(function () {
+            output = helper([{ ...mockResponses[0], nomis_mappings: [] }])(
+              mockField
+            )
+          })
+
+          it('should update validation', function () {
+            expect(output).to.deep.equal([
+              'mock-field',
+              {
+                label: {
+                  text: 'Please answer this question',
+                },
+                dependentQuestionKey: 'violent-or-dangerous',
+                validate: [
+                  {
+                    type: 'custom_validation',
+                    message: 'Fix custom validation',
+                  },
+                  {
+                    type: 'required',
+                    message: 'Fix required validation',
+                  },
+                ],
+              },
+            ])
+          })
+        })
+
+        context('with NOMIS mappings', function () {
+          beforeEach(function () {
+            output = helper([
+              { ...mockResponses[0], nomis_mappings: [{ foo: 'bar' }] },
+            ])(mockField)
+          })
+
+          it('should remove required validation', function () {
+            expect(output[1].validate).to.deep.equal([
+              {
+                type: 'custom_validation',
+                message: 'Fix custom validation',
+              },
+            ])
+          })
+
+          it('should append optional to label', function () {
+            expect(output[1].label).to.deep.equal({
+              text: 'Please answer this question (optional)',
+            })
+          })
+
+          it('should not mutate field', function () {
+            expect(output).to.deep.equal([
+              'mock-field',
+              {
+                label: {
+                  text: 'Please answer this question (optional)',
+                },
+                dependentQuestionKey: 'violent-or-dangerous',
+                validate: [
+                  {
+                    type: 'custom_validation',
+                    message: 'Fix custom validation',
+                  },
+                ],
+              },
+            ])
+          })
+        })
+      })
+    })
+  })
+})

--- a/common/services/frameworks.js
+++ b/common/services/frameworks.js
@@ -40,6 +40,7 @@ function buildCommentField(
   const field = {
     rows,
     component,
+    dependentQuestionKey: dependentField,
     name: `${dependentField}--${kebabCase(dependentValue)}`,
     id: `${dependentField}--${kebabCase(dependentValue)}`,
     classes: inputWidthClasses[charWidth] || 'govuk-input--width-20',

--- a/common/services/frameworks.test.js
+++ b/common/services/frameworks.test.js
@@ -354,6 +354,7 @@ describe('Services', function () {
                   text: 'Yes, I agree',
                   conditional: {
                     rows: 2,
+                    dependentQuestionKey: 'question-key',
                     name: 'question-key--yes-i-agree',
                     id: 'question-key--yes-i-agree',
                     component: 'govukTextarea',
@@ -379,6 +380,7 @@ describe('Services', function () {
                   text: 'No, I do not agree',
                   conditional: {
                     rows: 4,
+                    dependentQuestionKey: 'question-key',
                     name: 'question-key--no-i-do-not-agree',
                     id: 'question-key--no-i-do-not-agree',
                     component: 'govukInput',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Conditionally apply validation to follow up comments from the Person Escort Record framework.

### Why did it change

In order to support the new addition of NOMIS information the validation rules need to be made more
dynamic so that if information exists within NOMIS, we do not require the user to provide further details.

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

- [P4-2210](https://dsdmoj.atlassian.net/browse/P4-2210)

## Screenshots
<!--- (Optional) Include screenshots if changes update interfaces or components -->
<!--- Delete/copy as appropriate --->

| Before | After |
| ------ | ----- |
| With NOMIS mappings | |
| <kbd>![image](https://user-images.githubusercontent.com/3327997/95979106-0a01f500-0e13-11eb-9cff-de6d2c37f862.png)</kbd> | <kbd>![image](https://user-images.githubusercontent.com/3327997/95978805-9829ab80-0e12-11eb-91d0-98309f3d6181.png)</kbd> |
| Validation with NOMIS mappings | |
| <kbd>![image](https://user-images.githubusercontent.com/3327997/95979145-17b77a80-0e13-11eb-850c-af63b7a42683.png)</kbd> | <kbd>![image](https://user-images.githubusercontent.com/3327997/95978875-b099c600-0e12-11eb-9dd6-5a7ad359252b.png)</kbd> |
| Without NOMIS mappings | |
| <kbd>![image](https://user-images.githubusercontent.com/3327997/95977994-7c71d580-0e11-11eb-9948-f3c1cf50d795.png)</kbd> | No change |

## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [x] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed

### Other considerations

Commit messages with a `fix` or `feat` type are automatically used to generate the [changelog](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/CHANGELOG.md) and
[GitHub release notes](https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/releases) during the release task. Please make sure they will read well on their own in a
summary of changes and that the commit body gives a more detailed description of those changes if necessary.

- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
- [x] Update [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md) with any new instructions or tasks
