### PR TITLE
test: Use member test for array contents

### DIFF
--- a/common/lib/user.test.js
+++ b/common/lib/user.test.js
@@ -114,7 +114,7 @@ describe('User class', function () {
       })
 
       it('should contain empty permissions', function () {
-        expect(permissions).to.deep.equal([])
+        expect(permissions).to.have.members([])
       })
     })
 
@@ -147,7 +147,7 @@ describe('User class', function () {
           'move:update:video_remand',
         ]
 
-        expect(permissions).to.deep.equal(policePermissions)
+        expect(permissions).to.have.members(policePermissions)
       })
     })
 
@@ -157,7 +157,7 @@ describe('User class', function () {
       })
 
       it('should contain correct permission', function () {
-        expect(permissions).to.deep.equal([
+        expect(permissions).to.have.members([
           'moves:view:outgoing',
           'moves:view:incoming',
           'moves:download',
@@ -196,7 +196,7 @@ describe('User class', function () {
           'move:cancel:proposed',
         ]
 
-        expect(permissions).to.deep.equal(stcPermissions)
+        expect(permissions).to.have.members(stcPermissions)
       })
     })
 
@@ -206,7 +206,7 @@ describe('User class', function () {
       })
 
       it('should contain correct permission', function () {
-        expect(permissions).to.deep.equal([
+        expect(permissions).to.have.members([
           'dashboard:view',
           'moves:view:outgoing',
           'moves:view:incoming',
@@ -234,7 +234,7 @@ describe('User class', function () {
       })
 
       it('should contain correct permission', function () {
-        expect(permissions).to.deep.equal([
+        expect(permissions).to.have.members([
           'moves:view:outgoing',
           'moves:view:incoming',
           'moves:download',
@@ -253,7 +253,7 @@ describe('User class', function () {
       })
 
       it('should contain correct permission', function () {
-        expect(permissions).to.deep.equal([
+        expect(permissions).to.have.members([
           'dashboard:view',
           'allocations:view',
           'allocation:person:assign',
@@ -275,7 +275,7 @@ describe('User class', function () {
       })
 
       it('should contain correct permission', function () {
-        expect(permissions).to.deep.equal([
+        expect(permissions).to.have.members([
           'allocations:view',
           'allocation:create',
           'allocation:cancel',
@@ -294,7 +294,7 @@ describe('User class', function () {
       })
 
       it('should contain correct permission', function () {
-        expect(permissions).to.deep.equal([
+        expect(permissions).to.have.members([
           'locations:all',
           'moves:view:outgoing',
           'moves:view:incoming',
@@ -310,7 +310,7 @@ describe('User class', function () {
       })
 
       it('should contain correct permission', function () {
-        expect(permissions).to.deep.equal([
+        expect(permissions).to.have.members([
           'dashboard:view',
           'moves:view:outgoing',
           'moves:view:incoming',
@@ -326,7 +326,7 @@ describe('User class', function () {
       })
 
       it('should contain correct permission', function () {
-        expect(permissions).to.deep.equal([
+        expect(permissions).to.have.members([
           'person_escort_record:view',
           'person_escort_record:create',
           'person_escort_record:update',
@@ -394,7 +394,7 @@ describe('User class', function () {
           'person_escort_record:confirm',
         ]
 
-        expect(permissions.sort()).to.deep.equal(allPermissions.sort())
+        expect(permissions).to.have.members(allPermissions)
       })
     })
   })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

### Proposed changes

The current permission tests require the permissions to be in the same order as defined in the config. However, that is not what we're actually wanting to test.

### What changed
As per [this medium post](https://medium.com/building-ibotta/testing-arrays-and-objects-with-chai-js-4b372310fe6d) the usage of `deep.equal` has been replaced with `have.members`

<!--- Describe the changes in detail - the "what"-->

## Checklists

### Testing

#### Automated testing

- [ ] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed

### Other considerations

Commit messages with a `fix` or `feat` type are automatically used to generate the [changelog](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/CHANGELOG.md) and
[GitHub release notes](https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/releases) during the release task. Please make sure they will read well on their own in a
summary of changes and that the commit body gives a more detailed description of those changes if necessary.

- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
- [ ] Update [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md) with any new instructions or tasks
