### PR TITLE
[P4-2317] fix(allocation): Stop person removal from an active or completed move

### DIFF
--- a/app/move/controllers/unassign.js
+++ b/app/move/controllers/unassign.js
@@ -4,6 +4,7 @@ const moveService = require('../../../common/services/move')
 class UnassignController extends FormWizardController {
   middlewareChecks() {
     this.use(this.checkAllocation)
+    this.use(this.checkEligibility)
     super.middlewareChecks()
   }
 
@@ -19,6 +20,20 @@ class UnassignController extends FormWizardController {
     }
 
     next()
+  }
+
+  checkEligibility(req, res, next) {
+    const { allocation, id, profile, status } = req.move
+
+    if (['requested', 'booked'].includes(status)) {
+      return next()
+    }
+
+    res.render('move/views/unassign-ineligible', {
+      allocation,
+      moveId: id,
+      fullname: profile?.person?.fullname,
+    })
   }
 
   middlewareLocals() {

--- a/app/move/views/unassign-ineligible.njk
+++ b/app/move/views/unassign-ineligible.njk
@@ -1,0 +1,52 @@
+{% extends "form-wizard.njk" %}
+
+{% block pageTitle %}
+  {{ t("validation::page_title_prefix") }}: {{ t("validation::assign_conflict.heading") }}
+{% endblock %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+    text: t("actions::back_to_allocation"),
+    href: "/allocation/" + allocation.id
+  }) }}
+
+  {{ super() }}
+{% endblock %}
+
+{% block contentHeader %}
+  {% set errorMsg %}
+    <p class="govuk-!-margin-top-4">
+      {{ t("validation::unassign_ineligible.message", {
+        href: "/move/" + existingMoveId,
+        name: person.fullname | upper,
+        location: move.to_location.title,
+        date: move.date | formatDateWithDay
+      }) | safe }}
+    </p>
+
+    <p class="govuk-!-margin-top-2">
+      {{ t("validation::unassign_ineligible.instructions", {
+        allocation_href: "/allocation/" + allocation.id,
+        move_href: "/move/" + moveId,
+        name: fullname,
+        count: allocation.moves_count,
+        from_location: allocation.from_location.title,
+        to_location: allocation.to_location.title
+      }) | safe }}
+    </p>
+  {% endset %}
+
+  {{ appMessage({
+    focusOnload: true,
+    classes: "app-message--error",
+    title: {
+      text: t("validation::unassign_ineligible.heading")
+    },
+    content: {
+      html: errorMsg
+    }
+  }) }}
+{% endblock %}
+
+{% block contentMain %}
+{% endblock %}

--- a/locales/en/validation.json
+++ b/locales/en/validation.json
@@ -38,6 +38,11 @@
     "message": "This person needs a special vehicle and cannot be part of an allocation move.",
     "instructions": "<a href=\"{{allocationhHref}}\">Add a different person</a> or <a href=\"{{moveHref}}\">create a single request</a> if <strong>{{name}}</strong> still needs to move."
   },
+  "unassign_ineligible": {
+    "heading": "This person cannot be removed from this allocation",
+    "message": "A person cannot be removed once the move is in transit or completed.",
+    "instructions": "View the <a href=\"{{move_href}}\"><strong>move for {{name}}</strong></a> or the <strong><a href=\"{{allocation_href}}\">allocation for $t(n_person)</a></strong> from <strong>{{from_location}}</strong> to <strong>{{to_location}}</strong>."
+  },
   "LIMIT_FILE_SIZE": "must be smaller than 50MB",
   "LIMIT_PART_COUNT": "has too many parts",
   "LIMIT_FILE_COUNT": "has too mamy files",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

This change adds a check to the form wizard that handles the removal
of a person and displays a message to the user if this action cannot be
done.

This change still persists the button on the allocation page to remove a person instead of removing it
as simply removing might confused the user as to the circumstances in which it is not available.

Another option would be to disable the button and add a message as to why this action isn't possible
but this part of the interface already felt quite complicated and introducing this message might add extra
things to digest on one screen.

This is also based on a per move basis so can't be done as a single action on the allocation. Therefore, the
message has been moved to the step when a user attempts to complete the action. This was also much more
straightforward to implement a fix at this stage to prevent the error continually appearing in Sentry.

### Why did it change

Currently the API does not allow a person (or profile) to be removed
from a move that has been started (`in_transit`) or that has taken
place(`completed`).

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

- [P4-2317](https://dsdmoj.atlassian.net/browse/P4-2317)

## Screenshots
<!--- (Optional) Include screenshots if changes update interfaces or components -->
<!--- Delete/copy as appropriate --->

| Before | After |
| ------ | ----- |
| <kbd>![image](https://user-images.githubusercontent.com/3327997/96580530-5300f000-12d0-11eb-83d8-67f4063775cd.png)</kbd> | <kbd>![image](https://user-images.githubusercontent.com/3327997/96584995-e63d2400-12d6-11eb-9f98-ed3a539a25a5.png)</kbd> |

## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [x] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed

### Other considerations

Commit messages with a `fix` or `feat` type are automatically used to generate the [changelog](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/CHANGELOG.md) and
[GitHub release notes](https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/releases) during the release task. Please make sure they will read well on their own in a
summary of changes and that the commit body gives a more detailed description of those changes if necessary.

- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
- [x] Update [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md) with any new instructions or tasks
