### PR TITLE
feat: Select radio item when only one result

### DIFF
--- a/app/move/controllers/create/person-search-results.js
+++ b/app/move/controllers/create/person-search-results.js
@@ -41,6 +41,7 @@ class PersonSearchResultsController extends PersonController {
       return {
         html: componentService.getComponent('appCard', card),
         value: person.id,
+        checked: req.people.length === 1,
       }
     })
     next()

--- a/app/move/controllers/create/person-search-results.test.js
+++ b/app/move/controllers/create/person-search-results.test.js
@@ -175,7 +175,7 @@ describe('Move controllers', function () {
         nextSpy = sinon.spy()
       })
 
-      context('with people items', function () {
+      context('with multiple results', function () {
         const mockPeople = [
           {
             id: 1,
@@ -196,10 +196,12 @@ describe('Move controllers', function () {
           expect(req.form.options.fields.people.items).to.deep.equal([
             {
               value: 1,
+              checked: false,
               html: 'appCard',
             },
             {
               value: 2,
+              checked: false,
               html: 'appCard',
             },
           ])
@@ -242,7 +244,58 @@ describe('Move controllers', function () {
         })
       })
 
-      context('without people items', function () {
+      context('with one result', function () {
+        const mockPeople = [
+          {
+            id: 1,
+            name: 'foo',
+          },
+        ]
+
+        beforeEach(function () {
+          req.people = mockPeople
+          controller.setPeopleItems(req, {}, nextSpy)
+        })
+
+        it('should set people items property with checked property', function () {
+          expect(req.form.options.fields.people.items).to.deep.equal([
+            {
+              value: 1,
+              checked: true,
+              html: 'appCard',
+            },
+          ])
+        })
+
+        it('should call presenter correct number of times', function () {
+          expect(presenters.profileToCardComponent.callCount).to.equal(1)
+        })
+
+        it('should call presenter correctly', function () {
+          expect(
+            presenters.profileToCardComponent.firstCall
+          ).to.be.calledWithExactly({ showTags: false })
+          expect(profileToCardComponentStub.firstCall).to.be.calledWithExactly({
+            person: mockPeople[0],
+          })
+        })
+
+        it('should call component service correct number of times', function () {
+          expect(componentService.getComponent.callCount).to.equal(1)
+        })
+
+        it('should call component service correctly', function () {
+          expect(
+            componentService.getComponent.firstCall
+          ).to.be.calledWithExactly('appCard', { person: mockPeople[0] })
+        })
+
+        it('should call next', function () {
+          expect(nextSpy).to.be.calledOnceWithExactly()
+        })
+      })
+
+      context('with no results', function () {
         beforeEach(function () {
           controller.setPeopleItems(req, {}, nextSpy)
         })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

This change addresses something seen from error validation analytics,
where if there is only one result when searching for a person, that
result will now be automatically selected.

Closes #809

### Why did it change

The analytics showed a lot of validation errors for this particular
field, which suggests that the user behaviour is for this item to
already be selected.

## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [ ] ~Added end-to-end tests to cover any journey changes~

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [x] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed

### Other considerations

Commit messages with a `fix` or `feat` type are automatically used to generate the [changelog](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/CHANGELOG.md) and
[GitHub release notes](https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/releases) during the release task. Please make sure they will read well on their own in a
summary of changes and that the commit body gives a more detailed description of those changes if necessary.

- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
- [x] Update [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md) with any new instructions or tasks
