### PR TITLE
Find and inflate unpopulated resources returned to api-client [P4-2337]

### DIFF
--- a/common/lib/api-client/index.js
+++ b/common/lib/api-client/index.js
@@ -12,6 +12,7 @@ const {
   requestHeaders,
   requestInclude,
   requestTimeout,
+  processResponse,
 } = require('./middleware')
 const models = require('./models')
 
@@ -55,6 +56,8 @@ module.exports = function () {
   insertRequestMiddleware(requestTimeout(API.TIMEOUT))
   insertRequestMiddleware(requestHeaders)
   insertRequestMiddleware(requestInclude)
+
+  instance.insertMiddlewareAfter('axios-request', processResponse)
 
   // define models
   Object.entries(models).forEach(([modelName, model]) => {

--- a/common/lib/api-client/index.test.js
+++ b/common/lib/api-client/index.test.js
@@ -1,4 +1,3 @@
-const { expect } = require('chai')
 const proxyquire = require('proxyquire').noCallThru()
 
 const mockConfig = {
@@ -47,6 +46,7 @@ describe('Back-end API client', function () {
     let requestStub
     let requestIncludeStub
     let requestTimeoutStub
+    let processResponseStub
     let middlewareMock
 
     beforeEach(function () {
@@ -59,9 +59,11 @@ describe('Back-end API client', function () {
       requestStub = sinon.stub()
       requestIncludeStub = sinon.stub()
       requestTimeoutStub = sinon.stub().returnsArg(0)
+      processResponseStub = sinon.stub()
       JsonApiStub.prototype.init = sinon.stub()
       JsonApiStub.prototype.replaceMiddleware = sinon.stub()
       JsonApiStub.prototype.insertMiddlewareBefore = sinon.stub()
+      JsonApiStub.prototype.insertMiddlewareAfter = sinon.stub()
       JsonApiStub.prototype.define = sinon.stub()
       middlewareMock = {
         auth: authStub,
@@ -73,6 +75,7 @@ describe('Back-end API client', function () {
         requestInclude: requestIncludeStub,
         requestHeaders: requestHeadersStub,
         requestTimeout: requestTimeoutStub,
+        processResponse: processResponseStub,
       }
 
       jsonApi = proxyquire('./', {
@@ -172,6 +175,18 @@ describe('Back-end API client', function () {
             expect(
               JsonApiStub.prototype.insertMiddlewareBefore.callCount
             ).to.equal(6)
+          })
+
+          it('should insert process response middleware', function () {
+            expect(
+              JsonApiStub.prototype.insertMiddlewareAfter.getCall(0)
+            ).to.be.calledWithExactly('axios-request', processResponseStub)
+          })
+
+          it('should call insertMiddlewareAfter correct number of times', function () {
+            expect(
+              JsonApiStub.prototype.insertMiddlewareAfter.callCount
+            ).to.equal(1)
           })
 
           it('should call replaceMiddleware correct number of times', function () {

--- a/common/lib/api-client/middleware/index.js
+++ b/common/lib/api-client/middleware/index.js
@@ -3,6 +3,7 @@ const cacheKey = require('./cache-key')
 const errors = require('./errors')
 const getCache = require('./get-cache')
 const post = require('./post')
+const processResponse = require('./process-response')
 const request = require('./request')
 const requestHeaders = require('./request-headers')
 const requestInclude = require('./request-include')
@@ -18,4 +19,5 @@ module.exports = {
   requestHeaders,
   requestInclude,
   requestTimeout,
+  processResponse,
 }

--- a/common/lib/api-client/middleware/process-response.js
+++ b/common/lib/api-client/middleware/process-response.js
@@ -1,0 +1,26 @@
+const findUnpopulatedResources = require('../../find-unpopulated-resources')
+
+const processResponseMiddleware = {
+  name: 'process-response',
+  req: function req(response) {
+    const { req = {} } = response
+
+    if (req.preserveResourceRefs) {
+      response.data.included = response.data.included || []
+      const populateOptions =
+        req.preserveResourceRefs === true ? {} : req.preserveResourceRefs
+      const missingIncludes = findUnpopulatedResources(
+        response.data,
+        populateOptions
+      ).filter(
+        missing =>
+          !response.data.included.some(included => included.id === missing.id)
+      )
+      response.data.included = response.data.included.concat(missingIncludes)
+    }
+
+    return response
+  },
+}
+
+module.exports = processResponseMiddleware

--- a/common/lib/api-client/middleware/process-response.test.js
+++ b/common/lib/api-client/middleware/process-response.test.js
@@ -1,0 +1,139 @@
+const proxyquire = require('proxyquire')
+
+const findUnpopulatedResourcesStub = sinon.stub()
+
+const middleware = proxyquire('./process-response', {
+  '../../find-unpopulated-resources': findUnpopulatedResourcesStub,
+})
+
+describe('API Client', function () {
+  describe('Response processing middleware', function () {
+    describe('#process-response', function () {
+      context('when payload includes a response', function () {
+        it('should return payload as is', function () {
+          const payload = { req: {}, res: {} }
+          expect(middleware.req(payload)).to.deep.equal({ ...payload })
+        })
+      })
+
+      context('when payload contains a response', function () {
+        let response
+        let processedResponse
+
+        beforeEach(function () {
+          findUnpopulatedResourcesStub.resetHistory()
+          response = {
+            data: {
+              data: {},
+              included: [{ id: 'foo', type: 'foos' }],
+            },
+            req: {},
+          }
+        })
+
+        context('and the response should not be processed', function () {
+          beforeEach(function () {
+            processedResponse = middleware.req(
+              JSON.parse(JSON.stringify(response))
+            )
+          })
+          it('should return the response unchanged', function () {
+            expect(processedResponse).to.deep.equal(response)
+          })
+        })
+
+        context('and the response should be processed', function () {
+          beforeEach(function () {
+            findUnpopulatedResourcesStub.returns([
+              {
+                id: 'bar',
+                type: 'bars',
+              },
+            ])
+            response.req.preserveResourceRefs = true
+          })
+
+          context('when preserveResourceRefs is set to true', function () {
+            beforeEach(function () {
+              processedResponse = middleware.req(response)
+            })
+            it('should look for matched resources', function () {
+              expect(findUnpopulatedResourcesStub).to.be.calledOnceWithExactly(
+                response.data,
+                {}
+              )
+            })
+          })
+
+          context('when preserveResourceRefs is an object', function () {
+            beforeEach(function () {
+              response.req.preserveResourceRefs = { foo: 'bar' }
+              processedResponse = middleware.req(response)
+            })
+            it('should look for matched resources and pass the preserveResourceRefs object as options', function () {
+              expect(
+                findUnpopulatedResourcesStub
+              ).to.be.calledOnceWithExactly(response.data, { foo: 'bar' })
+            })
+          })
+
+          context(
+            'when matched resources is not already in included',
+            function () {
+              beforeEach(function () {
+                processedResponse = middleware.req(response)
+              })
+              it('should not add the matched resources', function () {
+                expect(processedResponse.data.included).to.deep.equal([
+                  {
+                    id: 'foo',
+                    type: 'foos',
+                  },
+                  {
+                    id: 'bar',
+                    type: 'bars',
+                  },
+                ])
+              })
+            }
+          )
+
+          context('when response has no pre-existing included', function () {
+            beforeEach(function () {
+              delete response.data.included
+              processedResponse = middleware.req(response)
+            })
+            it('should still add the matched resources', function () {
+              expect(processedResponse.data.included).to.deep.equal([
+                {
+                  id: 'bar',
+                  type: 'bars',
+                },
+              ])
+            })
+          })
+
+          context('when matched resources already in included', function () {
+            beforeEach(function () {
+              findUnpopulatedResourcesStub.returns([
+                {
+                  id: 'foo',
+                  type: 'foos',
+                },
+              ])
+              processedResponse = middleware.req(response)
+            })
+            it('should not add the matched resources', function () {
+              expect(processedResponse.data.included).to.deep.equal([
+                {
+                  id: 'foo',
+                  type: 'foos',
+                },
+              ])
+            })
+          })
+        })
+      })
+    })
+  })
+})

--- a/common/lib/api-client/middleware/request.js
+++ b/common/lib/api-client/middleware/request.js
@@ -16,6 +16,11 @@ function requestMiddleware({ cacheExpiry = 60, useRedisCache = false } = {}) {
 
       debug('API REQUEST', req.url)
 
+      if (req.params.populateResources) {
+        req.populateResources = req.params.populateResources
+        delete req.params.populateResources
+      }
+
       // start timer for metrics and logging
       const clientTimer = timer()
 
@@ -43,6 +48,7 @@ function requestMiddleware({ cacheExpiry = 60, useRedisCache = false } = {}) {
           throw error
         })
 
+      response.req = req
       return response
     },
   }

--- a/common/lib/api-client/middleware/request.test.js
+++ b/common/lib/api-client/middleware/request.test.js
@@ -79,6 +79,20 @@ describe('API Client', function () {
       })
     })
 
+    context('when response’s resources should be populated', function () {
+      beforeEach(async function () {
+        payload.req.params.populateResources = 'foo'
+        response = await requestMiddleware().req(payload)
+      })
+
+      it('should remove populateResources property from params', function () {
+        expect(response.req.params.populateResources).to.be.undefined
+      })
+      it('should copy populateResources property to req object', function () {
+        expect(response.req.populateResources).to.equal('foo')
+      })
+    })
+
     context('when response should not be cached', function () {
       beforeEach(async function () {
         response = await requestMiddleware({ useRedisCache: true }).req(payload)

--- a/common/lib/find-unpopulated-resources.checks.js
+++ b/common/lib/find-unpopulated-resources.checks.js
@@ -1,0 +1,43 @@
+function isNonObject(obj) {
+  let nonObj = false
+
+  if (obj === null) {
+    nonObj = true
+  } else if (typeof obj !== 'object') {
+    nonObj = true
+  } else if (Array.isArray(obj)) {
+    nonObj = true
+  }
+
+  return nonObj
+}
+
+function isSkippableObject(obj, { include, exclude = [] } = {}) {
+  let skip = false
+
+  if (include && obj.type && !include.includes(obj.type)) {
+    skip = true
+  } else if (exclude.includes(obj.type)) {
+    skip = true
+  }
+
+  return skip
+}
+
+function isUnpopulatedObject(obj) {
+  let unpopulated = true
+
+  if (Object.keys(obj).length !== 2) {
+    unpopulated = false
+  } else if (!obj.id || !obj.type) {
+    unpopulated = false
+  }
+
+  return unpopulated
+}
+
+module.exports = {
+  isNonObject,
+  isSkippableObject,
+  isUnpopulatedObject,
+}

--- a/common/lib/find-unpopulated-resources.checks.test.js
+++ b/common/lib/find-unpopulated-resources.checks.test.js
@@ -1,0 +1,103 @@
+const {
+  isNonObject,
+  isSkippableObject,
+  isUnpopulatedObject,
+} = require('./find-unpopulated-resources.checks')
+
+describe('findUnpopulatedResources checks', function () {
+  describe('#isNonObject', function () {
+    context('when input is object', function () {
+      it('should return false', function () {
+        expect(isNonObject({})).to.equal(false)
+      })
+    })
+
+    context('when input is undefined', function () {
+      it('should return false', function () {
+        expect(isNonObject(null)).to.equal(true)
+      })
+    })
+
+    context('when input is null', function () {
+      it('should return false', function () {
+        expect(isNonObject(null)).to.equal(true)
+      })
+    })
+
+    context('when input is string', function () {
+      it('should return false', function () {
+        expect(isNonObject('foo')).to.equal(true)
+      })
+    })
+
+    context('when input is number', function () {
+      it('should return false', function () {
+        expect(isNonObject(23)).to.equal(true)
+      })
+    })
+
+    context('when input is array', function () {
+      it('should return false', function () {
+        expect(isNonObject([])).to.equal(true)
+      })
+    })
+  })
+
+  describe('#isSkippableObject', function () {
+    const obj = { type: 'foo' }
+
+    context('when no options set', function () {
+      it('should return false', function () {
+        expect(isSkippableObject(obj)).to.equal(false)
+      })
+    })
+
+    context('when object type is explicitly included', function () {
+      it('should return true', function () {
+        expect(isSkippableObject(obj, { include: ['foo'] })).to.equal(false)
+      })
+    })
+
+    context('when object type is not explicitly included', function () {
+      it('should return true', function () {
+        expect(isSkippableObject(obj, { include: ['bar'] })).to.equal(true)
+      })
+    })
+
+    context('when object type is excluded', function () {
+      it('should return true', function () {
+        expect(isSkippableObject(obj, { exclude: ['foo'] })).to.equal(true)
+      })
+    })
+  })
+
+  describe('#isUnpopulatedObject', function () {
+    context('when object is unpopulated', function () {
+      it('should return true', function () {
+        expect(isUnpopulatedObject({ type: 'foo', id: 'bar' })).to.equal(true)
+      })
+    })
+
+    context('when object is populated', function () {
+      it('should return false', function () {
+        expect(
+          isUnpopulatedObject({ type: 'foo', id: 'bar', key: 'value' })
+        ).to.equal(false)
+      })
+    })
+
+    context('when object is missing id', function () {
+      it('should return false', function () {
+        expect(isUnpopulatedObject({ type: 'foo', key: 'value' })).to.equal(
+          false
+        )
+      })
+    })
+
+    context('when object is missing type', function () {
+      it('should return false', function () {
+        expect(isUnpopulatedObject({ id: 'bar', key: 'value' })).to.equal(false)
+      })
+    })
+  })
+})

--- a/common/lib/find-unpopulated-resources.js
+++ b/common/lib/find-unpopulated-resources.js
@@ -1,0 +1,39 @@
+const checks = require('./find-unpopulated-resources.checks')
+
+function processArray(obj, options) {
+  if (Array.isArray(obj)) {
+    return obj.forEach(item => findUnpopulatedResources(item, options))
+  }
+}
+
+function processObject(obj, options) {
+  const { resources } = options
+
+  if (checks.isUnpopulatedObject(obj)) {
+    resources.push(obj)
+  } else {
+    Object.keys(obj).forEach(key => findUnpopulatedResources(obj[key], options))
+  }
+}
+
+function findUnpopulatedResources(obj, options = {}) {
+  const { seenResources = [], resources = [] } = options
+  options.seenResources = seenResources
+  options.resources = resources
+
+  if (obj === null || seenResources.includes(obj)) {
+    return
+  }
+
+  seenResources.push(obj)
+
+  processArray(obj, options)
+
+  if (!checks.isNonObject(obj) && !checks.isSkippableObject(obj, options)) {
+    processObject(obj, options)
+  }
+
+  return resources
+}
+
+module.exports = findUnpopulatedResources

--- a/common/lib/find-unpopulated-resources.test.js
+++ b/common/lib/find-unpopulated-resources.test.js
@@ -1,0 +1,88 @@
+const findUnpopulatedResources = require('./find-unpopulated-resources')
+
+describe('findUnpopulatedResources', function () {
+  context('when data contains an unpopulated resource', function () {
+    it('should return unpopulated resource', function () {
+      const unpopulated = findUnpopulatedResources({
+        foo: { id: 'foo', type: 'foos' },
+      })
+      expect(unpopulated).to.deep.equal([{ id: 'foo', type: 'foos' }])
+    })
+  })
+
+  context('when data contains a nested unpopulated resource', function () {
+    it('should return unpopulated resource', function () {
+      const unpopulated = findUnpopulatedResources({
+        bar: { foo: { id: 'foo', type: 'foos' } },
+      })
+      expect(unpopulated).to.deep.equal([{ id: 'foo', type: 'foos' }])
+    })
+  })
+
+  context(
+    'when data contains an unpopulated resource in an array',
+    function () {
+      it('should return unpopulated resource', function () {
+        const unpopulated = findUnpopulatedResources({
+          foo: [{ id: 'foo', type: 'foos' }],
+        })
+        expect(unpopulated).to.deep.equal([{ id: 'foo', type: 'foos' }])
+      })
+    }
+  )
+
+  context('when data contains a populated resource', function () {
+    it('should return nothing', function () {
+      const unpopulated = findUnpopulatedResources({
+        foo: { id: 'foo', type: 'foos', foo: 'bars' },
+      })
+      expect(unpopulated).to.deep.equal([])
+    })
+  })
+
+  context(
+    'when data contains an unpopulated resource multiple times',
+    function () {
+      it('should return unpopulated resource', function () {
+        const foo = { id: 'foo', type: 'foos' }
+        const unpopulated = findUnpopulatedResources({
+          foo,
+          anotherFoo: foo,
+        })
+        expect(unpopulated).to.deep.equal([{ id: 'foo', type: 'foos' }])
+      })
+    }
+  )
+
+  context(
+    'when data contains an unpopulated resource that should be excluded',
+    function () {
+      it('should only return non-excluded unpopulated resources', function () {
+        const unpopulated = findUnpopulatedResources(
+          {
+            foo: { id: 'foo', type: 'foos' },
+            bar: { id: 'bar', type: 'bars' },
+          },
+          { exclude: ['bars'] }
+        )
+        expect(unpopulated).to.deep.equal([{ id: 'foo', type: 'foos' }])
+      })
+    }
+  )
+
+  context(
+    'when data contains an unpopulated resource that should be included',
+    function () {
+      it('should only return included unpopulated resources', function () {
+        const unpopulated = findUnpopulatedResources(
+          {
+            foo: { id: 'foo', type: 'foos' },
+            bar: { id: 'bar', type: 'bars' },
+          },
+          { include: ['foos'] }
+        )
+        expect(unpopulated).to.deep.equal([{ id: 'foo', type: 'foos' }])
+      })
+    }
+  )
+})

--- a/common/lib/populate-resources.js
+++ b/common/lib/populate-resources.js
@@ -1,0 +1,36 @@
+const moveService = require('../services/move')
+const personEscortRecordService = require('../services/person-escort-record')
+const referenceDataService = require('../services/reference-data')
+
+const findUnpopulatedResources = require('./find-unpopulated-resources')
+
+const lookupMethods = {
+  locations: referenceDataService.getLocationById,
+  moves: moveService.getById,
+  person_escort_records: personEscortRecordService.getById,
+}
+
+const populateResources = async (obj, options, processed = []) => {
+  const unpopulated = findUnpopulatedResources(obj, options).filter(
+    resource => !processed.includes(resource)
+  )
+
+  if (!unpopulated.length) {
+    return
+  }
+
+  for (const resource of unpopulated) {
+    const lookupMethod = lookupMethods[resource.type]
+
+    if (lookupMethod) {
+      const newProp = await lookupMethod(resource.id)
+      Object.keys(newProp).forEach(prop => {
+        resource[prop] = newProp[prop]
+      })
+    }
+  }
+
+  return populateResources(obj, options, unpopulated)
+}
+
+module.exports = populateResources

--- a/common/lib/populate-resources.test.js
+++ b/common/lib/populate-resources.test.js
@@ -1,0 +1,183 @@
+const proxyquire = require('proxyquire')
+
+const moveService = {
+  getById: sinon.stub().resolves({ id: 'move', type: 'moves', foo: 'bar' }),
+}
+const personEscortRecordService = {
+  getById: sinon
+    .stub()
+    .resolves({ id: 'per', type: 'person_escort_records', foo: 'bar' }),
+}
+const referenceDataService = {
+  getLocationById: sinon
+    .stub()
+    .resolves({ id: 'loc', type: 'locations', foo: 'bar' }),
+}
+const findUnpopulatedResources = require('./find-unpopulated-resources')
+const findUnpopulatedResourcesStub = sinon
+  .stub()
+  .callsFake(findUnpopulatedResources)
+
+const populateResources = proxyquire('./populate-resources', {
+  '../services/move': moveService,
+  '../services/person-escort-record': personEscortRecordService,
+  '../services/reference-data': referenceDataService,
+  './find-unpopulated-resources': findUnpopulatedResourcesStub,
+})
+
+describe('populateResources', function () {
+  beforeEach(function () {
+    moveService.getById.resetHistory()
+    personEscortRecordService.getById.resetHistory()
+    referenceDataService.getLocationById.resetHistory()
+  })
+
+  context('when data contains a populated resource', function () {
+    let data
+    beforeEach(async function () {
+      data = {
+        move: { id: 'move', type: 'moves', foo: 'baz' },
+      }
+      await populateResources(data)
+    })
+    it('should not lookup the resource', function () {
+      expect(moveService.getById).to.not.be.called
+    })
+    it('should leave the move untouched', function () {
+      expect(data).to.deep.equal({
+        move: { id: 'move', type: 'moves', foo: 'baz' },
+      })
+    })
+  })
+
+  context(
+    'when data contains an unpopulated resource for which no lookup exists',
+    function () {
+      let data
+      beforeEach(async function () {
+        data = {
+          x: { id: 'x', type: 'xs' },
+        }
+        await populateResources(data)
+      })
+
+      it('should leave the resource untouched', function () {
+        expect(data).to.deep.equal({
+          x: { id: 'x', type: 'xs' },
+        })
+      })
+    }
+  )
+
+  context('when data contains an unpopulated move', function () {
+    let data
+    beforeEach(async function () {
+      data = {
+        move: { id: 'move', type: 'moves' },
+      }
+      await populateResources(data)
+    })
+    it('should lookup the move', function () {
+      expect(moveService.getById).to.be.calledOnceWithExactly('move')
+    })
+    it('should populate with resolved move', function () {
+      expect(data).to.deep.equal({
+        move: { id: 'move', type: 'moves', foo: 'bar' },
+      })
+    })
+  })
+
+  context('when data contains an unpopulated PER', function () {
+    let data
+    beforeEach(async function () {
+      data = {
+        per: { id: 'per', type: 'person_escort_records' },
+      }
+      await populateResources(data)
+    })
+    it('should lookup the PER', function () {
+      expect(personEscortRecordService.getById).to.be.calledOnceWithExactly(
+        'per'
+      )
+    })
+    it('should populate with resolved PER', function () {
+      expect(data).to.deep.equal({
+        per: { id: 'per', type: 'person_escort_records', foo: 'bar' },
+      })
+    })
+  })
+
+  context('when data contains an unpopulated location', function () {
+    let data
+    beforeEach(async function () {
+      data = {
+        location: { id: 'loc', type: 'locations' },
+      }
+      await populateResources(data)
+    })
+    it('should lookup the location', function () {
+      expect(referenceDataService.getLocationById).to.be.calledOnceWithExactly(
+        'loc'
+      )
+    })
+    it('should populate with resolved location', function () {
+      expect(data).to.deep.equal({
+        location: { id: 'loc', type: 'locations', foo: 'bar' },
+      })
+    })
+  })
+
+  context('when data contains different unpopulated resources', function () {
+    let data
+    beforeEach(async function () {
+      data = {
+        move: { id: 'move', type: 'moves' },
+        per: { id: 'per', type: 'person_escort_records' },
+        location: { id: 'loc', type: 'locations' },
+      }
+      await populateResources(data)
+    })
+
+    it('should populate with resolved location', function () {
+      expect(data).to.deep.equal({
+        move: { id: 'move', type: 'moves', foo: 'bar' },
+        per: { id: 'per', type: 'person_escort_records', foo: 'bar' },
+        location: { id: 'loc', type: 'locations', foo: 'bar' },
+      })
+    })
+  })
+})
+
+context('when data contains multiple refs to unpopulated move', function () {
+  let data
+  beforeEach(async function () {
+    data = {
+      move: { id: 'move', type: 'moves' },
+      anuthaMove: { id: 'move', type: 'moves' },
+    }
+    await populateResources(data)
+  })
+
+  it('should populate all refs with resolved move', function () {
+    expect(data).to.deep.equal({
+      move: { id: 'move', type: 'moves', foo: 'bar' },
+      anuthaMove: { id: 'move', type: 'moves', foo: 'bar' },
+    })
+  })
+
+  context('when passed options', function () {
+    let data
+    beforeEach(async function () {
+      data = {
+        move: { id: 'move', type: 'moves' },
+      }
+      await populateResources(data, { exclude: ['moves'] })
+    })
+
+    it('should pass those options to findUnpopulatedResources', function () {
+      expect(data).to.deep.equal({
+        move: { id: 'move', type: 'moves' },
+      })
+    })
+  })
+})

--- a/common/services/move.js
+++ b/common/services/move.js
@@ -206,13 +206,13 @@ const moveService = {
     return response
   },
 
-  getById(id, { include } = {}) {
+  getById(id, { include, preserveResourceRefs } = {}) {
     if (!id) {
       return Promise.reject(new Error(noMoveIdMessage))
     }
 
     return apiClient
-      .find('move', id, { include })
+      .find('move', id, { include, preserveResourceRefs })
       .then(response => response.data)
       .then(this.transform)
   },

--- a/common/services/move.test.js
+++ b/common/services/move.test.js
@@ -964,6 +964,7 @@ describe('Move Service', function () {
         it('should call find method with data', function () {
           expect(apiClient.find).to.be.calledOnceWithExactly('move', mockId, {
             include: undefined,
+            preserveResourceRefs: undefined,
           })
         })
 
@@ -987,6 +988,21 @@ describe('Move Service', function () {
         it('should pass include paramter to api client', function () {
           expect(apiClient.find).to.be.calledOnceWithExactly('move', mockId, {
             include: ['foo', 'bar'],
+            preserveResourceRefs: undefined,
+          })
+        })
+      })
+
+      context('when called with preserveResourceRefs parameter', function () {
+        beforeEach(async function () {
+          move = await moveService.getById(mockId, {
+            preserveResourceRefs: true,
+          })
+        })
+        it('should pass preserveResourceRefs param on', function () {
+          expect(apiClient.find).to.be.calledOnceWithExactly('move', mockId, {
+            include: undefined,
+            preserveResourceRefs: true,
           })
         })
       })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

- Find and inflate unpopulated resources returned to api-client
  
Modifications to `common/lib/api-client/middleware/request.js` and `common/lib/api-client/middleware/process-response.js` allow for minimal resource stubs  to be added to the included section.
    
`common/lib/find-unpopulated-resources.js` allows for the detection of unpopulated resources  in any data structure passed to it
    
`common/lib/populate-resources.js` allows for the inflation of any unpopulated resources in any data structure passed to it

- Enable move#getById to ask for population of resources

### Why did it change

Some backend endpoints do not allow for the retrieval of resources using includes.
    
Devour sets any resource referenced as a relationship but not present in the included section to null.

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

- [P4-2337 - Create view for timeline component](https://dsdmoj.atlassian.net/browse/P4-2337)

## Screenshots
<!--- (Optional) Include screenshots if changes update interfaces or components -->
<!--- Delete/copy as appropriate --->

n/a

## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed



### Other considerations


- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics

