### PR TITLE
fix: Apply transformer to duplicate resources correctly

### DIFF
--- a/common/lib/api-client/transformers/transform-resource.js
+++ b/common/lib/api-client/transformers/transform-resource.js
@@ -2,17 +2,31 @@ const { cloneDeep } = require('lodash')
 
 module.exports = function transformResource(transformer) {
   return function deserializer(item, included) {
+    if (!transformer) {
+      return this.deserialize.resource.call(this, item, included)
+    }
+
     const _this = cloneDeep(this)
     const modelName = this.pluralize.singular(item.type)
 
+    // Ensure we remove this deserializer to avoid infinite loop
     delete _this.models[modelName].options.deserializer
 
-    const deserialized = _this.deserialize.resource.call(_this, item, included)
+    // call devour deserializer
+    const deserializedData = _this.deserialize.resource.call(
+      _this,
+      item,
+      included
+    )
 
-    if (!transformer) {
-      return deserialized
-    }
+    const transformedData = transformer(deserializedData)
 
-    return transformer(deserialized)
+    // we need to clear the cache to avoid the original resource being loaded
+    // the cache is a collection and doesn't allow an item to be updated
+    this.deserialize.cache.clear()
+    // set the new transformed data to the cache for future deserializations
+    this.deserialize.cache.set(item.type, item.id, transformedData)
+
+    return transformedData
   }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

This change clears the cache when an item is transformed and sets the
new values so that any future occurrences return the correct structure.

This is slightly less efficient that being able to udpate a cached
resource but [devour doesn't currently support](https://github.com/twg/devour/blob/71e158307d462018be0c43164d285e9a959d0983/src/middleware/json-api/_deserialize.js#L15-L34) a method to do this.

### Why did it change

In some instances, if the same resource is return multiple times within
a collection, for example a person in a list of moves, the transformer
was only being called once because devour would cache that resource within
its deserializer.

This meant that if the same person was being moved on the same day they
wouldn't have the fullname property that parts of the app expect.

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

- [P4-XXXX]()

## Screenshots
<!--- (Optional) Include screenshots if changes update interfaces or components -->
<!--- Delete/copy as appropriate --->

| Before | After |
| ------ | ----- |
| <kbd><img src="https://user-images.githubusercontent.com/3327997/100093018-dae99500-2e4e-11eb-9a6d-f50d456b7dd5.png"></kbd> | <kbd><img src="https://user-images.githubusercontent.com/3327997/100092929-bf7e8a00-2e4e-11eb-842b-49630359d027.png"></kbd> |

## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [x] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed

### Other considerations

Commit messages with a `fix` or `feat` type are automatically used to generate the [changelog](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/CHANGELOG.md) and
[GitHub release notes](https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/releases) during the release task. Please make sure they will read well on their own in a
summary of changes and that the commit body gives a more detailed description of those changes if necessary.

- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
- [x] Update [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md) with any new instructions or tasks
