### PR TITLE
[P4-2077] Display banner when NOMIS sync fails

### DIFF
--- a/app/person-escort-record/controllers/framework-step.js
+++ b/app/person-escort-record/controllers/framework-step.js
@@ -78,10 +78,21 @@ class FrameworkStepController extends FormWizardController {
   middlewareLocals() {
     super.middlewareLocals()
     this.use(this.setPageTitleLocals)
+    this.use(this.setSyncStatusBanner)
   }
 
   setPageTitleLocals(req, res, next) {
     res.locals.frameworkSection = req.frameworkSection.name
+    next()
+  }
+
+  setSyncStatusBanner(req, res, next) {
+    const { nomis_sync_status: syncStatus } = req.personEscortRecord
+
+    res.locals.syncFailures = syncStatus
+      .filter(type => type.status === 'failed')
+      .map(type => type.resource_type)
+
     next()
   }
 

--- a/app/person-escort-record/views/framework-step.njk
+++ b/app/person-escort-record/views/framework-step.njk
@@ -2,6 +2,37 @@
 
 {% set mainClasses = "interruption-card" if options.stepType == 'interruption-card' %}
 
+{% block contentHeader %}
+  {% if syncFailures.length > 0 %}
+    {% set html %}
+      <p class="govuk-!-margin-bottom-3">
+        {{ t("person-escort-record::sync_status.failed.message") }}
+      </p>
+
+      <ul>
+        {% for type in syncFailures %}
+          <li>
+            {{ t("person-escort-record::sync_status.failed.resource_types." + type) }}
+          </li>
+        {% endfor %}
+      </ul>
+    {% endset %}
+
+    {{ appMessage({
+      allowDismiss: false,
+      classes: "app-message--warning govuk-!-margin-bottom-4",
+      title: {
+        text: t("person-escort-record::sync_status.failed.title")
+      },
+      content: {
+        html: html
+      }
+    }) }}
+  {% endif %}
+
+  {{ super() }}
+{% endblock %}
+
 {% block pageTitle %}
   {{ t(options.pageTitle) }}
   – {{ t(frameworkSection) }}

--- a/common/lib/api-client/models.js
+++ b/common/lib/api-client/models.js
@@ -393,6 +393,7 @@ module.exports = {
       created_at: '',
       confirmed_at: '',
       version: '',
+      nomis_sync_status: '',
       move: {
         jsonApi: 'hasOne',
         type: 'moves',

--- a/locales/en/person-escort-record.json
+++ b/locales/en/person-escort-record.json
@@ -11,6 +11,17 @@
     "in_progress": "In progress",
     "completed": "Completed"
   },
+  "sync_status": {
+    "failed": {
+      "title": "Some NOMIS information could not be included",
+      "message": "The following information could not be included. Check NOMIS for the most up to date information:",
+      "resource_types": {
+        "alerts": "alerts",
+        "personal_care_needs": "personal care needs",
+        "reasonable_adjustments": "reasonable adjustments"
+      }
+    }
+  },
   "journeys": {
     "confirm": {
       "heading":"Confirm and complete this Person Escort Record",

--- a/test/fixtures/api-client/person_escort_record.create.json
+++ b/test/fixtures/api-client/person_escort_record.create.json
@@ -6,6 +6,20 @@
       "status": "not_started",
       "confirmed_at": null,
       "created_at": "2020-06-09T01:00:40+01:00",
+      "nomis_sync_status": [
+        {
+          "resource_type": "alerts",
+          "status": "success"
+        },
+        {
+          "resource_type": "personal_care_needs",
+          "status": "success"
+        },
+        {
+          "resource_type": "reasonable_adjustments",
+          "status": "success"
+        }
+      ],
       "version": "1.1"
     },
     "relationships": {

--- a/test/fixtures/api-client/person_escort_record.find.json
+++ b/test/fixtures/api-client/person_escort_record.find.json
@@ -6,6 +6,20 @@
       "status": "not_started",
       "confirmed_at": "2020-06-15T09:52:10+01:00",
       "created_at": "2020-06-09T01:00:40+01:00",
+      "nomis_sync_status": [
+        {
+          "resource_type": "alerts",
+          "status": "failed"
+        },
+        {
+          "resource_type": "personal_care_needs",
+          "status": "success"
+        },
+        {
+          "resource_type": "reasonable_adjustments",
+          "status": "failed"
+        }
+      ],
       "version": "1.1"
     },
     "relationships": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

This adds a new banner to the framework steps when any information
coming from NOMIS fails.

### Why did it change

It contains a list of information that could not be included so that the
user knows to check NOMIS for that information.

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

- [P4-2077](https://dsdmoj.atlassian.net/browse/P4-2077)

## Screenshots
<!--- (Optional) Include screenshots if changes update interfaces or components -->
<!--- Delete/copy as appropriate --->

<kbd><img width="784" alt="Screenshot 2020-10-14 at 12 25 24" src="https://user-images.githubusercontent.com/3327997/95992817-48ed7600-0e26-11eb-973e-c8167bb95173.png"></kbd>

## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [x] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed

### Other considerations

Commit messages with a `fix` or `feat` type are automatically used to generate the [changelog](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/CHANGELOG.md) and
[GitHub release notes](https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/releases) during the release task. Please make sure they will read well on their own in a
summary of changes and that the commit body gives a more detailed description of those changes if necessary.

- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
- [x] Update [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md) with any new instructions or tasks
