### PR TITLE
fix(per): Handle when followup comments does not have any validations

### DIFF
--- a/common/helpers/frameworks/set-validation-rules.js
+++ b/common/helpers/frameworks/set-validation-rules.js
@@ -7,7 +7,7 @@ function setValidationRules(responses = []) {
       field.dependentQuestionKey,
     ])
 
-    if (!response) {
+    if (!response || !field.validate) {
       return [key, field]
     }
 

--- a/common/helpers/frameworks/set-validation-rules.test.js
+++ b/common/helpers/frameworks/set-validation-rules.test.js
@@ -153,6 +153,63 @@ describe('Framework helpers', function () {
             ])
           })
         })
+
+        context('without validations', function () {
+          const mockFieldWithoutValidations = [
+            'mock-field',
+            {
+              label: {
+                text: 'Please answer this question',
+              },
+              dependentQuestionKey: 'violent-or-dangerous',
+            },
+          ]
+          context('without NOMIS mappings', function () {
+            beforeEach(function () {
+              output = helper([{ ...mockResponses[0], nomis_mappings: [] }])(
+                mockFieldWithoutValidations
+              )
+            })
+
+            it('should not add validations', function () {
+              expect(output).to.deep.equal([
+                'mock-field',
+                {
+                  label: {
+                    text: 'Please answer this question',
+                  },
+                  dependentQuestionKey: 'violent-or-dangerous',
+                },
+              ])
+            })
+          })
+
+          context('with NOMIS mappings', function () {
+            beforeEach(function () {
+              output = helper([
+                { ...mockResponses[0], nomis_mappings: [{ foo: 'bar' }] },
+              ])(mockFieldWithoutValidations)
+            })
+
+            it('should not update label', function () {
+              expect(output[1].label).to.deep.equal({
+                text: 'Please answer this question',
+              })
+            })
+
+            it('should not add validations', function () {
+              expect(output).to.deep.equal([
+                'mock-field',
+                {
+                  label: {
+                    text: 'Please answer this question',
+                  },
+                  dependentQuestionKey: 'violent-or-dangerous',
+                },
+              ])
+            })
+          })
+        })
       })
     })
   })


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

This catches a scenario where a followup comment from the Person Escort
Record framework doesn't have any validations.

Fixes BOOK-A-SECURE-MOVE-FRONTEND-W

### Why did it change

Previously the helper assumed validations existed.

## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [x] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed

### Other considerations

Commit messages with a `fix` or `feat` type are automatically used to generate the [changelog](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/CHANGELOG.md) and
[GitHub release notes](https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/releases) during the release task. Please make sure they will read well on their own in a
summary of changes and that the commit body gives a more detailed description of those changes if necessary.

- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
- [x] Update [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md) with any new instructions or tasks
