### PR TITLE
build: Increase book-a-secure-move-frameworks version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2148,6 +2148,10 @@
       "version": "git+https://github.com/ministryofjustice/hmpps-book-secure-move-frameworks.git#c53c4797798ae723d88815f968912c2d011c5c3b",
       "from": "git+https://github.com/ministryofjustice/hmpps-book-secure-move-frameworks.git#v1.3.0"
     },
+    "@hmpps-book-secure-move-frameworks/1.4.0": {
+      "version": "git+https://github.com/ministryofjustice/hmpps-book-secure-move-frameworks.git#e1cae252f7d5c16abc8c4a7d3a320a53a51fc13d",
+      "from": "git+https://github.com/ministryofjustice/hmpps-book-secure-move-frameworks.git#v1.4.0"
+    },
     "@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "@hmpps-book-secure-move-frameworks/1.1.0": "git+https://github.com/ministryofjustice/hmpps-book-secure-move-frameworks.git#v1.1.0",
     "@hmpps-book-secure-move-frameworks/1.2.0": "git+https://github.com/ministryofjustice/hmpps-book-secure-move-frameworks.git#v1.2.0",
     "@hmpps-book-secure-move-frameworks/1.3.0": "git+https://github.com/ministryofjustice/hmpps-book-secure-move-frameworks.git#v1.3.0",
+    "@hmpps-book-secure-move-frameworks/1.4.0": "git+https://github.com/ministryofjustice/hmpps-book-secure-move-frameworks.git#v1.4.0",
     "@ministryofjustice/frontend": "0.0.19-alpha",
     "@sentry/node": "5.26.0",
     "accessible-autocomplete": "2.0.3",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Add a new version of the framework.

### Why did it change

This allows the app to use the latest Person Escort Record framework.

## Checklists

### Testing

#### Automated testing

- [ ] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [ ] No environment variables were added or changed

### Other considerations

Commit messages with a `fix` or `feat` type are automatically used to generate the [changelog](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/CHANGELOG.md) and
[GitHub release notes](https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/releases) during the release task. Please make sure they will read well on their own in a
summary of changes and that the commit body gives a more detailed description of those changes if necessary.

- [ ] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
- [ ] Update [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md) with any new instructions or tasks
