### PR TITLE
[P4-2419] Form has been tampered with errors

### DIFF
--- a/app/move/controllers/create/document.js
+++ b/app/move/controllers/create/document.js
@@ -20,8 +20,8 @@ class DocumentUploadController extends CreateBaseController {
   }
 
   middlewareSetup() {
-    super.middlewareSetup()
     this.use(upload.array('documents'))
+    super.middlewareSetup()
     // must be called after multer to correctly parse the form body
     this.use(this.setNextStep)
   }

--- a/common/components/multi-file-upload/multi-file-upload.js
+++ b/common/components/multi-file-upload/multi-file-upload.js
@@ -44,7 +44,7 @@ MultiFileUpload.prototype = {
     this.$previewNode.removeAttribute('data-dz-preview-template')
     this.$dropzone = this.$module.querySelector('[data-dz-dropzone]')
     this.previewTemplate = this.$previewNode.outerHTML
-    this.xrsfToken = document.querySelector('input[name="x-csrf-token"]').value
+    this.xrsfToken = document.querySelector('input[name="_csrf"]').value
   },
 
   bindEvents() {
@@ -71,7 +71,7 @@ MultiFileUpload.prototype = {
       ...this.params,
       previewTemplate: this.previewTemplate,
       params: {
-        'x-csrf-token': this.xrsfToken,
+        _csrf: this.xrsfToken,
       },
     })
 
@@ -143,7 +143,7 @@ MultiFileUpload.prototype = {
   deleteFile(fileId) {
     const formData = {
       delete: fileId,
-      'x-csrf-token': this.xrsfToken,
+      _csrf: this.xrsfToken,
     }
     const config = {
       headers: { 'X-Requested-With': 'XMLHttpRequest' },

--- a/common/controllers/form-wizard/index.js
+++ b/common/controllers/form-wizard/index.js
@@ -2,9 +2,9 @@ const Sentry = require('@sentry/node')
 const { Controller } = require('hmpo-form-wizard')
 const { map, fromPairs, forEach, mapKeys } = require('lodash')
 
-const fieldHelpers = require('../helpers/field')
+const fieldHelpers = require('../../helpers/field')
 
-class FormController extends Controller {
+class BaseController extends Controller {
   middlewareSetup() {
     super.middlewareSetup()
     this.use(this.setInitialValues)
@@ -160,11 +160,12 @@ class FormController extends Controller {
       [
         'SESSION_TIMEOUT',
         'CSRF_ERROR',
+        'EBADCSRFTOKEN',
         'MISSING_PREREQ',
         'MISSING_LOCATION',
       ].includes(err.code)
     ) {
-      if (err.code === 'CSRF_ERROR') {
+      if (err.code === 'CSRF_ERROR' || err.code === 'EBADCSRFTOKEN') {
         Sentry.captureException(err)
       }
 
@@ -198,5 +199,8 @@ class FormController extends Controller {
     super.render(req, res, next)
   }
 }
+
+let FormController = BaseController
+FormController = require('./mixins/csrf')(FormController)
 
 module.exports = FormController

--- a/common/controllers/form-wizard/mixins/csrf.js
+++ b/common/controllers/form-wizard/mixins/csrf.js
@@ -1,0 +1,33 @@
+const csrf = require('csurf')
+const { includes } = require('lodash')
+
+const safeMethods = ['GET', 'HEAD', 'OPTIONS']
+
+module.exports = Controller =>
+  class extends Controller {
+    middlewareSetup() {
+      super.middlewareSetup()
+      this.use(csrf())
+    }
+
+    csrfGenerateSecret(req, res, next) {
+      next()
+    }
+
+    csrfCheckToken(req, res, next) {
+      next()
+    }
+
+    csrfSetToken(req, res, next) {
+      if (!includes(safeMethods, req.method)) {
+        return next()
+      }
+
+      // The HTTP method is safe. No need to verify a
+      // token. Instead, provide a new one for future
+      // verification.
+      res.locals['csrf-token'] = req.csrfToken()
+
+      next()
+    }
+  }

--- a/common/controllers/form-wizard/mixins/csrf.test.js
+++ b/common/controllers/form-wizard/mixins/csrf.test.js
@@ -1,0 +1,100 @@
+const proxyquire = require('proxyquire')
+
+class Controller {
+  constructor(options) {
+    this.options = options || {}
+    // run sinon stub with options of this controller
+    Controller.constructor.call(this, options)
+  }
+}
+
+Controller.constructor = sinon.stub()
+Controller.prototype.use = sinon.stub()
+Controller.prototype.middlewareSetup = sinon.stub()
+
+describe('Form wizard', function () {
+  describe('mixins/csrf', function () {
+    let BaseController, StubController
+    let req, res, next, controller, csrfStub, csrfMixin
+
+    beforeEach(function () {
+      const options = {}
+
+      csrfStub = sinon.stub().returns({})
+      csrfMixin = proxyquire('./csrf', {
+        csurf: () => csrfStub,
+      })
+
+      BaseController = Controller
+      StubController = csrfMixin(BaseController)
+      controller = new StubController(options)
+
+      req = {
+        form: { options },
+        method: 'GET',
+      }
+      res = {
+        locals: {},
+      }
+      next = sinon.stub()
+    })
+
+    it('should export a function', function () {
+      expect(csrfMixin).to.be.a('function')
+      expect(csrfMixin).to.have.length(1)
+    })
+
+    it('should extend a passed controller', function () {
+      expect(controller).to.be.an.instanceOf(BaseController)
+    })
+
+    describe('middlewareSetup override', function () {
+      it('calls the super method', function () {
+        controller.middlewareSetup()
+        expect(BaseController.prototype.middlewareSetup).to.have.been.calledOnce
+      })
+
+      it('uses the csrfGenerateSecret middleware', function () {
+        controller.middlewareSetup()
+        expect(BaseController.prototype.use).to.have.been.calledWithExactly(
+          csrfStub
+        )
+      })
+    })
+
+    describe('csrfGenerateSecret middleware', function () {
+      it('calls callback immediately', function () {
+        controller.csrfGenerateSecret(req, res, next)
+        expect(next).to.have.been.calledOnceWithExactly()
+      })
+    })
+
+    describe('csrfCheckToken middleware', function () {
+      it('calls callback immediately', function () {
+        controller.csrfCheckToken(req, res, next)
+        expect(next).to.have.been.calledOnceWithExactly()
+      })
+    })
+
+    describe('csrfSetToken middleware', function () {
+      it('generates a token on GET requests', function () {
+        req.method = 'GET'
+        req.csrfToken = sinon.stub().returns('A New Token')
+
+        controller.csrfSetToken(req, res, next)
+
+        expect(res.locals['csrf-token']).to.equal('A New Token')
+        expect(next).to.have.been.calledOnceWithExactly()
+      })
+
+      it('should not call csrf.create on POST requests', function () {
+        req.method = 'POST'
+
+        controller.csrfSetToken(req, res, next)
+
+        expect(res.locals['csrf-token']).to.be.undefined
+        expect(next).to.have.been.calledOnceWithExactly()
+      })
+    })
+  })
+})

--- a/common/templates/form-wizard.njk
+++ b/common/templates/form-wizard.njk
@@ -58,7 +58,7 @@
   >
 
     {% if formMethod == 'post' %}
-      <input type="hidden" name="x-csrf-token" value="{{ getLocal('csrf-token') }}">
+      <input type="hidden" name="_csrf" value="{{ getLocal('csrf-token') }}">
     {% endif %}
 
     {% block beforeFields %}

--- a/locales/en/errors.json
+++ b/locales/en/errors.json
@@ -31,6 +31,10 @@
     "heading": "$t(errors::tampered_with.heading)",
     "content": "$t(errors::tampered_with.content)"
   },
+  "ebadcsrftoken": {
+    "heading": "$t(errors::tampered_with.heading)",
+    "content": "$t(errors::tampered_with.content)"
+  },
   "unauthorized": {
     "heading": "You don’t have permission to view this page",
     "content": "If you think you should have access please contact the support team."

--- a/package-lock.json
+++ b/package-lock.json
@@ -10681,6 +10681,41 @@
         }
       }
     },
+    "csurf": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/csurf/-/csurf-1.11.0.tgz",
+      "integrity": "sha512-UCtehyEExKTxgiu8UHdGvHj4tnpE/Qctue03Giq5gPgMQ9cg/ciod5blZQ5a4uCEenNQjxyGuzygLdKUmee/bQ==",
+      "requires": {
+        "cookie": "0.4.0",
+        "cookie-signature": "1.0.6",
+        "csrf": "3.1.0",
+        "http-errors": "~1.7.3"
+      },
+      "dependencies": {
+        "cookie": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz",
+          "integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg=="
+        },
+        "http-errors": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.3.tgz",
+          "integrity": "sha512-ZTTX0MWrsQ2ZAhA1cejAwDLycFsd7I7nVtnkT3Ol0aqodaKW+0CTZDQ1uBv5whptCnc8e8HeRRJxRs0kmm/Qfw==",
+          "requires": {
+            "depd": "~1.1.2",
+            "inherits": "2.0.4",
+            "setprototypeof": "1.1.1",
+            "statuses": ">= 1.5.0 < 2",
+            "toidentifier": "1.0.0"
+          }
+        },
+        "inherits": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+        }
+      }
+    },
     "cuint": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/cuint/-/cuint-0.2.2.tgz",

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "convert-hrtime": "3.0.0",
     "cookie-parser": "1.4.5",
     "core-js": "3.7.0",
+    "csurf": "1.11.0",
     "date-fns": "2.16.1",
     "debug": "4.3.0",
     "devour-client": "2.1.0",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

This change overriddes the methods used to generate and verify the
CSRF token for all form wizard instances to use a globally set secret
that is stored separately on the user's session.

This will help prevent the CSRF errors that sometimes occur when a user
is interacting with different form wizards in multiple tabs.

### Why did it change

Currently each form wizard sets a CSRF token for each instance. This is
stored in the session using the SessionModel. When changes are made to
this session, for example creating a new CSRF token, the SessionModel
uses the values it had for the session at the request to [save back
to the session](https://github.com/HMPO/hmpo-form-wizard/blob/c8131187ddaafd220af89e75b8c2a400f4bdd78e/lib/model.js#L42-L45).

This can lead to the CSRF secret being reset to a previous value in
some cases where multiple tabs are opened in quick succession.

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

- [P4-2419](https://dsdmoj.atlassian.net/browse/P4-2419)

## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [x] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed

### Other considerations

Commit messages with a `fix` or `feat` type are automatically used to generate the [changelog](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/CHANGELOG.md) and
[GitHub release notes](https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/releases) during the release task. Please make sure they will read well on their own in a
summary of changes and that the commit body gives a more detailed description of those changes if necessary.

- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
- [x] Update [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md) with any new instructions or tasks
