### PR TITLE
Show both NOMIS "High Security Hospitals" & "Hospital" location types for type ahead on Hospital moves [P4-2408]

### DIFF
--- a/app/move/controllers/create/move-details.js
+++ b/app/move/controllers/create/move-details.js
@@ -18,9 +18,12 @@ class MoveDetailsController extends CreateBaseController {
     this.use(
       commonMiddleware.setLocationItems('police', 'to_location_police_transfer')
     )
+    // hospitals come in 2 different flavours for obscure “legacy” reasons
+    // book-a-secure-move makes no distinction between them
+    // selecting a location from either results in a move_type of `hospital`
     this.use(
       commonMiddleware.setLocationItems(
-        'high_security_hospital',
+        ['hospital', 'high_security_hospital'],
         'to_location_hospital'
       )
     )

--- a/app/move/controllers/create/move-details.test.js
+++ b/app/move/controllers/create/move-details.test.js
@@ -24,50 +24,63 @@ describe('Move controllers', function () {
         expect(BaseController.prototype.middlewareSetup).to.have.been.calledOnce
       })
 
+      it('should call correct number of middleware', function () {
+        expect(controller.use.callCount).to.equal(7)
+      })
+
       it('should call setMoveType middleware', function () {
         expect(controller.use.firstCall).to.have.been.calledWith(
           controller.setMoveTypes
         )
       })
 
-      it('should call setLocationItems middleware', function () {
-        expect(controller.use.secondCall).to.have.been.calledWith(
-          commonMiddleware.setLocationItems()
-        )
-      })
-
-      it('should call setLocationItems middleware', function () {
-        expect(controller.use.thirdCall).to.have.been.calledWith(
-          commonMiddleware.setLocationItems()
-        )
-      })
-
-      it('should call setLocationItems middleware', function () {
-        expect(controller.use.getCall(3)).to.have.been.calledWith(
-          commonMiddleware.setLocationItems()
-        )
-      })
-
-      it('should call setLocationItems middleware', function () {
-        expect(controller.use.getCall(4)).to.have.been.calledWith(
-          commonMiddleware.setLocationItems()
-        )
-      })
-
-      it('should call setLocationItems middleware', function () {
-        expect(controller.use.getCall(5)).to.have.been.calledWith(
-          commonMiddleware.setLocationItems()
-        )
-      })
-
-      it('should call setLocationItems middleware', function () {
-        expect(controller.use.getCall(6)).to.have.been.calledWith(
-          commonMiddleware.setLocationItems()
-        )
-      })
-
       it('should call correct number of middleware', function () {
-        expect(controller.use.callCount).to.equal(7)
+        expect(commonMiddleware.setLocationItems.callCount).to.equal(6)
+      })
+
+      it('should call setLocationItems middleware to set court locations', function () {
+        expect(
+          commonMiddleware.setLocationItems.getCall(0)
+        ).to.have.been.calledWith('court', 'to_location_court_appearance')
+      })
+
+      it('should call setLocationItems middleware to set prison locations', function () {
+        expect(
+          commonMiddleware.setLocationItems.getCall(1)
+        ).to.have.been.calledWith('prison', 'to_location_prison_transfer')
+      })
+
+      it('should call setLocationItems middleware to set police locations', function () {
+        expect(
+          commonMiddleware.setLocationItems.getCall(2)
+        ).to.have.been.calledWith('police', 'to_location_police_transfer')
+      })
+
+      it('should call setLocationItems middleware to set hospital locations', function () {
+        expect(
+          commonMiddleware.setLocationItems.getCall(3)
+        ).to.have.been.calledWith(
+          'high_security_hospital',
+          'to_location_hospital'
+        )
+      })
+
+      it('should call setLocationItems middleware to set SCH locations', function () {
+        expect(
+          commonMiddleware.setLocationItems.getCall(4)
+        ).to.have.been.calledWith(
+          'secure_childrens_home',
+          'to_location_secure_childrens_home'
+        )
+      })
+
+      it('should call setLocationItems middleware to set STC locations', function () {
+        expect(
+          commonMiddleware.setLocationItems.getCall(5)
+        ).to.have.been.calledWith(
+          'secure_training_centre',
+          'to_location_secure_training_centre'
+        )
       })
     })
 

--- a/app/move/controllers/create/move-details.test.js
+++ b/app/move/controllers/create/move-details.test.js
@@ -60,7 +60,7 @@ describe('Move controllers', function () {
         expect(
           commonMiddleware.setLocationItems.getCall(3)
         ).to.have.been.calledWith(
-          'high_security_hospital',
+          ['hospital', 'high_security_hospital'],
           'to_location_hospital'
         )
       })

--- a/common/middleware/set-location-items.js
+++ b/common/middleware/set-location-items.js
@@ -13,14 +13,35 @@ function setLocationItems(locationType, fieldName) {
     }
 
     try {
-      const locations = await referenceDataService.getLocationsByType(
-        locationType
+      if (!Array.isArray(locationType)) {
+        locationType = [locationType]
+      }
+
+      const locationString = locationType[0]
+
+      const locations = (
+        await Promise.all(
+          locationType.map(x => referenceDataService.getLocationsByType(x))
+        )
       )
+        .reduce((acc, val) => acc.concat(val))
+        .sort((a, b) => {
+          if (a.title < b.title) {
+            return -1
+          }
+
+          if (a.title > b.title) {
+            return 1
+          }
+
+          return 0
+        })
+
       const items = fieldHelpers.insertInitialOption(
         locations
           .filter(referenceDataHelpers.filterDisabled())
           .map(fieldHelpers.mapReferenceDataToOption),
-        locationType
+        locationString
       )
 
       set(req, `form.options.fields.${fieldName}.items`, items)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

`setLocationItems` can now be passed an array of location types which will be combined and sorted alphabetically.

Hospital location items are now made up of locations matching both `high_security_hospital` and `hospital`

### Why did it change

Users could not select a non high security hospital

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

- [P4-2408 - Show both NOMIS "High Security Hospitals" & "Hospital" location types for type ahead on Hospital moves](https://dsdmoj.atlassian.net/browse/P4-2408)

## Screenshots
<!--- (Optional) Include screenshots if changes update interfaces or components -->
<!--- Delete/copy as appropriate --->

As before. Just adds extra items to hospital dropdown

## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed

### Other considerations

- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
