### PR TITLE
build: Prevent dependabot suggesting major updates to node

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,3 +27,6 @@ updates:
     schedule:
       interval: 'weekly'
       day: 'sunday'
+    ignore:
+      - dependency-name: 'node'
+        versions: ['15.x']

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,7 @@ updates:
     commit-message:
       prefix: 'build'
       include: 'scope'
+    open-pull-requests-limit: 3
   - package-ecosystem: 'docker'
     directory: '/'
     schedule:
@@ -30,3 +31,4 @@ updates:
     ignore:
       - dependency-name: 'node'
         versions: ['15.x']
+    open-pull-requests-limit: 1

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,8 @@ updates:
         versions: ['>=4']
       - dependency-name: 'webpack-merge'
         versions: ['>=5']
+      - dependency-name: 'mini-css-extract-plugin'
+        versions: ['>=1']
     commit-message:
       prefix: 'build'
       include: 'scope'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Prevent major node updates.

### Why did it change

We want to stick to even releases of Node so this prevents dependabot
over-eagerly asking us to bump the version.
