### PR TITLE
Transform move events into data consumable by timeline component

### DIFF
--- a/common/helpers/events/add-triggered-events.js
+++ b/common/helpers/events/add-triggered-events.js
@@ -1,0 +1,19 @@
+const i18n = require('../../../config/i18n')
+
+// Add any faux events triggered by other events
+const addTriggeredEvents = moveEvents => {
+  moveEvents = [...moveEvents]
+  const eventsWithTriggers = moveEvents.filter(event => {
+    return i18n.exists(`events::${event.event_type}.triggers`)
+  })
+  eventsWithTriggers.forEach(event => {
+    const eventIndex = moveEvents.indexOf(event)
+    moveEvents.splice(eventIndex + 1, 0, {
+      ...event,
+      event_type: i18n.t(`events::${event.event_type}.triggers`),
+    })
+  })
+  return moveEvents
+}
+
+module.exports = addTriggeredEvents

--- a/common/helpers/events/add-triggered-events.test.js
+++ b/common/helpers/events/add-triggered-events.test.js
@@ -1,0 +1,61 @@
+const i18n = require('../../../config/i18n')
+
+const addTriggeredEvents = require('./add-triggered-events')
+
+const mockEvents = [
+  { event_type: 'foo', value: 1 },
+  { event_type: 'bar', value: 2 },
+  { event_type: 'baz', value: 3 },
+]
+
+describe('Timeline events', function () {
+  describe('#addTriggeredEvents', function () {
+    let events
+    beforeEach(function () {
+      events = {}
+      sinon.stub(i18n, 't').returnsArg(0)
+      sinon.stub(i18n, 'exists').returns(false)
+    })
+
+    context('When there are no triggered events', function () {
+      beforeEach(function () {
+        events = addTriggeredEvents(mockEvents)
+      })
+      it('should leave the events untouched', function () {
+        expect(events).to.deep.equal(mockEvents)
+      })
+    })
+
+    context('When there are triggered events', function () {
+      beforeEach(function () {
+        i18n.exists.returns(true)
+        events = addTriggeredEvents(mockEvents)
+      })
+      it('should insert the triggered events', function () {
+        expect(events).to.deep.equal([
+          { event_type: 'foo', value: 1 },
+          { event_type: 'events::foo.triggers', value: 1 },
+          { event_type: 'bar', value: 2 },
+          { event_type: 'events::bar.triggers', value: 2 },
+          { event_type: 'baz', value: 3 },
+          { event_type: 'events::baz.triggers', value: 3 },
+        ])
+      })
+    })
+
+    context('When there are some triggered events', function () {
+      beforeEach(function () {
+        i18n.exists.onCall(1).returns(true)
+        events = addTriggeredEvents(mockEvents)
+      })
+      it('should insert the triggered events only for the necessary corresponding events', function () {
+        expect(events).to.deep.equal([
+          { event_type: 'foo', value: 1 },
+          { event_type: 'bar', value: 2 },
+          { event_type: 'events::bar.triggers', value: 2 },
+          { event_type: 'baz', value: 3 },
+        ])
+      })
+    })
+  })
+})

--- a/common/helpers/events/event-details-helpers.js
+++ b/common/helpers/events/event-details-helpers.js
@@ -1,0 +1,86 @@
+const pluralize = require('pluralize')
+
+const i18n = require('../../../config/i18n')
+const { event: eventModel } = require('../../lib/api-client/models')
+
+const eventRelationships = Object.keys(eventModel.fields).filter(field => {
+  return typeof eventModel.fields[field] === 'object'
+})
+
+// add resources that belong to move and are common to all events
+// NB. move.supplier will exist even when event.supplier does not
+const getMoveDetails = move => ({
+  move,
+  person: move.profile?.person || {},
+})
+
+// if an event has a supplier, the supplier was the agent
+// if not, check the locales for a default agent
+// finally, use PMU as default agent
+const getEventAgency = event => {
+  let agency = event.supplier ? 'supplier' : undefined
+
+  if (!agency) {
+    const defaultAgencyKey = `events::${event.event_type}.default_agency`
+    agency = i18n.exists(defaultAgencyKey)
+      ? i18n.t(defaultAgencyKey)
+      : i18n.t('events::default_agency')
+  }
+
+  return { agency }
+}
+
+// add context (if any) to event
+const getEventContext = event => {
+  const contextKeyDefinition = `events::${event.event_type}.contextKey`
+
+  const contextKey = i18n.exists(contextKeyDefinition)
+    ? i18n.t(contextKeyDefinition)
+    : undefined
+
+  const context = event.details?.[contextKey]
+  return { context }
+}
+
+// add event relationships
+const getEventRelationships = event => {
+  return eventRelationships.reduce((acc, rel) => {
+    if (event[rel]) {
+      acc[rel] = event[rel]
+    }
+
+    return acc
+  }, {})
+}
+
+// add eventable resources to details object
+// eg event.eventable.type === 'journeys'
+// => event.details.journey
+const getEventableDetails = event => {
+  const details = {}
+
+  if (event.eventable && event.eventable.type) {
+    details[pluralize.singular(event.eventable.type)] = event.eventable
+  }
+
+  return details
+}
+
+// add standard common properties of the event itself
+const getEventProperties = event => {
+  // eslint-disable-next-line camelcase
+  const { notes, occurred_at } = event
+  return {
+    notes,
+    occurred_at,
+  }
+}
+
+module.exports = {
+  getMoveDetails,
+  getEventAgency,
+  getEventContext,
+  getEventRelationships,
+  getEventableDetails,
+  getEventProperties,
+}

