### PR TITLE
[P4-2294][P4-2066] Show previous answer for a Person Escort Record question

### DIFF
--- a/app/person-escort-record/views/framework-step.njk
+++ b/app/person-escort-record/views/framework-step.njk
@@ -30,6 +30,18 @@
     }) }}
   {% endif %}
 
+  {% if hasPrefilledResponses %}
+    {{ appMessage({
+      allowDismiss: false,
+      classes: "govuk-!-margin-bottom-4",
+      title: {
+        text: t("person-escort-record::prefilled_banner.title", {
+          date: prefilledSourceDate | formatDateWithRelativeDay + " at " + prefilledSourceDate | formatTime
+        })
+      }
+    }) }}
+  {% endif %}
+
   {{ super() }}
 {% endblock %}
 

--- a/common/assets/scss/utilities/_all.scss
+++ b/common/assets/scss/utilities/_all.scss
@@ -1,4 +1,5 @@
 @import "border";
+@import "form";
 @import "links";
 @import "print";
 @import "typography";

--- a/common/assets/scss/utilities/_form.scss
+++ b/common/assets/scss/utilities/_form.scss
@@ -1,0 +1,20 @@
+// Add support to show when a field contains a message
+.app-form-group--message:not(.govuk-form-group--error) {
+  padding-left: govuk-spacing(3);
+  border-left: 5px solid govuk-colour("blue");
+
+}
+.app-form-group__message-text {
+  @include govuk-font($size: 19, $weight: bold);
+  margin-top: govuk-spacing(3);
+  margin-bottom: govuk-spacing(3);
+  display: block;
+  color: govuk-colour("blue");
+
+  a,
+  a:active,
+  a:hover,
+  a:visited {
+    color: govuk-colour("blue");
+  }
+}

--- a/common/components/framework-response/framework-response.yaml
+++ b/common/components/framework-response/framework-response.yaml
@@ -11,23 +11,34 @@ params:
     type: string
     required: false
     description: The URL to the question. Used in the `href` when no response has been provided yet
+  - name: responded
+    type: string
+    required: false
+    description: Determines whether the answer has been provided, if false it will show a link to the question URL
+  - name: prefilled
+    type: string
+    required: false
+    description: Determines if the value shown has been prefilled. If true, will link to the question URL with review text
 
 examples:
   - name: string
     data:
       value: Example string response
       valueType: string
+      responded: true
   - name: object
     data:
       value:
         option: "Yes"
       valueType: object::followup_comment
+      responded: true
   - name: object with details
     data:
       value:
         option: "Yes"
         details: Example further details for this response
       valueType: object::followup_comment
+      responded: true
   - name: array
     data:
       value:
@@ -35,6 +46,7 @@ examples:
         - Item two
         - Item three
       valueType: array
+      responded: true
   - name: collection
     data:
       value:
@@ -45,6 +57,7 @@ examples:
         -
           option: Item three
       valueType: collection::followup_comment
+      responded: true
   - name: collection with details
     data:
       value:
@@ -58,14 +71,24 @@ examples:
           option: Item three
           details: Further details for option three
       valueType: collection::followup_comment
+      responded: true
   - name: additional HTML
     data:
       value: Example string response
       valueType: string
+      responded: true
       afterContent:
         html: Some example <strong>HTML</strong>
   - name: unanswered
     data:
+      responded: false
+      questionUrl: /step-url#question-id
+  - name: prefilled
+    data:
+      value: Example string response
+      valueType: string
+      responded: false
+      prefilled: true
       questionUrl: /step-url#question-id
   - name: empty answer
     data:

--- a/common/components/framework-response/template.njk
+++ b/common/components/framework-response/template.njk
@@ -1,40 +1,46 @@
-{% if params.value and params.valueType %}
-  {% if params.valueType === 'object::followup_comment' %}
-    <p class="govuk-!-font-size-16">
-      {{ params.value.option }}{{ " — " + params.value.details if params.value.details }}
-    </p>
-  {% endif %}
+{% if params.responded %}
+  {% if params.value and params.valueType %}
+    {% if params.valueType === 'object::followup_comment' %}
+      <p class="govuk-!-font-size-16">
+        {{ params.value.option }}{{ " — " + params.value.details if params.value.details }}
+      </p>
+    {% endif %}
 
