### PR TITLE
feat(allocation): Improve allocations listing performance

### DIFF
--- a/app/allocation/controllers/view.js
+++ b/app/allocation/controllers/view.js
@@ -5,7 +5,7 @@ const presenters = require('../../../common/presenters')
 function viewAllocation(personEscortRecordFeature = false) {
   return (req, res) => {
     const { allocation, canAccess } = req
-    const { moves, status } = allocation
+    const { moves, status, totalSlots } = allocation
     const bannerStatuses = ['cancelled']
     const movesWithoutProfile = moves.filter(move => !move.profile)
     const movesWithProfile = moves.filter(move => move.profile)
@@ -48,7 +48,7 @@ function viewAllocation(personEscortRecordFeature = false) {
       unassignedMoveId: movesWithoutProfile.length
         ? movesWithoutProfile[0].id
         : undefined,
-      totalCount: moves.length,
+      totalCount: totalSlots,
       remainingCount: movesWithoutProfile.length,
       addedCount: movesWithProfile.length,
       moves: sortBy(

--- a/app/allocation/views/view.njk
+++ b/app/allocation/views/view.njk
@@ -77,79 +77,81 @@
     {% endif %}
   </section>
 
-  <section class="govuk-!-margin-top-8">
-    <h2 class="govuk-heading-m govuk-!-margin-bottom-1">
-      {{ t("allocation::view.people.heading") }}
-    </h2>
+  {% if allocation.status != "cancelled" %}
+    <section class="govuk-!-margin-top-8">
+      <h2 class="govuk-heading-m govuk-!-margin-bottom-1">
+        {{ t("allocation::view.people.heading") }}
+      </h2>
 
-    <h3 class="govuk-heading-s">
-      {% if remainingCount === 0 %}
-        <span class="app-icon app-icon--tick app-green">{{ t("allocation::view.people.complete") }}</span>
-      {% elif canAccess('allocation:person:assign') %}
-        {{ t("allocation::view.people.progress", {
-          count: remainingCount,
-          context: "remaining"
-        }) }}
-      {% else %}
-        {{ t("allocation::view.people.progress", {
-          count: totalCount,
-          addedCount: addedCount
-        }) }}
-      {% endif %}
-    </h3>
+      <h3 class="govuk-heading-s">
+        {% if remainingCount === 0 %}
+          <span class="app-icon app-icon--tick app-green">{{ t("allocation::view.people.complete") }}</span>
+        {% elif canAccess('allocation:person:assign') %}
+          {{ t("allocation::view.people.progress", {
+            count: remainingCount,
+            context: "remaining"
+          }) }}
+        {% else %}
+          {{ t("allocation::view.people.progress", {
+            count: totalCount,
+            addedCount: addedCount
+          }) }}
+        {% endif %}
+      </h3>
 
-    {% if canAccess('allocation:person:assign') and remainingCount %}
-      <p>
-        {{ t("allocation::view.people.special_vehicle_instruction", {
-          href:"/move/new"
-        }) | safe }}
-      </p>
-
-      {{ govukButton({
-        href: "/move/" + unassignedMoveId + "/assign",
-        html: t("actions::add_person", {
-          context: "another" if addedCount !== 0
-        })
-      }) }}
-    {% endif %}
-  </section>
-
-  {% for move in moves %}
-    <div class="app-!-position-relative">
-      {{ appCard(move.card) }}
-
-      {# TODO: consider handling actions within card component #}
-      {# TODO: consider whether long names may cause overlap problems #}
-      {% if move.profile and canAccess('allocation:person:assign') %}
-        <p class="app-!-position-top-right govuk-!-margin-top-3">
-          {{ govukButton({
-            href: "/move/" + move.id + "/unassign",
-            html: t("actions::remove_person", {
-              name: move.profile.person.fullname
-            }),
-            classes: "govuk-button--secondary"
-          })}}
+      {% if canAccess('allocation:person:assign') and remainingCount %}
+        <p>
+          {{ t("allocation::view.people.special_vehicle_instruction", {
+            href:"/move/new"
+          }) | safe }}
         </p>
-      {% endif %}
 
-      {% if move.removeMoveHref %}
-        <div>
-          <a class="app-!-position-top-right govuk-!-margin-top-7 govuk-!-margin-right-3 app-font-weight-normal" href="{{move.removeMoveHref}}">
-            {{ t("actions::person_unassign_confirmation") }}
-          </a>
-        </div>
+        {{ govukButton({
+          href: "/move/" + unassignedMoveId + "/assign",
+          html: t("actions::add_person", {
+            context: "another" if addedCount !== 0
+          })
+        }) }}
       {% endif %}
+    </section>
 
-    </div>
-  {% else %}
-    {{ appMessage({
-      classes: "app-message--muted",
-      allowDismiss: false,
-      content: {
-        html: t("allocation::view.people.no_results")
-      }
-    }) }}
-  {% endfor %}
+    {% for move in moves %}
+      <div class="app-!-position-relative">
+        {{ appCard(move.card) }}
+
+        {# TODO: consider handling actions within card component #}
+        {# TODO: consider whether long names may cause overlap problems #}
+        {% if move.profile and canAccess('allocation:person:assign') %}
+          <p class="app-!-position-top-right govuk-!-margin-top-3">
+            {{ govukButton({
+              href: "/move/" + move.id + "/unassign",
+              html: t("actions::remove_person", {
+                name: move.profile.person.fullname
+              }),
+              classes: "govuk-button--secondary"
+            })}}
+          </p>
+        {% endif %}
+
+        {% if move.removeMoveHref %}
+          <div>
+            <a class="app-!-position-top-right govuk-!-margin-top-7 govuk-!-margin-right-3 app-font-weight-normal" href="{{move.removeMoveHref}}">
+              {{ t("actions::person_unassign_confirmation") }}
+            </a>
+          </div>
+        {% endif %}
+
+      </div>
+    {% else %}
+      {{ appMessage({
+        classes: "app-message--muted",
+        allowDismiss: false,
+        content: {
+          html: t("allocation::view.people.no_results")
+        }
+      }) }}
+    {% endfor %}
+  {% endif %}
 
   {% if canAccess("allocation:cancel") and allocation.status != "cancelled" %}
     <p class="govuk-!-margin-top-9 govuk-!-margin-bottom-0">

--- a/common/presenters/allocations-to-table-component.js
+++ b/common/presenters/allocations-to-table-component.js
@@ -4,6 +4,13 @@ const componentService = require('../services/component')
 
 const tablePresenters = require('./table')
 
+function showProgress(data, showRemaining) {
+  const { totalSlots, unfilledSlots, filledSlots } = data
+  return showRemaining
+    ? _byRemaining(totalSlots, unfilledSlots)
+    : _byAdded(totalSlots, filledSlots)
+}
+
 function _byRemaining(totalSlots, unfilledSlots) {
   const isComplete = unfilledSlots === 0
   const inProgress = unfilledSlots !== totalSlots
@@ -61,7 +68,6 @@ function allocationsToTableComponent({
       },
       row: {
         html: data => {
-          const { totalSlots, unfilledSlots, filledSlots } = data
           const classes = {
             complete: 'govuk-tag--green',
             by_remaining: 'govuk-tag--yellow',
@@ -70,9 +76,7 @@ function allocationsToTableComponent({
           }
           const opts =
             data.status !== 'cancelled'
-              ? showRemaining
-                ? _byRemaining(totalSlots, unfilledSlots)
-                : _byAdded(totalSlots, filledSlots)
+              ? showProgress(data, showRemaining)
               : { context: 'cancelled' }
 
           return componentService.getComponent('govukTag', {

--- a/common/presenters/allocations-to-table-component.js
+++ b/common/presenters/allocations-to-table-component.js
@@ -45,7 +45,7 @@ function allocationsToTableComponent({
           scope: 'row',
         },
         html: data => {
-          const count = data.moves.length
+          const { totalSlots: count } = data
           return `<a href="/allocation/${data.id}">${count} ${i18n.t('person', {
             count,
           })}</a>`
@@ -61,8 +61,7 @@ function allocationsToTableComponent({
       },
       row: {
         html: data => {
-          const totalSlots = data.moves.length
-          const unfilledSlots = data.moves.filter(move => !move.profile).length
+          const { totalSlots, unfilledSlots } = data
           const classes = {
             complete: 'govuk-tag--green',
             by_remaining: 'govuk-tag--yellow',

--- a/common/presenters/allocations-to-table-component.js
+++ b/common/presenters/allocations-to-table-component.js
@@ -14,13 +14,13 @@ function _byRemaining(totalSlots, unfilledSlots) {
   }
 }
 
-function _byAdded(totalSlots, unfilledSlots) {
-  const isComplete = unfilledSlots === 0
-  const inProgress = unfilledSlots !== totalSlots
+function _byAdded(totalSlots, filledSlots) {
+  const isComplete = filledSlots === totalSlots
+  const inProgress = filledSlots > 0
 
   return {
     context: inProgress ? (isComplete ? 'complete' : 'by_added') : '',
-    count: totalSlots - unfilledSlots,
+    count: filledSlots,
   }
 }
 
@@ -61,16 +61,19 @@ function allocationsToTableComponent({
       },
       row: {
         html: data => {
-          const { totalSlots, unfilledSlots } = data
+          const { totalSlots, unfilledSlots, filledSlots } = data
           const classes = {
             complete: 'govuk-tag--green',
             by_remaining: 'govuk-tag--yellow',
             by_added: 'govuk-tag--yellow',
             default: 'govuk-tag--red',
           }
-          const opts = showRemaining
-            ? _byRemaining(totalSlots, unfilledSlots)
-            : _byAdded(totalSlots, unfilledSlots)
+          const opts =
+            data.status !== 'cancelled'
+              ? showRemaining
+                ? _byRemaining(totalSlots, unfilledSlots)
+                : _byAdded(totalSlots, filledSlots)
+              : { context: 'cancelled' }
 
           return componentService.getComponent('govukTag', {
             text: i18n.t('collections::labels.progress_status', opts),

--- a/common/presenters/allocations-to-table-component.test.js
+++ b/common/presenters/allocations-to-table-component.test.js
@@ -21,11 +21,9 @@ const mockAllocations = [
       key: 'hmp_ashfield',
       title: 'HMP Ashfield',
     },
-    moves: [
-      { id: '1', profile: {} },
-      { id: '2', profile: {} },
-      { id: '3', profile: {} },
-    ],
+    totalSlots: 3,
+    filledSlots: 3,
+    unfilledSlots: 0,
   },
   {
     id: '05140394-c517-45d9-8c24-9b4913972d87',
@@ -42,11 +40,9 @@ const mockAllocations = [
       key: 'hmirc_the_verne',
       title: 'HMIRC The Verne',
     },
-    moves: [
-      { id: '1', profile: null },
-      { id: '2', profile: null },
-      { id: '3', profile: null },
-    ],
+    totalSlots: 3,
+    filledSlots: 0,
+    unfilledSlots: 3,
   },
   {
     id: 'c213ebd7-fd77-4b27-aa0c-5545204f3521',
@@ -63,11 +59,9 @@ const mockAllocations = [
       key: 'hmp_yoi_parc',
       title: 'HMP/YOI Parc',
     },
-    moves: [
-      { id: '1', profile: {} },
-      { id: '2', profile: null },
-      { id: '3', profile: null },
-    ],
+    totalSlots: 3,
+    filledSlots: 1,
+    unfilledSlots: 2,
   },
 ]
 

--- a/common/presenters/allocations-to-table-component.test.js
+++ b/common/presenters/allocations-to-table-component.test.js
@@ -63,6 +63,26 @@ const mockAllocations = [
     filledSlots: 1,
     unfilledSlots: 2,
   },
+  {
+    id: 'd213ebd7-fd77-4b27-aa0c-5545204f3521',
+    date: '2020-05-03',
+    created_at: '2020-04-20T10:44:37+01:00',
+    updated_at: '2020-04-20T10:44:37+01:00',
+    status: 'cancelled',
+    from_location: {
+      id: 'b9e8bc2b-9224-4a8f-b1e7-19b2973c30fa',
+      key: 'hmp_yoi_thorn_cross',
+      title: 'HMP/YOI Thorn Cross',
+    },
+    to_location: {
+      id: '8f5347f8-6463-4eea-8ec5-9d00c02e0acd',
+      key: 'hmp_yoi_parc',
+      title: 'HMP/YOI Parc',
+    },
+    totalSlots: 5,
+    filledSlots: 3,
+    unfilledSlots: 2,
+  },
 ]
 
 describe('#allocationsToTableComponent', function () {
@@ -135,7 +155,7 @@ describe('#allocationsToTableComponent', function () {
 
       describe('rows', function () {
         it('should return the correct number', function () {
-          expect(output.rows).to.have.length(3)
+          expect(output.rows).to.have.length(4)
         })
 
         it('should return correct number of columns', function () {
@@ -275,6 +295,49 @@ describe('#allocationsToTableComponent', function () {
             )
           })
         })
+
+        describe('Cancelled allocation', function () {
+          it('should return allocation correctly', function () {
+            expect(output.rows[3]).to.deep.equal([
+              {
+                html: `<a href="/allocation/${mockAllocations[3].id}">5 person</a>`,
+                attributes: {
+                  scope: 'row',
+                },
+              },
+              {
+                html: 'govukTag',
+              },
+              {
+                text: mockAllocations[3].from_location.title,
+              },
+              {
+                text: mockAllocations[3].to_location.title,
+              },
+              {
+                text: mockAllocations[3].date,
+              },
+            ])
+          })
+
+          it('should call tag component correctly', function () {
+            expect(
+              componentService.getComponent.getCall(3)
+            ).to.be.calledWithExactly('govukTag', {
+              classes: 'govuk-tag--red',
+              text: 'collections::labels.progress_status',
+            })
+          })
+
+          it('should call i18n with correct data', function () {
+            expect(i18n.t.getCall(7)).to.be.calledWithExactly(
+              'collections::labels.progress_status',
+              {
+                context: 'cancelled',
+              }
+            )
+          })
+        })
       })
     })
 
@@ -333,7 +396,7 @@ describe('#allocationsToTableComponent', function () {
 
       describe('rows', function () {
         it('should return the correct number', function () {
-          expect(output.rows).to.have.length(3)
+          expect(output.rows).to.have.length(4)
         })
 
         describe('filled allocation', function () {

--- a/common/services/allocation.js
+++ b/common/services/allocation.js
@@ -83,8 +83,17 @@ const allocationService = {
   },
   transform({ includeCancelled = false } = {}) {
     return function transformAllocation(result) {
+      const { total: totalSlots, filled: filledSlots } =
+        result.meta?.moves || {}
+
+      result = { ...result }
+      delete result.meta
+
       return {
         ...result,
+        totalSlots,
+        filledSlots,
+        unfilledSlots: totalSlots ? totalSlots - filledSlots : undefined,
         moves: result.moves
           .filter(
             move => includeCancelled || !['cancelled'].includes(move.status)
@@ -104,7 +113,7 @@ const allocationService = {
     fromLocations = [],
     toLocations = [],
     locations = [],
-    include = ['from_location', 'moves', 'moves.profile', 'to_location'],
+    include = ['from_location', 'to_location'],
     isAggregation = false,
     status,
     sortBy,

--- a/common/services/allocation.js
+++ b/common/services/allocation.js
@@ -94,6 +94,7 @@ const allocationService = {
           set(result, 'meta.moves.total', result.moves.length)
         }
       }
+      // TODO: end
 
       const {
         total: totalSlots,

--- a/common/services/allocation.test.js
+++ b/common/services/allocation.test.js
@@ -24,6 +24,12 @@ const mockAllocations = [
   {
     id: '12345',
     status: 'requested',
+    meta: {
+      moves: {
+        total: 10,
+        filled: 9,
+      },
+    },
     moves: [
       {
         status: 'cancelled',
@@ -171,6 +177,9 @@ describe('Allocation service', function () {
         expect(output).to.deep.equal({
           id: '12345',
           status: 'requested',
+          totalSlots: 10,
+          filledSlots: 9,
+          unfilledSlots: 1,
           moves: [
             {
               profile: {
@@ -218,6 +227,9 @@ describe('Allocation service', function () {
         expect(output).to.deep.equal({
           id: '12345',
           status: 'requested',
+          totalSlots: 10,
+          filledSlots: 9,
+          unfilledSlots: 1,
           moves: [
             {
               profile: {
@@ -265,6 +277,9 @@ describe('Allocation service', function () {
         expect(output).to.deep.equal({
           id: '12345',
           status: 'requested',
+          totalSlots: 10,
+          filledSlots: 9,
+          unfilledSlots: 1,
           moves: [
             {
               status: 'cancelled',
@@ -305,6 +320,23 @@ describe('Allocation service', function () {
               },
             },
           ],
+        })
+      })
+    })
+
+    context('with no meta moves info is present`', function () {
+      beforeEach(function () {
+        output = allocationService.transform({ includeCancelled: false })({
+          moves: [],
+        })
+      })
+
+      it('should set the slots values to undefined', function () {
+        expect(output).to.deep.equal({
+          totalSlots: undefined,
+          filledSlots: undefined,
+          unfilledSlots: undefined,
+          moves: [],
         })
       })
     })
@@ -649,7 +681,7 @@ describe('Allocation service', function () {
         expect(allocationService.getAll).to.be.calledOnceWithExactly({
           isAggregation: false,
           includeCancelled: false,
-          include: ['from_location', 'moves', 'moves.profile', 'to_location'],
+          include: ['from_location', 'to_location'],
           filter: {},
         })
       })
@@ -706,7 +738,7 @@ describe('Allocation service', function () {
           expect(allocationService.getAll).to.be.calledOnceWithExactly({
             isAggregation: false,
             includeCancelled: false,
-            include: ['from_location', 'moves', 'moves.profile', 'to_location'],
+            include: ['from_location', 'to_location'],
             filter: {
               'filter[locations]': mockFromLocationId,
             },
@@ -730,7 +762,7 @@ describe('Allocation service', function () {
           expect(allocationService.getAll).to.be.calledOnceWithExactly({
             isAggregation: true,
             includeCancelled: false,
-            include: ['from_location', 'moves', 'moves.profile', 'to_location'],
+            include: ['from_location', 'to_location'],
             filter: {
               'filter[locations]': mockFromLocationId,
             },
@@ -778,7 +810,7 @@ describe('Allocation service', function () {
           expect(allocationService.getAll).to.be.calledOnceWithExactly({
             isAggregation: false,
             includeCancelled: true,
-            include: ['from_location', 'moves', 'moves.profile', 'to_location'],
+            include: ['from_location', 'to_location'],
             filter: {
               'filter[locations]': mockFromLocationId,
               'filter[status]': 'cancelled',

--- a/common/services/allocation.test.js
+++ b/common/services/allocation.test.js
@@ -161,6 +161,104 @@ describe('Allocation service', function () {
       sinon.stub(moveService, 'transform').returnsArg(0)
     })
 
+    // TODO: Remove when individual allocations return meta.moves info
+    describe('single allocation', function () {
+      context('when there is no meta object', function () {
+        beforeEach(function () {
+          const allocation = {
+            ...mockAllocations[0],
+            meta: undefined,
+            moves: mockAllocations[0].moves.slice(),
+          }
+          output = allocationService.transform()(allocation)
+        })
+
+        it('should return correct output', function () {
+          expect(output).to.deep.equal({
+            id: '12345',
+            status: 'requested',
+            totalSlots: 3,
+            filledSlots: undefined,
+            unfilledSlots: undefined,
+            moves: [
+              {
+                profile: {
+                  person: {
+                    name: 'James Stephens',
+                  },
+                },
+              },
+              {
+                status: 'requested',
+                profile: {
+                  person: {
+                    name: 'Hugh Jack',
+                  },
+                },
+              },
+              {
+                profile: {
+                  person: {
+                    name: 'Steve Adams',
+                  },
+                },
+              },
+            ],
+          })
+        })
+      })
+
+      context(
+        'when allocation is cancelled and there is no meta object',
+        function () {
+          beforeEach(function () {
+            const allocation = {
+              ...mockAllocations[0],
+              meta: undefined,
+              status: 'cancelled',
+              moves: mockAllocations[0].moves.slice(),
+            }
+            output = allocationService.transform()(allocation)
+          })
+
+          it('should return correct output', function () {
+            expect(output).to.deep.equal({
+              id: '12345',
+              status: 'cancelled',
+              totalSlots: 5,
+              filledSlots: undefined,
+              unfilledSlots: undefined,
+              moves: [
+                {
+                  profile: {
+                    person: {
+                      name: 'James Stephens',
+                    },
+                  },
+                },
+                {
+                  status: 'requested',
+                  profile: {
+                    person: {
+                      name: 'Hugh Jack',
+                    },
+                  },
+                },
+                {
+                  profile: {
+                    person: {
+                      name: 'Steve Adams',
+                    },
+                  },
+                },
+              ],
+            })
+          })
+        }
+      )
+    })
+    // TODO: end
+
     context('with no arguments', function () {
       beforeEach(function () {
         output = allocationService.transform()(mockAllocations[0])

--- a/common/services/allocation.test.js
+++ b/common/services/allocation.test.js
@@ -28,6 +28,7 @@ const mockAllocations = [
       moves: {
         total: 10,
         filled: 9,
+        unfilled: 1,
       },
     },
     moves: [

--- a/locales/en/collections.json
+++ b/locales/en/collections.json
@@ -59,6 +59,7 @@
     "progress_status_new": "None added",
     "progress_status_complete": "Filled",
     "progress_status_by_added": "{{count}} added",
-    "progress_status_by_remaining": "{{count}} remaining"
+    "progress_status_by_remaining": "{{count}} remaining",
+    "progress_status_cancelled": "Cancelled"
   }
 }


### PR DESCRIPTION
This PR depends on this BE PR
https://github.com/ministryofjustice/hmpps-book-secure-move-api/pull/1070 (which has now been merged)

## Proposed changes

### What changed

Switch to using allocation's `metadata` to determine slots rather than having to ask for `moves` and `moves.profile`.

Additonally displays 'CANCELLED' rather than '0' for a cancelled allocation's progress when listing it.

Also displays the number of moves on the individual allocation view rather than '0'.

### Why did it change

Reduce the number of includes required to render the list of allocations

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

- [P4-2341 - FE - Support Metadata in FE client for Allocation Dashboard](https://dsdmoj.atlassian.net/browse/P4-2341)

## Screenshots
<!--- (Optional) Include screenshots if changes update interfaces or components -->
<!--- Delete/copy as appropriate --->


| Before | After |
| ------ | ----- |
|<kbd>![Allocations_for_26_Oct_to_1_Nov_2020__This_week_](https://user-images.githubusercontent.com/4856/97456183-870f8d00-1930-11eb-826d-83b5774c4469.png)</kbd>|<kbd>![Allocations_for_26_Oct_to_1_Nov_2020__This_week_](https://user-images.githubusercontent.com/4856/97456365-b7572b80-1930-11eb-9fc1-cf0c33d546ae.png)</kbd>|
|<kbd>![Allocation_for_0_people_from_WETHERBY__HMPYOI__to_DARTMOOR__HMP__on_28_Oct_2020](https://user-images.githubusercontent.com/4856/97457165-67c52f80-1931-11eb-9a79-caf785b384b1.png)</kbd>|<kbd>![Allocation_for_0_people_from_WETHERBY__HMPYOI__to_DARTMOOR__HMP__on_28_Oct_2020](https://user-images.githubusercontent.com/4856/97457382-9a6f2800-1931-11eb-86df-28a3d3237658.png)</kbd>|


## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed

### Other considerations


- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics

