### PR TITLE
feat: Add support for in-session feature flags

### DIFF
--- a/app/allocation/controllers/view.js
+++ b/app/allocation/controllers/view.js
@@ -2,8 +2,10 @@ const { sortBy } = require('lodash')
 
 const presenters = require('../../../common/presenters')
 
-function viewAllocation(personEscortRecordFeature = false) {
+function viewAllocation() {
   return (req, res) => {
+    const personEscortRecordFeature =
+      req.session.featureFlags.PERSON_ESCORT_RECORD
     const { allocation, canAccess } = req
     const { moves, status } = allocation
     const bannerStatuses = ['cancelled']

--- a/app/allocation/controllers/view.test.js
+++ b/app/allocation/controllers/view.test.js
@@ -86,6 +86,9 @@ describe('Allocation controllers', function () {
         t: sinon.stub().returnsArg(0),
         canAccess: sinon.stub().returns(false),
         allocation: { ...allocationExample },
+        session: {
+          featureFlags: {},
+        },
       }
       mockRes = {
         render: sinon.stub(),

--- a/app/allocation/index.js
+++ b/app/allocation/index.js
@@ -3,7 +3,6 @@ const wizard = require('hmpo-form-wizard')
 
 const FormWizardController = require('../../common/controllers/form-wizard')
 const { protectRoute } = require('../../common/middleware/permissions')
-const { FEATURE_FLAGS } = require('../../config')
 const { setMove } = require('../move/middleware')
 
 const { createControllers, viewAllocation } = require('./controllers')
@@ -70,11 +69,7 @@ router.use(
   wizard(cancelSteps, cancelFields, cancelConfig)
 )
 
-router.get(
-  '/:allocationId',
-  protectRoute('allocations:view'),
-  viewAllocation(FEATURE_FLAGS.PERSON_ESCORT_RECORD)
-)
+router.get('/:allocationId', protectRoute('allocations:view'), viewAllocation())
 
 // Export
 module.exports = {

--- a/app/move/controllers/view.js
+++ b/app/move/controllers/view.js
@@ -1,7 +1,6 @@
 const { isEmpty, find, sortBy } = require('lodash')
 
 const presenters = require('../../../common/presenters')
-const { FEATURE_FLAGS } = require('../../../config')
 const updateSteps = require('../steps/update')
 
 const getUpdateLinks = require('./view/view.update.links')
@@ -35,7 +34,7 @@ module.exports = function view(req, res) {
     person_escort_record: personEscortRecord,
   } = profile || {}
   const personEscortRecordIsEnabled =
-    FEATURE_FLAGS.PERSON_ESCORT_RECORD &&
+    req.session.featureFlags.PERSON_ESCORT_RECORD &&
     req.canAccess('person_escort_record:view')
   const personEscortRecordIsCompleted =
     !isEmpty(personEscortRecord) &&

--- a/app/move/controllers/view.test.js
+++ b/app/move/controllers/view.test.js
@@ -129,6 +129,9 @@ describe('Move controllers', function () {
           user: {
             permissions: userPermissions,
           },
+          featureFlags: {
+            PERSON_ESCORT_RECORD: true,
+          },
         },
         move: mockMove,
         originalUrl: mockOriginalUrl,
@@ -737,18 +740,17 @@ describe('Move controllers', function () {
       })
 
       context('when feature flag is disabled', function () {
-        const controllerWithoutPER = proxyquire('./view', {
-          ...pathStubs,
-          '../../../config': {
-            FEATURE_FLAGS: {
-              PERSON_ESCORT_RECORD: false,
-            },
-          },
+        let previousPerFlag
+        beforeEach(function () {
+          previousPerFlag = req.session.featureFlags.PERSON_ESCORT_RECORD
+          req.session.featureFlags.PERSON_ESCORT_RECORD = false
+
+          controller(req, res)
+          params = res.render.args[0][1]
         })
 
-        beforeEach(function () {
-          controllerWithoutPER(req, res)
-          params = res.render.args[0][1]
+        afterEach(function () {
+          req.session.featureFlags.PERSON_ESCORT_RECORD = previousPerFlag
         })
 
         it('should set personEscortRecordIsEnabled to false', function () {

--- a/app/moves/index.js
+++ b/app/moves/index.js
@@ -15,7 +15,6 @@ const {
 } = require('../../common/middleware/collection')
 const { protectRoute } = require('../../common/middleware/permissions')
 const setRequestFilters = require('../../common/middleware/set-request-filters')
-const { FEATURE_FLAGS } = require('../../config')
 const requestFilterFields = require('../filters/fields')
 
 const {
@@ -82,11 +81,7 @@ viewRouter.get(
   COLLECTION_MIDDLEWARE,
   [
     setBodyMoves('outgoing', 'fromLocationId'),
-    setResultsMoves(
-      'outgoing',
-      'to_location',
-      FEATURE_FLAGS.PERSON_ESCORT_RECORD
-    ),
+    setResultsMoves('outgoing', 'to_location'),
   ],
   renderAsCards
 )
@@ -107,11 +102,7 @@ viewRouter.get(
   COLLECTION_MIDDLEWARE,
   [
     setBodyMoves('incoming', 'toLocationId'),
-    setResultsMoves(
-      'incoming',
-      'from_location',
-      FEATURE_FLAGS.PERSON_ESCORT_RECORD
-    ),
+    setResultsMoves('incoming', 'from_location'),
   ],
   renderAsCards
 )

--- a/app/moves/middleware/set-results.moves.js
+++ b/app/moves/middleware/set-results.moves.js
@@ -3,13 +3,15 @@ const { omitBy, isUndefined } = require('lodash')
 const presenters = require('../../../common/presenters')
 const moveService = require('../../../common/services/move')
 
-function setResultsMoves(bodyKey, locationKey, personEscortRecordFeature) {
+function setResultsMoves(bodyKey, locationKey) {
   return async function handleResults(req, res, next) {
     try {
       if (!req.session?.currentLocation) {
         return next()
       }
 
+      const personEscortRecordFeature =
+        req.session.featureFlags.PERSON_ESCORT_RECORD
       const args = omitBy(req.body[bodyKey], isUndefined)
       const [activeMoves, cancelledMoves] = await Promise.all([
         moveService.getActive(args),

--- a/common/lib/metrics.js
+++ b/common/lib/metrics.js
@@ -89,6 +89,7 @@ const getDefaultLabels = config => {
 
   // add feature flags if any to labels
   const flags = Object.keys(FEATURE_FLAGS).reduce((acc, key) => {
+    // FIXME: Feature flags are now based on the session, so how do we get these values into our instrumentat?
     acc[`FEATURE_FLAG_${key}`] = FEATURE_FLAGS[key]
     return acc
   }, {})

--- a/config/index.js
+++ b/config/index.js
@@ -246,4 +246,7 @@ module.exports = {
       },
     },
   },
+  SESSION_INJECTION_ENABLED: /true/i.test(
+    process.env.SESSION_INJECTION_ENABLED
+  ),
 }

--- a/config/index.js
+++ b/config/index.js
@@ -221,6 +221,8 @@ module.exports = {
     },
   },
   FEATURE_FLAGS: {
+    // FIXME: Perhaps now we are using this as code we should change this to be of the format
+    // personEscortRecord
     PERSON_ESCORT_RECORD: /true/i.test(
       process.env.FEATURE_FLAG_PERSON_ESCORT_RECORD
     ),

--- a/server.js
+++ b/server.js
@@ -151,6 +151,17 @@ if (config.IS_DEV) {
   app.use(development.setUserLocations(config.USER_LOCATIONS))
 }
 
+// Session injection middleware
+app.all('*', function (req, res, next) {
+  req.session.featureFlags = config.FEATURE_FLAGS
+  next()
+})
+
+if (config.SESSION_INJECTION_ENABLED) {
+  const SessionInjection = require('hmpo-form-wizard').SessionInjection
+  app.use('/debug/session', new SessionInjection().middleware())
+}
+
 app.use(
   ensureAuthenticated({
     provider: config.DEFAULT_AUTH_PROVIDER,


### PR DESCRIPTION
## Proposed changes

Currently feature flags are set one time as the server starts up. This means that in order to change feature flags, the server needs to be restarted. This means it is not possible to have a browser test that uses feature flags. Middleware can be tested on its own, but combinations of middleware, such as when used with an Express router, cannot be tested. 

This PR uses a [form-wizard feature](https://github.com/HMPO/hmpo-form-wizard#session-injection) called session injection. This allows a variety of request variables to be changed on a per request basis, storing the result in the session object.

This should hopefully also allow work behind feature flags to be previewed on heroku.

Note: Unit tests should continue to test individual usage of feature flags, this new feature is only to enable testing them at a browser level.

### What changed

There is currently only one feature flag in current use - `PERSON_ESCORT_RECORD` - these updates are the changes to the scaffolding required to support this feature, plus the changes required to support the `PERSON_ESCORT_RECORD` feature.

- Load feature flags from env vars into req.session.featureFlags
- Change uses of config.featureFlags to use req.session.featureFlags
- Update tests to use req.session.featureFlags

<!--- Describe the changes in detail - the "what"-->

### Why did it change

<!--- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

- [P4-XXXX]()

## Screenshots
<!--- (Optional) Include screenshots if changes update interfaces or components -->
<!--- Delete/copy as appropriate --->

| Before | After |
| ------ | ----- |
| <kbd><img src=""></kbd> | <kbd><img src=""></kbd> |

## Checklists

### Testing

#### Automated testing

- [ ] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [ ] No environment variables were added or changed

<!--- Delete if changes DO NOT include new environment variables -->
- [ ] Documented in the [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md)
- [ ] Added to [continous integration](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-book-secure-move-frontend)
- [ ] Added to staging environment (deployment repository)
- [ ] Added to preproduction environment (deployment repository)
- [ ] Added to production environment (deployment repository)

### Other considerations

Commit messages with a `fix` or `feat` type are automatically used to generate the [changelog](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/CHANGELOG.md) and
[GitHub release notes](https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/releases) during the release task. Please make sure they will read well on their own in a
summary of changes and that the commit body gives a more detailed description of those changes if necessary.

- [ ] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
- [ ] Update [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md) with any new instructions or tasks