--- a/common/helpers/events/event-details-helpers.test.js
+++ b/common/helpers/events/event-details-helpers.test.js
@@ -1,0 +1,239 @@
+const proxyquire = require('proxyquire')
+
+const i18n = require('../../../config/i18n')
+
+const {
+  getMoveDetails,
+  getEventAgency,
+  getEventContext,
+  getEventRelationships,
+  getEventableDetails,
+  getEventProperties,
+} = proxyquire('./event-details-helpers', {
+  '../../../common/lib/api-client/models': {
+    event: {
+      fields: {
+        event_type: '',
+        prop_a: '',
+        prop_b: '',
+        details: '',
+        eventable: {
+          jsonApi: 'hasOne',
+        },
+        rel_a: {
+          jsonApi: 'hasOne',
+          type: 'rel_as',
+        },
+        rel_b: {
+          jsonApi: 'hasOne',
+          type: 'rel_bs',
+        },
+      },
+    },
+  },
+})
+
+describe('Timeline events', function () {
+  describe('Event details helpers', function () {
+    beforeEach(function () {
+      sinon.stub(i18n, 't').returnsArg(0)
+      sinon.stub(i18n, 'exists').returns(false)
+    })
+
+    describe('#getMoveDetails', function () {
+      it('should return the move and person', function () {
+        const mockMove = { id: 'move', profile: { person: { id: 'person' } } }
+        const details = getMoveDetails(mockMove)
+        expect(details).to.deep.equal({
+          move: mockMove,
+          person: mockMove.profile.person,
+        })
+      })
+
+      it('should return just the move if it has no profile', function () {
+        const mockMove = { id: 'move' }
+        const details = getMoveDetails(mockMove)
+        expect(details).to.deep.equal({
+          move: mockMove,
+          person: {},
+        })
+      })
+    })
+
+    describe('#getEventAgency', function () {
+      describe('when the event has a supplier', function () {
+        it('should return supplier as the agency', function () {
+          const mockEvent = {
+            supplier: 'supplier',
+          }
+          const details = getEventAgency(mockEvent)
+          expect(details).to.deep.equal({
+            agency: 'supplier',
+          })
+        })
+      })
+
+      describe('when the event has no supplier but has a default agency', function () {
+        const mockEvent = { event_type: 'foo' }
+        let details
+        beforeEach(function () {
+          i18n.exists.returns(true)
+          details = getEventAgency(mockEvent)
+        })
+        it('should lookup the default agency for the event type', function () {
+          expect(i18n.exists).to.be.calledOnceWithExactly(
+            'events::foo.default_agency'
+          )
+        })
+
+        it('should get default agency for event type', function () {
+          expect(i18n.t).to.be.calledOnceWithExactly(
+            'events::foo.default_agency'
+          )
+        })
+
+        it('should return the event default as the agency', function () {
+          expect(details).to.deep.equal({
+            agency: 'events::foo.default_agency',
+          })
+        })
+      })
+
+      describe('when the event has no supplier and no default agency', function () {
+        const mockEvent = { event_type: 'foo' }
+        let details
+        beforeEach(function () {
+          details = getEventAgency(mockEvent)
+        })
+        it('should lookup the default agency for the event type', function () {
+          expect(i18n.exists).to.be.calledOnceWithExactly(
+            'events::foo.default_agency'
+          )
+        })
+
+        it('should get the base default agency', function () {
+          expect(i18n.t).to.be.calledOnceWithExactly('events::default_agency')
+        })
+
+        it('should return base default agency as the agency', function () {
+          expect(details).to.deep.equal({
+            agency: 'events::default_agency',
+          })
+        })
+      })
+    })
+
+    describe('#getEventContext', function () {
+      describe('when the event has no context key', function () {
+        it('should return undefined for the context', function () {
+          const mockEvent = {
+            event_type: 'foo',
+            details: {
+              'events::foo.contextKey': 'bar',
+            },
+          }
+          const details = getEventContext(mockEvent)
+          expect(details).to.deep.equal({
+            context: undefined,
+          })
+        })
+      })
+
+      describe('when the event has a context key and a value for that property', function () {
+        beforeEach(function () {
+          i18n.exists.returns(true)
+        })
+        it('should return the property value as the context', function () {
+          const mockEvent = {
+            event_type: 'foo',
+            details: {
+              'events::foo.contextKey': 'bar',
+            },
+          }
+          const details = getEventContext(mockEvent)
+          expect(details).to.deep.equal({
+            context: 'bar',
+          })
+        })
+      })
+
+      describe('when the event has a context key but no value for that property', function () {
+        beforeEach(function () {
+          i18n.exists.returns(true)
+        })
+        it('should return undefined for the context', function () {
+          const mockEvent = {
+            event_type: 'foo',
+          }
+          const details = getEventContext(mockEvent)
+          expect(details).to.deep.equal({
+            context: undefined,
+          })
+        })
+      })
+    })
+
+    describe('#getEventRelationships', function () {
+      it('should only return relationships defined in model', function () {
+        const mockEvent = {
+          rel_a: 'rel_a',
+          rel_b: 'rel_b',
+          eventable: 'eventable',
+          prop_a: 'prop_a',
+          prop_b: 'prop_b',
+          details: {},
+        }
+        const details = getEventRelationships(mockEvent)
+        expect(details).to.deep.equal({
+          rel_a: 'rel_a',
+          rel_b: 'rel_b',
+          eventable: 'eventable',
+        })
+      })
+    })
+
+    describe('#getEventableDetails', function () {
+      it('should return the eventable as a property named as its singularised type', function () {
+        const mockEvent = {
+          eventable: {
+            id: 'bar',
+            type: 'foos',
+          },
+        }
+        const details = getEventableDetails(mockEvent)
+        expect(details).to.deep.equal({
+          foo: {
+            id: 'bar',
+            type: 'foos',
+          },
+        })
+      })
+
+      it('should return not the eventable as a property if it has no type', function () {
+        const mockEvent = {
+          eventable: {
+            id: 'bar',
+          },
+        }
+        const details = getEventableDetails(mockEvent)
+        expect(details).to.deep.equal({})
+      })
+    })
+
+    describe('#getEventProperties', function () {
+      it('should return the notes and timestamp', function () {
+        const mockEvent = {
+          notes: 'notes',
+          occurred_at: 'timestamp',
+          foo: 'foo',
+          details: { bar: 'baz' },
+        }
+        const details = getEventProperties(mockEvent)
+        expect(details).to.deep.equal({
+          notes: 'notes',
+          occurred_at: 'timestamp',
+        })
+      })
+    })
+  })
+})

--- a/common/helpers/events/set-event-details.js
+++ b/common/helpers/events/set-event-details.js
@@ -1,0 +1,36 @@
+const eventDetailsHelpers = require('./event-details-helpers')
+
+/**
+ * Update event details to contain all relevant properties and relationships
+ *
+ * @param {*} event
+ * @param {*} move
+ * @returns [{object}]
+ * {
+ *   move,
+ *   person
+ *   agency
+ *   context
+ *   ...relationships
+ *   [eventable]
+ *   notes
+ *   occurred_at
+ *   ...details
+ * }
+ */
+const setEventDetails = (event, move) => {
+  return {
+    ...event,
+    details: {
+      ...eventDetailsHelpers.getMoveDetails(move),
+      ...eventDetailsHelpers.getEventAgency(event),
+      ...eventDetailsHelpers.getEventContext(event),
+      ...eventDetailsHelpers.getEventRelationships(event),
+      ...eventDetailsHelpers.getEventableDetails(event),
+      ...eventDetailsHelpers.getEventProperties(event),
+      ...event.details,
+    },
+  }
+}
+
+module.exports = setEventDetails

--- a/common/helpers/events/set-event-details.test.js
+++ b/common/helpers/events/set-event-details.test.js
@@ -1,0 +1,92 @@
+const eventDetailsHelpers = require('./event-details-helpers')
+const setEventDetails = require('./set-event-details')
+
+const mockEvent = { event_type: 'foo', details: { detailProp: 'detailProp' } }
+
+describe('Timeline events', function () {
+  describe('#setEventDetails', function () {
+    let events
+
+    const mockMove = { move: 'move' }
+    beforeEach(function () {
+      events = {}
+      sinon.stub(eventDetailsHelpers, 'getMoveDetails').returns({
+        ...mockMove,
+        person: 'person',
+      })
+      sinon
+        .stub(eventDetailsHelpers, 'getEventAgency')
+        .returns({ agency: 'agency' })
+      sinon
+        .stub(eventDetailsHelpers, 'getEventContext')
+        .returns({ context: 'context' })
+      sinon
+        .stub(eventDetailsHelpers, 'getEventRelationships')
+        .returns({ eventRelationship: 'eventRelationship' })
+      sinon
+        .stub(eventDetailsHelpers, 'getEventableDetails')
+        .returns({ eventDetail: 'eventDetail' })
+      sinon
+        .stub(eventDetailsHelpers, 'getEventProperties')
+        .returns({ eventProp: 'eventProp' })
+    })
+
+    context('When setting the details for an event', function () {
+      beforeEach(function () {
+        events = setEventDetails(mockEvent, mockMove)
+      })
+
+      it('should add the move details', function () {
+        expect(eventDetailsHelpers.getMoveDetails).to.be.calledOnceWithExactly(
+          mockMove
+        )
+      })
+
+      it('should add the event agency', function () {
+        expect(eventDetailsHelpers.getEventAgency).to.be.calledOnceWithExactly(
+          mockEvent
+        )
+      })
+
+      it('should add the event context', function () {
+        expect(eventDetailsHelpers.getEventContext).to.be.calledOnceWithExactly(
+          mockEvent
+        )
+      })
+
+      it('should add the event relationships', function () {
+        expect(
+          eventDetailsHelpers.getEventRelationships
+        ).to.be.calledOnceWithExactly(mockEvent)
+      })
+
+      it('should add the eventable', function () {
+        expect(
+          eventDetailsHelpers.getEventableDetails
+        ).to.be.calledOnceWithExactly(mockEvent)
+      })
+
+      it('should add the event properties', function () {
+        expect(
+          eventDetailsHelpers.getEventProperties
+        ).to.be.calledOnceWithExactly(mockEvent)
+      })
+
+      it('should return the combined details', function () {
+        expect(events).to.deep.equal({
+          event_type: 'foo',
+          details: {
+            move: 'move',
+            person: 'person',
+            agency: 'agency',
+            context: 'context',
+            eventRelationship: 'eventRelationship',
+            eventDetail: 'eventDetail',
+            eventProp: 'eventProp',
+            detailProp: 'detailProp',
+          },
+        })
+      })
+    })
+  })
+})

--- a/common/presenters/events-to-timeline-component.js
+++ b/common/presenters/events-to-timeline-component.js
@@ -1,0 +1,63 @@
+const i18n = require('../../config/i18n')
+const addTriggeredEvents = require('../helpers/events/add-triggered-events')
+const setEventDetails = require('../helpers/events/set-event-details')
+
+const getItem = ({
+  component,
+  labelClasses,
+  heading,
+  description,
+  timestamp,
+  byline,
+}) => {
+  return {
+    label: {
+      classes: labelClasses,
+      html: heading,
+    },
+    classes: 'app-timeline__item',
+    html: description,
+    datetime: {
+      timestamp,
+      type: 'datetime',
+    },
+    byline: {
+      html: byline,
+    },
+  }
+}
+
+const eventsToTimelineComponent = (moveEvents, move) => {
+  const items = addTriggeredEvents(moveEvents).map(moveEvent => {
+    const event = setEventDetails(moveEvent, move)
+
+    const { details, event_type: eventType } = event
+    const statusChange = i18n.exists(`events::${eventType}.statusChange`)
+    const labelClasses = statusChange ? 'moj-badge' : undefined
+
+    const heading = i18n.t(`events::${eventType}.heading`, details)
+    const description = i18n
+      .t(`events::${eventType}.description`, details)
+      .replace(/^<br>/, '')
+    // Some strings that get added together are prefixed with a <br>.
+    // This enables them to be used as the first item or where a previous string doesn't get output
+    // and not insert additional space without having to make the <br> conditional
+
+    // TODO: when we have user info for event, update the following with something like
+    // const byline = i18n.t('events::byline', details)
+    const byline = ''
+
+    const timestamp = event.occurred_at
+
+    return getItem({
+      labelClasses,
+      heading,
+      description,
+      timestamp,
+      byline,
+    })
+  })
+  return { items }
+}
+
+module.exports = eventsToTimelineComponent

--- a/common/presenters/events-to-timeline-component.test.js
+++ b/common/presenters/events-to-timeline-component.test.js
@@ -1,0 +1,114 @@
+const proxyquire = require('proxyquire')
+
+const i18n = require('../../config/i18n')
+
+const addTriggeredEvents = sinon.stub().returnsArg(0)
+const setEventDetails = sinon.stub().returnsArg(0)
+
+const eventsToTimelineComponent = proxyquire('./events-to-timeline-component', {
+  '../helpers/events/add-triggered-events': addTriggeredEvents,
+  '../helpers/events/set-event-details': setEventDetails,
+})
+
+describe('Presenters', function () {
+  describe('#eventsToTimelineComponent()', function () {
+    let transformedResponse
+    const mockEvents = [
+      {
+        event_type: 'foo',
+        occurred_at: '2020-10-03',
+        details: {
+          hello: 'world',
+        },
+      },
+    ]
+    const mockMove = { id: 'move', timeline_events: mockEvents }
+
+    beforeEach(function () {
+      addTriggeredEvents.resetHistory()
+      setEventDetails.resetHistory()
+      sinon.stub(i18n, 't').returnsArg(0)
+      sinon.stub(i18n, 'exists').returns(false)
+    })
+
+    context('when transforming event', function () {
+      beforeEach(function () {
+        transformedResponse = eventsToTimelineComponent(mockEvents, mockMove)
+      })
+
+      it('should add triggered events if needed', function () {
+        expect(addTriggeredEvents).to.be.calledOnceWithExactly(mockEvents)
+      })
+
+      it('should set the event details', function () {
+        expect(setEventDetails).to.be.calledOnceWithExactly(
+          mockEvents[0],
+          mockMove
+        )
+      })
+
+      it('should check whether the event is a triggered status change', function () {
+        expect(i18n.exists).to.be.calledOnceWithExactly(
+          'events::foo.statusChange'
+        )
+      })
+
+      it('should get the expected number of i18n string', function () {
+        expect(i18n.t).to.be.calledTwice
+      })
+
+      it('should get the heading for the event', function () {
+        expect(i18n.t.firstCall.args).to.deep.equal([
+          'events::foo.heading',
+          mockEvents[0].details,
+        ])
+      })
+
+      it('should get the heading for the event', function () {
+        expect(i18n.t.secondCall.args).to.deep.equal([
+          'events::foo.description',
+          mockEvents[0].details,
+        ])
+      })
+
+      it('should return the expected data', function () {
+        expect(transformedResponse).to.deep.equal({
+          items: [
+            {
+              label: { html: 'events::foo.heading', classes: undefined },
+              classes: 'app-timeline__item',
+              html: 'events::foo.description',
+              datetime: { timestamp: '2020-10-03', type: 'datetime' },
+              byline: { html: '' },
+            },
+          ],
+        })
+      })
+    })
+
+    context('when event is a triggered status change', function () {
+      beforeEach(function () {
+        i18n.exists.returns(true)
+        transformedResponse = eventsToTimelineComponent(mockEvents, mockMove)
+      })
+
+      it('should add the expected class name', function () {
+        expect(transformedResponse.items[0].label.classes).to.equal('moj-badge')
+      })
+    })
+
+    context(
+      'when event description starts with an HTML line break',
+      function () {
+        beforeEach(function () {
+          i18n.t.onCall(1).returns('<br>description')
+          transformedResponse = eventsToTimelineComponent(mockEvents)
+        })
+
+        it('should strip the leading line break', function () {
+          expect(transformedResponse.items[0].html).to.equal('description')
+        })
+      }
+    )
+  })
+})

