### PR TITLE
Use unique form wizard for individual resources

### DIFF
--- a/app/allocation/config/cancel.config.js
+++ b/app/allocation/config/cancel.config.js
@@ -1,0 +1,12 @@
+const FormWizardController = require('../../../common/controllers/form-wizard')
+
+module.exports = function config(id) {
+  return {
+    controller: FormWizardController,
+    name: `cancel-allocation-${id}`,
+    templatePath: 'allocation/views/',
+    template: '../../../form-wizard',
+    journeyName: `cancel-allocation-${id}`,
+    journeyPageTitle: 'actions::cancel_allocation',
+  }
+}

--- a/app/allocation/config/create.config.js
+++ b/app/allocation/config/create.config.js
@@ -1,0 +1,10 @@
+const FormWizardController = require('../../../common/controllers/form-wizard')
+
+module.exports = {
+  controller: FormWizardController,
+  name: 'create-an-allocation',
+  templatePath: 'allocation/views/create/',
+  template: '../../../form-wizard',
+  journeyName: 'create-an-allocation',
+  journeyPageTitle: 'actions::create_allocation',
+}

--- a/app/allocation/config/index.js
+++ b/app/allocation/config/index.js
@@ -1,0 +1,9 @@
+const cancelConfig = require('./cancel.config')
+const createConfig = require('./create.config')
+const removeConfig = require('./remove.config')
+
+module.exports = {
+  cancelConfig,
+  createConfig,
+  removeConfig,
+}

--- a/app/allocation/config/remove.config.js
+++ b/app/allocation/config/remove.config.js
@@ -1,0 +1,12 @@
+const FormWizardController = require('../../../common/controllers/form-wizard')
+
+module.exports = function config(id) {
+  return {
+    controller: FormWizardController,
+    name: `remove-move-from-allocation-${id}`,
+    templatePath: 'allocation/views/cancel/',
+    template: '../../../form-wizard',
+    journeyName: `remove-move-from-allocation-${id}`,
+    journeyPageTitle: 'actions::cancel_move',
+  }
+}

--- a/app/allocation/index.js
+++ b/app/allocation/index.js
@@ -1,46 +1,14 @@
 const router = require('express').Router()
-const wizard = require('hmpo-form-wizard')
 
-const FormWizardController = require('../../common/controllers/form-wizard')
 const { protectRoute } = require('../../common/middleware/permissions')
+const wizard = require('../../common/middleware/unique-form-wizard')
 const { setMove } = require('../move/middleware')
 
+const { cancelConfig, removeMoveConfig, createConfig } = require('./config')
 const { createControllers, viewAllocation } = require('./controllers')
 const { cancelFields, createFields } = require('./fields')
 const { setAllocation } = require('./middleware')
 const { cancelSteps, removeMoveSteps, createSteps } = require('./steps')
-
-const wizardConfig = {
-  controller: FormWizardController,
-  template: 'form-wizard',
-}
-const createConfig = {
-  ...wizardConfig,
-  controller: FormWizardController,
-  name: 'create-an-allocation',
-  templatePath: 'allocation/views/create/',
-  template: '../../../form-wizard',
-  journeyName: 'create-an-allocation',
-  journeyPageTitle: 'actions::create_allocation',
-}
-const cancelConfig = {
-  ...wizardConfig,
-  controller: FormWizardController,
-  name: 'cancel-an-allocation',
-  templatePath: 'allocation/views/',
-  template: '../../../form-wizard',
-  journeyName: 'cancel-an-allocation',
-  journeyPageTitle: 'actions::cancel_allocation',
-}
-const removeMoveConfig = {
-  ...wizardConfig,
-  controller: FormWizardController,
-  name: 'remove-a-move-from-an-allocation',
-  templatePath: 'allocation/views/cancel/',
-  template: '../../../form-wizard',
-  journeyName: 'remove-a-move-from-an-allocation',
-  journeyPageTitle: 'actions::cancel_move',
-}
 
 router.param('allocationId', setAllocation)
 router.param('moveId', setMove)
@@ -60,13 +28,13 @@ router.get(
 router.use(
   '/:allocationId/:moveId/remove',
   protectRoute('allocation:cancel'),
-  wizard(removeMoveSteps, {}, removeMoveConfig)
+  wizard(removeMoveSteps, {}, removeMoveConfig, 'params.allocationId')
 )
 
 router.use(
   '/:allocationId/cancel',
   protectRoute('allocation:cancel'),
-  wizard(cancelSteps, cancelFields, cancelConfig)
+  wizard(cancelSteps, cancelFields, cancelConfig, 'params.allocationId')
 )
 
 router.get('/:allocationId', protectRoute('allocations:view'), viewAllocation)

--- a/app/move/config/assign.config.js
+++ b/app/move/config/assign.config.js
@@ -1,0 +1,12 @@
+const AssignBaseController = require('../controllers/assign/base')
+
+module.exports = function config(id) {
+  return {
+    controller: AssignBaseController,
+    journeyName: `assign-person-${id}`,
+    journeyPageTitle: 'allocation::person:assign',
+    name: `assign-person-${id}`,
+    template: '../../../form-wizard',
+    templatePath: 'move/views/create/',
+  }
+}

--- a/app/move/config/cancel.config.js
+++ b/app/move/config/cancel.config.js
@@ -1,0 +1,10 @@
+const FormWizardController = require('../../../common/controllers/form-wizard')
+
+module.exports = function config(id) {
+  return {
+    controller: FormWizardController,
+    journeyName: `cancel-move-${id}`,
+    name: `cancel-move-${id}`,
+    template: 'form-wizard',
+  }
+}

--- a/app/move/config/create.config.js
+++ b/app/move/config/create.config.js
@@ -1,0 +1,10 @@
+const CreateBaseController = require('../controllers/create/base')
+
+module.exports = {
+  controller: CreateBaseController,
+  journeyName: 'create-a-move',
+  journeyPageTitle: 'actions::create_move',
+  name: 'create-a-move',
+  template: '../../../form-wizard',
+  templatePath: 'move/views/create/',
+}

--- a/app/move/config/index.js
+++ b/app/move/config/index.js
@@ -1,0 +1,15 @@
+const assignConfig = require('./assign.config')
+const cancelConfig = require('./cancel.config')
+const createConfig = require('./create.config')
+const reviewConfig = require('./review.config')
+const unassignConfig = require('./unassign.config')
+const updateConfig = require('./update.config')
+
+module.exports = {
+  assignConfig,
+  cancelConfig,
+  createConfig,
+  reviewConfig,
+  unassignConfig,
+  updateConfig,
+}

--- a/app/move/config/review.config.js
+++ b/app/move/config/review.config.js
@@ -1,0 +1,10 @@
+const FormWizardController = require('../../../common/controllers/form-wizard')
+
+module.exports = function config(id) {
+  return {
+    controller: FormWizardController,
+    template: 'form-wizard',
+    name: `review-move-${id}`,
+    journeyName: `review-move-${id}`,
+  }
+}

--- a/app/move/config/unassign.config.js
+++ b/app/move/config/unassign.config.js
@@ -1,0 +1,12 @@
+const FormWizardController = require('../../../common/controllers/form-wizard')
+
+module.exports = function config(id) {
+  return {
+    controller: FormWizardController,
+    journeyName: `unassign-person-${id}`,
+    journeyPageTitle: 'actions::cancel_allocation',
+    name: `unassign-person-${id}`,
+    template: '../../../form-wizard',
+    templatePath: 'move/views/',
+  }
+}

--- a/app/move/config/update.config.js
+++ b/app/move/config/update.config.js
@@ -1,0 +1,10 @@
+const UpdateBaseController = require('../controllers/update/base')
+
+module.exports = function config(id) {
+  return {
+    controller: UpdateBaseController,
+    templatePath: 'move/views/create/',
+    template: '../../../form-wizard',
+    journeyPageTitle: 'actions::update_move',
+  }
+}

--- a/app/move/index.js
+++ b/app/move/index.js
@@ -1,23 +1,23 @@
 // NPM dependencies
 const express = require('express')
 const router = express.Router()
-const moveRouter = express.Router()
-const wizard = require('hmpo-form-wizard')
+const moveRouter = express.Router({ mergeParams: true })
 
 // Local dependencies
-const FormWizardController = require('../../common/controllers/form-wizard')
 const { uuidRegex } = require('../../common/helpers/url')
 const { protectRoute } = require('../../common/middleware/permissions')
+const wizard = require('../../common/middleware/unique-form-wizard')
 const personEscortRecordApp = require('../person-escort-record')
 
 const {
-  assign,
-  confirmation,
-  create,
-  update,
-  timeline,
-  view,
-} = require('./controllers')
+  assignConfig,
+  cancelConfig,
+  createConfig,
+  reviewConfig,
+  unassignConfig,
+  updateConfig,
+} = require('./config')
+const { confirmation, timeline, view } = require('./controllers')
 const {
   assignFields,
   cancelFields,
@@ -39,55 +39,6 @@ const {
   unassign: unassignSteps,
   update: updateSteps,
 } = require('./steps')
-
-const wizardConfig = {
-  controller: FormWizardController,
-  template: 'form-wizard',
-}
-const createConfig = {
-  ...wizardConfig,
-  controller: create.Base,
-  name: 'create-a-move',
-  templatePath: 'move/views/create/',
-  template: '../../../form-wizard',
-  journeyName: 'create-a-move',
-  journeyPageTitle: 'actions::create_move',
-}
-const updateConfig = {
-  ...wizardConfig,
-  controller: update.Base,
-  templatePath: 'move/views/create/',
-  template: '../../../form-wizard',
-  journeyPageTitle: 'actions::update_move',
-}
-const cancelConfig = {
-  ...wizardConfig,
-  name: 'cancel-move',
-  journeyName: 'cancel-move',
-}
-const reviewConfig = {
-  ...wizardConfig,
-  name: 'review-move',
-  journeyName: 'review-move',
-}
-const assignConfig = {
-  ...wizardConfig,
-  controller: assign.Base,
-  name: 'allocation:person:assign',
-  templatePath: 'move/views/create/',
-  template: '../../../form-wizard',
-  journeyName: 'allocation:person:assign',
-  journeyPageTitle: 'allocation::person:assign',
-}
-const unassignConfig = {
-  ...wizardConfig,
-  controller: FormWizardController,
-  name: 'unassign-an-allocation',
-  templatePath: 'move/views/',
-  template: '../../../form-wizard',
-  journeyName: 'unassign-an-allocation',
-  journeyPageTitle: 'actions::cancel_allocation',
-}
 
 // Define param middleware
 router.param('moveId', setMove)
@@ -121,24 +72,27 @@ moveRouter.use(personEscortRecordApp.mountpath, personEscortRecordApp.router)
 moveRouter.use(
   '/cancel',
   protectRoute(['move:cancel', 'move:cancel:proposed']),
-  wizard(cancelSteps, cancelFields, cancelConfig)
+  wizard(cancelSteps, cancelFields, cancelConfig, 'params.moveId')
 )
-moveRouter.use('/review', wizard(reviewSteps, reviewFields, reviewConfig))
+moveRouter.use(
+  '/review',
+  wizard(reviewSteps, reviewFields, reviewConfig, 'params.moveId')
+)
 moveRouter.use(
   '/assign',
   protectRoute('allocation:person:assign'),
-  wizard(assignSteps, assignFields, assignConfig)
+  wizard(assignSteps, assignFields, assignConfig, 'params.moveId')
 )
 moveRouter.use(
   '/unassign',
   protectRoute('allocation:person:assign'),
-  wizard(unassignSteps, cancelFields, unassignConfig)
+  wizard(unassignSteps, cancelFields, unassignConfig, 'params.moveId')
 )
 
 updateSteps.forEach(updateJourney => {
   const { key, steps } = updateJourney
   const updateStepConfig = {
-    ...updateConfig,
+    ...updateConfig(),
     name: `update-move-${key}`,
     journeyName: `update-move-${key}`,
   }

--- a/app/person-escort-record/app/confirm/config.js
+++ b/app/person-escort-record/app/confirm/config.js
@@ -1,6 +1,8 @@
-module.exports = {
-  hideSidebar: true,
-  name: 'confirm-person-escort-record',
-  journeyName: 'confirm-person-escort-record',
-  journeyPageTitle: 'person-escort-record::heading',
+module.exports = function config(id) {
+  return {
+    hideSidebar: true,
+    name: `confirm-person-escort-record-${id}`,
+    journeyName: `confirm-person-escort-record-${id}`,
+    journeyPageTitle: 'person-escort-record::heading',
+  }
 }

--- a/app/person-escort-record/app/confirm/index.js
+++ b/app/person-escort-record/app/confirm/index.js
@@ -1,8 +1,8 @@
 // NPM dependencies
 const router = require('express').Router()
-const wizard = require('hmpo-form-wizard')
 
 const { protectRoute } = require('../../../../common/middleware/permissions')
+const wizard = require('../../../../common/middleware/unique-form-wizard')
 
 const config = require('./config')
 const fields = require('./fields')
@@ -12,7 +12,7 @@ const steps = require('./steps')
 router.use(protectRoute('person_escort_record:confirm'))
 
 // Define routes
-router.use(wizard(steps, fields, config))
+router.use(wizard(steps, fields, config, 'assessment.id'))
 
 // Export
 module.exports = {

--- a/app/person-escort-record/app/new/index.js
+++ b/app/person-escort-record/app/new/index.js
@@ -1,8 +1,8 @@
 // NPM dependencies
 const router = require('express').Router()
-const wizard = require('hmpo-form-wizard')
 
 const { protectRoute } = require('../../../../common/middleware/permissions')
+const wizard = require('../../../../common/middleware/unique-form-wizard')
 
 const config = require('./config')
 const steps = require('./steps')

--- a/common/lib/framework-form-wizard.js
+++ b/common/lib/framework-form-wizard.js
@@ -1,8 +1,8 @@
-const wizard = require('hmpo-form-wizard')
 const { startCase } = require('lodash')
 
 const FrameworkSectionController = require('../controllers/framework/framework-section')
 const FrameworkStepController = require('../controllers/framework/framework-step')
+const wizard = require('../middleware/unique-form-wizard')
 
 function defineFormWizard(req, res, next) {
   const { key, steps } = req.frameworkSection

--- a/common/lib/framework-form-wizard.test.js
+++ b/common/lib/framework-form-wizard.test.js
@@ -7,7 +7,7 @@ const wizardReqStub = sinon.stub()
 const wizardStub = sinon.stub().returns(wizardReqStub)
 
 const router = proxyquire('./framework-form-wizard', {
-  'hmpo-form-wizard': wizardStub,
+  '../middleware/unique-form-wizard': wizardStub,
 })
 
 const mockFramework = {

--- a/common/middleware/index.js
+++ b/common/middleware/index.js
@@ -1,5 +1,7 @@
 const setLocationItems = require('./set-location-items')
+const uniqueFormWizard = require('./unique-form-wizard')
 
 module.exports = {
   setLocationItems,
+  uniqueFormWizard,
 }

--- a/common/middleware/unique-form-wizard.js
+++ b/common/middleware/unique-form-wizard.js
@@ -1,0 +1,15 @@
+const wizard = require('hmpo-form-wizard')
+const { get } = require('lodash')
+
+module.exports = function uniqueFormWizard(steps, fields, config, uniqueKey) {
+  return (req, res, next) => {
+    if (typeof config !== 'function') {
+      return wizard(steps, fields, config)(req, res, next)
+    }
+
+    const uniqueVal = get(req, uniqueKey)
+    const uniqueConfig = uniqueVal ? config(uniqueVal) : config()
+
+    return wizard(steps, fields, uniqueConfig)(req, res, next)
+  }
+}

--- a/common/middleware/unique-form-wizard.test.js
+++ b/common/middleware/unique-form-wizard.test.js
@@ -1,0 +1,148 @@
+const proxyquire = require('proxyquire')
+
+const mwStub = sinon.stub().callsFake(() => true)
+const hmpoFormWizardStub = sinon.stub().returns(mwStub)
+const wizard = proxyquire('./unique-form-wizard', {
+  'hmpo-form-wizard': hmpoFormWizardStub,
+})
+
+const mockSteps = {
+  '/step-one': {},
+  '/step-two': {},
+}
+const mockFields = {
+  'field-one': {
+    name: 'one',
+  },
+  'field-two': {
+    name: 'two',
+  },
+}
+
+describe('#uniqueFormWizard', function () {
+  let req, res, nextSpy
+
+  beforeEach(function () {
+    hmpoFormWizardStub.resetHistory()
+    mwStub.resetHistory()
+    nextSpy = sinon.spy()
+    req = {}
+    res = {}
+  })
+
+  context('without unique key', function () {
+    beforeEach(function () {
+      wizard(mockSteps, mockFields, { foo: 'bar' })(req, res, nextSpy)
+    })
+
+    it('should call wizard correctly', function () {
+      expect(hmpoFormWizardStub).to.be.calledOnceWithExactly(
+        mockSteps,
+        mockFields,
+        { foo: 'bar' }
+      )
+    })
+
+    it('should wizard with middleware args', function () {
+      expect(mwStub).to.be.calledOnceWithExactly(req, res, nextSpy)
+    })
+  })
+
+  context('with unique key', function () {
+    let mockConfig
+
+    beforeEach(function () {
+      req = {
+        params: {
+          id: '12345',
+        },
+      }
+      mockConfig = sinon.stub().callsFake((arg = '') => {
+        return { foo: 'bar', id: arg }
+      })
+    })
+
+    context('with key that exists', function () {
+      beforeEach(function () {
+        wizard(
+          mockSteps,
+          mockFields,
+          mockConfig,
+          'params.id'
+        )(req, res, nextSpy)
+      })
+
+      it('should call wizard correctly', function () {
+        expect(hmpoFormWizardStub).to.be.calledOnceWithExactly(
+          mockSteps,
+          mockFields,
+          {
+            foo: 'bar',
+            id: '12345',
+          }
+        )
+      })
+
+      it('should wizard with middleware args', function () {
+        expect(mwStub).to.be.calledOnceWithExactly(req, res, nextSpy)
+      })
+
+      it('should pass unique val to config', function () {
+        expect(mockConfig).to.be.calledOnceWithExactly('12345')
+      })
+    })
+
+    context('with key that does not exist', function () {
+      beforeEach(function () {
+        wizard(
+          mockSteps,
+          mockFields,
+          mockConfig,
+          'path.does.not.exist'
+        )(req, res, nextSpy)
+      })
+
+      it('should call wizard correctly', function () {
+        expect(hmpoFormWizardStub).to.be.calledOnceWithExactly(
+          mockSteps,
+          mockFields,
+          {
+            foo: 'bar',
+            id: '',
+          }
+        )
+      })
+
+      it('should wizard with middleware args', function () {
+        expect(mwStub).to.be.calledOnceWithExactly(req, res, nextSpy)
+      })
+
+      it('should not pass unique val to config', function () {
+        expect(mockConfig).to.be.calledOnceWithExactly()
+      })
+    })
+
+    context('when config is an object', function () {
+      beforeEach(function () {
+        wizard(
+          mockSteps,
+          mockFields,
+          { foo: 'bar' },
+          'params.id'
+        )(req, res, nextSpy)
+      })
+
+      it('should call wizard correctly', function () {
+        expect(hmpoFormWizardStub).to.be.calledOnceWithExactly(
+          mockSteps,
+          mockFields,
+          { foo: 'bar' }
+        )
+      })
+
+      it('should wizard with middleware args', function () {
+        expect(mwStub).to.be.calledOnceWithExactly(req, res, nextSpy)
+      })
+    })
+  })
+})


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

This change creates a wizard using the UUID of the resource in cases
where it is intended to be individual.

### Why did it change

Currently form wizards used as part of a particular resource share
the same journey and wizard names.

This can lead to unintended side-effects when these wizards are accessed
through different URLs or opened in new windows or tabs.

For example, if a wizard is submitted with errors in one tab and opened
up in another those errors will be persisted, and in some cases the
redirect will occur on the original resource instead of the intended one.

## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [x] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed

### Other considerations

Commit messages with a `fix` or `feat` type are automatically used to generate the [changelog](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/CHANGELOG.md) and
[GitHub release notes](https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/releases) during the release task. Please make sure they will read well on their own in a
summary of changes and that the commit body gives a more detailed description of those changes if necessary.

- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
- [x] Update [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md) with any new instructions or tasks
