### PR TITLE
Add req context to services and api client

### DIFF
--- a/app/move/controllers/cancel.js
+++ b/app/move/controllers/cancel.js
@@ -2,7 +2,6 @@ const { pick } = require('lodash')
 
 const FormWizardController = require('../../../common/controllers/form-wizard')
 const presenters = require('../../../common/presenters')
-const moveService = require('../../../common/services/move')
 
 class CancelController extends FormWizardController {
   middlewareChecks() {
@@ -51,6 +50,7 @@ class CancelController extends FormWizardController {
           break
       }
 
+      const moveService = req.services.move()
       await moveService.cancel(moveId, {
         reason: data.cancellation_reason,
         ...(cancellationReasonComment && {

--- a/app/move/controllers/cancel.test.js
+++ b/app/move/controllers/cancel.test.js
@@ -1,6 +1,5 @@
 const FormWizardController = require('../../../common/controllers/form-wizard')
 const presenters = require('../../../common/presenters')
-const moveService = require('../../../common/services/move')
 
 const CancelController = require('./cancel')
 
@@ -143,7 +142,14 @@ describe('Move controllers', function () {
     describe('#successHandler()', function () {
       let req, res, nextSpy
 
+      let moveService
+
       beforeEach(function () {
+        moveService = {
+          cancel: sinon.stub(),
+        }
+
+        moveService.cancel.resetHistory()
         nextSpy = sinon.spy()
         req = {
           form: {
@@ -160,6 +166,9 @@ describe('Move controllers', function () {
           journeyModel: {
             reset: sinon.stub(),
           },
+          services: {
+            move: () => moveService,
+          },
           move: mockMove,
         }
         res = {
@@ -169,7 +178,7 @@ describe('Move controllers', function () {
 
       context('when move save is successful', function () {
         beforeEach(async function () {
-          sinon.stub(moveService, 'cancel').resolves({})
+          moveService.cancel.resolves({})
           await controller.successHandler(req, res, nextSpy)
         })
 
@@ -197,7 +206,7 @@ describe('Move controllers', function () {
         const errorMock = new Error('Problem')
 
         beforeEach(async function () {
-          sinon.stub(moveService, 'cancel').throws(errorMock)
+          moveService.cancel.throws(errorMock)
           await controller.successHandler(req, res, nextSpy)
         })
 
@@ -221,7 +230,7 @@ describe('Move controllers', function () {
             'cancelled for other reason'
           req.form.options.allFields.cancellation_reason_other_comment = {}
 
-          sinon.stub(moveService, 'cancel').resolves({})
+          moveService.cancel.resolves({})
           await controller.successHandler(req, res, nextSpy)
 
           expect(moveService.cancel).to.be.calledWithExactly(mockMove.id, {
@@ -238,7 +247,7 @@ describe('Move controllers', function () {
             'cancelled by pmu comment'
           req.form.options.allFields.cancellation_reason_cancelled_by_pmu_comment = {}
 
-          sinon.stub(moveService, 'cancel').resolves({})
+          moveService.cancel.resolves({})
           await controller.successHandler(req, res, nextSpy)
 
           expect(moveService.cancel).to.be.calledWithExactly(mockMove.id, {
@@ -250,7 +259,7 @@ describe('Move controllers', function () {
         it('should cancel without a comment if "pmu comment" not provided', async function () {
           mockValues.cancellation_reason = 'cancelled_by_pmu'
 
-          sinon.stub(moveService, 'cancel').resolves({})
+          moveService.cancel.resolves({})
           await controller.successHandler(req, res, nextSpy)
 
           expect(moveService.cancel).to.be.calledWithExactly(mockMove.id, {

--- a/app/move/middleware.js
+++ b/app/move/middleware.js
@@ -1,5 +1,4 @@
 const allocationService = require('../../common/services/allocation')
-const moveService = require('../../common/services/move')
 
 module.exports = {
   setMove: async (req, res, next, moveId) => {
@@ -8,6 +7,7 @@ module.exports = {
     }
 
     try {
+      const moveService = req.services.move()
       req.move = await moveService.getById(moveId)
       next()
     } catch (error) {

--- a/app/move/middleware.test.js
+++ b/app/move/middleware.test.js
@@ -1,5 +1,4 @@
 const allocationService = require('../../common/services/allocation')
-const moveService = require('../../common/services/move')
 
 const middleware = require('./middleware')
 
@@ -15,16 +14,24 @@ const errorStub = new Error('Problem')
 describe('Move middleware', function () {
   describe('#setMove()', function () {
     let req, res, nextSpy
+    let moveService
 
     beforeEach(function () {
-      req = {}
+      moveService = {
+        getById: sinon.stub().resolves(),
+      }
+      req = {
+        services: {
+          move: () => moveService,
+        },
+      }
       res = {}
       nextSpy = sinon.spy()
     })
 
     context('when no move ID exists', function () {
       beforeEach(async function () {
-        sinon.stub(moveService, 'getById').resolves(moveStub)
+        moveService.getById.resolves(moveStub)
 
         await middleware.setMove(req, res, nextSpy)
       })
@@ -45,7 +52,7 @@ describe('Move middleware', function () {
     context('when move ID exists', function () {
       context('when API call returns succesfully', function () {
         beforeEach(async function () {
-          sinon.stub(moveService, 'getById').resolves(moveStub)
+          moveService.getById.resolves(moveStub)
 
           await middleware.setMove(req, res, nextSpy, mockMoveId)
         })
@@ -66,9 +73,9 @@ describe('Move middleware', function () {
 
       context('when API call returns an error', function () {
         beforeEach(async function () {
-          sinon.stub(moveService, 'getById').throws(errorStub)
+          moveService.getById.throws(errorStub)
 
-          await middleware.setMove({}, res, nextSpy, mockMoveId)
+          await middleware.setMove(req, res, nextSpy, mockMoveId)
         })
 
         it('should not set response data to request object', function () {

--- a/common/lib/api-client/index.js
+++ b/common/lib/api-client/index.js
@@ -15,17 +15,13 @@ const {
 } = require('./middleware')
 const models = require('./models')
 
-let instance
-
-module.exports = function () {
-  if (instance) {
-    return instance
-  }
-
-  instance = new JsonApi({
+module.exports = function (req) {
+  const instance = new JsonApi({
     apiUrl: API.BASE_URL,
     logger: false,
   })
+
+  instance._originalReq = req
 
   instance.replaceMiddleware('errors', errors)
   instance.replaceMiddleware('POST', post(FILE_UPLOADS.MAX_FILE_SIZE))

--- a/common/lib/api-client/index.test.js
+++ b/common/lib/api-client/index.test.js
@@ -83,12 +83,22 @@ describe('Back-end API client', function () {
       })
     })
 
-    context('on first call', function () {
+    context('on instantiation', function () {
       let client
+
+      context('with no request object', function () {
+        beforeEach(function () {
+          client = jsonApi()
+        })
+
+        it('should not set the original request on the instance', function () {
+          expect(client._originalReq).to.be.undefined
+        })
+      })
 
       context('with auth client ID and secret', function () {
         beforeEach(function () {
-          client = jsonApi()
+          client = jsonApi({ foo: 'bar' })
         })
 
         it('should create a new client', function () {
@@ -100,7 +110,10 @@ describe('Back-end API client', function () {
 
         it('should return an client API', function () {
           expect(client).to.be.a('object')
-          expect(client).to.deep.equal(new JsonApiStub())
+        })
+
+        it('should set orginal request on client', function () {
+          expect(client._originalReq).to.deep.equal({ foo: 'bar' })
         })
 
         describe('middleware', function () {
@@ -291,28 +304,36 @@ describe('Back-end API client', function () {
         thirdInstance = jsonApi()
       })
 
-      it('should only create one new client', function () {
-        expect(JsonApiStub.prototype.init).to.be.calledOnce
+      it('should return a new client each time', function () {
+        expect(JsonApiStub.prototype.init).to.be.calledThrice
       })
 
       describe('first instance', function () {
         it('should return an client API', function () {
           expect(firstInstance).to.be.a('object')
-          expect(firstInstance).to.deep.equal(new JsonApiStub())
-        })
-      })
-
-      describe('third instance', function () {
-        it('should return an client API', function () {
-          expect(thirdInstance).to.be.a('object')
-          expect(thirdInstance).to.deep.equal(new JsonApiStub())
+          expect(firstInstance.constructor.name).to.equal('JsonApiStub')
         })
       })
 
       describe('second instance', function () {
         it('should return an client API', function () {
           expect(secondInstance).to.be.a('object')
-          expect(secondInstance).to.deep.equal(new JsonApiStub())
+          expect(secondInstance.constructor.name).to.equal('JsonApiStub')
+        })
+      })
+
+      describe('third instance', function () {
+        it('should return an client API', function () {
+          expect(thirdInstance).to.be.a('object')
+          expect(thirdInstance.constructor.name).to.equal('JsonApiStub')
+        })
+      })
+
+      describe('instances', function () {
+        it('should not be the same', function () {
+          expect(firstInstance).to.not.equal(secondInstance)
+          expect(firstInstance).to.not.equal(thirdInstance)
+          expect(secondInstance).to.not.equal(thirdInstance)
         })
       })
     })

--- a/common/lib/api-client/middleware/request-headers.js
+++ b/common/lib/api-client/middleware/request-headers.js
@@ -7,11 +7,19 @@ module.exports = {
       return payload
     }
 
-    const { req } = payload
+    const { jsonApi, req } = payload
+
+    const { _originalReq } = jsonApi
+
+    const requestHeadersOptions = {
+      ...(_originalReq && {
+        req: _originalReq,
+      }),
+    }
 
     req.headers = {
       ...req.headers,
-      ...getRequestHeaders(),
+      ...getRequestHeaders(requestHeadersOptions),
     }
     return payload
   },

--- a/common/lib/api-client/middleware/request-headers.test.js
+++ b/common/lib/api-client/middleware/request-headers.test.js
@@ -13,13 +13,14 @@ describe('API Client', function () {
     describe('#request-headers', function () {
       context('when payload includes a response', function () {
         it('should return payload as is', function () {
-          const payload = { req: {}, res: {} }
+          const payload = { req: {}, res: {}, jsonApi: {} }
           expect(middleware.req(payload)).to.deep.equal({ ...payload })
         })
       })
 
       context('when payload contains a request', function () {
         let request
+        const originalRequest = { foo: 'bar' }
 
         beforeEach(function () {
           request = {
@@ -27,11 +28,16 @@ describe('API Client', function () {
               Accept: 'Something',
             },
           }
-          middleware.req({ req: request })
+          middleware.req({
+            req: request,
+            jsonApi: { _originalReq: originalRequest },
+          })
         })
 
         it('should get the request headers', function () {
-          expect(getRequestHeadersStub).to.be.calledOnceWithExactly()
+          expect(getRequestHeadersStub).to.be.calledOnceWithExactly({
+            req: originalRequest,
+          })
         })
 
         it('should add the default request headers', function () {

--- a/common/lib/api-client/request-headers.js
+++ b/common/lib/api-client/request-headers.js
@@ -5,11 +5,16 @@ const {
   APP_VERSION,
 } = require('../../../config')
 
-module.exports = (format = 'application/vnd.api+json') => {
-  return {
+module.exports = ({ req = {}, format = 'application/vnd.api+json' } = {}) => {
+  const idempotencyKey = uuid.v4()
+  const transactionId = req.transactionId || `auto-${idempotencyKey}`
+  const headers = {
     'User-Agent': `hmpps-book-secure-move-frontend/${APP_VERSION}`,
     Accept: `${format}; version=${VERSION}`,
     'Accept-Encoding': 'gzip',
-    'Idempotency-Key': uuid.v4(),
+    'Idempotency-Key': idempotencyKey,
+    'X-Transaction-Id': transactionId,
   }
+
+  return headers
 }

--- a/common/lib/api-client/request-headers.test.js
+++ b/common/lib/api-client/request-headers.test.js
@@ -43,6 +43,10 @@ describe('API Client', function () {
         it('should return the `Idempotency-Key` header', function () {
           expect(headers['Idempotency-Key']).to.equal('#uuid')
         })
+
+        it('should return the `X-Transaction-Id` header', function () {
+          expect(headers['X-Transaction-Id']).to.equal('auto-#uuid')
+        })
       })
     })
 
@@ -50,7 +54,7 @@ describe('API Client', function () {
       let headers
 
       beforeEach(function () {
-        headers = getRequestHeaders('format/foo')
+        headers = getRequestHeaders({ format: 'format/foo' })
       })
 
       it('should return `Accept` header with specified format and the api version', function () {
@@ -58,19 +62,23 @@ describe('API Client', function () {
           `format/foo; version=${config.API.VERSION}`
         )
       })
+    })
 
-      it('should return the `User-Agent` header', function () {
-        expect(headers['User-Agent']).to.equal(
-          'hmpps-book-secure-move-frontend/chuck-d'
-        )
-      })
+    context('when called with a request', function () {
+      let headers
 
-      it('should return the `Accept-Encoding` header', function () {
-        expect(headers['Accept-Encoding']).to.equal('gzip')
+      beforeEach(function () {
+        headers = getRequestHeaders({
+          req: { transactionId: '#transactionId' },
+        })
       })
 
       it('should return the `Idempotency-Key` header', function () {
         expect(headers['Idempotency-Key']).to.equal('#uuid')
+      })
+
+      it('should return req’s transactionId as the `X-Transaction-Id` header', function () {
+        expect(headers['X-Transaction-Id']).to.equal('#transactionId')
       })
     })
   })

--- a/common/lib/api-client/rest-client.js
+++ b/common/lib/api-client/rest-client.js
@@ -9,7 +9,7 @@ const getRequestHeaders = require('./request-headers')
 
 const restClient = async (url, args, options = {}) => {
   const authorizationHeader = await auth.getAuthorizationHeader()
-  const requestHeaders = getRequestHeaders(options.format)
+  const requestHeaders = getRequestHeaders({ ...options })
   const headers = {
     ...authorizationHeader,
     ...requestHeaders,

--- a/common/lib/api-client/rest-client.test.js
+++ b/common/lib/api-client/rest-client.test.js
@@ -41,7 +41,7 @@ describe('API Client', async function () {
       })
 
       it('should get the default client headers', function () {
-        expect(getRequestHeadersStub).to.be.calledOnceWithExactly(undefined)
+        expect(getRequestHeadersStub).to.be.calledOnceWithExactly({})
       })
 
       it('should make the expected request', function () {
@@ -125,9 +125,9 @@ describe('API Client', async function () {
       })
 
       it('should pass the expected format to the method that returns the default client headers', function () {
-        expect(getRequestHeadersStub).to.be.calledOnceWithExactly(
-          'application/foo'
-        )
+        expect(getRequestHeadersStub).to.be.calledOnceWithExactly({
+          format: 'application/foo',
+        })
       })
     })
 

--- a/common/lib/monitoring.js
+++ b/common/lib/monitoring.js
@@ -1,0 +1,77 @@
+/* eslint-disable no-console */
+const timer = require('./timer')
+
+const wrapMethodAsync = (methodName, method, methodOptions, context) => {
+  return async (...args) => {
+    const methodTimer = timer()
+
+    try {
+      const result = await method.apply(null, args)
+      const duration = methodTimer()
+      console.log(
+        `${methodName}, success, took ${duration}, tId:${context?.transactionId}`
+      )
+      // TODO: metrics call
+      // TODO: log success
+      return result
+    } catch (error) {
+      const duration = methodTimer()
+      console.log(`${methodName}, error, took ${duration}`, error.stack)
+      // TODO: metrics call
+      // TODO: log error
+      throw error
+    }
+  }
+}
+
+const wrapMethodSync = (methodName, method, methodOptions) => {
+  return (...args) => {
+    const methodTimer = timer()
+
+    try {
+      const result = method.apply(null, args)
+      const duration = methodTimer()
+      console.log(`${methodName}, success, took ${duration}`)
+      // TODO: metrics call
+      // TODO: log success
+      return result
+    } catch (error) {
+      const duration = methodTimer()
+      console.log(`${methodName}, error, took ${duration}`)
+      // TODO: metrics call
+      // TODO: log error
+      throw error
+    }
+  }
+}
+
+const wrapMethod = {
+  async: wrapMethodAsync,
+  sync: wrapMethodSync,
+}
+
+const wrapMethods = (name, service, options) => {
+  Object.keys(options).forEach(methodKey => {
+    const methodOptions = {
+      async: true,
+      log: true,
+      metrics: true,
+      ...(options[methodKey] === true ? {} : options[methodKey]),
+    }
+
+    const _method = service[methodKey]
+    const methodName = `${name}.${methodKey}`
+    const methodType = methodOptions.async ? 'async' : 'sync'
+
+    service[methodKey] = wrapMethod[methodType](
+      methodName,
+      _method,
+      methodOptions,
+      service.context
+    )
+  })
+}
+
+module.exports = {
+  wrapMethods,
+}

--- a/common/middleware/set-services.js
+++ b/common/middleware/set-services.js
@@ -1,0 +1,25 @@
+const services = require('../services')
+
+const setServices = (req, res, next) => {
+  const servicesCache = {}
+
+  const servicesWithReq = Object.keys(services).reduce((acc, serviceKey) => {
+    if (!servicesCache[serviceKey]) {
+      const originalService = services[serviceKey]
+
+      if (!originalService.addRequestContext) {
+        servicesCache[serviceKey] = originalService
+      } else {
+        servicesCache[serviceKey] = originalService.addRequestContext(req)
+      }
+    }
+
+    acc[serviceKey] = () => servicesCache[serviceKey]
+
+    return acc
+  }, {})
+  req.services = servicesWithReq
+  next()
+}
+
+module.exports = setServices

--- a/common/middleware/set-services.test.js
+++ b/common/middleware/set-services.test.js
@@ -1,0 +1,57 @@
+const proxyquire = require('proxyquire').noCallThru()
+
+const services = {
+  foo: {
+    addRequestContext: sinon.stub().returns({ method: 'foo - with context' }),
+  },
+  bar: {
+    method: 'bar - without context',
+  },
+}
+
+const setServices = proxyquire('./set-services', {
+  '../services': services,
+})
+
+describe('Middleware', function () {
+  describe('#setServices', function () {
+    const next = sinon.spy()
+    let req
+    beforeEach(function () {
+      req = {}
+      services.foo.addRequestContext.resetHistory()
+
+      setServices(req, {}, next)
+    })
+
+    it('should add context to service', function () {
+      expect(services.foo.addRequestContext).to.be.calledOnceWithExactly(req)
+    })
+
+    it('should add services object to request', function () {
+      expect(req.services).to.exist
+    })
+
+    it('should add service functions to services', function () {
+      expect(Object.keys(req.services)).to.deep.equal(['foo', 'bar'])
+    })
+
+    it('should return expected values from service functions which had context added', function () {
+      expect(req.services.foo()).to.deep.equal({ method: 'foo - with context' })
+    })
+
+    it('should return same values from service functions which had context added', function () {
+      expect(req.services.foo()).to.equal(req.services.foo())
+    })
+
+    it('should return expected values from service functions which did not have context added', function () {
+      expect(req.services.bar()).to.deep.equal({
+        method: 'bar - without context',
+      })
+    })
+
+    it('should return same values from service functions which did not have context added', function () {
+      expect(req.services.bar()).to.deep.equal(req.services.bar())
+    })
+  })
+})

--- a/common/middleware/set-transaction-id.js
+++ b/common/middleware/set-transaction-id.js
@@ -1,0 +1,8 @@
+const uuid = require('uuid')
+
+const setTransactionId = (req, res, next) => {
+  req.transactionId = req.get('x-request-id') || uuid.v4()
+  next()
+}
+
+module.exports = setTransactionId

--- a/common/middleware/set-transaction-id.test.js
+++ b/common/middleware/set-transaction-id.test.js
@@ -1,0 +1,58 @@
+const proxyquire = require('proxyquire').noCallThru()
+
+const uuid = {}
+
+const setTransactionId = proxyquire('./set-transaction-id', {
+  uuid,
+})
+
+describe('Middleware', function () {
+  describe('#setTranasctionId', function () {
+    let next
+    let req
+    beforeEach(function () {
+      uuid.v4 = sinon.stub().returns('#uuid')
+      next = sinon.spy()
+      req = {
+        get: sinon.stub(),
+      }
+    })
+
+    context('When request has no request id', function () {
+      beforeEach(function () {
+        setTransactionId(req, {}, next)
+      })
+
+      it('should check the x-request-id header', function () {
+        expect(req.get).to.be.calledOnceWithExactly('x-request-id')
+      })
+
+      it('should create an id for the request', function () {
+        expect(uuid.v4).to.be.calledOnceWithExactly()
+      })
+
+      it('should set the transaction id on the request', function () {
+        expect(req.transactionId).to.equal('#uuid')
+      })
+    })
+
+    context('When request has an request id', function () {
+      beforeEach(function () {
+        req.get.returns('#xRequestId')
+        setTransactionId(req, {}, next)
+      })
+
+      it('should check the x-request-id header', function () {
+        expect(req.get).to.be.calledOnceWithExactly('x-request-id')
+      })
+
+      it('should not create an id for the request', function () {
+        expect(uuid.v4).to.not.be.called
+      })
+
+      it('should set the transaction id on the request', function () {
+        expect(req.transactionId).to.equal('#xRequestId')
+      })
+    })
+  })
+})

--- a/common/services/allocation.js
+++ b/common/services/allocation.js
@@ -1,148 +1,158 @@
 const dateFunctions = require('date-fns')
 const { mapValues, pickBy } = require('lodash')
 
-const apiClient = require('../lib/api-client')()
-const moveService = require('../services/move')
+const ApiClient = require('../lib/api-client')
 
 const batchRequest = require('./batch-request')
+const MoveService = require('./move')
 
-function getAll({
-  filter = {},
-  combinedData = [],
-  page = 1,
-  includeCancelled = false,
-  isAggregation = false,
-  include,
-} = {}) {
-  return apiClient
-    .findAll('allocation', {
-      ...filter,
-      page,
-      per_page: isAggregation ? 1 : 100,
-      include: isAggregation ? [] : include,
-    })
-    .then(response => {
-      const { data, links, meta } = response
-      const results = [...combinedData, ...data]
+const addRequestContext = req => {
+  const apiClient = ApiClient(req)
+  const moveService = MoveService.addRequestContext(req)
 
-      if (isAggregation) {
-        return meta.pagination.total_objects
+  function getAll({
+    filter = {},
+    combinedData = [],
+    page = 1,
+    includeCancelled = false,
+    isAggregation = false,
+    include,
+  } = {}) {
+    return apiClient
+      .findAll('allocation', {
+        ...filter,
+        page,
+        per_page: isAggregation ? 1 : 100,
+        include: isAggregation ? [] : include,
+      })
+      .then(response => {
+        const { data, links, meta } = response
+        const results = [...combinedData, ...data]
+
+        if (isAggregation) {
+          return meta.pagination.total_objects
+        }
+
+        const hasNext = links.next && data.length !== 0
+
+        if (!hasNext) {
+          return results.map(allocationService.transform({ includeCancelled }))
+        }
+
+        return allocationService.getAll({
+          filter,
+          combinedData: results,
+          page: page + 1,
+          include,
+        })
+      })
+  }
+
+  const allocationService = {
+    cancel(id, { reason, comment } = {}) {
+      if (!id) {
+        return Promise.reject(new Error('No allocation id supplied'))
       }
 
-      const hasNext = links.next && data.length !== 0
+      const timestamp = dateFunctions.formatISO(new Date())
 
-      if (!hasNext) {
-        return results.map(allocationService.transform({ includeCancelled }))
+      return apiClient
+        .one('allocation', id)
+        .all('cancel')
+        .post({
+          timestamp,
+          cancellation_reason: reason,
+          cancellation_reason_comment: comment,
+        })
+        .then(response => response.data)
+    },
+
+    format(data) {
+      const booleansAndNulls = ['complete_in_full', 'sentence_length']
+      const relationships = ['to_location', 'from_location']
+
+      return mapValues(data, (value, key) => {
+        if (booleansAndNulls.includes(key)) {
+          try {
+            value = JSON.parse(value)
+          } catch (e) {}
+        }
+
+        if (relationships.includes(key) && typeof value === 'string') {
+          return { id: value }
+        }
+
+        return value
+      })
+    },
+    transform({ includeCancelled = false } = {}) {
+      return function transformAllocation(result) {
+        return {
+          ...result,
+          moves: result.moves
+            .filter(
+              move => includeCancelled || !['cancelled'].includes(move.status)
+            )
+            .map(moveService.transform),
+        }
       }
+    },
+    create(data) {
+      return apiClient
+        .create('allocation', allocationService.format(data))
+        .then(response => response.data)
+        .then(allocationService.transform())
+    },
+    getByDateAndLocation({
+      moveDate = [],
+      fromLocations = [],
+      toLocations = [],
+      locations = [],
+      include = ['from_location', 'moves', 'moves.profile', 'to_location'],
+      isAggregation = false,
+      status,
+      sortBy,
+      sortDirection,
+    } = {}) {
+      const [moveDateFrom, moveDateTo] = moveDate
 
       return allocationService.getAll({
-        filter,
-        combinedData: results,
-        page: page + 1,
+        isAggregation,
         include,
+        // TODO: This can be removed once move count and progress are returned
+        // by the API as resouce meta
+        includeCancelled: status ? status.includes('cancelled') : false,
+        filter: pickBy({
+          'filter[status]': status,
+          'filter[from_locations]': fromLocations.join(','),
+          'filter[to_locations]': toLocations.join(','),
+          'filter[locations]': locations.join(','),
+          'filter[date_from]': moveDateFrom,
+          'filter[date_to]': moveDateTo,
+          'sort[by]': sortBy,
+          'sort[direction]': sortDirection,
+        }),
       })
-    })
+    },
+    getAll(props) {
+      return batchRequest(getAll, props, [
+        'from_locations',
+        'to_locations',
+        'locations',
+      ])
+    },
+    getById(id, { include } = {}) {
+      return apiClient
+        .find('allocation', id, { include })
+        .then(response => response.data)
+        .then(allocationService.transform())
+    },
+  }
+
+  return allocationService
 }
 
-const allocationService = {
-  cancel(id, { reason, comment } = {}) {
-    if (!id) {
-      return Promise.reject(new Error('No allocation id supplied'))
-    }
-
-    const timestamp = dateFunctions.formatISO(new Date())
-
-    return apiClient
-      .one('allocation', id)
-      .all('cancel')
-      .post({
-        timestamp,
-        cancellation_reason: reason,
-        cancellation_reason_comment: comment,
-      })
-      .then(response => response.data)
-  },
-
-  format(data) {
-    const booleansAndNulls = ['complete_in_full', 'sentence_length']
-    const relationships = ['to_location', 'from_location']
-
-    return mapValues(data, (value, key) => {
-      if (booleansAndNulls.includes(key)) {
-        try {
-          value = JSON.parse(value)
-        } catch (e) {}
-      }
-
-      if (relationships.includes(key) && typeof value === 'string') {
-        return { id: value }
-      }
-
-      return value
-    })
-  },
-  transform({ includeCancelled = false } = {}) {
-    return function transformAllocation(result) {
-      return {
-        ...result,
-        moves: result.moves
-          .filter(
-            move => includeCancelled || !['cancelled'].includes(move.status)
-          )
-          .map(moveService.transform),
-      }
-    }
-  },
-  create(data) {
-    return apiClient
-      .create('allocation', allocationService.format(data))
-      .then(response => response.data)
-      .then(allocationService.transform())
-  },
-  getByDateAndLocation({
-    moveDate = [],
-    fromLocations = [],
-    toLocations = [],
-    locations = [],
-    include = ['from_location', 'moves', 'moves.profile', 'to_location'],
-    isAggregation = false,
-    status,
-    sortBy,
-    sortDirection,
-  } = {}) {
-    const [moveDateFrom, moveDateTo] = moveDate
-
-    return allocationService.getAll({
-      isAggregation,
-      include,
-      // TODO: This can be removed once move count and progress are returned
-      // by the API as resouce meta
-      includeCancelled: status ? status.includes('cancelled') : false,
-      filter: pickBy({
-        'filter[status]': status,
-        'filter[from_locations]': fromLocations.join(','),
-        'filter[to_locations]': toLocations.join(','),
-        'filter[locations]': locations.join(','),
-        'filter[date_from]': moveDateFrom,
-        'filter[date_to]': moveDateTo,
-        'sort[by]': sortBy,
-        'sort[direction]': sortDirection,
-      }),
-    })
-  },
-  getAll(props) {
-    return batchRequest(getAll, props, [
-      'from_locations',
-      'to_locations',
-      'locations',
-    ])
-  },
-  getById(id, { include } = {}) {
-    return apiClient
-      .find('allocation', id, { include })
-      .then(response => response.data)
-      .then(allocationService.transform())
-  },
-}
+const allocationService = addRequestContext()
+allocationService.addRequestContext = addRequestContext
 
 module.exports = allocationService

--- a/common/services/court-hearing.js
+++ b/common/services/court-hearing.js
@@ -1,31 +1,39 @@
 const { mapValues, pickBy } = require('lodash')
 
-const apiClient = require('../lib/api-client')()
+const ApiClient = require('../lib/api-client')
 
-const courtHearingService = {
-  format(data) {
-    const relationships = ['move']
+const addRequestContext = req => {
+  const apiClient = ApiClient(req)
 
-    return mapValues(pickBy(data), (value, key) => {
-      if (relationships.includes(key) && typeof value === 'string') {
-        return { id: value }
+  const courtHearingService = {
+    format(data) {
+      const relationships = ['move']
+
+      return mapValues(pickBy(data), (value, key) => {
+        if (relationships.includes(key) && typeof value === 'string') {
+          return { id: value }
+        }
+
+        return value
+      })
+    },
+
+    create(data, disableSaveToNomis = false) {
+      const params = {}
+
+      if (disableSaveToNomis) {
+        params.do_not_save_to_nomis = true
       }
 
-      return value
-    })
-  },
-
-  create(data, disableSaveToNomis = false) {
-    const params = {}
-
-    if (disableSaveToNomis) {
-      params.do_not_save_to_nomis = true
-    }
-
-    return apiClient
-      .create('court_hearing', courtHearingService.format(data), params)
-      .then(response => response.data)
-  },
+      return apiClient
+        .create('court_hearing', courtHearingService.format(data), params)
+        .then(response => response.data)
+    },
+  }
+  return courtHearingService
 }
+
+const courtHearingService = addRequestContext()
+courtHearingService.addRequestContext = addRequestContext
 
 module.exports = courtHearingService

--- a/common/services/court-hearing.test.js
+++ b/common/services/court-hearing.test.js
@@ -1,6 +1,11 @@
-const apiClient = require('../lib/api-client')()
+const proxyquire = require('proxyquire')
 
-const courtHearingService = require('./court-hearing')
+const apiClient = {}
+const ApiClient = sinon.stub().callsFake(req => apiClient)
+
+const courtHearingService = proxyquire('./court-hearing', {
+  '../lib/api-client': ApiClient,
+})
 
 const mockCourtHearing = {
   start_time: '2020-10-20T13:00:00+00:00',
@@ -11,6 +16,10 @@ const mockCourtHearing = {
 }
 
 describe('Court Hearing Service', function () {
+  beforeEach(function () {
+    ApiClient.resetHistory()
+  })
+
   describe('#format()', function () {
     const mockMoveId = 'b695d0f0-af8e-4b97-891e-92020d6820b9'
 
@@ -96,7 +105,7 @@ describe('Court Hearing Service', function () {
     let courtHearing
 
     beforeEach(async function () {
-      sinon.stub(apiClient, 'create').resolves(mockResponse)
+      apiClient.create = sinon.stub().resolves(mockResponse)
     })
 
     context('by default', function () {

--- a/common/services/document.js
+++ b/common/services/document.js
@@ -1,19 +1,27 @@
 const FormData = require('form-data')
 
-const apiClient = require('../lib/api-client')()
+const ApiClient = require('../lib/api-client')
 
-const documentService = {
-  create(file, data) {
-    const formData = new FormData()
-    formData.append('data[attributes][file]', data, {
-      filename: file.originalname,
-      knownLength: file.size,
-    })
+const addRequestContext = req => {
+  const apiClient = ApiClient(req)
 
-    return apiClient
-      .create('document', formData)
-      .then(response => response.data)
-  },
+  const documentService = {
+    create(file, data) {
+      const formData = new FormData()
+      formData.append('data[attributes][file]', data, {
+        filename: file.originalname,
+        knownLength: file.size,
+      })
+
+      return apiClient
+        .create('document', formData)
+        .then(response => response.data)
+    },
+  }
+  return documentService
 }
+
+const documentService = addRequestContext()
+documentService.addRequestContext = addRequestContext
 
 module.exports = documentService

--- a/common/services/document.test.js
+++ b/common/services/document.test.js
@@ -4,12 +4,19 @@ function MockFormData() {}
 
 MockFormData.prototype.append = sinon.stub()
 
+const apiClient = {}
+const ApiClient = sinon.stub().callsFake(req => apiClient)
+
 const documentService = proxyquire('./document', {
+  '../lib/api-client': ApiClient,
   'form-data': MockFormData,
 })
-const apiClient = require('../lib/api-client')()
 
 describe('Document Service', function () {
+  beforeEach(function () {
+    ApiClient.resetHistory()
+  })
+
   describe('#create()', function () {
     const mockFileData = {
       originalname: 'Original filename',
@@ -25,7 +32,7 @@ describe('Document Service', function () {
     let document
 
     beforeEach(async function () {
-      sinon.stub(apiClient, 'create').resolves(mockResponse)
+      apiClient.create = sinon.stub().resolves(mockResponse)
 
       document = await documentService.create(mockFileData, mockBuffer)
     })

--- a/common/services/move.js
+++ b/common/services/move.js
@@ -1,283 +1,294 @@
 const dateFunctions = require('date-fns')
 const { mapValues, omitBy, isUndefined, isEmpty, get } = require('lodash')
 
-const apiClient = require('../lib/api-client')()
+const ApiClient = require('../lib/api-client')
 const restClient = require('../lib/api-client/rest-client')
-const personService = require('../services/person')
-const profileService = require('../services/profile')
+const PersonService = require('../services/person')
+const ProfileService = require('../services/profile')
 
 const batchRequest = require('./batch-request')
 
-function getAll({
-  filter = {},
-  combinedData = [],
-  page = 1,
-  isAggregation = false,
-  include,
-} = {}) {
-  return apiClient
-    .findAll('move', {
-      ...filter,
-      include: isAggregation ? [] : include,
-      page,
-      per_page: isAggregation ? 1 : 100,
-    })
-    .then(response => {
-      const { data, links, meta } = response
-      const moves = [...combinedData, ...data]
+const addRequestContext = req => {
+  const apiClient = ApiClient(req)
+  const personService = PersonService.addRequestContext(req)
+  const profileService = ProfileService.addRequestContext(req)
 
-      if (isAggregation) {
-        return meta.pagination.total_objects
-      }
-
-      const hasNext = links.next && data.length !== 0
-
-      if (!hasNext) {
-        return moves
-      }
-
-      return getAll({
-        filter,
-        combinedData: moves,
-        page: page + 1,
-        include,
-      })
-    })
-}
-
-const noMoveIdMessage = 'No move ID supplied'
-const moveService = {
-  transform(move) {
-    // We have to pretend that 'secure_childrens_home', 'secure_training_centre' are valid `move_type`s
-    const youthTransfer = ['secure_childrens_home', 'secure_training_centre']
-    const locationType = get(move, 'to_location.location_type')
-
-    if (youthTransfer.includes(locationType)) {
-      move.move_type = locationType
-    }
-
-    return {
-      ...move,
-      profile: profileService.transform(move.profile),
-      person: personService.transform(move.person),
-    }
-  },
-  format(data) {
-    const booleansAndNulls = ['move_agreed']
-    const relationships = [
-      'to_location',
-      'from_location',
-      'person',
-      'prison_transfer_reason',
-      'supplier',
-    ]
-
-    // We have to pretend that 'secure_childrens_home', 'secure_training_centre' are valid `move_type`s
-    const youthTransfer = ['secure_childrens_home', 'secure_training_centre']
-
-    if (youthTransfer.includes(data.move_type)) {
-      data.move_type = 'prison_transfer'
-    }
-
-    return mapValues(omitBy(data, isUndefined), (value, key) => {
-      if (booleansAndNulls.includes(key)) {
-        try {
-          value = JSON.parse(value)
-        } catch (e) {}
-      }
-
-      if (relationships.includes(key) && typeof value === 'string') {
-        return { id: value }
-      }
-
-      return value
-    })
-  },
-
-  async getAll(props = {}) {
-    const results = await batchRequest(getAll, props, [
-      'from_location_id',
-      'to_location_id',
-    ])
-
-    if (props.isAggregation) {
-      return results
-    }
-
-    return results.map(this.transform)
-  },
-
-  getActive({
-    dateRange = [],
-    fromLocationId,
-    toLocationId,
-    supplierId,
+  function getAll({
+    filter = {},
+    combinedData = [],
+    page = 1,
     isAggregation = false,
+    include,
   } = {}) {
-    const [startDate, endDate] = dateRange
-    return moveService.getAll({
-      isAggregation,
-      include: [
-        'profile',
-        'profile.person_escort_record.flags',
-        'profile.person',
-        'profile.person.gender',
+    return apiClient
+      .findAll('move', {
+        ...filter,
+        include: isAggregation ? [] : include,
+        page,
+        per_page: isAggregation ? 1 : 100,
+      })
+      .then(response => {
+        const { data, links, meta } = response
+        const moves = [...combinedData, ...data]
+
+        if (isAggregation) {
+          return meta.pagination.total_objects
+        }
+
+        const hasNext = links.next && data.length !== 0
+
+        if (!hasNext) {
+          return moves
+        }
+
+        return getAll({
+          filter,
+          combinedData: moves,
+          page: page + 1,
+          include,
+        })
+      })
+  }
+
+  const noMoveIdMessage = 'No move ID supplied'
+  const moveService = {
+    transform(move) {
+      // We have to pretend that 'secure_childrens_home', 'secure_training_centre' are valid `move_type`s
+      const youthTransfer = ['secure_childrens_home', 'secure_training_centre']
+      const locationType = get(move, 'to_location.location_type')
+
+      if (youthTransfer.includes(locationType)) {
+        move.move_type = locationType
+      }
+
+      return {
+        ...move,
+        profile: profileService.transform(move.profile),
+        person: personService.transform(move.person),
+      }
+    },
+    format(data) {
+      const booleansAndNulls = ['move_agreed']
+      const relationships = [
         'to_location',
         'from_location',
-      ],
-      filter: omitBy(
-        {
-          'filter[status]': 'requested,accepted,booked,in_transit,completed',
-          'filter[date_from]': startDate,
-          'filter[date_to]': endDate,
-          'filter[from_location_id]': fromLocationId,
-          'filter[to_location_id]': toLocationId,
-          'filter[supplier_id]': supplierId,
-        },
-        isEmpty
-      ),
-    })
-  },
+        'person',
+        'prison_transfer_reason',
+        'supplier',
+      ]
 
-  getCancelled({
-    dateRange = [],
-    fromLocationId,
-    toLocationId,
-    supplierId,
-    isAggregation = false,
-  } = {}) {
-    const [startDate, endDate] = dateRange
-    return moveService.getAll({
-      isAggregation,
-      include: ['profile.person'],
-      filter: omitBy(
-        {
-          'filter[status]': 'cancelled',
-          'filter[date_from]': startDate,
-          'filter[date_to]': endDate,
-          'filter[from_location_id]': fromLocationId,
-          'filter[to_location_id]': toLocationId,
-          'filter[supplier_id]': supplierId,
-        },
-        isEmpty
-      ),
-    })
-  },
+      // We have to pretend that 'secure_childrens_home', 'secure_training_centre' are valid `move_type`s
+      const youthTransfer = ['secure_childrens_home', 'secure_training_centre']
 
-  async getDownload({
-    status = 'requested,accepted,booked,in_transit,completed,cancelled',
-    dateRange = [],
-    createdAtDate = [],
-    fromLocationId,
-    toLocationId,
-    supplierId = undefined,
-    dateOfBirthFrom,
-    dateOfBirthTo,
-  } = {}) {
-    const [startDate, endDate] = dateRange
-    const [createdAtFrom, createdAtTo] = createdAtDate
-    const filter = omitBy(
-      {
-        status,
-        date_from: startDate,
-        date_to: endDate,
-        created_at_from: createdAtFrom,
-        created_at_to: createdAtTo,
-        from_location_id: Array.isArray(fromLocationId)
-          ? fromLocationId.join(',')
-          : fromLocationId,
-        to_location_id: Array.isArray(toLocationId)
-          ? toLocationId.join(',')
-          : toLocationId,
-        supplier_id: supplierId,
-        date_of_birth_from: dateOfBirthFrom,
-        date_of_birth_to: dateOfBirthTo,
-      },
-      isEmpty
-    )
-
-    const response = await restClient.post(
-      '/moves/csv',
-      { filter },
-      {
-        format: 'text/csv',
+      if (youthTransfer.includes(data.move_type)) {
+        data.move_type = 'prison_transfer'
       }
-    )
-    return response
-  },
 
-  getById(id, { include } = {}) {
-    if (!id) {
-      return Promise.reject(new Error(noMoveIdMessage))
-    }
+      return mapValues(omitBy(data, isUndefined), (value, key) => {
+        if (booleansAndNulls.includes(key)) {
+          try {
+            value = JSON.parse(value)
+          } catch (e) {}
+        }
 
-    return apiClient
-      .find('move', id, { include })
-      .then(response => response.data)
-      .then(this.transform)
-  },
+        if (relationships.includes(key) && typeof value === 'string') {
+          return { id: value }
+        }
 
-  create(data) {
-    return apiClient
-      .create('move', moveService.format(data))
-      .then(response => response.data)
-      .then(this.transform)
-  },
-
-  update(data) {
-    if (!data.id) {
-      return Promise.reject(new Error(noMoveIdMessage))
-    }
-
-    return apiClient
-      .update('move', moveService.format(data))
-      .then(response => response.data)
-      .then(this.transform)
-  },
-
-  redirect(data) {
-    if (!data.id) {
-      return Promise.reject(new Error(noMoveIdMessage))
-    }
-
-    const timestamp = dateFunctions.formatISO(new Date())
-    return apiClient
-      .one('move', data.id)
-      .all('redirect')
-      .post({
-        timestamp,
-        ...data,
+        return value
       })
-  },
+    },
 
-  unassign(id) {
-    return moveService.update({
-      id,
-      profile: {
-        id: null,
-      },
-      move_agreed: null,
-      move_agreed_by: null,
-    })
-  },
+    async getAll(props = {}) {
+      const results = await batchRequest(getAll, props, [
+        'from_location_id',
+        'to_location_id',
+      ])
 
-  cancel(id, { reason, comment } = {}) {
-    if (!id) {
-      return Promise.reject(new Error(noMoveIdMessage))
-    }
+      if (props.isAggregation) {
+        return results
+      }
 
-    const timestamp = dateFunctions.formatISO(new Date())
+      return results.map(this.transform)
+    },
 
-    return apiClient
-      .one('move', id)
-      .all('cancel')
-      .post({
-        timestamp,
-        cancellation_reason: reason,
-        cancellation_reason_comment: comment,
+    getActive({
+      dateRange = [],
+      fromLocationId,
+      toLocationId,
+      supplierId,
+      isAggregation = false,
+    } = {}) {
+      const [startDate, endDate] = dateRange
+      return moveService.getAll({
+        isAggregation,
+        include: [
+          'profile',
+          'profile.person_escort_record.flags',
+          'profile.person',
+          'profile.person.gender',
+          'to_location',
+          'from_location',
+        ],
+        filter: omitBy(
+          {
+            'filter[status]': 'requested,accepted,booked,in_transit,completed',
+            'filter[date_from]': startDate,
+            'filter[date_to]': endDate,
+            'filter[from_location_id]': fromLocationId,
+            'filter[to_location_id]': toLocationId,
+            'filter[supplier_id]': supplierId,
+          },
+          isEmpty
+        ),
       })
-      .then(response => response.data)
-  },
+    },
+
+    getCancelled({
+      dateRange = [],
+      fromLocationId,
+      toLocationId,
+      supplierId,
+      isAggregation = false,
+    } = {}) {
+      const [startDate, endDate] = dateRange
+      return moveService.getAll({
+        isAggregation,
+        include: ['profile.person'],
+        filter: omitBy(
+          {
+            'filter[status]': 'cancelled',
+            'filter[date_from]': startDate,
+            'filter[date_to]': endDate,
+            'filter[from_location_id]': fromLocationId,
+            'filter[to_location_id]': toLocationId,
+            'filter[supplier_id]': supplierId,
+          },
+          isEmpty
+        ),
+      })
+    },
+
+    async getDownload({
+      status = 'requested,accepted,booked,in_transit,completed,cancelled',
+      dateRange = [],
+      createdAtDate = [],
+      fromLocationId,
+      toLocationId,
+      supplierId = undefined,
+      dateOfBirthFrom,
+      dateOfBirthTo,
+    } = {}) {
+      const [startDate, endDate] = dateRange
+      const [createdAtFrom, createdAtTo] = createdAtDate
+      const filter = omitBy(
+        {
+          status,
+          date_from: startDate,
+          date_to: endDate,
+          created_at_from: createdAtFrom,
+          created_at_to: createdAtTo,
+          from_location_id: Array.isArray(fromLocationId)
+            ? fromLocationId.join(',')
+            : fromLocationId,
+          to_location_id: Array.isArray(toLocationId)
+            ? toLocationId.join(',')
+            : toLocationId,
+          supplier_id: supplierId,
+          date_of_birth_from: dateOfBirthFrom,
+          date_of_birth_to: dateOfBirthTo,
+        },
+        isEmpty
+      )
+
+      const response = await restClient.post(
+        '/moves/csv',
+        { filter },
+        {
+          format: 'text/csv',
+          req,
+        }
+      )
+      return response
+    },
+
+    getById(id, { include } = {}) {
+      if (!id) {
+        return Promise.reject(new Error(noMoveIdMessage))
+      }
+
+      return apiClient
+        .find('move', id, { include })
+        .then(response => response.data)
+        .then(this.transform)
+    },
+
+    create(data) {
+      return apiClient
+        .create('move', moveService.format(data))
+        .then(response => response.data)
+        .then(this.transform)
+    },
+
+    update(data) {
+      if (!data.id) {
+        return Promise.reject(new Error(noMoveIdMessage))
+      }
+
+      return apiClient
+        .update('move', moveService.format(data))
+        .then(response => response.data)
+        .then(this.transform)
+    },
+
+    redirect(data) {
+      if (!data.id) {
+        return Promise.reject(new Error(noMoveIdMessage))
+      }
+
+      const timestamp = dateFunctions.formatISO(new Date())
+      return apiClient
+        .one('move', data.id)
+        .all('redirect')
+        .post({
+          timestamp,
+          ...data,
+        })
+    },
+
+    unassign(id) {
+      return moveService.update({
+        id,
+        profile: {
+          id: null,
+        },
+        move_agreed: null,
+        move_agreed_by: null,
+      })
+    },
+
+    cancel(id, { reason, comment } = {}) {
+      if (!id) {
+        return Promise.reject(new Error(noMoveIdMessage))
+      }
+
+      const timestamp = dateFunctions.formatISO(new Date())
+
+      return apiClient
+        .one('move', id)
+        .all('cancel')
+        .post({
+          timestamp,
+          cancellation_reason: reason,
+          cancellation_reason_comment: comment,
+        })
+        .then(response => response.data)
+    },
+  }
+  return moveService
 }
+
+const moveService = addRequestContext()
+moveService.addRequestContext = addRequestContext
 
 module.exports = moveService

--- a/common/services/move.test.js
+++ b/common/services/move.test.js
@@ -83,7 +83,7 @@ describe('Move Service', function () {
       person: mockPerson,
     }
     let move
-    beforeEach(function () {
+    beforeEach(async function () {
       // restore the stub as its stubbed before every test for convenience
       moveService.transform.restore()
 
@@ -119,7 +119,7 @@ describe('Move Service', function () {
     })
 
     context('with youth-like moves', function () {
-      it('should upgrade the move type', function () {
+      it('should upgrade the move type', async function () {
         const transformed = moveService.transform({
           id: '__move__',
           profile: mockProfile,

--- a/common/services/person-escort-record.js
+++ b/common/services/person-escort-record.js
@@ -1,65 +1,74 @@
 const { FRAMEWORKS } = require('../../config')
-const apiClient = require('../lib/api-client')()
-const profileService = require('../services/profile')
+const ApiClient = require('../lib/api-client')
+const ProfileService = require('../services/profile')
 
 const noIdMessage = 'No resource ID supplied'
 
-const personEscortRecordService = {
-  transformResponse({ data = {} } = {}) {
-    return {
-      ...data,
-      profile: profileService.transform(data.profile),
-    }
-  },
+const addRequestContext = req => {
+  const apiClient = ApiClient(req)
+  const profileService = ProfileService.addRequestContext(req)
 
-  create(profileId) {
-    return apiClient
-      .create('person_escort_record', {
-        version: FRAMEWORKS.CURRENT_VERSION,
-        profile: {
-          id: profileId,
-        },
-      })
-      .then(response => response.data)
-  },
+  const personEscortRecordService = {
+    transformResponse({ data = {} } = {}) {
+      return {
+        ...data,
+        profile: profileService.transform(data.profile),
+      }
+    },
 
-  confirm(id) {
-    if (!id) {
-      return Promise.reject(new Error(noIdMessage))
-    }
+    create(profileId) {
+      return apiClient
+        .create('person_escort_record', {
+          version: FRAMEWORKS.CURRENT_VERSION,
+          profile: {
+            id: profileId,
+          },
+        })
+        .then(response => response.data)
+    },
 
-    return apiClient
-      .update('person_escort_record', {
-        id,
-        status: 'confirmed',
-      })
-      .then(this.transformResponse)
-  },
+    confirm(id) {
+      if (!id) {
+        return Promise.reject(new Error(noIdMessage))
+      }
 
-  getById(id) {
-    if (!id) {
-      return Promise.reject(new Error(noIdMessage))
-    }
+      return apiClient
+        .update('person_escort_record', {
+          id,
+          status: 'confirmed',
+        })
+        .then(this.transformResponse)
+    },
 
-    return apiClient
-      .find('person_escort_record', id)
-      .then(this.transformResponse)
-  },
+    getById(id) {
+      if (!id) {
+        return Promise.reject(new Error(noIdMessage))
+      }
 
-  respond(id, data = []) {
-    if (!id) {
-      return Promise.reject(new Error(noIdMessage))
-    }
+      return apiClient
+        .find('person_escort_record', id)
+        .then(this.transformResponse)
+    },
 
-    if (data.length === 0) {
-      return Promise.resolve([])
-    }
+    respond(id, data = []) {
+      if (!id) {
+        return Promise.reject(new Error(noIdMessage))
+      }
 
-    return apiClient
-      .one('person_escort_record', id)
-      .all('framework_response')
-      .patch(data)
-  },
+      if (data.length === 0) {
+        return Promise.resolve([])
+      }
+
+      return apiClient
+        .one('person_escort_record', id)
+        .all('framework_response')
+        .patch(data)
+    },
+  }
+  return personEscortRecordService
 }
+
+const personEscortRecordService = addRequestContext()
+personEscortRecordService.addRequestContext = addRequestContext
 
 module.exports = personEscortRecordService

--- a/common/services/person.js
+++ b/common/services/person.js
@@ -1,6 +1,6 @@
 const { mapKeys, mapValues, omitBy, isNil } = require('lodash')
 
-const apiClient = require('../lib/api-client')()
+const ApiClient = require('../lib/api-client')
 
 const unformat = require('./person/person.unformat')
 
@@ -8,122 +8,130 @@ const relationshipKeys = ['gender', 'ethnicity']
 
 const dateKeys = ['date_of_birth']
 
-const personService = {
-  transform(person) {
-    if (!person) {
-      return person
-    }
+const addRequestContext = req => {
+  const apiClient = ApiClient(req)
 
-    return {
-      ...person,
-      image_url: `/person/${person.id}/image`,
-      fullname: [person.last_name, person.first_names]
-        .filter(Boolean)
-        .join(', '),
-    }
-  },
-
-  format(data) {
-    const formatted = mapValues(data, (value, key) => {
-      if (typeof value === 'string') {
-        if (relationshipKeys.includes(key)) {
-          return { id: value }
-        }
+  const personService = {
+    transform(person) {
+      if (!person) {
+        return person
       }
 
-      return value
-    })
+      return {
+        ...person,
+        image_url: `/person/${person.id}/image`,
+        fullname: [person.last_name, person.first_names]
+          .filter(Boolean)
+          .join(', '),
+      }
+    },
 
-    return omitBy(formatted, isNil)
-  },
+    format(data) {
+      const formatted = mapValues(data, (value, key) => {
+        if (typeof value === 'string') {
+          if (relationshipKeys.includes(key)) {
+            return { id: value }
+          }
+        }
 
-  unformat(
-    person,
-    fields = [],
-    { relationship = relationshipKeys, date = dateKeys } = {}
-  ) {
-    return unformat(person, fields, {
-      relationship,
-      date,
-    })
-  },
-
-  create(data) {
-    return apiClient
-      .create('person', personService.format(data))
-      .then(response => response.data)
-      .then(person => personService.transform(person))
-  },
-
-  update(data) {
-    if (!data.id) {
-      return
-    }
-
-    return apiClient
-      .update('person', personService.format(data))
-      .then(response => response.data)
-      .then(person => personService.transform(person))
-  },
-
-  getImageUrl(personId) {
-    if (!personId) {
-      return Promise.reject(new Error('No ID supplied'))
-    }
-
-    return apiClient
-      .one('person', personId)
-      .all('image')
-      .get()
-      .then(response => response.data.url)
-  },
-
-  getActiveCourtCases(personId) {
-    if (!personId) {
-      return Promise.reject(new Error('No ID supplied'))
-    }
-
-    return apiClient
-      .one('person', personId)
-      .all('court_case')
-      .get({
-        'filter[active]': true,
-        // TODO: remove if/when devour adds model info to get method
-        include: ['location'],
+        return value
       })
-      .then(response => response.data)
-  },
 
-  getTimetableByDate(personId, date) {
-    if (!personId) {
-      return Promise.reject(new Error('No ID supplied'))
-    }
+      return omitBy(formatted, isNil)
+    },
 
-    return apiClient
-      .one('person', personId)
-      .all('timetable_entry')
-      .get({
-        filter: {
-          date_from: date,
-          date_to: date,
-        },
-        // TODO: remove if/when devour adds model info to get method
-        include: ['location'],
+    unformat(
+      person,
+      fields = [],
+      { relationship = relationshipKeys, date = dateKeys } = {}
+    ) {
+      return unformat(person, fields, {
+        relationship,
+        date,
       })
-      .then(response => response.data)
-  },
+    },
 
-  getByIdentifiers(identifiers, { include } = {}) {
-    const filter = {
-      ...mapKeys(identifiers, (value, key) => `filter[${key}]`),
-      include,
-    }
+    create(data) {
+      return apiClient
+        .create('person', personService.format(data))
+        .then(response => response.data)
+        .then(person => personService.transform(person))
+    },
 
-    return apiClient
-      .findAll('person', filter)
-      .then(response => response.data)
-      .then(data => data.map(person => personService.transform(person)))
-  },
+    update(data) {
+      if (!data.id) {
+        return
+      }
+
+      return apiClient
+        .update('person', personService.format(data))
+        .then(response => response.data)
+        .then(person => personService.transform(person))
+    },
+
+    getImageUrl(personId) {
+      if (!personId) {
+        return Promise.reject(new Error('No ID supplied'))
+      }
+
+      return apiClient
+        .one('person', personId)
+        .all('image')
+        .get()
+        .then(response => response.data.url)
+    },
+
+    getActiveCourtCases(personId) {
+      if (!personId) {
+        return Promise.reject(new Error('No ID supplied'))
+      }
+
+      return apiClient
+        .one('person', personId)
+        .all('court_case')
+        .get({
+          'filter[active]': true,
+          // TODO: remove if/when devour adds model info to get method
+          include: ['location'],
+        })
+        .then(response => response.data)
+    },
+
+    getTimetableByDate(personId, date) {
+      if (!personId) {
+        return Promise.reject(new Error('No ID supplied'))
+      }
+
+      return apiClient
+        .one('person', personId)
+        .all('timetable_entry')
+        .get({
+          filter: {
+            date_from: date,
+            date_to: date,
+          },
+          // TODO: remove if/when devour adds model info to get method
+          include: ['location'],
+        })
+        .then(response => response.data)
+    },
+
+    getByIdentifiers(identifiers, { include } = {}) {
+      const filter = {
+        ...mapKeys(identifiers, (value, key) => `filter[${key}]`),
+        include,
+      }
+
+      return apiClient
+        .findAll('person', filter)
+        .then(response => response.data)
+        .then(data => data.map(person => personService.transform(person)))
+    },
+  }
+  return personService
 }
+
+const personService = addRequestContext()
+personService.addRequestContext = addRequestContext
 
 module.exports = personService

--- a/common/services/person.test.js
+++ b/common/services/person.test.js
@@ -1,11 +1,13 @@
 const { forEach } = require('lodash')
 const proxyquire = require('proxyquire')
 
-const apiClient = require('../lib/api-client')()
-
 const unformatStub = sinon.stub()
 
+const apiClient = {}
+const ApiClient = sinon.stub().callsFake(req => apiClient)
+
 const personService = proxyquire('./person', {
+  '../lib/api-client': ApiClient,
   './person/person.unformat': unformatStub,
 })
 
@@ -18,6 +20,10 @@ const mockPerson = {
 }
 
 describe('Person Service', function () {
+  beforeEach(function () {
+    ApiClient.resetHistory()
+  })
+
   describe('#transform()', function () {
     let transformed
 
@@ -265,7 +271,7 @@ describe('Person Service', function () {
     let person
 
     beforeEach(async function () {
-      sinon.stub(apiClient, 'create').resolves(mockResponse)
+      apiClient.create = sinon.stub().resolves(mockResponse)
       sinon.stub(personService, 'transform').returnsArg(0)
       sinon.stub(personService, 'format').returnsArg(0)
 
@@ -302,7 +308,7 @@ describe('Person Service', function () {
     let person
 
     beforeEach(async function () {
-      sinon.stub(apiClient, 'update').resolves(mockResponse)
+      apiClient.update = sinon.stub().resolves(mockResponse)
       sinon.stub(personService, 'transform').returnsArg(0)
       sinon.stub(personService, 'format').returnsArg(0)
     })
@@ -356,9 +362,9 @@ describe('Person Service', function () {
     let imageUrl
 
     beforeEach(async function () {
-      sinon.stub(apiClient, 'one').returnsThis()
-      sinon.stub(apiClient, 'all').returnsThis()
-      sinon.stub(apiClient, 'get').resolves(mockResponse)
+      apiClient.all = sinon.stub().returns(apiClient)
+      apiClient.one = sinon.stub().returns(apiClient)
+      apiClient.get = sinon.stub().resolves(mockResponse)
     })
 
     context('without ID', function () {
@@ -401,9 +407,9 @@ describe('Person Service', function () {
     let imageUrl
 
     beforeEach(async function () {
-      sinon.stub(apiClient, 'one').returnsThis()
-      sinon.stub(apiClient, 'all').returnsThis()
-      sinon.stub(apiClient, 'get').resolves(mockResponse)
+      apiClient.all = sinon.stub().returns(apiClient)
+      apiClient.one = sinon.stub().returns(apiClient)
+      apiClient.get = sinon.stub().resolves(mockResponse)
     })
 
     context('without ID', function () {
@@ -449,9 +455,9 @@ describe('Person Service', function () {
     let imageUrl
 
     beforeEach(async function () {
-      sinon.stub(apiClient, 'one').returnsThis()
-      sinon.stub(apiClient, 'all').returnsThis()
-      sinon.stub(apiClient, 'get').resolves(mockResponse)
+      apiClient.all = sinon.stub().returns(apiClient)
+      apiClient.one = sinon.stub().returns(apiClient)
+      apiClient.get = sinon.stub().resolves(mockResponse)
     })
 
     context('without ID', function () {
@@ -518,7 +524,7 @@ describe('Person Service', function () {
     let person
 
     beforeEach(async function () {
-      sinon.stub(apiClient, 'findAll').resolves(mockResponse)
+      apiClient.findAll = sinon.stub().resolves(mockResponse)
       sinon.stub(personService, 'transform').returnsArg(0)
     })
 

--- a/common/services/reference-data.test.js
+++ b/common/services/reference-data.test.js
@@ -1,11 +1,12 @@
 const { sortBy } = require('lodash')
 const proxyquire = require('proxyquire')
 
-const apiClient = require('../lib/api-client')()
-
+const apiClient = {}
+const ApiClient = sinon.stub().callsFake(req => apiClient)
 const restClient = sinon.stub()
 
 const referenceDataService = proxyquire('./reference-data', {
+  '../lib/api-client': ApiClient,
   '../lib/api-client/rest-client': restClient,
 })
 
@@ -69,8 +70,12 @@ const mockRegions = [
     title: 'Region B',
   },
 ]
-
 describe('Reference Data Service', function () {
+  beforeEach(async function () {
+    ApiClient.resetHistory()
+    apiClient.findAll = sinon.stub()
+    apiClient.find = sinon.stub()
+  })
   context('', function () {
     describe('#getGenders()', function () {
       const mockResponse = {
@@ -79,9 +84,7 @@ describe('Reference Data Service', function () {
       let response
 
       beforeEach(async function () {
-        sinon.stub(apiClient, 'findAll')
         apiClient.findAll.withArgs('gender').resolves(mockResponse)
-
         response = await referenceDataService.getGenders()
       })
 
@@ -105,9 +108,7 @@ describe('Reference Data Service', function () {
       let response
 
       beforeEach(async function () {
-        sinon.stub(apiClient, 'findAll')
         apiClient.findAll.withArgs('ethnicity').resolves(mockResponse)
-
         response = await referenceDataService.getEthnicities()
       })
 
@@ -129,10 +130,6 @@ describe('Reference Data Service', function () {
         data: mockAssessmentQuestions,
       }
       let response
-
-      beforeEach(async function () {
-        sinon.stub(apiClient, 'findAll')
-      })
 
       context('with no category', function () {
         beforeEach(async function () {
@@ -218,10 +215,6 @@ describe('Reference Data Service', function () {
         filterOne: 'foo',
       }
       let locations
-
-      beforeEach(function () {
-        sinon.stub(apiClient, 'findAll')
-      })
 
       context('with only one page', function () {
         beforeEach(function () {
@@ -375,7 +368,7 @@ describe('Reference Data Service', function () {
           apiClient.findAll.resolves(mockResponse)
           await referenceDataService.getLocations({ include: ['foo', 'bar'] })
         })
-        it('should pass include paramter to api client', function () {
+        it('should pass include parameter to api client', function () {
           expect(apiClient.findAll).to.be.calledOnceWithExactly('location', {
             page: 1,
             per_page: 100,
@@ -402,8 +395,7 @@ describe('Reference Data Service', function () {
         let location
 
         beforeEach(async function () {
-          sinon.stub(apiClient, 'find').resolves(mockResponse)
-
+          apiClient.find.resolves(mockResponse)
           location = await referenceDataService.getLocationById(mockId)
         })
 
@@ -427,8 +419,7 @@ describe('Reference Data Service', function () {
         }
 
         beforeEach(async function () {
-          sinon.stub(apiClient, 'find').resolves(mockResponse)
-
+          apiClient.find.resolves(mockResponse)
           await referenceDataService.getLocationById(mockId, {
             include: ['foo', 'bar'],
           })
@@ -500,7 +491,8 @@ describe('Reference Data Service', function () {
           let filters
 
           beforeEach(function () {
-            filters = referenceDataService.getLocations.args[0][0].filter
+            const getLocationsArgs = referenceDataService.getLocations.args
+            filters = getLocationsArgs[0][0].filter
           })
 
           it('should set nomis_agency_id filter to agency ID', function () {
@@ -687,9 +679,7 @@ describe('Reference Data Service', function () {
       let response
 
       beforeEach(async function () {
-        sinon.stub(apiClient, 'findAll')
         apiClient.findAll.withArgs('supplier').resolves(mockResponse)
-
         response = await referenceDataService.getSuppliers()
       })
 
@@ -723,8 +713,7 @@ describe('Reference Data Service', function () {
         let response
 
         beforeEach(async function () {
-          sinon.stub(apiClient, 'find').resolves(mockResponse)
-
+          apiClient.find.resolves(mockResponse)
           response = await referenceDataService.getSupplierByKey(mockKey)
         })
 
@@ -747,16 +736,14 @@ describe('Reference Data Service', function () {
       }
 
       let response
-      let stubForFind
 
       beforeEach(async function () {
-        stubForFind = sinon.stub(apiClient, 'findAll').resolves(mockResponse)
-
+        apiClient.findAll.resolves(mockResponse)
         response = await referenceDataService.getPrisonTransferReasons()
       })
 
       it('should request the list of reasons for transfer', function () {
-        expect(stubForFind).to.be.calledOnceWithExactly(
+        expect(apiClient.findAll).to.be.calledOnceWithExactly(
           'prison_transfer_reason'
         )
       })
@@ -772,16 +759,14 @@ describe('Reference Data Service', function () {
       }
 
       let response
-      let serviceStub
 
       beforeEach(async function () {
-        serviceStub = sinon.stub(apiClient, 'findAll').resolves(mockResponse)
-
+        apiClient.findAll.resolves(mockResponse)
         response = await referenceDataService.getAllocationComplexCases()
       })
 
       it('should request the list of allocation complex cases', function () {
-        expect(serviceStub).to.be.calledOnceWithExactly(
+        expect(apiClient.findAll).to.be.calledOnceWithExactly(
           'allocation_complex_case'
         )
       })
@@ -809,10 +794,6 @@ describe('Reference Data Service', function () {
         },
       }
       let regions
-
-      beforeEach(function () {
-        sinon.stub(apiClient, 'findAll')
-      })
 
       context('with only one page', function () {
         beforeEach(function () {
@@ -923,8 +904,7 @@ describe('Reference Data Service', function () {
         let region
 
         beforeEach(async function () {
-          sinon.stub(apiClient, 'find').resolves(mockResponse)
-
+          apiClient.find.resolves(mockResponse)
           region = await referenceDataService.getRegionById(mockId)
         })
 
@@ -939,15 +919,14 @@ describe('Reference Data Service', function () {
         })
       })
 
-      context('with explict include parameter', function () {
+      context('with explicit include parameter', function () {
         const mockId = 'regiona-222b-4522-9d65-4ef429f9081e'
         const mockResponse = {
           data: mockRegions[0],
         }
 
         beforeEach(async function () {
-          sinon.stub(apiClient, 'find').resolves(mockResponse)
-
+          apiClient.find.resolves(mockResponse)
           await referenceDataService.getRegionById(mockId, {
             include: ['foo', 'bar'],
           })

--- a/common/services/single-request.js
+++ b/common/services/single-request.js
@@ -1,183 +1,194 @@
 const dateFunctions = require('date-fns')
 const { isNil, isUndefined, mapValues, omitBy, pick } = require('lodash')
 
-const apiClient = require('../lib/api-client')()
+const ApiClient = require('../lib/api-client')
 
-const moveService = require('./move')
+const MoveService = require('./move')
 
 const noMoveIdMessage = 'No move ID supplied'
-const singleRequestService = {
-  getAll({
-    status,
-    moveDate = [],
-    createdAtDate = [],
-    fromLocationId,
-    toLocationId,
-    dateOfBirthFrom,
-    dateOfBirthTo,
-    include,
-    isAggregation = false,
-    sortBy = 'created_at',
-    sortDirection = 'desc',
-  } = {}) {
-    const [moveDateFrom, moveDateTo] = moveDate
-    const [createdAtFrom, createdAtTo] = createdAtDate
 
-    let statusFilter
+const addRequestContext = req => {
+  const apiClient = ApiClient(req)
+  const moveService = MoveService.addRequestContext(req)
 
-    switch (status) {
-      case 'pending':
-        statusFilter = {
-          'filter[status]': 'proposed',
-        }
-        break
-      case 'approved':
-        statusFilter = {
-          'filter[status]': 'requested,accepted,booked,in_transit,completed',
-        }
-        break
-      case 'rejected':
-        statusFilter = {
-          'filter[status]': 'cancelled',
-          'filter[cancellation_reason]': 'rejected',
-        }
-        break
-      case 'cancelled':
-        statusFilter = {
-          'filter[status]': 'cancelled',
-          // TODO: Find a better filter for this. Currently we will need to add any new reasons from the API here.
-          'filter[cancellation_reason]':
-            'made_in_error,supplier_declined_to_move,cancelled_by_pmu,other',
-        }
-        break
-      default:
-        statusFilter = {
-          'filter[status]': status,
-        }
-    }
+  const singleRequestService = {
+    getAll({
+      status,
+      moveDate = [],
+      createdAtDate = [],
+      fromLocationId,
+      toLocationId,
+      dateOfBirthFrom,
+      dateOfBirthTo,
+      include,
+      isAggregation = false,
+      sortBy = 'created_at',
+      sortDirection = 'desc',
+    } = {}) {
+      const [moveDateFrom, moveDateTo] = moveDate
+      const [createdAtFrom, createdAtTo] = createdAtDate
 
-    return moveService.getAll({
-      isAggregation,
-      include: include || [
-        'from_location',
-        'to_location',
-        'profile.person',
-        'prison_transfer_reason',
-      ],
-      filter: omitBy(
-        {
-          ...statusFilter,
-          'filter[has_relationship_to_allocation]': false,
-          'filter[from_location_id]': fromLocationId,
-          'filter[to_location_id]': toLocationId,
-          'filter[date_from]': moveDateFrom,
-          'filter[date_to]': moveDateTo,
-          'filter[date_of_birth_from]': dateOfBirthFrom,
-          'filter[date_of_birth_to]': dateOfBirthTo,
-          'filter[created_at_from]': createdAtFrom,
-          'filter[created_at_to]': createdAtTo,
-          'filter[move_type]': 'prison_transfer',
-          'sort[by]': sortBy,
-          'sort[direction]': sortDirection,
-        },
-        isNil
-      ),
-    })
-  },
+      let statusFilter
 
-  async getDownload(args) {
-    return moveService.getDownload(args)
-  },
-
-  getCancelled({
-    moveDate = [],
-    createdAtDate = [],
-    fromLocationId,
-    include,
-    sortBy = 'created_at',
-    sortDirection = 'desc',
-  } = {}) {
-    const [moveDateFrom, moveDateTo] = moveDate
-    const [createdAtFrom, createdAtTo] = createdAtDate
-    const dateRanges = omitBy(
-      {
-        'filter[date_from]': moveDateFrom,
-        'filter[date_to]': moveDateTo,
-        'filter[created_at_from]': createdAtFrom,
-        'filter[created_at_to]': createdAtTo,
-      },
-      isUndefined
-    )
-
-    return moveService.getAll({
-      isAggregation: false,
-      include: include || [
-        'from_location',
-        'to_location',
-        'profile.person',
-        'prison_transfer_reason',
-      ],
-      filter: {
-        'filter[has_relationship_to_allocation]': false,
-        'filter[from_location_id]': fromLocationId,
-        'filter[status]': 'cancelled',
-        'filter[allocation]': false,
-        'filter[move_type]': 'prison_transfer',
-        'filter[rejection_reason]': undefined,
-        'sort[by]': sortBy,
-        'sort[direction]': sortDirection,
-        ...dateRanges,
-      },
-    })
-  },
-
-  approve(id, { date } = {}) {
-    if (!id) {
-      return Promise.reject(new Error(noMoveIdMessage))
-    }
-
-    return apiClient
-      .update('move', {
-        id,
-        date,
-        status: 'requested',
-      })
-      .then(response => response.data)
-  },
-
-  reject(id, data = {}) {
-    if (!id) {
-      return Promise.reject(new Error(noMoveIdMessage))
-    }
-
-    const booleansAndNulls = ['rebook']
-    const fields = [
-      'rejection_reason',
-      'cancellation_reason_other_comment',
-      'rebook',
-    ]
-
-    const mappedData = mapValues(pick(data, fields), (value, key) => {
-      if (booleansAndNulls.includes(key)) {
-        try {
-          value = JSON.parse(value)
-        } catch (e) {}
+      switch (status) {
+        case 'pending':
+          statusFilter = {
+            'filter[status]': 'proposed',
+          }
+          break
+        case 'approved':
+          statusFilter = {
+            'filter[status]': 'requested,accepted,booked,in_transit,completed',
+          }
+          break
+        case 'rejected':
+          statusFilter = {
+            'filter[status]': 'cancelled',
+            'filter[cancellation_reason]': 'rejected',
+          }
+          break
+        case 'cancelled':
+          statusFilter = {
+            'filter[status]': 'cancelled',
+            // TODO: Find a better filter for this. Currently we will need to add any new reasons from the API here.
+            'filter[cancellation_reason]':
+              'made_in_error,supplier_declined_to_move,cancelled_by_pmu,other',
+          }
+          break
+        default:
+          statusFilter = {
+            'filter[status]': status,
+          }
       }
 
-      return value
-    })
-
-    const timestamp = dateFunctions.formatISO(new Date())
-
-    return apiClient
-      .one('move', id)
-      .all('reject')
-      .post({
-        timestamp,
-        ...mappedData,
+      return moveService.getAll({
+        isAggregation,
+        include: include || [
+          'from_location',
+          'to_location',
+          'profile.person',
+          'prison_transfer_reason',
+        ],
+        filter: omitBy(
+          {
+            ...statusFilter,
+            'filter[has_relationship_to_allocation]': false,
+            'filter[from_location_id]': fromLocationId,
+            'filter[to_location_id]': toLocationId,
+            'filter[date_from]': moveDateFrom,
+            'filter[date_to]': moveDateTo,
+            'filter[date_of_birth_from]': dateOfBirthFrom,
+            'filter[date_of_birth_to]': dateOfBirthTo,
+            'filter[created_at_from]': createdAtFrom,
+            'filter[created_at_to]': createdAtTo,
+            'filter[move_type]': 'prison_transfer',
+            'sort[by]': sortBy,
+            'sort[direction]': sortDirection,
+          },
+          isNil
+        ),
       })
-      .then(response => response.data)
-  },
+    },
+
+    async getDownload(args) {
+      return moveService.getDownload(args)
+    },
+
+    getCancelled({
+      moveDate = [],
+      createdAtDate = [],
+      fromLocationId,
+      include,
+      sortBy = 'created_at',
+      sortDirection = 'desc',
+    } = {}) {
+      const [moveDateFrom, moveDateTo] = moveDate
+      const [createdAtFrom, createdAtTo] = createdAtDate
+      const dateRanges = omitBy(
+        {
+          'filter[date_from]': moveDateFrom,
+          'filter[date_to]': moveDateTo,
+          'filter[created_at_from]': createdAtFrom,
+          'filter[created_at_to]': createdAtTo,
+        },
+        isUndefined
+      )
+
+      return moveService.getAll({
+        isAggregation: false,
+        include: include || [
+          'from_location',
+          'to_location',
+          'profile.person',
+          'prison_transfer_reason',
+        ],
+        filter: {
+          'filter[has_relationship_to_allocation]': false,
+          'filter[from_location_id]': fromLocationId,
+          'filter[status]': 'cancelled',
+          'filter[allocation]': false,
+          'filter[move_type]': 'prison_transfer',
+          'filter[rejection_reason]': undefined,
+          'sort[by]': sortBy,
+          'sort[direction]': sortDirection,
+          ...dateRanges,
+        },
+      })
+    },
+
+    approve(id, { date } = {}) {
+      if (!id) {
+        return Promise.reject(new Error(noMoveIdMessage))
+      }
+
+      return apiClient
+        .update('move', {
+          id,
+          date,
+          status: 'requested',
+        })
+        .then(response => response.data)
+    },
+
+    reject(id, data = {}) {
+      if (!id) {
+        return Promise.reject(new Error(noMoveIdMessage))
+      }
+
+      const booleansAndNulls = ['rebook']
+      const fields = [
+        'rejection_reason',
+        'cancellation_reason_other_comment',
+        'rebook',
+      ]
+
+      const mappedData = mapValues(pick(data, fields), (value, key) => {
+        if (booleansAndNulls.includes(key)) {
+          try {
+            value = JSON.parse(value)
+          } catch (e) {}
+        }
+
+        return value
+      })
+
+      const timestamp = dateFunctions.formatISO(new Date())
+
+      return apiClient
+        .one('move', id)
+        .all('reject')
+        .post({
+          timestamp,
+          ...mappedData,
+        })
+        .then(response => response.data)
+    },
+  }
+
+  return singleRequestService
 }
+
+const singleRequestService = addRequestContext()
+singleRequestService.addRequestContext = addRequestContext
 
 module.exports = singleRequestService

--- a/server.js
+++ b/server.js
@@ -15,6 +15,7 @@ const morgan = require('morgan')
 const responseTime = require('response-time')
 const favicon = require('serve-favicon')
 const slashify = require('slashify')
+const uuid = require('uuid')
 
 // Local dependencies
 const healthcheckApp = require('./app/healthcheck')
@@ -51,6 +52,12 @@ const app = express()
 if (config.IS_PRODUCTION) {
   app.enable('trust proxy')
 }
+
+// Ensure we have a useful transaction id
+app.use((req, res, next) => {
+  req.transactionId = req.get('x-request-id') || uuid.v4()
+  next()
+})
 
 if (config.SENTRY.DSN) {
   Sentry.init({

--- a/server.js
+++ b/server.js
@@ -33,6 +33,7 @@ const sentryEnrichScope = require('./common/middleware/sentry-enrich-scope')
 const sentryRequestId = require('./common/middleware/sentry-request-id')
 const setLocations = require('./common/middleware/set-locations')
 const setPrimaryNavigation = require('./common/middleware/set-primary-navigation')
+const setServices = require('./common/middleware/set-services')
 const setUser = require('./common/middleware/set-user')
 const config = require('./config')
 const i18n = require('./config/i18n')
@@ -195,6 +196,9 @@ app.use(
 
 // Ensure body processed after reauthentication
 app.use(processOriginalRequestBody())
+
+// Set services
+app.use(setServices)
 
 // Add permission checker
 app.use(setCanAccess)

--- a/server.js
+++ b/server.js
@@ -15,7 +15,6 @@ const morgan = require('morgan')
 const responseTime = require('response-time')
 const favicon = require('serve-favicon')
 const slashify = require('slashify')
-const uuid = require('uuid')
 
 // Local dependencies
 const healthcheckApp = require('./app/healthcheck')
@@ -34,6 +33,7 @@ const sentryRequestId = require('./common/middleware/sentry-request-id')
 const setLocations = require('./common/middleware/set-locations')
 const setPrimaryNavigation = require('./common/middleware/set-primary-navigation')
 const setServices = require('./common/middleware/set-services')
+const setTransactionId = require('./common/middleware/set-transaction-id')
 const setUser = require('./common/middleware/set-user')
 const config = require('./config')
 const i18n = require('./config/i18n')
@@ -55,10 +55,7 @@ if (config.IS_PRODUCTION) {
 }
 
 // Ensure we have a useful transaction id
-app.use((req, res, next) => {
-  req.transactionId = req.get('x-request-id') || uuid.v4()
-  next()
-})
+app.use(setTransactionId)
 
 if (config.SENTRY.DSN) {
   Sentry.init({


### PR DESCRIPTION
This is where I got to when I add req to every single service call…

https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/compare/api-client/request-id

but the amount of awful calls with undefined or empty objects in them led me to despair. Yes, `req` could be moved to be first argument to reduce the what position should it be in discombobulation and the need for unnecessary args, but it just felt as if it was totally orthogonal to (indeed, irrelevant to) the actual service methods

So I went back to the drawing board and came up with the changes in this PR

tldr;
```js
const moveService = require('./common/services/move')
```
still works but you can now also do
```js
const MoveService = require('./common/services/move')
const moveService = MoveService.addRequestContext(req)
```
This allows for the individual usages of the service calls to be updated individually rather than having to do it in one massive big bang. I’ve update the move cancel controller and move middleware, but nowt else. (Potentially, after all the service uses had been updated, the services could be refactored to be classes? Or do it now and bit the bullet?)

There is now `req.services` that exposes a method for each of the services registered in `common/services/index` (Was that even being used before?) - those methods add the req context automatically and also reuse any cached instance.
Beyond that, the last 2 commits show possible automated/unified handling of logging+metrics for the services.

Anyhow, comments or screams and curses welcome

## Proposed changes

### What changed

<!--- Describe the changes in detail - the "what"-->

### Why did it change

<!--- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

- [P4-XXXX]()

## Screenshots
<!--- (Optional) Include screenshots if changes update interfaces or components -->
<!--- Delete/copy as appropriate --->

| Before | After |
| ------ | ----- |
| <kbd><img src=""></kbd> | <kbd><img src=""></kbd> |

## Checklists

### Testing

#### Automated testing

- [ ] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [ ] No environment variables were added or changed

<!--- Delete if changes DO NOT include new environment variables -->
- [ ] Documented in the [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md)
- [ ] Added to [continous integration](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-book-secure-move-frontend)
- [ ] Added to staging environment (deployment repository)
- [ ] Added to preproduction environment (deployment repository)
- [ ] Added to production environment (deployment repository)

### Other considerations

Commit messages with a `fix` or `feat` type are automatically used to generate the [changelog](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/CHANGELOG.md) and
[GitHub release notes](https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/releases) during the release task. Please make sure they will read well on their own in a
summary of changes and that the commit body gives a more detailed description of those changes if necessary.

- [ ] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
- [ ] Update [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md) with any new instructions or tasks
