### PR TITLE
Extract setting youth move to own module [P4-2337]

### DIFF
--- a/app/move/controllers/view.js
+++ b/app/move/controllers/view.js
@@ -5,6 +5,7 @@ const updateSteps = require('../steps/update')
 
 const getUpdateLinks = require('./view/view.update.links')
 const getUpdateUrls = require('./view/view.update.urls')
+const setYouthMove = require('./view/view.youth-move')
 
 module.exports = function view(req, res) {
   const { move, originalUrl, framework = {} } = req
@@ -16,14 +17,7 @@ module.exports = function view(req, res) {
     rejection_reason: rejectionReason,
   } = move
 
-  // We have to pretend that 'secure_childrens_home', 'secure_training_centre' are valid `move_type`s
-  const youthTransfer = ['secure_childrens_home', 'secure_training_centre']
-  const toLocationType = move?.to_location?.location_type
-  const fromLocationType = move?.from_location?.location_type
-
-  if (toLocationType === 'prison' && youthTransfer.includes(fromLocationType)) {
-    move.move_type = fromLocationType
-  }
+  setYouthMove(move)
 
   const bannerStatuses = ['cancelled']
   const updateUrls = getUpdateUrls(updateSteps, move, req)
@@ -65,6 +59,7 @@ module.exports = function view(req, res) {
   const urls = {
     update: updateUrls,
   }
+
   const assessment = presenters
     .assessmentAnswersByCategory(assessmentAnswers)
     .filter(category => category.key !== 'court')

--- a/app/move/controllers/view.test.js
+++ b/app/move/controllers/view.test.js
@@ -4,6 +4,7 @@ const presenters = require('../../../common/presenters')
 
 const getUpdateUrls = sinon.stub()
 const getUpdateLinks = sinon.stub()
+const setYouthMove = sinon.stub()
 
 const updateSteps = []
 const frameworkStub = {
@@ -13,6 +14,7 @@ const pathStubs = {
   '../steps/update': updateSteps,
   './view/view.update.urls': getUpdateUrls,
   './view/view.update.links': getUpdateLinks,
+  './view/view.youth-move': setYouthMove,
 }
 const controller = proxyquire('./view', pathStubs)
 
@@ -68,7 +70,7 @@ const mockMove = {
   ],
 }
 
-const mockUrls = {
+const mockUpdateUrls = {
   somewhere: '/somewhere',
 }
 const mockUpdateLinks = {
@@ -83,7 +85,7 @@ const mockUpdateLinks = {
 }
 const mockOriginalUrl = '/url-to-move'
 
-getUpdateUrls.returns(mockUrls)
+getUpdateUrls.returns(mockUpdateUrls)
 getUpdateLinks.returns(mockUpdateLinks)
 
 describe('Move controllers', function () {
@@ -94,6 +96,7 @@ describe('Move controllers', function () {
     beforeEach(function () {
       getUpdateUrls.resetHistory()
       getUpdateLinks.resetHistory()
+      setYouthMove.resetHistory()
       sinon
         .stub(presenters, 'moveToMetaListComponent')
         .returns('__moveToMetaListComponent__')
@@ -386,7 +389,7 @@ describe('Move controllers', function () {
         it('should call getUpdateLinks with expected args', function () {
           expect(getUpdateLinks).to.be.calledOnceWithExactly(
             updateSteps,
-            mockUrls
+            mockUpdateUrls
           )
         })
 
@@ -402,29 +405,11 @@ describe('Move controllers', function () {
       })
     })
 
-    context('with youth transfer moves', function () {
-      ;['secure_childrens_home', 'secure_training_centre'].forEach(function (
-        youthTransferType
-      ) {
-        const youthTransferMove = {
-          to_location: {
-            location_type: 'prison',
-          },
-          from_location: {
-            location_type: youthTransferType,
-          },
-        }
-        it(`should upgrade the move when ${youthTransferType} to prison`, function () {
-          req.move = {
-            ...youthTransferMove,
-          }
-          controller(req, res)
-          expect(getUpdateUrls).to.be.calledOnceWithExactly(
-            updateSteps,
-            { ...youthTransferMove, move_type: youthTransferType },
-            req
-          )
-        })
+    context('move types', function () {
+      it('should update move type if necessary', function () {
+        req.move = {}
+        controller(req, res)
+        expect(setYouthMove).to.be.calledOnceWithExactly(req.move)
       })
     })
 

--- a/app/move/controllers/view/view.youth-move.js
+++ b/app/move/controllers/view/view.youth-move.js
@@ -1,0 +1,12 @@
+const setYouthMove = move => {
+  // We have to pretend that 'secure_childrens_home', 'secure_training_centre' are valid `move_type`s
+  const youthTransfer = ['secure_childrens_home', 'secure_training_centre']
+  const toLocationType = move?.to_location?.location_type
+  const fromLocationType = move?.from_location?.location_type
+
+  if (toLocationType === 'prison' && youthTransfer.includes(fromLocationType)) {
+    move.move_type = fromLocationType
+  }
+}
+
+module.exports = setYouthMove

--- a/app/move/controllers/view/view.youth-move.test.js
+++ b/app/move/controllers/view/view.youth-move.test.js
@@ -1,0 +1,51 @@
+const setYouthMove = require('./view.youth-move')
+
+describe('#view', function () {
+  describe('#setYouthMove', function () {
+    let youthTransferMove
+    beforeEach(function () {
+      youthTransferMove = {
+        to_location: {
+          location_type: 'prison',
+        },
+        from_location: {
+          location_type: 'prison',
+        },
+      }
+    })
+
+    context('with youth transfer moves', function () {
+      let move
+      beforeEach(function () {
+        move = {
+          ...youthTransferMove,
+        }
+        setYouthMove(move)
+      })
+      it('should not update the move when from prison to prison', function () {
+        expect(move.move_type).to.be.undefined
+      })
+    })
+
+    context('with youth transfer moves', function () {
+      ;['secure_childrens_home', 'secure_training_centre'].forEach(function (
+        youthTransferType
+      ) {
+        let move
+        beforeEach(function () {
+          youthTransferMove.from_location.location_type = youthTransferType
+          move = {
+            ...youthTransferMove,
+          }
+          setYouthMove(move)
+        })
+        it(`should upgrade the move when from ${youthTransferType} to prison`, function () {
+          expect(move).to.deep.equal({
+            ...youthTransferMove,
+            move_type: youthTransferType,
+          })
+        })
+      })
+    })
+  })
+})


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Extracts the setting of youth moves out of view controller into separate module

### Why did it change

Allows the code to be reused by other controllers

Preparatory work ahead of https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/pull/888

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

- [P4-2337 - Create view for timeline component](https://dsdmoj.atlassian.net/browse/P4-2337)

## Screenshots
<!--- (Optional) Include screenshots if changes update interfaces or components -->
<!--- Delete/copy as appropriate --->

n/a

## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed


### Other considerations

- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics

