### PR TITLE
[P4-2419] Ensure form wizards are unique for each Person Escort Record

### DIFF
--- a/app/person-escort-record/router.js
+++ b/app/person-escort-record/router.js
@@ -5,6 +5,7 @@ const FrameworkStepController = require('./controllers/framework-step')
 
 function defineFormWizard(req, res, next) {
   const { key, steps } = req.frameworkSection
+  const { id: personEscortRecordId } = req.personEscortRecord
   const firstStep = Object.values(steps)[0]
   const wizardFields = req.framework.questions
   const wizardSteps = {
@@ -25,9 +26,11 @@ function defineFormWizard(req, res, next) {
   const wizardConfig = {
     controller: FrameworkStepController,
     entryPoint: true,
-    journeyName: `person-escort-record-${key}`,
+    // Unique for each Person Escort Record and section
+    journeyName: `person-escort-record-${personEscortRecordId}-${key}`,
     journeyPageTitle: 'Person escort record',
-    name: `person-escort-record-${key}`,
+    // Unique for each Person Escort Record
+    name: `person-escort-record-${personEscortRecordId}`,
     template: 'framework-step',
     templatePath: 'person-escort-record/views/',
     defaultFormatters: ['trim', 'singlespaces', 'apostrophes', 'quotes'],

--- a/app/person-escort-record/router.test.js
+++ b/app/person-escort-record/router.test.js
@@ -50,6 +50,9 @@ describe('Person Escort Record router', function () {
 
     beforeEach(function () {
       req = {
+        personEscortRecord: {
+          id: '12345',
+        },
         framework: mockFramework,
         frameworkSection: {
           key: 'section-one',
@@ -95,9 +98,9 @@ describe('Person Escort Record router', function () {
         const config = {
           controller: FrameworkStepController,
           entryPoint: true,
-          journeyName: `person-escort-record-${req.frameworkSection.key}`,
+          journeyName: `person-escort-record-${req.personEscortRecord.id}-${req.frameworkSection.key}`,
           journeyPageTitle: 'Person escort record',
-          name: `person-escort-record-${req.frameworkSection.key}`,
+          name: `person-escort-record-${req.personEscortRecord.id}`,
           template: 'framework-step',
           templatePath: 'person-escort-record/views/',
           defaultFormatters: ['trim', 'singlespaces', 'apostrophes', 'quotes'],

--- a/locales/en/errors.json
+++ b/locales/en/errors.json
@@ -25,7 +25,7 @@
   },
   "tampered_with": {
     "heading": "This form has been tampered with",
-    "content": "Try to reload the page and submit the form again in a few moments."
+    "content": "Try to <a href=\"\">reload the page</a> and submit the form again in a few moments."
   },
   "csrf_error": {
     "heading": "$t(errors::tampered_with.heading)",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

This change uses the ID of the Person Escort Record to create the form wizard and journey keys so that they are unique for each record.

This also introduces a link to the error page to make it easier to refresh a form that has been tampered with.

### Why did it change

We have seen lots of CSRF errors reported in Sentry. This occurs when a new CSRF token is generating for that form wizard and its journey.

Currently the key is not unique per Person Escort Record form wizard which means that if a user opens an existing record in another tab, for example to compare the previous information or re-use some information, and then try and submit the form step, it will have regenerated the CSRF token and the initial form step will now error.

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

- [P4-2419](https://dsdmoj.atlassian.net/browse/P4-2419)

## Screenshots
<!--- (Optional) Include screenshots if changes update interfaces or components -->
<!--- Delete/copy as appropriate --->

| Before | After |
| ------ | ----- |
| <kbd>![image](https://user-images.githubusercontent.com/3327997/97710039-2066ac80-1ab3-11eb-98fd-2e5c8e9b8938.png)</kbd> | <kbd>![image](https://user-images.githubusercontent.com/3327997/97709971-0f1da000-1ab3-11eb-8bad-9aa06c2f2cb0.png)</kbd> |
| <kbd>![csrf-before](https://user-images.githubusercontent.com/3327997/97712033-c5828480-1ab5-11eb-9e00-d12c1b69b381.gif)</kbd> | <kbd>![csrf-after](https://user-images.githubusercontent.com/3327997/97711234-bc44e800-1ab4-11eb-898b-d6fb7a62dd4e.gif)</kbd> |


## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [x] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed

### Other considerations

Commit messages with a `fix` or `feat` type are automatically used to generate the [changelog](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/CHANGELOG.md) and
[GitHub release notes](https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/releases) during the release task. Please make sure they will read well on their own in a
summary of changes and that the commit body gives a more detailed description of those changes if necessary.

- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
- [x] Update [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md) with any new instructions or tasks
