### PR TITLE
Capture CSRF errors in Sentry

### DIFF
--- a/common/controllers/form-wizard.js
+++ b/common/controllers/form-wizard.js
@@ -164,6 +164,10 @@ class FormController extends Controller {
         'MISSING_LOCATION',
       ].includes(err.code)
     ) {
+      if (err.code === 'CSRF_ERROR') {
+        Sentry.captureException(err)
+      }
+
       return res.render('form-wizard-error', {
         journeyName: req.form.options.journeyName.replace('-', '_'),
         journeyBaseUrl: req.baseUrl,

--- a/common/controllers/form-wizard.test.js
+++ b/common/controllers/form-wizard.test.js
@@ -368,6 +368,7 @@ describe('Form wizard', function () {
         redirect: sinon.spy(),
         render: sinon.spy(),
       }
+      sinon.stub(Sentry, 'captureException')
       sinon.spy(FormController.prototype, 'errorHandler')
     })
 
@@ -405,6 +406,10 @@ describe('Form wizard', function () {
         controller.errorHandler(errorMock, reqMock, resMock)
       })
 
+      it('should not send error to sentry', function () {
+        expect(Sentry.captureException).not.to.be.called
+      })
+
       it('should render the timeout template', function () {
         expect(resMock.render.args[0][0]).to.equal('form-wizard-error')
       })
@@ -437,6 +442,10 @@ describe('Form wizard', function () {
         }
 
         controller.errorHandler(errorMock, reqMock, resMock)
+      })
+
+      it('should not send error to sentry', function () {
+        expect(Sentry.captureException).not.to.be.called
       })
 
       it('should render the timeout template', function () {
@@ -473,6 +482,10 @@ describe('Form wizard', function () {
         controller.errorHandler(errorMock, reqMock, resMock)
       })
 
+      it('should not send error to sentry', function () {
+        expect(Sentry.captureException).not.to.be.called
+      })
+
       it('should render the timeout template', function () {
         expect(resMock.render.args[0][0]).to.equal('form-wizard-error')
       })
@@ -507,6 +520,10 @@ describe('Form wizard', function () {
         controller.errorHandler(errorMock, reqMock, resMock)
       })
 
+      it('should send error to sentry', function () {
+        expect(Sentry.captureException).to.be.calledOnceWithExactly(errorMock)
+      })
+
       it('should render the timeout template', function () {
         expect(resMock.render.args[0][0]).to.equal('form-wizard-error')
       })
@@ -532,7 +549,6 @@ describe('Form wizard', function () {
 
         nextSpy = sinon.spy()
         sinon.spy(Sentry, 'withScope')
-        sinon.stub(Sentry, 'captureException')
 
         controller.errorHandler(errorMock, {}, {}, nextSpy)
       })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

This change means that we will start to log them in Sentry so that we
can understand how often they are occurring and if there is a way to
reduce these occurrences.

### Why did it change

There have been reports from users that they are seeing CSRF (This form
has been tampered with) errors frequently in production.

## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

### Other considerations

Commit messages with a `fix` or `feat` type are automatically used to generate the [changelog](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/CHANGELOG.md) and
[GitHub release notes](https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/releases) during the release task. Please make sure they will read well on their own in a
summary of changes and that the commit body gives a more detailed description of those changes if necessary.

- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
- [x] Update [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md) with any new instructions or tasks
