### PR TITLE
test: Correctly restore core dates after mocking

### DIFF
--- a/app/move/controllers/create/base.test.js
+++ b/app/move/controllers/create/base.test.js
@@ -588,6 +588,10 @@ describe('Move controllers', function () {
         nextSpy = sinon.spy()
       })
 
+      afterEach(function () {
+        this.clock.restore()
+      })
+
       context('with no timestamp in the session', function () {
         beforeEach(function () {
           req.sessionModel.get.withArgs('journeyTimestamp').returns(undefined)

--- a/app/move/controllers/create/move-date.test.js
+++ b/app/move/controllers/create/move-date.test.js
@@ -212,6 +212,10 @@ describe('Move controllers', function () {
           controller.process(req, {}, nextSpy)
         })
 
+        afterEach(function () {
+          this.clock.restore()
+        })
+
         it('should set value of date to tomorrow', function () {
           expect(req.form.values.date).to.equal('2017-08-11')
         })

--- a/app/move/controllers/create/save.test.js
+++ b/app/move/controllers/create/save.test.js
@@ -789,6 +789,10 @@ describe('Move controllers', function () {
           await controller.successHandler(req, res, nextSpy)
         })
 
+        afterEach(function () {
+          this.clock.restore()
+        })
+
         it('should send journey time to analytics', function () {
           expect(analytics.sendJourneyTime).to.be.calledOnceWithExactly({
             utv: capitalize(req.form.options.name),

--- a/app/moves/middleware/set-body-request-filters/age.test.js
+++ b/app/moves/middleware/set-body-request-filters/age.test.js
@@ -4,8 +4,14 @@ const ageFilter = require('./age')
 
 describe('age filter', function () {
   const now = new Date('2020-01-01T02:00')
+  let clock
+
   beforeEach(function () {
-    sinon.useFakeTimers(now.getTime())
+    clock = sinon.useFakeTimers(now.getTime())
+  })
+
+  afterEach(function () {
+    clock.restore()
   })
 
   describe('when called without an age value', function () {

--- a/common/presenters/move-to-additional-info-list-component.test.js
+++ b/common/presenters/move-to-additional-info-list-component.test.js
@@ -22,6 +22,10 @@ describe('Presenters', function () {
       sinon.stub(i18n, 't').returnsArg(0)
     })
 
+    afterEach(function () {
+      timezoneMock.unregister()
+    })
+
     context('when provided no move', function () {
       beforeEach(function () {
         transformedResponse = moveToSummaryListComponent()

--- a/common/presenters/move-to-meta-list-component.test.js
+++ b/common/presenters/move-to-meta-list-component.test.js
@@ -25,6 +25,10 @@ describe('Presenters', function () {
       sinon.stub(i18n, 't').returns('__translated__')
     })
 
+    afterEach(function () {
+      timezoneMock.unregister()
+    })
+
     context('when provided with a mock move object', function () {
       let transformedResponse
 

--- a/common/presenters/move-to-summary-list-component.test.js
+++ b/common/presenters/move-to-summary-list-component.test.js
@@ -28,6 +28,10 @@ describe('Presenters', function () {
       sinon.stub(i18n, 't').returnsArg(0)
     })
 
+    afterEach(function () {
+      timezoneMock.unregister()
+    })
+
     context('when provided no move', function () {
       beforeEach(function () {
         transformedResponse = moveToSummaryListComponent()


### PR DESCRIPTION
###  Proposed changes

When using date mocking libraries, it is important to restore the original behaviour at the end of the tests, otherwise weird failures will occur with unrelated tests.

### What changed

Restore original behaviour after using sinon / timezoneMock

## Checklists

### Testing

#### Automated testing

- [ ] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed

### Other considerations

Commit messages with a `fix` or `feat` type are automatically used to generate the [changelog](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/CHANGELOG.md) and
[GitHub release notes](https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/releases) during the release task. Please make sure they will read well on their own in a
summary of changes and that the commit body gives a more detailed description of those changes if necessary.

- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
- [ ] Update [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md) with any new instructions or tasks
