### PR TITLE
chore: Don't set development permissions if they already exist

### DIFF
--- a/common/middleware/development.js
+++ b/common/middleware/development.js
@@ -15,8 +15,9 @@ function bypassAuth(bypass) {
 
 function setUserPermissions(permissions) {
   return (req, res, next) => {
-    if (permissions) {
-      req.session.user = req.session.user || {}
+    req.session.user = req.session.user || {}
+
+    if (permissions && !req.session.user.permissions) {
       req.session.user.permissions = permissions.split(',')
     }
 

--- a/common/middleware/development.test.js
+++ b/common/middleware/development.test.js
@@ -59,11 +59,7 @@ describe('Development specific middleware', function () {
 
     beforeEach(function () {
       req = {
-        session: {
-          user: {
-            permissions: [],
-          },
-        },
+        session: {},
       }
     })
 
@@ -90,8 +86,8 @@ describe('Development specific middleware', function () {
         middleware.setUserPermissions()(req, {}, nextSpy)
       })
 
-      it('should not update permissions', function () {
-        expect(req.session.user.permissions).to.deep.equal([])
+      it('should not set permissions', function () {
+        expect(req.session.user.permissions).to.be.undefined
       })
 
       it('should call next', function () {
@@ -115,6 +111,23 @@ describe('Development specific middleware', function () {
           'two',
           'three',
         ])
+      })
+
+      it('should call next', function () {
+        expect(nextSpy).to.be.calledOnceWithExactly()
+      })
+    })
+
+    context('when permissions exist', function () {
+      beforeEach(function () {
+        req.session.user = {
+          permissions: ['foo', 'bar'],
+        }
+        middleware.setUserPermissions('one,two,three')(req, {}, nextSpy)
+      })
+
+      it('should not update permissions', function () {
+        expect(req.session.user.permissions).to.deep.equal(['foo', 'bar'])
       })
 
       it('should call next', function () {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Only set development permissions if they don't exist.

### Why did it change

This prevents the permissions being overridden on every request.

It also means that they can be updated via another method like session
injection and won't be overridden.