### PR TITLE
Fix metrics 404

### DIFF
--- a/common/lib/metrics.js
+++ b/common/lib/metrics.js
@@ -47,21 +47,27 @@ prometheusClient = {
   },
 }
 
+const uuidRegex = /\b[0-9a-f]{8}\b-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-\b[0-9a-f]{12}\b/gi
+const dateRegex = /\d{4}-\d{2}-\d{2}/g
+const authCallbackRegex = /(callback\?code)=.*/
+const assetRegex = /\.[0-9a-f]{8}\.(js|css|woff.*|svg|png|jpg|gif)$/
+
 /**
  * Normalise path
  *
  * @param {string} path
  * Path to normalise
  *
+ * Replaces uuids, dates and build shas
+ *
  * @return {string}
  */
 const normalizePath = path => {
   const normalizedPath = path
-    .replace(
-      /\b[0-9a-f]{8}\b-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-\b[0-9a-f]{12}\b/gi,
-      ':uuid'
-    )
-    .replace(/\d{4}-\d{2}-\d{2}/g, ':date')
+    .replace(uuidRegex, ':uuid')
+    .replace(dateRegex, ':date')
+    .replace(authCallbackRegex, '$1=:code')
+    .replace(assetRegex, '.:sha.$1')
   return normalizedPath
 }
 

--- a/common/lib/metrics.js
+++ b/common/lib/metrics.js
@@ -152,9 +152,11 @@ const getClient = () => {
 /**
  * Prometheus metrics route middleware
  */
-const summaryRoute = (req, res) => {
+const summaryRoute = (req, res, next) => {
   if (req.get('x-forwarded-host')) {
-    throw new Error(404)
+    const error = new Error('External metrics access')
+    error.statusCode = 404
+    return next(error)
   }
 
   const contentType = promster.getContentType()

--- a/common/lib/metrics.test.js
+++ b/common/lib/metrics.test.js
@@ -211,6 +211,7 @@ describe('Monitoring', function () {
     describe('#summaryRoute', function () {
       let req
       let res
+      let next
 
       beforeEach(function () {
         promster.getContentType.returns('metrics-content-type')
@@ -222,11 +223,12 @@ describe('Monitoring', function () {
           setHeader: sinon.stub(),
           end: sinon.stub(),
         }
+        next = sinon.stub()
       })
       describe('When accessing the metrics endpoint', function () {
         beforeEach(function () {
           // invoke the summary route
-          metrics.summaryRoute(req, res)
+          metrics.summaryRoute(req, res, next)
         })
 
         it('should set the metrics content type', function () {
@@ -244,14 +246,14 @@ describe('Monitoring', function () {
       describe('When attempting to access the metrics endpoint from an external client', function () {
         beforeEach(function () {
           req.get.returns('external-ip')
+          metrics.summaryRoute(req, res, next)
         })
 
-        it('should reject the request', function () {
-          try {
-            expect(metrics.summaryRoute(req, res)).to.have.thrown
-          } catch (e) {
-            expect(e.message).to.equal('404')
-          }
+        it('should return page not found', function () {
+          expect(next).to.be.calledOnce
+          const error = next.firstCall.args[0]
+          expect(error.message).to.equal('External metrics access')
+          expect(error.statusCode).to.equal(404)
         })
       })
     })

--- a/common/lib/metrics.test.js
+++ b/common/lib/metrics.test.js
@@ -295,6 +295,48 @@ describe('Monitoring', function () {
         expect(path).to.equal('/:date/:date')
       })
 
+      it('should obfusctate auth callback path', function () {
+        const path = metrics.normalizePath('/foo/callback?code=SOOPERSEKRIT!99')
+        expect(path).to.equal('/foo/callback?code=:code')
+      })
+
+      context('when asset paths contain build sha', function () {
+        it('should normalise .js', function () {
+          const path = metrics.normalizePath('/foo/bar.62f6496e.js')
+          expect(path).to.equal('/foo/bar.:sha.js')
+        })
+
+        it('should normalise .css', function () {
+          const path = metrics.normalizePath('/foo/bar.62f6496e.css')
+          expect(path).to.equal('/foo/bar.:sha.css')
+        })
+
+        it('should normalise .woff', function () {
+          const path = metrics.normalizePath('/foo/bar.62f6496e.woff2')
+          expect(path).to.equal('/foo/bar.:sha.woff2')
+        })
+
+        it('should normalise .svg', function () {
+          const path = metrics.normalizePath('/foo/bar.62f6496e.svg')
+          expect(path).to.equal('/foo/bar.:sha.svg')
+        })
+
+        it('should normalise .png', function () {
+          const path = metrics.normalizePath('/foo/bar.62f6496e.png')
+          expect(path).to.equal('/foo/bar.:sha.png')
+        })
+
+        it('should normalise .jpg', function () {
+          const path = metrics.normalizePath('/foo/bar.62f6496e.jpg')
+          expect(path).to.equal('/foo/bar.:sha.jpg')
+        })
+
+        it('should normalise .gif', function () {
+          const path = metrics.normalizePath('/foo/bar.62f6496e.gif')
+          expect(path).to.equal('/foo/bar.:sha.gif')
+        })
+      })
+
       it('should not obfusctate other path', function () {
         const path = metrics.normalizePath('/foo/bar')
         expect(path).to.equal('/foo/bar')


### PR DESCRIPTION
## Proposed changes

### What changed

1. Fixed metrics 404 handling when called externally
  A `404` error was being thrown rather than passed to `next` middleware.
  This led to a `500` actually being served

2. Minor improvement of metrics recording

    - Obfuscated code returned by auth callback
    - Normalised asset paths when recording metrics

eg. 
```
/connect/hmpps/callback?code=foo => /connect/hmpps/callback?code=:code
/assets/app.a1b2c3d4.js => /assets/app.:sha.js
```


### Why did it change
1. returns an actual 404 now
2. treats such paths as the same and provides more unified metrics and doesn't inadvertently expose the auth code (not a security issue per se, but better not to)

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

n/a

## Screenshots
<!--- (Optional) Include screenshots if changes update interfaces or components -->
<!--- Delete/copy as appropriate --->

n/a

## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed



### Other considerations



- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics

