### PR TITLE
fix(per): Correct styling used to indicate when a question is prefilled

### DIFF
--- a/common/assets/scss/utilities/_form.scss
+++ b/common/assets/scss/utilities/_form.scss
@@ -17,4 +17,8 @@
   a:visited {
     color: govuk-colour("blue");
   }
+
+  .govuk-hint & {
+    color: govuk-colour("blue");
+  }
 }

--- a/common/helpers/frameworks/render-previous-answer-to-field.js
+++ b/common/helpers/frameworks/render-previous-answer-to-field.js
@@ -28,7 +28,7 @@ function renderPreviousAnswerToField({ responses = [] } = {}) {
     `
 
     set(copy, 'hint.html', hintContent)
-    set(copy, 'formGroup.classes', 'app-form-group__message-text')
+    set(copy, 'formGroup.classes', 'app-form-group--message')
 
     return [key, copy]
   }

--- a/common/helpers/frameworks/render-previous-answer-to-field.test.js
+++ b/common/helpers/frameworks/render-previous-answer-to-field.test.js
@@ -81,9 +81,7 @@ describe('#renderPreviousAnswerToField', function () {
       })
 
       it('should append form group class', function () {
-        expect(output[1].formGroup.classes).to.equal(
-          'app-form-group__message-text'
-        )
+        expect(output[1].formGroup.classes).to.equal('app-form-group--message')
       })
 
       it('should append message to hint content', function () {
@@ -118,9 +116,7 @@ describe('#renderPreviousAnswerToField', function () {
       })
 
       it('should append form group class', function () {
-        expect(output[1].formGroup.classes).to.equal(
-          'app-form-group__message-text'
-        )
+        expect(output[1].formGroup.classes).to.equal('app-form-group--message')
       })
 
       it('should append message to existing hint content', function () {

--- a/common/presenters/framework-responses-to-meta-list-component.js
+++ b/common/presenters/framework-responses-to-meta-list-component.js
@@ -6,6 +6,7 @@ function _mapResponse(response) {
   const responseHtml = componentService.getComponent('appFrameworkResponse', {
     value: isEmpty(response.value) ? undefined : response.value,
     valueType: response.value_type,
+    responded: response.responded,
   })
   const description = response.question?.description
 

--- a/common/presenters/framework-responses-to-meta-list-component.test.js
+++ b/common/presenters/framework-responses-to-meta-list-component.test.js
@@ -28,6 +28,7 @@ describe('Presenters', function () {
         {
           value: 'string value',
           value_type: 'string',
+          responded: true,
           question: {
             description: 'String',
           },
@@ -35,6 +36,7 @@ describe('Presenters', function () {
         {
           value: { option: 'Yes' },
           value_type: 'object',
+          responded: false,
           question: {
             description: 'Object',
           },
@@ -42,6 +44,7 @@ describe('Presenters', function () {
         {
           value: ['One'],
           value_type: 'array',
+          responded: true,
           question: {
             description: 'Array',
           },
@@ -87,6 +90,7 @@ describe('Presenters', function () {
                 {
                   value: response.value,
                   valueType: response.value_type,
+                  responded: response.responded,
                 }
               )
             })
@@ -100,6 +104,7 @@ describe('Presenters', function () {
         {
           value: '',
           value_type: 'string',
+          responded: true,
           question: {
             description: 'String',
           },
@@ -107,6 +112,7 @@ describe('Presenters', function () {
         {
           value: {},
           value_type: 'object',
+          responded: false,
           question: {
             description: 'Object',
           },
@@ -114,6 +120,7 @@ describe('Presenters', function () {
         {
           value: [],
           value_type: 'array',
+          responded: true,
           question: {
             description: 'Array',
           },
@@ -159,6 +166,7 @@ describe('Presenters', function () {
                 {
                   value: undefined,
                   valueType: response.value_type,
+                  responded: response.responded,
                 }
               )
             })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

This change updates the styling to ensure the correct hierarchy and
that the correct classnames are used.

### Why did it change

The classnames were refactored but this meant some of the desired
styling was lost.

## Screenshots
<!--- (Optional) Include screenshots if changes update interfaces or components -->
<!--- Delete/copy as appropriate --->

| Before | After |
| ------ | ----- |
| <kbd>![image](https://user-images.githubusercontent.com/3327997/97440876-f5981f00-191f-11eb-836c-e3cc6cc473b3.png)</kbd> | <kbd>![image](https://user-images.githubusercontent.com/3327997/97440817-e1542200-191f-11eb-9d52-bcbe904ca803.png)</kbd> |
| <kbd>![image](https://user-images.githubusercontent.com/3327997/97444654-4c075c80-1924-11eb-8e7f-fcf0bc9aca26.png)</kbd> | <kbd>![image](https://user-images.githubusercontent.com/3327997/97444529-2b3f0700-1924-11eb-8563-54f9cf91fc62.png)</kbd> |
