### PR TITLE
Improve metrics url deduping

### DIFF
--- a/common/lib/metrics.js
+++ b/common/lib/metrics.js
@@ -50,6 +50,7 @@ prometheusClient = {
 const uuidRegex = /\b[0-9a-f]{8}\b-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-\b[0-9a-f]{12}\b/gi
 const dateRegex = /\d{4}-\d{2}-\d{2}/g
 const authCallbackRegex = /(callback\?code)=.*/
+const lookupValueRegex = /(filter\[(prison_number|police_national_computer)\])=[^&]+/g
 const assetRegex = /\.[0-9a-f]{8}\.(js|css|woff.*|svg|png|jpg|gif)$/
 
 /**
@@ -62,11 +63,13 @@ const assetRegex = /\.[0-9a-f]{8}\.(js|css|woff.*|svg|png|jpg|gif)$/
  *
  * @return {string}
  */
+// TODO: consider caching return value for path
 const normalizePath = path => {
   const normalizedPath = path
     .replace(uuidRegex, ':uuid')
     .replace(dateRegex, ':date')
     .replace(authCallbackRegex, '$1=:code')
+    .replace(lookupValueRegex, '$1=:lookup')
     .replace(assetRegex, '.:sha.$1')
   return normalizedPath
 }

--- a/common/lib/metrics.test.js
+++ b/common/lib/metrics.test.js
@@ -259,43 +259,43 @@ describe('Monitoring', function () {
     })
 
     describe('#normalizePath', function () {
-      it('should obfusctate path ending with a uuid', function () {
+      it('should obfuscate path ending with a uuid', function () {
         const path = metrics.normalizePath(
           '/foo/0ee995d1-9390-4e85-9f5a-c6a436716234'
         )
         expect(path).to.equal('/foo/:uuid')
       })
 
-      it('should obfusctate path containing a uuid', function () {
+      it('should obfuscate path containing a uuid', function () {
         const path = metrics.normalizePath(
           '/foo/0ee995d1-9390-4e85-9f5a-c6a436716234/bar'
         )
         expect(path).to.equal('/foo/:uuid/bar')
       })
 
-      it('should obfusctate path containing multiple uuids', function () {
+      it('should obfuscate path containing multiple uuids', function () {
         const path = metrics.normalizePath(
           '/ff59bf52-5e16-48c8-a154-616ad4ff247c/0ee995d1-9390-4e85-9f5a-c6a436716234'
         )
         expect(path).to.equal('/:uuid/:uuid')
       })
 
-      it('should obfusctate path ending with a date', function () {
+      it('should obfuscate path ending with a date', function () {
         const path = metrics.normalizePath('/foo/2020-09-23')
         expect(path).to.equal('/foo/:date')
       })
 
-      it('should obfusctate path containing a date', function () {
+      it('should obfuscate path containing a date', function () {
         const path = metrics.normalizePath('/foo/2020-09-23/bar')
         expect(path).to.equal('/foo/:date/bar')
       })
 
-      it('should obfusctate path containing multiple dates', function () {
+      it('should obfuscate path containing multiple dates', function () {
         const path = metrics.normalizePath('/2019-09-24/2020-09-23')
         expect(path).to.equal('/:date/:date')
       })
 
-      it('should obfusctate lookup values', function () {
+      it('should obfuscate lookup values', function () {
         const pathPolice = metrics.normalizePath(
           '/foo?bar=baz&filter[police_national_computer]=PNC&something=else'
         )
@@ -309,7 +309,7 @@ describe('Monitoring', function () {
         expect(pathPrison).to.equal('/foo?filter[prison_number]=:lookup')
       })
 
-      it('should obfusctate auth callback path', function () {
+      it('should obfuscate auth callback path', function () {
         const path = metrics.normalizePath('/foo/callback?code=SOOPERSEKRIT!99')
         expect(path).to.equal('/foo/callback?code=:code')
       })
@@ -351,7 +351,7 @@ describe('Monitoring', function () {
         })
       })
 
-      it('should not obfusctate other path', function () {
+      it('should not obfuscate other path', function () {
         const path = metrics.normalizePath('/foo/bar')
         expect(path).to.equal('/foo/bar')
       })

--- a/common/lib/metrics.test.js
+++ b/common/lib/metrics.test.js
@@ -295,6 +295,20 @@ describe('Monitoring', function () {
         expect(path).to.equal('/:date/:date')
       })
 
+      it('should obfusctate lookup values', function () {
+        const pathPolice = metrics.normalizePath(
+          '/foo?bar=baz&filter[police_national_computer]=PNC&something=else'
+        )
+        const pathPrison = metrics.normalizePath(
+          '/foo?filter[prison_number]=PRISON'
+        )
+        expect(pathPolice).to.equal(
+          '/foo?bar=baz&filter[police_national_computer]=:lookup&something=else'
+        )
+
+        expect(pathPrison).to.equal('/foo?filter[prison_number]=:lookup')
+      })
+
       it('should obfusctate auth callback path', function () {
         const path = metrics.normalizePath('/foo/callback?code=SOOPERSEKRIT!99')
         expect(path).to.equal('/foo/callback?code=:code')


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Obfuscate `filter[police_national_computer]` and `filter[prison_number]`query args in path used for recording metrics

### Why did it change

As these args were not obfuscated, so each lookup was treated as a separate and unique path

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

n/a

## Screenshots
<!--- (Optional) Include screenshots if changes update interfaces or components -->
<!--- Delete/copy as appropriate --->

n/a

## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes

#### Manual testing

Has been tested in the following browsers:

n/a
### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed



### Other considerations


- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics

