### PR TITLE
Support new frameworks version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2152,6 +2152,10 @@
       "version": "git+https://github.com/ministryofjustice/hmpps-book-secure-move-frameworks.git#e1cae252f7d5c16abc8c4a7d3a320a53a51fc13d",
       "from": "git+https://github.com/ministryofjustice/hmpps-book-secure-move-frameworks.git#v1.4.0"
     },
+    "@hmpps-book-secure-move-frameworks/1.5.0": {
+      "version": "git+https://github.com/ministryofjustice/hmpps-book-secure-move-frameworks.git#55713489b66f4167fdd667bb11a4a0cfee276f34",
+      "from": "git+https://github.com/ministryofjustice/hmpps-book-secure-move-frameworks.git#v1.5.0"
+    },
     "@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "@hmpps-book-secure-move-frameworks/1.2.0": "git+https://github.com/ministryofjustice/hmpps-book-secure-move-frameworks.git#v1.2.0",
     "@hmpps-book-secure-move-frameworks/1.3.0": "git+https://github.com/ministryofjustice/hmpps-book-secure-move-frameworks.git#v1.3.0",
     "@hmpps-book-secure-move-frameworks/1.4.0": "git+https://github.com/ministryofjustice/hmpps-book-secure-move-frameworks.git#v1.4.0",
+    "@hmpps-book-secure-move-frameworks/1.5.0": "git+https://github.com/ministryofjustice/hmpps-book-secure-move-frameworks.git#v1.5.0",
     "@ministryofjustice/frontend": "0.0.21",
     "@promster/express": "4.1.14",
     "@sentry/node": "5.27.1",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

This supports version 1.5.0 of the Person Escort Record framework,
which enables the ability to prefill from a previous record.

### Why did it change

To support the prefilling of the Person Escort Record we need to increase the latest version of the framework in the frontend.