-  {% if params.valueType === 'array' %}
-    <ul class="govuk-list govuk-list--bullet govuk-list--spaced govuk-!-margin-top-0 govuk-!-font-size-16">
-      {% for option in params.value %}
-        <li>{{ option }}</li>
-      {% endfor %}
-    </ul>
-  {% endif %}
+    {% if params.valueType === 'array' %}
+      <ul class="govuk-list govuk-list--bullet govuk-list--spaced govuk-!-margin-top-0 govuk-!-font-size-16">
+        {% for option in params.value %}
+          <li>{{ option }}</li>
+        {% endfor %}
+      </ul>
+    {% endif %}
 
-  {% if params.valueType === 'collection::followup_comment' %}
-    <ul class="govuk-list govuk-list--bullet govuk-list--spaced govuk-!-margin-top-0 govuk-!-font-size-16">
-      {% for item in params.value %}
-        <li>
-          {{ item.option }}{{ " — " + item.details if item.details }}
-        </li>
-      {% endfor %}
-    </ul>
-  {% endif %}
+    {% if params.valueType === 'collection::followup_comment' %}
+      <ul class="govuk-list govuk-list--bullet govuk-list--spaced govuk-!-margin-top-0 govuk-!-font-size-16">
+        {% for item in params.value %}
+          <li>
+            {{ item.option }}{{ " — " + item.details if item.details }}
+          </li>
+        {% endfor %}
+      </ul>
+    {% endif %}
 
-  {% if params.valueType === 'string' %}
-    <p class="govuk-!-font-size-16">
-      {{ params.value }}
-    </p>
-  {% endif %}
+    {% if params.valueType === 'string' %}
+      <p class="govuk-!-font-size-16">
+        {{ params.value }}
+      </p>
+    {% endif %}
 
-  {{ params.afterContent.html | safe if params.afterContent.html else params.afterContent.text }}
-{% else %}
-  {% if params.responded %}
+    {{ params.afterContent.html | safe if params.afterContent.html else params.afterContent.text }}
+  {% else %}
     <span class="app-secondary-text-colour">
       {{ t("empty_response") }}
     </span>
+  {% endif %}
+{% else %}
+  {% if params.prefilled %}
+    <a href="{{ params.questionUrl }}">
+      {{ t("actions::review_answer") }}
+    </a>
   {% else %}
     <a href="{{ params.questionUrl }}">
       {{ t("actions::answer_question") }}

--- a/common/components/framework-response/template.test.js
+++ b/common/components/framework-response/template.test.js
@@ -270,6 +270,37 @@ describe('Framework Response component', function () {
     })
   })
 
+  context('with prefilled answer', function () {
+    const example = examples.prefilled
+
+    beforeEach(function () {
+      sinon.stub(i18n, 't').returnsArg(0)
+
+      const $ = renderComponentHtmlToCheerio('framework-response', example)
+      $component = $('body')
+    })
+
+    it('should render a parent anchor', function () {
+      expect($component.children().first().get(0).tagName).to.equal('a')
+    })
+
+    it('should contain correct href for anchor', function () {
+      expect($component.children().first().attr('href')).to.equal(
+        '/step-url#question-id'
+      )
+    })
+
+    it('should translate text', function () {
+      expect(i18n.t).to.be.calledOnceWithExactly('actions::review_answer')
+    })
+
+    it('should contain correct text', function () {
+      expect($component.children().first().text().trim()).to.equal(
+        'actions::review_answer'
+      )
+    })
+  })
+
   context('without value', function () {
     const example = examples.unanswered
 

--- a/common/helpers/frameworks/index.js
+++ b/common/helpers/frameworks/index.js
@@ -2,14 +2,16 @@ const appendResponseToField = require('./append-response-to-field')
 const mapFieldFromName = require('./map-field-from-name')
 const reduceResponsesToFormValues = require('./reduce-responses-to-form-values')
 const renderNomisMappingsToField = require('./render-nomis-mappings-to-field')
+const renderPreviousAnswerToField = require('./render-previous-answer-to-field')
 const responsesToSaveReducer = require('./responses-to-save-reducer')
 const setValidationRules = require('./set-validation-rules')
 
 module.exports = {
-  mapFieldFromName,
   appendResponseToField,
+  mapFieldFromName,
   reduceResponsesToFormValues,
   renderNomisMappingsToField,
+  renderPreviousAnswerToField,
   responsesToSaveReducer,
   setValidationRules,
 }

--- a/common/helpers/frameworks/render-previous-answer-to-field.js
+++ b/common/helpers/frameworks/render-previous-answer-to-field.js
@@ -1,0 +1,37 @@
+const { find, set, cloneDeep } = require('lodash')
+
+const i18n = require('../../../config/i18n')
+
+function renderPreviousAnswerToField({ responses = [] } = {}) {
+  return ([key, field]) => {
+    const response = find(responses, ['question.key', key])
+
+    if (!response) {
+      return [key, field]
+    }
+
+    if (response.responded !== false) {
+      return [key, field]
+    }
+
+    if (response.prefilled !== true) {
+      return [key, field]
+    }
+
+    const copy = cloneDeep(field)
+    let hintContent = copy.hint?.html || ''
+
+    hintContent += `
+      <span class="app-form-group__message-text">
+        ${i18n.t('person-escort-record::prefilled_message')}
+      </span>
+    `
+
+    set(copy, 'hint.html', hintContent)
+    set(copy, 'formGroup.classes', 'app-form-group__message-text')
+
+    return [key, copy]
+  }
+}
+
+module.exports = renderPreviousAnswerToField

--- a/common/helpers/frameworks/render-previous-answer-to-field.test.js
+++ b/common/helpers/frameworks/render-previous-answer-to-field.test.js
@@ -1,0 +1,134 @@
+const i18n = require('../../../config/i18n')
+const filters = require('../../../config/nunjucks/filters')
+
+const helper = require('./render-previous-answer-to-field')
+
+describe('#renderPreviousAnswerToField', function () {
+  let output
+  const mockField = [
+    'mock-key',
+    {
+      foo: 'bar',
+    },
+  ]
+
+  beforeEach(function () {
+    sinon.stub(i18n, 't').returnsArg(0)
+    sinon.stub(filters, 'formatDateWithRelativeDay').returnsArg(0)
+    sinon.stub(filters, 'formatTime').returnsArg(0)
+  })
+
+  context('without response', function () {
+    beforeEach(function () {
+      output = helper()(mockField)
+    })
+
+    it('should return original field', function () {
+      expect(output).to.deep.equal(mockField)
+    })
+  })
+
+  context('with responded question', function () {
+    const mockResponse = {
+      responded: true,
+      prefilled: true,
+      question: {
+        key: 'mock-key',
+      },
+    }
+
+    beforeEach(function () {
+      output = helper({ responses: [mockResponse] })(mockField)
+    })
+
+    it('should return original field', function () {
+      expect(output).to.deep.equal(mockField)
+    })
+  })
+
+  context('without prefilled response', function () {
+    const mockResponse = {
+      responded: false,
+      prefilled: false,
+      question: {
+        key: 'mock-key',
+      },
+    }
+
+    beforeEach(function () {
+      output = helper({ responses: [mockResponse] })(mockField)
+    })
+
+    it('should return original field', function () {
+      expect(output).to.deep.equal(mockField)
+    })
+  })
+
+  context('with unresponded prefilled response', function () {
+    const mockResponse = {
+      responded: false,
+      prefilled: true,
+      question: {
+        key: 'mock-key',
+      },
+    }
+
+    context('without existing hint text', function () {
+      beforeEach(function () {
+        output = helper({
+          responses: [mockResponse],
+        })(mockField)
+      })
+
+      it('should append form group class', function () {
+        expect(output[1].formGroup.classes).to.equal(
+          'app-form-group__message-text'
+        )
+      })
+
+      it('should append message to hint content', function () {
+        expect(output[1].hint).to.deep.equal({
+          html:
+            '\n      <span class="app-form-group__message-text">\n        person-escort-record::prefilled_message\n      </span>\n    ',
+        })
+      })
+
+      it('should translate keys', function () {
+        expect(i18n.t).to.be.calledWithExactly(
+          'person-escort-record::prefilled_message'
+        )
+      })
+    })
+
+    context('with existing hint text', function () {
+      const mockFieldWithHint = [
+        'mock-key',
+        {
+          foo: 'bar',
+          hint: {
+            html: 'EXISTING_HINT',
+          },
+        },
+      ]
+
+      beforeEach(function () {
+        output = helper({
+          responses: [mockResponse],
+        })(mockFieldWithHint)
+      })
+
+      it('should append form group class', function () {
+        expect(output[1].formGroup.classes).to.equal(
+          'app-form-group__message-text'
+        )
+      })
+
+      it('should append message to existing hint content', function () {
+        expect(output[1].hint).to.deep.equal({
+          html:
+            'EXISTING_HINT\n      <span class="app-form-group__message-text">\n        person-escort-record::prefilled_message\n      </span>\n    ',
+        })
+      })
+    })
+  })
+})

--- a/common/lib/api-client/models.js
+++ b/common/lib/api-client/models.js
@@ -69,6 +69,7 @@ module.exports = {
         'profile.person_escort_record.responses.question.descendants.**',
         'profile.person_escort_record.responses.nomis_mappings',
         'profile.person_escort_record.flags',
+        'profile.person_escort_record.prefill_source',
         'profile.person',
         'profile.person.ethnicity',
         'profile.person.gender',
@@ -414,6 +415,10 @@ module.exports = {
         jsonApi: 'hasMany',
         type: 'framework_flags',
       },
+      prefill_source: {
+        jsonApi: 'hasOne',
+        type: 'person_escort_records',
+      },
     },
     options: {
       defaultInclude: [
@@ -425,6 +430,7 @@ module.exports = {
         'responses.question.descendants.**',
         'responses.nomis_mappings',
         'flags',
+        'prefill_source',
       ],
     },
   },
@@ -471,6 +477,7 @@ module.exports = {
       value: '',
       value_type: '',
       responded: '',
+      prefilled: '',
       person_escort_record: {
         jsonApi: 'hasOne',
         type: 'person_escort_records',

--- a/common/presenters/framework-field-summary-list-row.js
+++ b/common/presenters/framework-field-summary-list-row.js
@@ -52,6 +52,7 @@ function frameworkFieldToSummaryListRow(stepUrl) {
       value: isEmpty(response.value) ? undefined : response.value,
       valueType,
       responded: response.responded === true,
+      prefilled: response.prefilled === true,
       questionUrl: `${stepUrl}#${id}`,
     }
 

--- a/common/presenters/framework-field-summary-list-row.test.js
+++ b/common/presenters/framework-field-summary-list-row.test.js
@@ -43,6 +43,7 @@ describe('Presenters', function () {
               value: undefined,
               valueType: undefined,
               responded: false,
+              prefilled: false,
               questionUrl: `${mockStepUrl}#${mockField.id}`,
             }
           )
@@ -78,6 +79,7 @@ describe('Presenters', function () {
               value: undefined,
               valueType: undefined,
               responded: false,
+              prefilled: false,
               questionUrl: `${mockStepUrl}#${mockField.id}`,
             }
           )
@@ -125,6 +127,7 @@ describe('Presenters', function () {
               value: undefined,
               valueType: undefined,
               responded: false,
+              prefilled: false,
               questionUrl: `${mockStepUrl}#${mockField.id}`,
               afterContent: {
                 html: 'NOMIS_HTML',
@@ -178,6 +181,7 @@ describe('Presenters', function () {
               value: undefined,
               valueType: undefined,
               responded: false,
+              prefilled: false,
               questionUrl: `${mockStepUrl}#${mockField.id}`,
             }
           )
@@ -241,6 +245,7 @@ describe('Presenters', function () {
                 value: 'Yes',
                 valueType: 'string',
                 responded: false,
+                prefilled: false,
                 questionUrl: `${mockStepUrl}#${mockFieldWithFollowup.id}`,
               }
             )
@@ -250,6 +255,7 @@ describe('Presenters', function () {
                 value: undefined,
                 valueType: undefined,
                 responded: false,
+                prefilled: false,
                 questionUrl: `${mockStepUrl}#${mockFieldWithFollowup.items[0].followup[0].id}`,
               }
             )
@@ -297,6 +303,7 @@ describe('Presenters', function () {
                 value: 'No',
                 valueType: 'string',
                 responded: false,
+                prefilled: false,
                 questionUrl: `${mockStepUrl}#${mockFieldWithFollowup.id}`,
               }
             )
@@ -374,6 +381,7 @@ describe('Presenters', function () {
                   value: undefined,
                   valueType: test.valueType,
                   responded: false,
+                  prefilled: false,
                   questionUrl: `${mockStepUrl}#${mockField.id}`,
                 }
               )
@@ -402,6 +410,7 @@ describe('Presenters', function () {
                   value: test.nonEmptyValue,
                   valueType: test.valueType,
                   responded: false,
+                  prefilled: false,
                   questionUrl: `${mockStepUrl}#${mockField.id}`,
                 }
               )
@@ -433,6 +442,38 @@ describe('Presenters', function () {
               value: undefined,
               valueType: 'array',
               responded: true,
+              prefilled: false,
+              questionUrl: `${mockStepUrl}#${mockField.id}`,
+            }
+          )
+        })
+      })
+
+      context('when response has been prefilled', function () {
+        const mockResponse = {
+          value: 'An answer',
+          responded: false,
+          prefilled: true,
+          question: {
+            response_type: 'string',
+          },
+        }
+
+        beforeEach(function () {
+          response = frameworkFieldToSummaryListRow(mockStepUrl)({
+            ...mockField,
+            response: mockResponse,
+          })
+        })
+
+        it('should call component service with undefined value and responded value', function () {
+          expect(componentService.getComponent).to.be.calledOnceWithExactly(
+            'appFrameworkResponse',
+            {
+              value: 'An answer',
+              valueType: 'string',
+              responded: false,
+              prefilled: true,
               questionUrl: `${mockStepUrl}#${mockField.id}`,
             }
           )
@@ -571,6 +612,7 @@ describe('Presenters', function () {
                 value: test.value,
                 valueType: test.valueType,
                 responded: false,
+                prefilled: false,
                 questionUrl: `${mockStepUrl}#${test.id}`,
               }
             )
@@ -590,6 +632,7 @@ describe('Presenters', function () {
               value: undefined,
               valueType: 'collection::add_multiple_items',
               responded: false,
+              prefilled: false,
               questionUrl: `${mockStepUrl}#${mockField.id}`,
             }
           )

--- a/locales/en/actions.json
+++ b/locales/en/actions.json
@@ -22,6 +22,7 @@
   "cancel_move": "Cancel this move",
   "confirm_cancellation": "Confirm cancellation",
   "answer_question": "Answer question",
+  "review_answer": "Review answer",
   "change": "Change",
   "change_with_visually_hidden_text": "Change <span class=\"govuk-visually-hidden\">{{text}}</span>",
   "add_person": "Add person",

--- a/locales/en/person-escort-record.json
+++ b/locales/en/person-escort-record.json
@@ -22,6 +22,9 @@
       }
     }
   },
+  "prefilled_banner": {
+    "title": "Some answers on this page need to be reviewed. They are from the last Person Escort Record confirmed on {{date}}."
+  },
   "prefilled_message": "This answer needs to be reviewed",
   "journeys": {
     "confirm": {

--- a/locales/en/person-escort-record.json
+++ b/locales/en/person-escort-record.json
@@ -22,6 +22,7 @@
       }
     }
   },
+  "prefilled_message": "This answer needs to be reviewed",
   "journeys": {
     "confirm": {
       "heading":"Confirm and complete this Person Escort Record",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2152,6 +2152,10 @@
       "version": "git+https://github.com/ministryofjustice/hmpps-book-secure-move-frameworks.git#e1cae252f7d5c16abc8c4a7d3a320a53a51fc13d",
       "from": "git+https://github.com/ministryofjustice/hmpps-book-secure-move-frameworks.git#v1.4.0"
     },
+    "@hmpps-book-secure-move-frameworks/1.5.0": {
+      "version": "git+https://github.com/ministryofjustice/hmpps-book-secure-move-frameworks.git#55713489b66f4167fdd667bb11a4a0cfee276f34",
+      "from": "git+https://github.com/ministryofjustice/hmpps-book-secure-move-frameworks.git#v1.5.0"
+    },
     "@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "@hmpps-book-secure-move-frameworks/1.2.0": "git+https://github.com/ministryofjustice/hmpps-book-secure-move-frameworks.git#v1.2.0",
     "@hmpps-book-secure-move-frameworks/1.3.0": "git+https://github.com/ministryofjustice/hmpps-book-secure-move-frameworks.git#v1.3.0",
     "@hmpps-book-secure-move-frameworks/1.4.0": "git+https://github.com/ministryofjustice/hmpps-book-secure-move-frameworks.git#v1.4.0",
+    "@hmpps-book-secure-move-frameworks/1.5.0": "git+https://github.com/ministryofjustice/hmpps-book-secure-move-frameworks.git#v1.5.0",
     "@ministryofjustice/frontend": "0.0.21",
     "@promster/express": "4.1.14",
     "@sentry/node": "5.27.1",

--- a/test/fixtures/api-client/person_escort_record.create.json
+++ b/test/fixtures/api-client/person_escort_record.create.json
@@ -23,6 +23,12 @@
       "version": "1.1"
     },
     "relationships": {
+      "prefill_source": {
+        "data": {
+          "id": "2c952ca0-f750-4ac3-ac76-fb631445f974",
+          "type": "person_escort_records"
+        }
+      },
       "move": {
         "data": {
           "id": "dfa3ba99-10be-4bc6-bd7d-33cd99d2b48a",
@@ -296,6 +302,29 @@
     }
   },
   "included": [{
+    "id": "2c952ca0-f750-4ac3-ac76-fb631445f974",
+    "type": "person_escort_records",
+    "attributes": {
+      "status": "completed",
+      "confirmed_at": "2020-06-15T09:52:10+01:00",
+      "created_at": "2020-06-09T01:00:40+01:00",
+      "nomis_sync_status": [
+        {
+          "resource_type": "alerts",
+          "status": "failed"
+        },
+        {
+          "resource_type": "personal_care_needs",
+          "status": "success"
+        },
+        {
+          "resource_type": "reasonable_adjustments",
+          "status": "failed"
+        }
+      ],
+      "version": "1.1"
+    }
+  }, {
     "id": "76594a53-119a-40f3-aa47-b69ce9356f81",
     "type": "frameworks",
     "attributes": {

--- a/test/fixtures/api-client/person_escort_record.find.json
+++ b/test/fixtures/api-client/person_escort_record.find.json
@@ -23,6 +23,12 @@
       "version": "1.1"
     },
     "relationships": {
+      "prefill_source": {
+        "data": {
+          "id": "2c952ca0-f750-4ac3-ac76-fb631445f974",
+          "type": "person_escort_records"
+        }
+      },
       "move": {
         "data": {
           "id": "dfa3ba99-10be-4bc6-bd7d-33cd99d2b48a",
@@ -296,6 +302,29 @@
     }
   },
   "included": [{
+    "id": "2c952ca0-f750-4ac3-ac76-fb631445f974",
+    "type": "person_escort_records",
+    "attributes": {
+      "status": "completed",
+      "confirmed_at": "2020-06-15T09:52:10+01:00",
+      "created_at": "2020-06-09T01:00:40+01:00",
+      "nomis_sync_status": [
+        {
+          "resource_type": "alerts",
+          "status": "failed"
+        },
+        {
+          "resource_type": "personal_care_needs",
+          "status": "success"
+        },
+        {
+          "resource_type": "reasonable_adjustments",
+          "status": "failed"
+        }
+      ],
+      "version": "1.1"
+    }
+  }, {
     "id": "76594a53-119a-40f3-aa47-b69ce9356f81",
     "type": "frameworks",
     "attributes": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

This adds the ability to show a previous answer to a question on the Person Escort Record journey.

This is done as part of the rendering step within the framework step controller.

### Why did it change

In some cases users are moving the same person multiple times within a short period, for example a move to court each day of the week. In many cases the answers to the assessment remain the same. This feature allows users to see the previous answer to a question and review it rather than having to fill the information in again.

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

- [P4-2294](https://dsdmoj.atlassian.net/browse/P4-2294)
- [P4-2066](https://dsdmoj.atlassian.net/browse/P4-2066)

## Screenshots
<!--- (Optional) Include screenshots if changes update interfaces or components -->
<!--- Delete/copy as appropriate --->

<kbd>![booksecuremove-pr-916 herokuapp com_move_347296fb-ef85-4cf7-a5e5-d19b642ae2ad_person-escort-record_risk-information_security](https://user-images.githubusercontent.com/3327997/97300375-450e1a80-184e-11eb-8b37-00a1cc40be41.png)</kbd>


## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [x] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed

### Other considerations

Commit messages with a `fix` or `feat` type are automatically used to generate the [changelog](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/CHANGELOG.md) and
[GitHub release notes](https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/releases) during the release task. Please make sure they will read well on their own in a
summary of changes and that the commit body gives a more detailed description of those changes if necessary.

- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
- [x] Update [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md) with any new instructions or tasks
