### PR TITLE
fix: Ensure custom deserializer is removed before calling parent

### DIFF
--- a/common/lib/api-client/transformers/transform-resource.js
+++ b/common/lib/api-client/transformers/transform-resource.js
@@ -2,10 +2,6 @@ const { cloneDeep } = require('lodash')
 
 module.exports = function transformResource(transformer) {
   return function deserializer(item, included) {
-    if (!transformer) {
-      return this.deserialize.resource.call(this, item, included)
-    }
-
     const _this = cloneDeep(this)
     const modelName = this.pluralize.singular(item.type)
 
@@ -18,6 +14,10 @@ module.exports = function transformResource(transformer) {
       item,
       included
     )
+
+    if (!transformer) {
+      return deserializedData
+    }
 
     const transformedData = transformer(deserializedData)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

If the custom deserializer isn't removed this method will result in
an infinite loop as it will keep calling itself.

### Why did it change

We need to ensure this is removed, regardless of whether a transform
method is present or not.

## Checklists

### Testing

#### Automated testing

- [ ] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed
