### PR TITLE
chore: Remove tabs from move detail

### DIFF
--- a/app/move/views/view.njk
+++ b/app/move/views/view.njk
@@ -280,7 +280,6 @@
 {% endmacro %}
 
 {% block contentMain %}
-  {{ tabs(urls, 'view') }}
   {% if move.profile %}
     <div class="govuk-!-margin-bottom-9">
       <section class="app-!-position-relative">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

This temporarily removes the tabs from the move detail view.

The URL will still be accessible to those who know it but it won't
be able to be accessed by navigating to it.

### Why did it change

The API doesn't currently return the minimum events we desire so for
now the tabs won't be displayed on the detail view.