### PR TITLE
Ensure links to PER and tags on move:* views are absolute

### DIFF
--- a/app/move/controllers/view/view.locals.js
+++ b/app/move/controllers/view/view.locals.js
@@ -8,7 +8,8 @@ const getUpdateLinks = require('./view.update.links')
 const getUpdateUrls = require('./view.update.urls')
 
 function getViewLocals(req) {
-  const { move, originalUrl, framework = {} } = req
+  const { move, framework = {} } = req
+
   const {
     profile,
     status,
@@ -16,6 +17,9 @@ function getViewLocals(req) {
     cancellation_reason_comment: cancellationComments,
     rejection_reason: rejectionReason,
   } = move
+
+  const tabsUrls = getTabsUrls(move)
+  const moveUrl = tabsUrls.view
 
   // We have to pretend that 'secure_childrens_home', 'secure_training_centre' are valid `move_type`s
   const youthTransfer = ['secure_childrens_home', 'secure_training_centre']
@@ -41,7 +45,7 @@ function getViewLocals(req) {
   const personEscortRecordIsConfirmed = ['confirmed'].includes(
     personEscortRecord?.status
   )
-  const personEscortRecordUrl = `${originalUrl}/person-escort-record`
+  const personEscortRecordUrl = `${moveUrl}/person-escort-record`
   const showPersonEscortRecordBanner =
     personEscortRecordIsEnabled &&
     !['proposed'].includes(move?.status) &&
@@ -61,11 +65,12 @@ function getViewLocals(req) {
     sectionProgress: personEscortRecord?.meta?.section_progress,
   })
   const personEscortRecordTagList = presenters.frameworkFlagsToTagList(
-    personEscortRecord?.flags
+    personEscortRecord?.flags,
+    moveUrl
   )
   const urls = {
     update: updateUrls,
-    tabs: getTabsUrls(move),
+    tabs: tabsUrls,
   }
   const assessment = presenters
     .assessmentAnswersByCategory(assessmentAnswers)
@@ -112,7 +117,7 @@ function getViewLocals(req) {
     moveSummary: presenters.moveToMetaListComponent(move, updateActions),
     personalDetailsSummary: presenters.personToSummaryListComponent(person),
     additionalInfoSummary: presenters.moveToAdditionalInfoListComponent(move),
-    tagList: presenters.assessmentToTagList(assessmentAnswers),
+    tagList: presenters.assessmentToTagList(assessmentAnswers, moveUrl),
     canCancelMove:
       (userPermissions.includes('move:cancel') &&
         !move.allocation &&

--- a/app/move/controllers/view/view.locals.test.js
+++ b/app/move/controllers/view/view.locals.test.js
@@ -70,10 +70,12 @@ const mockMove = {
   ],
 }
 
+const mockMoveUrl = '/url-to-move'
 const mockUrls = {
   somewhere: '/somewhere',
 }
 const mockTabsUrls = {
+  view: mockMoveUrl,
   elsewhere: '/elsewhere',
 }
 const mockUpdateLinks = {
@@ -86,14 +88,13 @@ const mockUpdateLinks = {
     url: '/somewhere',
   },
 }
-const mockOriginalUrl = '/url-to-move'
 
 getUpdateUrls.returns(mockUrls)
 getTabsUrls.returns(mockTabsUrls)
 getUpdateLinks.returns(mockUpdateLinks)
 
 describe('Move controllers', function () {
-  describe('#view()', function () {
+  describe('#view locals()', function () {
     let req, res, params
     const userPermissions = ['permA']
 
@@ -133,7 +134,6 @@ describe('Move controllers', function () {
           },
         },
         move: mockMove,
-        originalUrl: mockOriginalUrl,
       }
       res = {
         render: sinon.spy(),
@@ -157,7 +157,7 @@ describe('Move controllers', function () {
         expect(
           presenters.frameworkToTaskListComponent
         ).to.be.calledOnceWithExactly({
-          baseUrl: `${mockOriginalUrl}/person-escort-record/`,
+          baseUrl: `${mockMoveUrl}/person-escort-record/`,
           deepLinkToFirstStep: true,
           frameworkSections: undefined,
           sectionProgress: undefined,
@@ -192,7 +192,7 @@ describe('Move controllers', function () {
       it('should contain a personEscortRecordUrl param', function () {
         expect(params).to.have.property('personEscortRecordUrl')
         expect(params.personEscortRecordUrl).to.equal(
-          `${mockOriginalUrl}/person-escort-record`
+          `${mockMoveUrl}/person-escort-record`
         )
       })
 
@@ -247,7 +247,8 @@ describe('Move controllers', function () {
 
       it('should call assessmentToTagList presenter with correct args', function () {
         expect(presenters.assessmentToTagList).to.be.calledOnceWithExactly(
-          mockAssessmentAnswers
+          mockAssessmentAnswers,
+          mockMoveUrl
         )
       })
 
@@ -494,7 +495,10 @@ describe('Move controllers', function () {
       })
 
       it('should call assessmentToTagList presenter with empty array', function () {
-        expect(presenters.assessmentToTagList).to.be.calledOnceWithExactly([])
+        expect(presenters.assessmentToTagList).to.be.calledOnceWithExactly(
+          [],
+          mockMoveUrl
+        )
       })
 
       it('should contain tag list param', function () {
@@ -589,7 +593,7 @@ describe('Move controllers', function () {
         it('should contain url to Person Escort Record', function () {
           expect(params).to.have.property('personEscortRecordUrl')
           expect(params.personEscortRecordUrl).to.equal(
-            `${mockOriginalUrl}/person-escort-record`
+            `${mockMoveUrl}/person-escort-record`
           )
         })
 
@@ -597,7 +601,7 @@ describe('Move controllers', function () {
           expect(
             presenters.frameworkToTaskListComponent
           ).to.be.calledOnceWithExactly({
-            baseUrl: `${mockOriginalUrl}/person-escort-record/`,
+            baseUrl: `${mockMoveUrl}/person-escort-record/`,
             deepLinkToFirstStep: true,
             frameworkSections: frameworkStub.sections,
             sectionProgress: mockPersonEscortRecord.meta.section_progress,
@@ -667,7 +671,7 @@ describe('Move controllers', function () {
         it('should contain url to Person Escort Record', function () {
           expect(params).to.have.property('personEscortRecordUrl')
           expect(params.personEscortRecordUrl).to.equal(
-            `${mockOriginalUrl}/person-escort-record`
+            `${mockMoveUrl}/person-escort-record`
           )
         })
 
@@ -675,7 +679,7 @@ describe('Move controllers', function () {
           expect(
             presenters.frameworkToTaskListComponent
           ).to.be.calledOnceWithExactly({
-            baseUrl: `${mockOriginalUrl}/person-escort-record/`,
+            baseUrl: `${mockMoveUrl}/person-escort-record/`,
             deepLinkToFirstStep: true,
             frameworkSections: frameworkStub.sections,
             sectionProgress: mockPersonEscortRecord.meta.section_progress,
@@ -685,7 +689,10 @@ describe('Move controllers', function () {
         it('should call frameworkFlagsToTagList presenter with correct args', function () {
           expect(
             presenters.frameworkFlagsToTagList
-          ).to.be.calledOnceWithExactly(mockPersonEscortRecord.flags)
+          ).to.be.calledOnceWithExactly(
+            mockPersonEscortRecord.flags,
+            mockMoveUrl
+          )
         })
 
         it('should contain Person Escort Record tasklist', function () {


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

- Get move url from view.tabs.urls
- Prefix tags with move url
- Use move url to create base PER url

### Why did it change

Links are broken on move timeline view and would be on any other move views introduced needing to share the main move view content 

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

n/a

## Screenshots
<!--- (Optional) Include screenshots if changes update interfaces or components -->
<!--- Delete/copy as appropriate --->

n/a

## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed


### Other considerations

- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
