### PR TITLE
fix(allocation): Ensure allocation service resource always has moves

### DIFF
--- a/common/services/allocation.js
+++ b/common/services/allocation.js
@@ -84,6 +84,7 @@ const allocationService = {
   transform({ includeCancelled = false } = {}) {
     return function transformAllocation(result) {
       // TODO: Remove when individual allocations return meta.moves info
+      // TODO: see moves filtering below too
       if (!result.meta?.moves && result.moves.length) {
         set(result, 'meta.moves.total', result.moves.length)
 
@@ -105,6 +106,11 @@ const allocationService = {
       result = { ...result }
       delete result.meta
 
+      // ensure that moves is not empty before attempting to transform them
+      // why? because the BE does not return moves for multiple allocations
+      result.moves = result.moves || []
+
+      // TODO: Remove includeCancelled malarkey when meta.moves info available
       return {
         ...result,
         totalSlots,

--- a/common/services/allocation.test.js
+++ b/common/services/allocation.test.js
@@ -423,6 +423,20 @@ describe('Allocation service', function () {
       })
     })
 
+    context('with no moves', function () {
+      beforeEach(function () {
+        const allocation = {
+          ...mockAllocations[0],
+        }
+        delete allocation.moves
+        output = allocationService.transform()(allocation)
+      })
+
+      it('should add an empty moves property', function () {
+        expect(output.moves).to.have.length(0)
+      })
+    })
+
     context('with no meta moves info is present`', function () {
       beforeEach(function () {
         output = allocationService.transform({ includeCancelled: false })({


### PR DESCRIPTION


## Proposed changes

### What changed

Ensures allocation resource object always has a `moves` property

### Why did it change

Endpoint that returns multiple allocations no longer includes move relationships in the response

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

- [IM-79 - Allocations unavailable in Staging](https://dsdmoj.atlassian.net/browse/IM-79)

## Screenshots
<!--- (Optional) Include screenshots if changes update interfaces or components -->
<!--- Delete/copy as appropriate --->



## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed



### Other considerations



- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics

