### PR TITLE
Correct populateResources to preserveResourceRefs renaming

### DIFF
--- a/common/lib/api-client/middleware/request.js
+++ b/common/lib/api-client/middleware/request.js
@@ -16,9 +16,9 @@ function requestMiddleware({ cacheExpiry = 60, useRedisCache = false } = {}) {
 
       debug('API REQUEST', req.url)
 
-      if (req.params.populateResources) {
-        req.populateResources = req.params.populateResources
-        delete req.params.populateResources
+      if (req.params.preserveResourceRefs) {
+        req.preserveResourceRefs = req.params.preserveResourceRefs
+        delete req.params.preserveResourceRefs
       }
 
       // start timer for metrics and logging

--- a/common/lib/api-client/middleware/request.test.js
+++ b/common/lib/api-client/middleware/request.test.js
@@ -81,15 +81,15 @@ describe('API Client', function () {
 
     context('when response’s resources should be populated', function () {
       beforeEach(async function () {
-        payload.req.params.populateResources = 'foo'
+        payload.req.params.preserveResourceRefs = 'foo'
         response = await requestMiddleware().req(payload)
       })
 
       it('should remove populateResources property from params', function () {
-        expect(response.req.params.populateResources).to.be.undefined
+        expect(response.req.params.preserveResourceRefs).to.be.undefined
       })
       it('should copy populateResources property to req object', function () {
-        expect(response.req.populateResources).to.equal('foo')
+        expect(response.req.preserveResourceRefs).to.equal('foo')
       })
     })
 

--- a/locales/en/events.json
+++ b/locales/en/events.json
@@ -208,7 +208,7 @@
     "select_rebook": "$t(events::MoveReject.rebook, {\"context\": \"{{rebook}}\"})",
     "rebook": "",
     "rebook_true": "<br>This move will be rebooked in 7 days",
-    "rebook_false": "<br>This move will not be rebooked",
+    "rebook_false": "<br>This move may be rebooked in 7 days if still required",
     "select_cancellation_reason_comment": "$t(events::MoveReject.cancellation_reason_comment, {\"context\": \"{{cancellation_reason_comment, exists}}\"})",
     "cancellation_reason_comment": "",
     "cancellation_reason_comment_true": "<br>Comment: {{cancellation_reason_comment}}"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

`populateResources` in the api-client request middleware got missed when renamed to `preserveResourceRefs`

### Why did it change

because of this omission, the resources never got preserved and, as a consequence, never got populated. This reinstates the desired behaviour.

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

- [P4-2337 - Create view for timeline component](https://dsdmoj.atlassian.net/browse/P4-2337)

## Screenshots
<!--- (Optional) Include screenshots if changes update interfaces or components -->
<!--- Delete/copy as appropriate --->

n/a
## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed


### Other considerations

- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