--- a/common/presenters/index.js
+++ b/common/presenters/index.js
@@ -8,6 +8,7 @@ const assessmentCategoryToSummaryListComponent = require('./assessment-category-
 const assessmentToTagList = require('./assessment-to-tag-list')
 const courtCaseToCardComponent = require('./court-case-to-card-component')
 const courtHearingToSummaryListComponent = require('./court-hearing-to-summary-list-component')
+const eventsToTimelineComponent = require('./events-to-timeline-component')
 const frameworkFieldToSummaryListRow = require('./framework-field-summary-list-row')
 const frameworkFlagsToTagList = require('./framework-flags-to-tag-list')
 const frameworkNomisMappingsToPanel = require('./framework-nomis-mappings-to-panel')
@@ -39,6 +40,7 @@ module.exports = {
   assessmentCategoryToSummaryListComponent,
   courtCaseToCardComponent,
   courtHearingToSummaryListComponent,
+  eventsToTimelineComponent,
   frameworkFieldToSummaryListRow,
   frameworkFlagsToTagList,
   frameworkNomisMappingsToPanel,

--- a/locales/en/events.json
+++ b/locales/en/events.json
@@ -1,0 +1,412 @@
+{
+  "additional": "{{user.name}}",
+  "select_agency": "$t(events::agency, {\"context\": \"{{agency}}\"})",
+  "agency": "",
+  "agency_user": "user",
+  "agency_pmu": "PMU",
+  "agency_supplier": "{{move.supplier.name}}",
+  "default_agency": "pmu",
+  "select_authorised_by": "$t(events::authorised_by, {\"context\": \"{{authorised_by, exists}}\"})",
+  "authorised_by": "",
+  "authorised_by_true": "<br>Authorised by {{authorised_by}}",
+  "select_fault_classification": "Incident has been classified as: $t(events::fault_classification, {\"context\": \"{{fault_classification}}\"})",
+  "fault_classification": "{{fault_classification}}",
+  "fault_classification_supplier": "Supplier’s fault",
+  "fault_classification_was_not_supplier": "Not supplier’s fault",
+  "fault_classification_investigation": "Under investigation",
+  "select_incident_vehicle": "$t(events::incident_vehicle, {\"context\": \"{{vehicle_reg, exists}}\"})",
+  "incident_vehicle": "",
+  "incident_vehicle_true": "The event occurred on vehicle {{vehicle_reg}}",
+  "incident_reported": "The incident was reported by {{supplier_personnel_numbers, oxfordJoin}} at {{reported_at, formatTime}}",
+  "incident_reported_classified": "<br>$t(events::incident_reported)<br>$t(events::select_fault_classification)",
+  "incident_level_details": "{{incident_level}} incident involving {{person.fullname}} occurred $t(events::select_incident_location_preposition) $t(events::select_incident_location_vehicle) $t(events::incident_reported_classified)",
+  "select_incident_location_preposition": "$t(events::incident_location_preposition, {\"context\": \"{{vehicle_reg, exists}}\"})",
+  "incident_location_preposition_true": "on",
+  "incident_location_preposition_false": "at",
+  "select_incident_location_vehicle": "$t(events::incident_location_vehicle, {\"context\": \"{{vehicle_reg, exists}}\"})",
+  "incident_location_vehicle_true": "vehicle {{vehicle_reg}}",
+  "incident_location_vehicle_false": "{{location.title}}",
+  "incident_escaped": "{{person.fullname}} escaped from $t(events::select_incident_location_vehicle) $t(events::incident_reported_classified)",
+  "no_events": "No events",
+  "JourneyAdmitThroughOuterGate": {
+    "heading": "Admitted through outer gate",
+    "description": "Vehicle {{journey.vehicle.registration}} admitted through outer gate of {{journey.to_location.title}}"
+  },
+  "JourneyArriveAtOuterGate": {
+    "heading": "Arrived at outer gate",
+    "description": "Vehicle {{journey.vehicle.registration}} arrived at outer gate of {{journey.to_location.title}}"
+  },
+  "JourneyCancel": {
+    "heading": "Journey cancelled",
+    "description": "Journey from {{journey.from_location.title}} to {{journey.to_location.title}} cancelled"
+  },
+  "JourneyChangeVehicle": {
+    "heading": "Vehicle changed",
+    "description": "{{person.fullname}} moved from {{previous_vehicle_reg}} to {{journey.vehicle.registration}}"
+  },
+  "JourneyComplete": {
+    "heading": "Journey completed",
+    "description": "Journey from {{journey.from_location.title}} to {{journey.to_location.title}} completed"
+  },
+  "JourneyExitThroughOuterGate": {
+    "heading": "Exited from outer gate",
+    "description": "Vehicle {{journey.vehicle.registration}} exited through outer gate of {{journey.from_location.title}}"
+  },
+  "JourneyHandoverToDestination": {
+    "heading": "Handover to establishment",
+    "description": "{{person.fullname}} handed over by {{move.supplier.name}} (Personnel number {{supplier_personnel_number}}) at {{journey.to_location.title}}"
+  },
+  "JourneyPersonBoardVehicle": {
+    "heading": "Boarded escort vehicle",
+    "description": "{{person.fullname}} boarded escort vehicle {{journey.vehicle.registration}}"
+  },
+  "JourneyPersonLeaveVehicle": {
+    "heading": "Left escort vehicle",
+    "description": "{{person.fullname}} left escort vehicle {{journey.vehicle.registration}}"
+  },
+  "JourneyReadyToExit": {
+    "heading": "Ready to exit",
+    "description": "Escort vehicle {{journey.vehicle.registration}} boarding complete, ready to exit from {{journey.from_location.title}}"
+  },
+  "JourneyReject": {
+    "heading": "Journey rejected",
+    "description": "Journey from {{journey.from_location.title}} to {{journey.to_location.title}} rejected by {{move.supplier.name}}"
+  },
+  "JourneyStart": {
+    "heading": "Journey started",
+    "description": "Journey from {{journey.from_location.title}} to {{journey.to_location.title}} started by {{move.supplier.name}}"
+  },
+  "JourneyUncancel": {
+    "heading": "Journey uncancelled",
+    "description": "Cancelled Journey from {{journey.from_location.title}} to {{journey.to_location.title}} revoked by {{move.supplier.name}}"
+  },
+  "JourneyUncomplete": {
+    "heading": "Journey uncompleted",
+    "description": "Completed Journey from {{journey.from_location.title}} to {{journey.to_location.title}} revoked by {{move.supplier.name}}"
+  },
+  "MoveAccept": {
+    "triggers": "StatusMoveBooked",
+    "heading": "Move accepted by {{move.supplier.name}}",
+    "description": ""
+  },
+  "MoveApprove": {
+    "triggers": "StatusMoveRequested",
+    "heading": "Approved by PMU",
+    "description": "Date of travel set to {{move.date, formatDateWithDay}}"
+  },
+  "MoveCancel": {
+    "triggers": "StatusMoveCancelled",
+    "heading": "Move cancelled by $t(events::select_agency)",
+    "description": "Move from {{move.from_location.title}} to {{move.to_location.title}} has been cancelled for the following reason: $t(events::MoveCancel.select_cancellation_reason) $t(events::MoveCancel.select_cancellation_reason_comment)",
+    "select_cancellation_reason": "$t(events::MoveCancel.cancellation_reason, {\"context\": \"{{cancellation_reason}}\"})",
+    "cancellation_reason_prefix": "<br>Cancellation reason:",
+    "cancellation_reason": "",
+    "cancellation_reason_supplier_declined_to_move": "$t(events::MoveCancel.cancellation_reason_prefix) {{move.supplier.name}} declined to move this person",
+    "cancellation_reason_cancelled_by_pmu": "$t(events::MoveCancel.cancellation_reason_prefix) Cancelled by Population Management Unit (PMU)",
+    "cancellation_reason_other": "",
+    "select_cancellation_reason_comment": "$t(events::MoveCancel.cancellation_reason_comment, {\"context\": \"{{cancellation_reason_comment, exists}}\"})",
+    "cancellation_reason_comment": "",
+    "cancellation_reason_comment_true": "<br>Additional comments:<br>{{cancellation_reason_comment}}"
+  },
+  "MoveCollectionByEscort": {
+    "heading": "Handover to {{move.supplier.name}}",
+    "description": "{{person.fullname}} has been received"
+  },
+  "MoveComplete": {
+    "triggers": "StatusMoveCompleted",
+    "heading": "Handover to {{move.to_location.title}}",
+    "description": "{{person.fullname}} has been received"
+  },
+  "MoveLockout": {
+    "contextKey": "reason",
+    "heading": "Lockout",
+    "description": "{{person.fullname}} locked out from {{move.from_location.title}} $t(events::MoveLockout.select_reason)",
+    "select_reason": "$t(events::MoveLockout.reason, {\"context\": \"{{reason}}\"})",
+    "reason": "due to **{{reason}}**",
+    "reason_no_space": "due to there being no space",
+    "reason_unachievable_redirection": "due to an unachievable redirection",
+    "reason_late_sitting_court": "due to the late sitting of the court",
+    "reason_unavailable_resource_vehicle_or_staff": "due to a vehicle or member of staff being unavailable",
+    "reason_traffic_issues": "due to traffic issues",
+    "reason_mechanical_or_other_vehicle_failure": "due to a mechanical or other vehicle failure",
+    "reason_ineffective_route_planning": "due to ineffective route planning",
+    "reason_unachievable_ptr_request": "due to an unachievable PTR request",
+    "reason_other": ""
+  },
+  "MoveLodgingStart": {
+    "heading": "Lodging started",
+    "description": "{{person.fullname}}  temporarily lodged at {{location.title}} $t(events::MoveLodgingStart.select_reason) $t(events::select_authorised_by)",
+    "select_reason": "$t(events::MoveLodgingStart.reason, {\"context\": \"{{reason}}\"})",
+    "reason": "due to **{{reason}}**",
+    "reason_overnight_lodging": "due to an overnight lodging",
+    "reason_lockout": "due to a lockout",
+    "reason_operation_hmcts": "due to Operation HMCTS",
+    "reason_court_cells": "due to court cells reaching capacity",
+    "reason_operation_tornado": "due to Operation Tornado",
+    "reason_operation_safeguard": "due to Operation Safeguard",
+    "reason_other": ""
+  },
+  "MoveLodgingEnd": {
+    "heading": "Lodging ended",
+    "description": "{{person.fullname}} collected by {{move.supplier.name}} from temporary lodging at {{location.title}}"
+  },
+  "MoveNotifyPremisesOfArrivalIn30Mins": {
+    "heading": "30 minute arrival notification",
+    "description": "{{move.supplier.name}} will arrive at {{move.to_location.title}} in 30 minutes"
+  },
+  "MoveNotifyPremisesOfEta": {
+    "heading": "{{move.to_location.title}} notified of expected time of arrival",
+    "description": "Expected arrival at {{expected_at, formatTime}}"
+  },
+  "MoveNotifyPremisesOfExpectedCollectionTime": {
+    "heading": "{{move.from_location.title}} notified of expected collection time",
+    "description": "Expected collection at {{expected_at, formatTime}}"
+  },
+  "MoveNotifySupplierOfMoveRequest": {
+    "heading": "{{move.supplier.name}} notified of move request",
+    "description": ""
+  },
+  "MoveOperationHMCTS": {
+    "heading": "Operation HMCTS enacted",
+    "description": "$t(events::select_authorised_by)"
+  },
+  "MoveOperationSafeguard": {
+    "heading": "Operation Safeguard enacted",
+    "description": "$t(events::select_authorised_by)"
+  },
+  "MoveOperationTornado": {
+    "heading": "Operation Tornado enacted",
+    "description": "$t(events::select_authorised_by)"
+  },
+  "MoveProposed": {
+    "triggers": "StatusMoveProposed",
+    "heading": "Proposed by user",
+    "description": ""
+  },
+  "MoveRedirect": {
+    "heading": "Redirected to {{move.to_location.title}}",
+    "description": "Move redirected $t(events::MoveRedirect.select_reason)",
+    "select_reason": "$t(events::MoveRedirect.reason, {\"context\": \"{{reason}}\"})",
+    "reason": "due to **{{reason}}**",
+    "reason_no_space": "as there was no space",
+    "reason_serious_incident": "due to a serious incident",
+    "reason_covid": "due to COVID",
+    "reason_receiving_prison_request": "as the receiving prison made a request",
+    "reason_force_majeure": "due to force majeure",
+    "reason_other": ""
+  },
+  "MoveReject": {
+    "triggers": "StatusMoveCancelled",
+    "alt_heading": "{{blammo, foo:gazi}} ",
+    "heading": "Rejected by $t(events::select_agency)",
+    "description": "Move from {{move.from_location.title}} to {{move.to_location.title}} rejected by $t(events::select_agency) $t(events::MoveReject.select_rejection_reason) $t(events::MoveReject.select_cancellation_reason_comment) $t(events::MoveReject.select_rebook)",
+    "select_rejection_reason": "$t(events::MoveReject.rejection_reason, {\"context\": \"{{rejection_reason}}\"})",
+    "rejection_reason_prefix": "<br>Rejection reason:",
+    "rejection_reason": "",
+    "rejection_reason_no_space_at_receiving_prison": "$t(events::MoveReject.rejection_reason_prefix) There was no space at {{move.to_location.title}}",
+    "rejection_reason_no_transport_available": "$t(events::MoveReject.rejection_reason_prefix) There was no transport available",
+    "select_rebook": "$t(events::MoveReject.rebook, {\"context\": \"{{rebook}}\"})",
+    "rebook": "",
+    "rebook_true": "<br>This move will be rebooked in 7 days",
+    "rebook_false": "<br>This move will not be rebooked",
+    "select_cancellation_reason_comment": "$t(events::MoveReject.cancellation_reason_comment, {\"context\": \"{{cancellation_reason_comment, exists}}\"})",
+    "cancellation_reason_comment": "",
+    "cancellation_reason_comment_true": "<br>Comment: {{cancellation_reason_comment}}"
+  },
+  "MoveRequested": {
+    "default_agency": "user",
+    "triggers": "StatusMoveRequested",
+    "heading": "Requested by $t(events::select_agency)",
+    "description": ""
+  },
+  "MoveStart": {
+    "triggers": "StatusMoveInTransit",
+    "heading": "Move started by {{move.supplier.name}}",
+    "description": ""
+  },
+  "MoveCrossSupplierPickUp": {
+    "heading": "Crossdeck move",
+    "description": "Move {{previous_move.reference}} picked up by {{move.supplier.name}}"
+  },
+  "MoveCrossSupplierDropOff": {
+    "heading": "Crossdeck move",
+    "description": "Drop off by {{supplier.name}}"
+  },
+  "PerCourtAllDocumentationProvidedToSupplier": {
+    "heading": "Documentation provided to supplier",
+    "description": "$t(events::PerCourtAllDocumentationProvidedToSupplier.select_subtype) made available to supplier personnel at {{court_location.title}}",
+    "select_subtype": "$t(events::PerCourtAllDocumentationProvidedToSupplier.subtype, {\"context\": \"{{subtype}}\"})",
+    "subtype": "",
+    "subtype_extradition_order": "Extradition order",
+    "subtype_placement_confirmation": "Placement confirmation",
+    "subtype_warrant": "Warrant"
+  },
+  "PerCourtAssignCellInCustody": {
+    "heading": "Person assigned to cell",
+    "description": "Assigned to {{court_cell_number}} at {{location.title}}"
+  },
+  "PerCourtCellShareRiskAssessment": {
+    "heading": "Cell share risk assessment completed",
+    "description": ""
+  },
+  "PerCourtExcessiveDelayNotDueToSupplier": {
+    "heading": "Court delayed",
+    "description": "Excessive delay due to $t(events::PerCourtExcessiveDelayNotDueToSupplier.select_subtype) at {{location.title}} between {{occurred_at, formatTime}} and {{ended_at, formatTime}}",
+    "select_subtype": "$t(events::PerCourtExcessiveDelayNotDueToSupplier.subtype, {\"context\": \"{{subtype}}\"})",
+    "subtype": "",
+    "subtype_making_prisoner_available_for_loading": "excessive delay accessing location when collecting or dropping off prisoner",
+    "subtype_access_to_or_from_location_when_collecting_dropping_off_prisoner": "excessive delay in making prisoner available for loading"
+  },
+  "PerCourtHearing": {
+    "heading": "Court hearing",
+    "description": "The $t(events::PerCourtHearing.hearing) was listed for {{court_listing_at, formatTime}} at {{location.title}}. The agreed arrival time was {{agreed_at, formatTime}}.<br>The $t(events::PerCourtHearing.hearing) started at {{started_at, formatTime}} and finished at {{ended_at, formatTime}}.<br>The following outcome was reached: {{court_outcome}}",
+    "hearing": "$t(events::PerCourtHearing.select_is_virtual) $t(events::PerCourtHearing.select_is_trial)",
+    "select_is_trial": "$t(events::PerCourtHearing.is_trial, {\"context\": \"{{is_trial}}\"})",
+    "is_trial": "hearing",
+    "is_trial_true": "trial",
+    "select_is_virtual": "$t(events::PerCourtHearing.is_virtual, {\"context\": \"{{is_virtual}}\"})",
+    "is_virtual": "",
+    "is_virtual_true": "virtual"
+  },
+  "PerCourtPreReleaseChecksCompleted": {
+    "heading": "Pre-release checks completed",
+    "description": ""
+  },
+  "PerCourtReadyInCustody": {
+    "heading": "{{person.fullname}} ready in custody",
+    "description": ""
+  },
+  "PerCourtRelease": {
+    "heading": "{{person.fullname}} released",
+    "description": ""
+  },
+  "PerCourtReleaseOnBail": {
+    "heading": "{{person.fullname}} released on bail",
+    "description": ""
+  },
+  "PerCourtReturnToCustodyAreaFromDock": {
+    "heading": "{{person.fullname}} returned to custody area from dock",
+    "description": ""
+  },
+  "PerCourtReturnToCustodyAreaFromVisitorArea": {
+    "heading": "{{person.fullname}} returned to custody area from visitor area",
+    "description": ""
+  },
+  "PerCourtTakeFromCustodyToDock": {
+    "heading": "{{person.fullname}} taken to court dock from custody area",
+    "description": ""
+  },
+  "PerCourtTakeToSeeVisitors": {
+    "heading": "{{person.fullname}} taken to visitor area",
+    "description": ""
+  },
+  "PerCourtTask": {
+    "heading": "Court task",
+    "description": "{{notes}}, completed by {{supplier_personnel_id}}"
+  },
+  "PerGeneric": {
+    "heading": "{{move.supplier.name}} has logged a generic event note",
+    "description": "{{notes}}"
+  },
+  "PerMedicalAid": {
+    "heading": "Medical attention requested",
+    "description": "{{person.fullname}} requested medical attention with {{supplier_personnel_number}}<br>Medical advice was provided by {{advised_by}} on {{advised_at, formatTime}}<br>Treatment was administered by {{treated_by}} on {{treated_at, formatTime}} $t(events::PerMedicalAid.select_location)",
+    "select_location": "$t(events::PerMedicalAid.location_vehicle, {\"context\": \"{{vehicle_reg, exists}}\"})",
+    "location_vehicle": "at {{location.title}}",
+    "location_vehicle_true": "inside the vehicle {{vehicle_reg}}"
+  },
+  "PerPrisonerWelfare": {
+    "heading": "Welfare offered",
+    "description": "{{person.fullname}} was offered $t(events::PerPrisonerWelfare.select_subtype) at {{occurred_at, formatTime}}<br>Welfare was {{outcome}}<br>{{supplier_personnel_number}} provided welfare at {{given_at, formatTime}}",
+    "select_subtype": "$t(events::PerPrisonerWelfare.subtype, {\"context\": \"{{subtype}}\"})",
+    "subtype": "",
+    "subtype_miscellaneous_welfare": "miscellaneous welfare",
+    "subtype_comfort_break": "comfort_break",
+    "subtype_food": "food",
+    "subtype_beverage": "a beverage",
+    "subtype_additional_clothing": "additional clothing",
+    "subtype_relevant_information_given": "relevant information"
+  },
+  "PersonMoveAssault": {
+    "heading": "Assault occurred",
+    "description": "{{supplier_personnel_numbers, oxfordJoin}} reported an assault event at {{reported_at, formatTime}} at {{location.title}}<br>$t(events::select_fault_classification)<br>$t(events::select_incident_vehicle)"
+  },
+  "PersonMoveDeathInCustody": {
+    "heading": "Death in custody",
+    "description": "{{supplier_personnel_numbers, oxfordJoin}} reported a death in custody at {{reported_at, formatTime}} at {{location.title}}<br>$t(events::select_fault_classification)<br>$t(events::select_incident_vehicle)"
+  },
+  "PersonMoveBookedIntoReceivingEstablishment": {
+    "heading": "{{person.fullname}} booked into {{location.title}}",
+    "description": ""
+  },
+  "PersonMoveMajorIncidentOther": {
+    "heading": "Major incident occurred",
+    "description": "$t(events::incident_level_details, {\"incident_level\": \"Major\"})"
+  },
+  "PersonMoveMinorIncidentOther": {
+    "heading": "Minor incident occurred",
+    "description": "$t(events::incident_level_details, {\"incident_level\": \"Minor\"})"
+  },
+  "PersonMovePersonEscapedKpi": {
+    "heading": "KPI Escape occured",
+    "description": "$t(events::incident_escaped)"
+  },
+  "PersonMovePersonEscaped": {
+    "heading": "Non KPI Escape occured",
+    "description": "$t(events::incident_escaped)"
+  },
+  "PersonMoveReleasedError": {
+    "heading": "Released in error",
+    "description": "{{person.fullname}} was released in error from {{location.title}} $t(events::incident_reported_classified)"
+  },
+  "PersonMoveRoadTrafficAccident": {
+    "heading": "Road traffic accident",
+    "description": "Vehicle {{vehicle_reg}} transporting {{person.fullname}} met with road traffic accident $t(events::incident_reported_classified)"
+  },
+  "PersonMoveSeriousInjury": {
+    "heading": "Serious injury sustained",
+    "description": "{{person.fullname}} sustained serious injury $t(events::select_incident_location_preposition) $t(events::select_incident_location_vehicle) $t(events::incident_reported_classified)"
+  },
+  "PersonMoveUsedForce": {
+    "heading": "Supplier used force",
+    "description": "{{move.supplier.name}} staff {{supplier_personnel_numbers}} used force on {{person.fullname}} <br>The incident was reported at {{reported_at, formatTime}} <br>$t(events::select_fault_classification)"
+  },
+  "PersonMoveVehicleBrokeDown": {
+    "heading": "Supplier vehicle breakdown",
+    "description": "Vehicle {{vehicle_reg}} transporting {{person.fullname}} broke down $t(events::incident_reported_classified)"
+  },
+  "PersonMoveVehicleSystemsFailed": {
+    "heading": "Supplier vehicle systems failed",
+    "description": "Vehicle {{vehicle_reg}} transporting {{person.fullname}} has had a system failure $t(events::incident_reported_classified)"
+  },
+  "StatusMoveBooked": {
+    "statusChange": true,
+    "heading": "Booked",
+    "description": "Move has been booked with {{move.supplier.name}}"
+  },
+  "StatusMoveCancelled": {
+    "statusChange": true,
+    "heading": "Cancelled",
+    "description": "Move has been cancelled"
+  },
+  "StatusMoveCompleted": {
+    "statusChange": true,
+    "heading": "Completed",
+    "description": "Move has been completed by {{move.supplier.name}}"
+  },
+  "StatusMoveInTransit": {
+    "statusChange": true,
+    "heading": "In transit",
+    "description": "Move is in transit with {{move.supplier.name}}"
+  },
+  "StatusMoveProposed": {
+    "statusChange": true,
+    "heading": "Proposed",
+    "description": "Move has been proposed by OCA"
+  },
+  "StatusMoveRequested": {
+    "statusChange": true,
+    "heading": "Requested",
+    "description": "Move has been requested with {{move.supplier.name}}"
+  }
+}

--- a/locales/en/events.json
+++ b/locales/en/events.json
@@ -381,32 +381,32 @@
   },
   "StatusMoveBooked": {
     "statusChange": true,
-    "heading": "Booked",
+    "heading": "$t(statuses::booked)",
     "description": "Move has been booked with {{move.supplier.name}}"
   },
   "StatusMoveCancelled": {
     "statusChange": true,
-    "heading": "Cancelled",
+    "heading": "$t(statuses::cancelled)",
     "description": "Move has been cancelled"
   },
   "StatusMoveCompleted": {
     "statusChange": true,
-    "heading": "Completed",
+    "heading": "$t(statuses::completed)",
     "description": "Move has been completed by {{move.supplier.name}}"
   },
   "StatusMoveInTransit": {
     "statusChange": true,
-    "heading": "In transit",
+    "heading": "$t(statuses::in_transit)",
     "description": "Move is in transit with {{move.supplier.name}}"
   },
   "StatusMoveProposed": {
     "statusChange": true,
-    "heading": "Proposed",
+    "heading": "$t(statuses::proposed)",
     "description": "Move has been proposed by OCA"
   },
   "StatusMoveRequested": {
     "statusChange": true,
-    "heading": "Requested",
+    "heading": "$t(statuses::requested)",
     "description": "Move has been requested with {{move.supplier.name}}"
   }
 }


### PR DESCRIPTION
Adds presenter for data transformation

Adds events locales to provide content

<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Adds presenter for transformation of events to timeline format

Takes details from each event and mixes in
- move and person
- who performed the event (agency)
- context if any
  - value determined by a `contextKey` for the corresponding event type as defined in `events.json`
- event's relationships
- event's `eventable` relationship as a singularised property
  - eg. an eventable with type `journeys' is mixed in as `journey`
- common event properties
  - eg. `notes` and `occurred_at` timestamp

Also adds status change pseudo-events which are displayed as a GDS badge rather than as the standard heading


<kbd>![Move_details_for_MELLIE__ROGER_–_Book_a_secure_move](https://user-images.githubusercontent.com/4856/99073114-32654680-25ad-11eb-901d-4bb377a9d67b.png)</kbd>

### Why did it change

Preparatory work ahead of https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/pull/888

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

- [P4-2337 - Create view for timeline component](https://dsdmoj.atlassian.net/browse/P4-2337)

## Screenshots
<!--- (Optional) Include screenshots if changes update interfaces or components -->
<!--- Delete/copy as appropriate --->

n/a

## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed



### Other considerations

- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics

