### PR TITLE
Make app filters available to as i18n formatters [P4-2337]

### DIFF
--- a/config/i18n/index.js
+++ b/config/i18n/index.js
@@ -1,6 +1,8 @@
 const i18next = require('i18next')
 const Backend = require('i18next-sync-fs-backend')
 
+const interpolation = require('./interpolation')
+
 i18next.use(Backend).init({
   initImmediate: false,
   lng: 'en',
@@ -16,6 +18,7 @@ i18next.use(Backend).init({
     'default',
     'actions',
     'errors',
+    'events',
     'fields',
     'filters',
     'locations',
@@ -30,6 +33,7 @@ i18next.use(Backend).init({
   backend: {
     loadPath: './locales/{{lng}}/{{ns}}.json',
   },
+  interpolation,
 })
 
 module.exports = i18next

--- a/config/i18n/interpolation.js
+++ b/config/i18n/interpolation.js
@@ -1,0 +1,22 @@
+const filters = require('../nunjucks/filters')
+
+const exists = value => value !== undefined && value !== ''
+
+const formatters = {
+  ...filters,
+  exists,
+}
+
+const interpolation = {
+  format: (value, format, lng) => {
+    let output = value
+
+    if (formatters[format]) {
+      output = formatters[format](value)
+    }
+
+    return output
+  },
+}
+
+module.exports = interpolation

--- a/config/i18n/interpolation.test.js
+++ b/config/i18n/interpolation.test.js
@@ -1,0 +1,25 @@
+const proxyquire = require('proxyquire')
+
+const interpolation = proxyquire('./interpolation', {
+  '../nunjucks/filters': {
+    foo: value => `foo ${value} bar`,
+  },
+})
+
+describe('i18n interpolation', function () {
+  it('should add the filters as formatters', function () {
+    expect(interpolation.format('hello', 'foo')).to.equal('foo hello bar')
+  })
+
+  context('exists formatter', function () {
+    it('should return true is the value exists', function () {
+      expect(interpolation.format('hello', 'exists')).to.equal(true)
+    })
+    it('should return false is the value is undefined', function () {
+      expect(interpolation.format(undefined, 'exists')).to.equal(false)
+    })
+    it('should return false is the value is an empty string', function () {
+      expect(interpolation.format('', 'exists')).to.equal(false)
+    })
+  })
+})

--- a/config/nunjucks/filters.js
+++ b/config/nunjucks/filters.js
@@ -17,6 +17,7 @@ const { filter, kebabCase, startCase } = require('lodash')
 const pluralize = require('pluralize')
 
 const parse = require('../../common/parsers')
+const { current_week: currentWeek } = require('../../locales/en/actions.json')
 const { DATE_FORMATS } = require('../index')
 
 function _isRelativeDate(date) {
@@ -114,7 +115,6 @@ function formatDateRange(value, delimiter = 'to') {
  * @example {{ "2019-02-21" | formatDateRange("DD/MM/YY") }}
  */
 function formatDateRangeAsRelativeWeek(value) {
-  const i18n = require('../i18n')
   const dates = filter(value)
 
   if (!value || !Array.isArray(value) || dates.length === 0) {
@@ -126,7 +126,7 @@ function formatDateRangeAsRelativeWeek(value) {
   }
 
   if (_isCurrentWeek(dates)) {
-    return i18n.t('actions::current_week')
+    return currentWeek
   }
 
   return formatDateRange(value)

--- a/config/nunjucks/filters.js
+++ b/config/nunjucks/filters.js
@@ -17,7 +17,6 @@ const { filter, kebabCase, startCase } = require('lodash')
 const pluralize = require('pluralize')
 
 const parse = require('../../common/parsers')
-const i18n = require('../i18n')
 const { DATE_FORMATS } = require('../index')
 
 function _isRelativeDate(date) {
@@ -115,6 +114,7 @@ function formatDateRange(value, delimiter = 'to') {
  * @example {{ "2019-02-21" | formatDateRange("DD/MM/YY") }}
  */
 function formatDateRangeAsRelativeWeek(value) {
+  const i18n = require('../i18n')
   const dates = filter(value)
 
   if (!value || !Array.isArray(value) || dates.length === 0) {
@@ -284,21 +284,23 @@ function formatTime(value) {
  * @example {{ ["one","two","three"] | oxfordJoin }}
  */
 function oxfordJoin(arr = [], lastDelimiter = 'and') {
-  if (arr.length === 0) {
-    return ''
-  }
+  let output
 
-  if (arr.length === 1) {
-    return arr[0]
-  }
-
-  if (arr.length === 2) {
+  if (!arr || !Array.isArray(arr)) {
+    output = arr
+  } else if (arr.length === 0) {
+    output = ''
+  } else if (arr.length === 1) {
+    output = arr[0]
+  } else if (arr.length === 2) {
     // joins all with "and" but no commas
-    return arr.join(` ${lastDelimiter} `)
+    output = arr.join(` ${lastDelimiter} `)
+  } else {
+    // joins all with commas, but last one gets ", and" (oxford comma!)
+    output = `${arr.slice(0, -1).join(', ')}, ${lastDelimiter} ${arr.slice(-1)}`
   }
 
-  // joins all with commas, but last one gets ", and" (oxford comma!)
-  return `${arr.slice(0, -1).join(', ')}, ${lastDelimiter} ${arr.slice(-1)}`
+  return output
 }
 
 function filesize(str) {

--- a/config/nunjucks/filters.js
+++ b/config/nunjucks/filters.js
@@ -1,3 +1,4 @@
+const mojFilters = require('@ministryofjustice/frontend/moj/filters/all')()
 const {
   format,
   isThisWeek,
@@ -307,6 +308,7 @@ function filesize(str) {
 }
 
 module.exports = {
+  ...mojFilters,
   formatDate,
   formatDateRange,
   formatDateRangeAsRelativeWeek,

--- a/config/nunjucks/filters.test.js
+++ b/config/nunjucks/filters.test.js
@@ -732,6 +732,34 @@ describe('Nunjucks filters', function () {
 
   describe('#oxfordJoin()', function () {
     context('by default', function () {
+      context('with undefined', function () {
+        it('should return undefined', function () {
+          const joined = filters.oxfordJoin()
+          expect(joined).to.equal('')
+        })
+      })
+
+      context('with a string', function () {
+        it('should return string untouched', function () {
+          const joined = filters.oxfordJoin('foo')
+          expect(joined).to.equal('foo')
+        })
+      })
+
+      context('with a number', function () {
+        it('should return number untouched', function () {
+          const joined = filters.oxfordJoin(23)
+          expect(joined).to.equal(23)
+        })
+      })
+
+      context('with a boolean', function () {
+        it('should return boolean untouched', function () {
+          const joined = filters.oxfordJoin(false)
+          expect(joined).to.equal(false)
+        })
+      })
+
       context('with no items', function () {
         it('should return empty string', function () {
           const joined = filters.oxfordJoin([])

--- a/config/nunjucks/filters.test.js
+++ b/config/nunjucks/filters.test.js
@@ -1,10 +1,13 @@
 const proxyquire = require('proxyquire')
 const timezoneMock = require('timezone-mock')
 
-const i18n = require('../i18n')
+const actions = {
+  current_week: 'This is the week that is',
+}
 
 const mockFilesizeResponse = '10 MB'
 const mockFilesizejs = sinon.stub().returns(mockFilesizeResponse)
+
 const filters = proxyquire('./filters', {
   '../index': {
     DATE_FORMATS: {
@@ -12,6 +15,7 @@ const filters = proxyquire('./filters', {
       WITH_DAY: 'EEEE d MMM yyyy',
     },
   },
+  '../../locales/en/actions.json': actions,
   filesize: mockFilesizejs,
 })
 
@@ -219,7 +223,9 @@ describe('Nunjucks filters', function () {
     context('when current date is this week', function () {
       it('should return date along with `This week`', function () {
         const formattedDate = filters.formatDateRangeWithRelativeWeek(dateRange)
-        expect(formattedDate).to.equal('14 to 20 Aug 2017 (This week)')
+        expect(formattedDate).to.equal(
+          `14 to 20 Aug 2017 (${actions.current_week})`
+        )
       })
     })
 
@@ -425,7 +431,6 @@ describe('Nunjucks filters', function () {
     beforeEach(function () {
       const mockDate = new Date('2020-04-06')
       this.clock = sinon.useFakeTimers(mockDate.getTime())
-      sinon.stub(i18n, 't').returnsArg(0)
     })
 
     afterEach(function () {
@@ -439,7 +444,7 @@ describe('Nunjucks filters', function () {
             '2020-04-06',
             '2020-04-12',
           ])
-          expect(formattedRange).to.equal('actions::current_week')
+          expect(formattedRange).to.equal(actions.current_week)
         })
       })
 
@@ -449,7 +454,7 @@ describe('Nunjucks filters', function () {
             '2020-04-08',
             '2020-04-12',
           ])
-          expect(formattedRange).to.equal('actions::current_week')
+          expect(formattedRange).to.equal(actions.current_week)
         })
 
         it('should return `This week`', function () {
@@ -457,7 +462,7 @@ describe('Nunjucks filters', function () {
             '2020-04-06',
             '2020-04-10',
           ])
-          expect(formattedRange).to.equal('actions::current_week')
+          expect(formattedRange).to.equal(actions.current_week)
         })
       })
     })

--- a/test/unit/component-helpers.js
+++ b/test/unit/component-helpers.js
@@ -9,6 +9,9 @@ const filters = require('../../config/nunjucks/filters')
 const templateGlobals = require('../../config/nunjucks/globals')
 const configPaths = require('../../config/paths')
 
+// eslint-disable-next-line no-process-env
+process.env.TZ = 'Europe/London'
+
 const views = [
   configPaths.components,
   configPaths.govukFrontend,

--- a/test/unit/component-helpers.js
+++ b/test/unit/component-helpers.js
@@ -5,6 +5,7 @@ const cheerio = require('cheerio')
 const yaml = require('js-yaml')
 const nunjucks = require('nunjucks')
 
+const filters = require('../../config/nunjucks/filters')
 const templateGlobals = require('../../config/nunjucks/globals')
 const configPaths = require('../../config/paths')
 
@@ -17,6 +18,11 @@ const views = [
 const nunjucksEnvironment = nunjucks.configure(views, {
   trimBlocks: true,
   lstripBlocks: true,
+})
+
+// Filters
+Object.keys(filters).forEach(filter => {
+  nunjucksEnvironment.addFilter(filter, filters[filter])
 })
 
 // Global variables


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Enables i18next interpolation to use same filters as nunjucks

Also adds a formatter `exists` which returns a boolean if the value passed is undefined or an empty string

### Why did it change

Filters sharing because there's no need to reinvent the wheel

`exists` formatter allows for construction of dynamic if/else style contexts when calling nested strings

Preparatory work ahead of https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/pull/888

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

- [P4-2337 - Create view for timeline component](https://dsdmoj.atlassian.net/browse/P4-2337)

## Screenshots
<!--- (Optional) Include screenshots if changes update interfaces or components -->
<!--- Delete/copy as appropriate --->

n/a

## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed


### Other considerations

- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics

