### PR TITLE
fix: Trim whitespace from person search inputs

### DIFF
--- a/app/move/controllers/create/person-search.js
+++ b/app/move/controllers/create/person-search.js
@@ -2,10 +2,11 @@ const PersonController = require('./person')
 
 class PersonSearchController extends PersonController {
   successHandler(req, res) {
+    const values = req.form?.values || {}
     const nextStep = this.getNextStep(req, res)
-    const filters = Object.keys(req.body)
+    const filters = Object.keys(values)
       .filter(key => key.includes('filter.'))
-      .map(name => `filter[${name.replace('filter.', '')}]=${req.body[name]}`)
+      .map(name => `filter[${name.replace('filter.', '')}]=${values[name]}`)
 
     this.setStepComplete(req, res)
 

--- a/app/move/controllers/create/person-search.test.js
+++ b/app/move/controllers/create/person-search.test.js
@@ -16,7 +16,9 @@ describe('Move controllers', function () {
           .returns('/next-step')
         sinon.stub(FormController.prototype, 'setStepComplete')
         req = {
-          body: {},
+          form: {
+            values: {},
+          },
         }
         res = {
           redirect: sinon.stub(),
@@ -26,7 +28,7 @@ describe('Move controllers', function () {
       context('with filters', function () {
         context('with one filter', function () {
           beforeEach(function () {
-            req.body = {
+            req.form.values = {
               'filter.police_national_computer': 'ABCD',
             }
             controller.successHandler(req, res)
@@ -47,7 +49,7 @@ describe('Move controllers', function () {
 
         context('with multiple filters', function () {
           beforeEach(function () {
-            req.body = {
+            req.form.values = {
               'filter.police_national_computer': 'ABCD',
               'filter.prison_number': '1234',
               'filter.cro_number': 'EFGH',
@@ -71,6 +73,23 @@ describe('Move controllers', function () {
 
       context('without filters', function () {
         beforeEach(function () {
+          controller.successHandler(req, res)
+        })
+
+        it('should set step complete', function () {
+          expect(
+            FormController.prototype.setStepComplete
+          ).to.be.calledOnceWithExactly(req, res)
+        })
+
+        it('should redirect without search', function () {
+          expect(res.redirect).to.be.calledOnceWithExactly('/next-step')
+        })
+      })
+
+      context('without form values', function () {
+        beforeEach(function () {
+          req = {}
           controller.successHandler(req, res)
         })
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

This change uses the saved form values for redirect to the results
step rather than the original `req.body` value. The saved values are
sanitized and have had the whitespace trimmed so are the safer values
to use.

### Why did it change

Before this change if a user entered a space before or after a search
term it would be passed to the next view and to the API and would produce
no results for the user.

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

- [P4-XXXX]()

## Screenshots
<!--- (Optional) Include screenshots if changes update interfaces or components -->
<!--- Delete/copy as appropriate --->

| Before | After |
| ------ | ----- |
| <kbd>![image](https://user-images.githubusercontent.com/3327997/98274381-43013580-1f8b-11eb-9860-6825822b9628.png)</kbd> | <kbd>![image](https://user-images.githubusercontent.com/3327997/98274381-43013580-1f8b-11eb-9860-6825822b9628.png)</kbd> |
| <kbd>![image](https://user-images.githubusercontent.com/3327997/98274328-311f9280-1f8b-11eb-83d2-2a362a7cc0c0.png)</kbd> | <kbd>![image](https://user-images.githubusercontent.com/3327997/98274164-01708a80-1f8b-11eb-889d-f0908768ecd1.png)</kbd> |

## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [x] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [ ] No environment variables were added or changed

### Other considerations

Commit messages with a `fix` or `feat` type are automatically used to generate the [changelog](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/CHANGELOG.md) and
[GitHub release notes](https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/releases) during the release task. Please make sure they will read well on their own in a
summary of changes and that the commit body gives a more detailed description of those changes if necessary.

- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
- [x] Update [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md) with any new instructions or tasks
