### PR TITLE
chore: Add groundwork for req context

### DIFF
--- a/common/lib/api-client/index.js
+++ b/common/lib/api-client/index.js
@@ -16,17 +16,13 @@ const {
 } = require('./middleware')
 const models = require('./models')
 
-let instance
-
-module.exports = function () {
-  if (instance) {
-    return instance
-  }
-
-  instance = new JsonApi({
+module.exports = function (req) {
+  const instance = new JsonApi({
     apiUrl: API.BASE_URL,
     logger: false,
   })
+
+  instance._originalReq = req
 
   instance.replaceMiddleware('errors', errors)
   instance.replaceMiddleware('POST', post(FILE_UPLOADS.MAX_FILE_SIZE))

--- a/common/lib/api-client/index.test.js
+++ b/common/lib/api-client/index.test.js
@@ -1,3 +1,4 @@
+const { expect } = require('chai')
 const proxyquire = require('proxyquire').noCallThru()
 
 const mockConfig = {
@@ -86,12 +87,22 @@ describe('Back-end API client', function () {
       })
     })
 
-    context('on first call', function () {
+    context('on instantiation', function () {
       let client
+
+      context('with no request object', function () {
+        beforeEach(function () {
+          client = jsonApi()
+        })
+
+        it('should not set the original request on the instance', function () {
+          expect(client._originalReq).to.be.undefined
+        })
+      })
 
       context('with auth client ID and secret', function () {
         beforeEach(function () {
-          client = jsonApi()
+          client = jsonApi({ foo: 'bar' })
         })
 
         it('should create a new client', function () {
@@ -103,7 +114,10 @@ describe('Back-end API client', function () {
 
         it('should return an client API', function () {
           expect(client).to.be.a('object')
-          expect(client).to.deep.equal(new JsonApiStub())
+        })
+
+        it('should set orginal request on client', function () {
+          expect(client._originalReq).to.deep.equal({ foo: 'bar' })
         })
 
         describe('middleware', function () {
@@ -175,18 +189,6 @@ describe('Back-end API client', function () {
             expect(
               JsonApiStub.prototype.insertMiddlewareBefore.callCount
             ).to.equal(6)
-          })
-
-          it('should insert process response middleware', function () {
-            expect(
-              JsonApiStub.prototype.insertMiddlewareAfter.getCall(0)
-            ).to.be.calledWithExactly('axios-request', processResponseStub)
-          })
-
-          it('should call insertMiddlewareAfter correct number of times', function () {
-            expect(
-              JsonApiStub.prototype.insertMiddlewareAfter.callCount
-            ).to.equal(1)
           })
 
           it('should call replaceMiddleware correct number of times', function () {
@@ -306,28 +308,36 @@ describe('Back-end API client', function () {
         thirdInstance = jsonApi()
       })
 
-      it('should only create one new client', function () {
-        expect(JsonApiStub.prototype.init).to.be.calledOnce
+      it('should return a new client each time', function () {
+        expect(JsonApiStub.prototype.init).to.be.calledThrice
       })
 
       describe('first instance', function () {
         it('should return an client API', function () {
           expect(firstInstance).to.be.a('object')
-          expect(firstInstance).to.deep.equal(new JsonApiStub())
-        })
-      })
-
-      describe('third instance', function () {
-        it('should return an client API', function () {
-          expect(thirdInstance).to.be.a('object')
-          expect(thirdInstance).to.deep.equal(new JsonApiStub())
+          expect(firstInstance.constructor.name).to.equal('JsonApiStub')
         })
       })
 
       describe('second instance', function () {
         it('should return an client API', function () {
           expect(secondInstance).to.be.a('object')
-          expect(secondInstance).to.deep.equal(new JsonApiStub())
+          expect(secondInstance.constructor.name).to.equal('JsonApiStub')
+        })
+      })
+
+      describe('third instance', function () {
+        it('should return an client API', function () {
+          expect(thirdInstance).to.be.a('object')
+          expect(thirdInstance.constructor.name).to.equal('JsonApiStub')
+        })
+      })
+
+      describe('instances', function () {
+        it('should not be the same', function () {
+          expect(firstInstance).to.not.equal(secondInstance)
+          expect(firstInstance).to.not.equal(thirdInstance)
+          expect(secondInstance).to.not.equal(thirdInstance)
         })
       })
     })

--- a/common/lib/api-client/middleware/request-headers.js
+++ b/common/lib/api-client/middleware/request-headers.js
@@ -7,11 +7,17 @@ module.exports = {
       return payload
     }
 
-    const { req } = payload
+    const { jsonApi, req } = payload
+    const { _originalReq } = jsonApi
+    const requestHeadersOptions = {
+      ...(_originalReq && {
+        req: _originalReq,
+      }),
+    }
 
     req.headers = {
       ...req.headers,
-      ...getRequestHeaders(),
+      ...getRequestHeaders(requestHeadersOptions),
     }
     return payload
   },

--- a/common/lib/api-client/middleware/request-headers.test.js
+++ b/common/lib/api-client/middleware/request-headers.test.js
@@ -13,13 +13,14 @@ describe('API Client', function () {
     describe('#request-headers', function () {
       context('when payload includes a response', function () {
         it('should return payload as is', function () {
-          const payload = { req: {}, res: {} }
+          const payload = { req: {}, res: {}, jsonApi: {} }
           expect(middleware.req(payload)).to.deep.equal({ ...payload })
         })
       })
 
       context('when payload contains a request', function () {
         let request
+        const originalRequest = { foo: 'bar' }
 
         beforeEach(function () {
           request = {
@@ -27,11 +28,16 @@ describe('API Client', function () {
               Accept: 'Something',
             },
           }
-          middleware.req({ req: request })
+          middleware.req({
+            req: request,
+            jsonApi: { _originalReq: originalRequest },
+          })
         })
 
         it('should get the request headers', function () {
-          expect(getRequestHeadersStub).to.be.calledOnceWithExactly()
+          expect(getRequestHeadersStub).to.be.calledOnceWithExactly({
+            req: originalRequest,
+          })
         })
 
         it('should add the default request headers', function () {

--- a/common/lib/api-client/request-headers.js
+++ b/common/lib/api-client/request-headers.js
@@ -5,11 +5,14 @@ const {
   APP_VERSION,
 } = require('../../../config')
 
-module.exports = (format = 'application/vnd.api+json') => {
+module.exports = ({ req = {}, format = 'application/vnd.api+json' } = {}) => {
+  const idempotencyKey = uuid.v4()
+  const transactionId = req.transactionId || `auto-${idempotencyKey}`
   return {
     'User-Agent': `hmpps-book-secure-move-frontend/${APP_VERSION}`,
     Accept: `${format}; version=${VERSION}`,
     'Accept-Encoding': 'gzip',
-    'Idempotency-Key': uuid.v4(),
+    'Idempotency-Key': idempotencyKey,
+    'X-Transaction-Id': transactionId,
   }
 }

--- a/common/lib/api-client/request-headers.test.js
+++ b/common/lib/api-client/request-headers.test.js
@@ -43,6 +43,10 @@ describe('API Client', function () {
         it('should return the `Idempotency-Key` header', function () {
           expect(headers['Idempotency-Key']).to.equal('#uuid')
         })
+
+        it('should return the `X-Transaction-Id` header', function () {
+          expect(headers['X-Transaction-Id']).to.equal('auto-#uuid')
+        })
       })
     })
 
@@ -50,7 +54,7 @@ describe('API Client', function () {
       let headers
 
       beforeEach(function () {
-        headers = getRequestHeaders('format/foo')
+        headers = getRequestHeaders({ format: 'format/foo' })
       })
 
       it('should return `Accept` header with specified format and the api version', function () {
@@ -58,19 +62,25 @@ describe('API Client', function () {
           `format/foo; version=${config.API.VERSION}`
         )
       })
+    })
 
-      it('should return the `User-Agent` header', function () {
-        expect(headers['User-Agent']).to.equal(
-          'hmpps-book-secure-move-frontend/chuck-d'
-        )
-      })
+    context('when called with a request', function () {
+      let headers
 
-      it('should return the `Accept-Encoding` header', function () {
-        expect(headers['Accept-Encoding']).to.equal('gzip')
+      beforeEach(function () {
+        headers = getRequestHeaders({
+          req: {
+            transactionId: '#transactionId',
+          },
+        })
       })
 
       it('should return the `Idempotency-Key` header', function () {
         expect(headers['Idempotency-Key']).to.equal('#uuid')
+      })
+
+      it('should return req’s transactionId as the `X-Transaction-Id` header', function () {
+        expect(headers['X-Transaction-Id']).to.equal('#transactionId')
       })
     })
   })

--- a/common/lib/api-client/rest-client.js
+++ b/common/lib/api-client/rest-client.js
@@ -9,7 +9,7 @@ const getRequestHeaders = require('./request-headers')
 
 const restClient = async (url, args, options = {}) => {
   const authorizationHeader = await auth.getAuthorizationHeader()
-  const requestHeaders = getRequestHeaders(options.format)
+  const requestHeaders = getRequestHeaders({ ...options })
   const headers = {
     ...authorizationHeader,
     ...requestHeaders,

--- a/common/lib/api-client/rest-client.test.js
+++ b/common/lib/api-client/rest-client.test.js
@@ -41,7 +41,7 @@ describe('API Client', async function () {
       })
 
       it('should get the default client headers', function () {
-        expect(getRequestHeadersStub).to.be.calledOnceWithExactly(undefined)
+        expect(getRequestHeadersStub).to.be.calledOnceWithExactly({})
       })
 
       it('should make the expected request', function () {
@@ -125,9 +125,9 @@ describe('API Client', async function () {
       })
 
       it('should pass the expected format to the method that returns the default client headers', function () {
-        expect(getRequestHeadersStub).to.be.calledOnceWithExactly(
-          'application/foo'
-        )
+        expect(getRequestHeadersStub).to.be.calledOnceWithExactly({
+          format: 'application/foo',
+        })
       })
     })
 

--- a/common/middleware/set-services.js
+++ b/common/middleware/set-services.js
@@ -1,0 +1,26 @@
+const services = require('../services')
+
+const setServices = (req, res, next) => {
+  const servicesRequestContext = {}
+
+  req.services = Object.keys(services).reduce((acc, serviceKey) => {
+    if (!servicesRequestContext[serviceKey]) {
+      const originalService = services[serviceKey]
+
+      if (!originalService.addRequestContext) {
+        servicesRequestContext[serviceKey] = originalService
+      } else {
+        servicesRequestContext[serviceKey] = originalService.addRequestContext(
+          req
+        )
+      }
+    }
+
+    acc[serviceKey] = () => servicesRequestContext[serviceKey]
+
+    return acc
+  }, {})
+  next()
+}
+
+module.exports = setServices

--- a/common/middleware/set-services.test.js
+++ b/common/middleware/set-services.test.js
@@ -1,0 +1,57 @@
+const proxyquire = require('proxyquire').noCallThru()
+
+const services = {
+  foo: {
+    addRequestContext: sinon.stub().returns({ method: 'foo - with context' }),
+  },
+  bar: {
+    method: 'bar - without context',
+  },
+}
+
+const setServices = proxyquire('./set-services', {
+  '../services': services,
+})
+
+describe('Middleware', function () {
+  describe('#setServices', function () {
+    const next = sinon.spy()
+    let req
+    beforeEach(function () {
+      req = {}
+      services.foo.addRequestContext.resetHistory()
+
+      setServices(req, {}, next)
+    })
+
+    it('should add context to service', function () {
+      expect(services.foo.addRequestContext).to.be.calledOnceWithExactly(req)
+    })
+
+    it('should add services object to request', function () {
+      expect(req.services).to.exist
+    })
+
+    it('should add service functions to services', function () {
+      expect(Object.keys(req.services)).to.deep.equal(['foo', 'bar'])
+    })
+
+    it('should return expected values from service functions which had context added', function () {
+      expect(req.services.foo()).to.deep.equal({ method: 'foo - with context' })
+    })
+
+    it('should return same values from service functions which had context added', function () {
+      expect(req.services.foo()).to.equal(req.services.foo())
+    })
+
+    it('should return expected values from service functions which did not have context added', function () {
+      expect(req.services.bar()).to.deep.equal({
+        method: 'bar - without context',
+      })
+    })
+
+    it('should return same values from service functions which did not have context added', function () {
+      expect(req.services.bar()).to.deep.equal(req.services.bar())
+    })
+  })
+})

--- a/common/middleware/set-transaction-id.js
+++ b/common/middleware/set-transaction-id.js
@@ -1,0 +1,8 @@
+const uuid = require('uuid')
+
+const setTransactionId = (req, res, next) => {
+  req.transactionId = req.get('x-request-id') || uuid.v4()
+  next()
+}
+
+module.exports = setTransactionId

--- a/common/middleware/set-transaction-id.test.js
+++ b/common/middleware/set-transaction-id.test.js
@@ -1,0 +1,58 @@
+const proxyquire = require('proxyquire').noCallThru()
+
+const uuid = {}
+
+const setTransactionId = proxyquire('./set-transaction-id', {
+  uuid,
+})
+
+describe('Middleware', function () {
+  describe('#setTranasctionId', function () {
+    let next
+    let req
+    beforeEach(function () {
+      uuid.v4 = sinon.stub().returns('#uuid')
+      next = sinon.spy()
+      req = {
+        get: sinon.stub(),
+      }
+    })
+
+    context('When request has no request id', function () {
+      beforeEach(function () {
+        setTransactionId(req, {}, next)
+      })
+
+      it('should check the x-request-id header', function () {
+        expect(req.get).to.be.calledOnceWithExactly('x-request-id')
+      })
+
+      it('should create an id for the request', function () {
+        expect(uuid.v4).to.be.calledOnceWithExactly()
+      })
+
+      it('should set the transaction id on the request', function () {
+        expect(req.transactionId).to.equal('#uuid')
+      })
+    })
+
+    context('When request has an request id', function () {
+      beforeEach(function () {
+        req.get.returns('#xRequestId')
+        setTransactionId(req, {}, next)
+      })
+
+      it('should check the x-request-id header', function () {
+        expect(req.get).to.be.calledOnceWithExactly('x-request-id')
+      })
+
+      it('should not create an id for the request', function () {
+        expect(uuid.v4).to.not.be.called
+      })
+
+      it('should set the transaction id on the request', function () {
+        expect(req.transactionId).to.equal('#xRequestId')
+      })
+    })
+  })
+})

--- a/common/services/court-hearing.test.js
+++ b/common/services/court-hearing.test.js
@@ -1,6 +1,11 @@
-const apiClient = require('../lib/api-client')()
+const proxyquire = require('proxyquire')
 
-const courtHearingService = require('./court-hearing')
+const apiClient = {}
+const ApiClient = sinon.stub().callsFake(req => apiClient)
+
+const courtHearingService = proxyquire('./court-hearing', {
+  '../lib/api-client': ApiClient,
+})
 
 const mockCourtHearing = {
   start_time: '2020-10-20T13:00:00+00:00',
@@ -96,7 +101,7 @@ describe('Court Hearing Service', function () {
     let courtHearing
 
     beforeEach(async function () {
-      sinon.stub(apiClient, 'create').resolves(mockResponse)
+      apiClient.create = sinon.stub().resolves(mockResponse)
     })
 
     context('by default', function () {

--- a/common/services/document.test.js
+++ b/common/services/document.test.js
@@ -4,10 +4,13 @@ function MockFormData() {}
 
 MockFormData.prototype.append = sinon.stub()
 
+const apiClient = {}
+const ApiClient = sinon.stub().callsFake(req => apiClient)
+
 const documentService = proxyquire('./document', {
   'form-data': MockFormData,
+  '../lib/api-client': ApiClient,
 })
-const apiClient = require('../lib/api-client')()
 
 describe('Document Service', function () {
   describe('#create()', function () {
@@ -25,7 +28,7 @@ describe('Document Service', function () {
     let document
 
     beforeEach(async function () {
-      sinon.stub(apiClient, 'create').resolves(mockResponse)
+      apiClient.create = sinon.stub().resolves(mockResponse)
 
       document = await documentService.create(mockFileData, mockBuffer)
     })

--- a/common/services/locations-free-spaces.test.js
+++ b/common/services/locations-free-spaces.test.js
@@ -1,11 +1,13 @@
 const proxyquire = require('proxyquire')
 
-const apiClient = require('../lib/api-client')()
+const apiClient = {}
+const ApiClient = sinon.stub().callsFake(req => apiClient)
 
 const restClient = sinon.stub()
 
 const locationsFreeSpacesService = proxyquire('./locations-free-spaces', {
   '../lib/api-client/rest-client': restClient,
+  '../lib/api-client': ApiClient,
 })
 
 const mockLocations = [
@@ -49,7 +51,7 @@ describe('Locations Free Spaces Service', function () {
     }
 
     beforeEach(function () {
-      sinon.stub(apiClient, 'findAll')
+      apiClient.findAll = sinon.stub()
     })
 
     context('with only one page', function () {

--- a/common/services/person-escort-record.test.js
+++ b/common/services/person-escort-record.test.js
@@ -1,6 +1,7 @@
 const proxyquire = require('proxyquire')
 
-const apiClient = require('../lib/api-client')()
+const apiClient = {}
+const ApiClient = sinon.stub().callsFake(req => apiClient)
 
 const mockFrameworksVersion = '2.5.3'
 const personEscortRecordService = proxyquire('./person-escort-record', {
@@ -9,6 +10,7 @@ const personEscortRecordService = proxyquire('./person-escort-record', {
       CURRENT_VERSION: mockFrameworksVersion,
     },
   },
+  '../lib/api-client': ApiClient,
 })
 
 const mockRecord = {
@@ -36,7 +38,7 @@ describe('Services', function () {
       let response
 
       beforeEach(async function () {
-        sinon.stub(apiClient, 'create').resolves(mockResponse)
+        apiClient.create = sinon.stub().resolves(mockResponse)
 
         response = await personEscortRecordService.create(mockMoveId)
       })
@@ -63,7 +65,7 @@ describe('Services', function () {
       const mockId = '8567f1a5-2201-4bc2-b655-f6526401303a'
 
       beforeEach(async function () {
-        sinon.stub(apiClient, 'update').resolves({
+        apiClient.update = sinon.stub().resolves({
           data: mockRecord,
         })
       })
@@ -102,7 +104,7 @@ describe('Services', function () {
       const mockId = '8567f1a5-2201-4bc2-b655-f6526401303a'
 
       beforeEach(async function () {
-        sinon.stub(apiClient, 'find').resolves({
+        apiClient.find = sinon.stub().resolves({
           data: mockRecord,
         })
       })
@@ -139,11 +141,11 @@ describe('Services', function () {
       const mockResponses = [{ id: '1' }, { id: '2' }]
 
       beforeEach(async function () {
-        sinon.stub(apiClient, 'patch').resolves({
+        apiClient.patch = sinon.stub().resolves({
           data: [],
         })
-        sinon.spy(apiClient, 'all')
-        sinon.spy(apiClient, 'one')
+        apiClient.all = sinon.stub().returns(apiClient)
+        apiClient.one = sinon.stub().returns(apiClient)
       })
 
       context('without ID', function () {

--- a/common/services/person.test.js
+++ b/common/services/person.test.js
@@ -1,10 +1,12 @@
 const proxyquire = require('proxyquire')
 
-const apiClient = require('../lib/api-client')()
-
 const unformatStub = sinon.stub()
 
+const apiClient = {}
+const ApiClient = sinon.stub().callsFake(req => apiClient)
+
 const personService = proxyquire('./person', {
+  '../lib/api-client': ApiClient,
   './person/person.unformat': unformatStub,
 })
 
@@ -21,6 +23,10 @@ const mockPerson = {
 }
 
 describe('Person Service', function () {
+  beforeEach(function () {
+    ApiClient.resetHistory()
+  })
+
   describe('default include', function () {
     expect(personService.defaultInclude).to.deep.equal(['ethnicity', 'gender'])
   })
@@ -186,7 +192,7 @@ describe('Person Service', function () {
     let person
 
     beforeEach(async function () {
-      sinon.stub(apiClient, 'create').resolves(mockResponse)
+      apiClient.create = sinon.stub().resolves(mockResponse)
       sinon.stub(personService, 'format').returnsArg(0)
 
       person = await personService.create(mockData)
@@ -224,7 +230,7 @@ describe('Person Service', function () {
       let person
 
       beforeEach(async function () {
-        sinon.stub(apiClient, 'find').resolves(mockResponse)
+        apiClient.find = sinon.stub().resolves(mockResponse)
       })
 
       context('when called without include parameter', function () {
@@ -302,7 +308,7 @@ describe('Person Service', function () {
     let person
 
     beforeEach(async function () {
-      sinon.stub(apiClient, 'update').resolves(mockResponse)
+      apiClient.update = sinon.stub().resolves(mockResponse)
       sinon.stub(personService, 'format').returnsArg(0)
     })
 
@@ -355,9 +361,9 @@ describe('Person Service', function () {
     let imageUrl
 
     beforeEach(async function () {
-      sinon.stub(apiClient, 'one').returnsThis()
-      sinon.stub(apiClient, 'all').returnsThis()
-      sinon.stub(apiClient, 'get').resolves(mockResponse)
+      apiClient.all = sinon.stub().returns(apiClient)
+      apiClient.one = sinon.stub().returns(apiClient)
+      apiClient.get = sinon.stub().resolves(mockResponse)
     })
 
     context('without ID', function () {
@@ -400,9 +406,9 @@ describe('Person Service', function () {
     let imageUrl
 
     beforeEach(async function () {
-      sinon.stub(apiClient, 'one').returnsThis()
-      sinon.stub(apiClient, 'all').returnsThis()
-      sinon.stub(apiClient, 'get').resolves(mockResponse)
+      apiClient.all = sinon.stub().returns(apiClient)
+      apiClient.one = sinon.stub().returns(apiClient)
+      apiClient.get = sinon.stub().resolves(mockResponse)
     })
 
     context('without ID', function () {
@@ -448,9 +454,9 @@ describe('Person Service', function () {
     let imageUrl
 
     beforeEach(async function () {
-      sinon.stub(apiClient, 'one').returnsThis()
-      sinon.stub(apiClient, 'all').returnsThis()
-      sinon.stub(apiClient, 'get').resolves(mockResponse)
+      apiClient.all = sinon.stub().returns(apiClient)
+      apiClient.one = sinon.stub().returns(apiClient)
+      apiClient.get = sinon.stub().resolves(mockResponse)
     })
 
     context('without ID', function () {
@@ -517,7 +523,7 @@ describe('Person Service', function () {
     let person
 
     beforeEach(async function () {
-      sinon.stub(apiClient, 'findAll').resolves(mockResponse)
+      apiClient.findAll = sinon.stub().resolves(mockResponse)
     })
 
     context('without filters', function () {

--- a/common/services/population.test.js
+++ b/common/services/population.test.js
@@ -1,11 +1,13 @@
 const proxyquire = require('proxyquire')
 
-const apiClient = require('../lib/api-client')()
+const apiClient = {}
+const ApiClient = sinon.stub().callsFake(req => apiClient)
 
 const restClient = sinon.stub()
 
 const populationService = proxyquire('./population', {
   '../lib/api-client/rest-client': restClient,
+  '../lib/api-client': ApiClient,
 })
 
 const mockPopulations = [
@@ -35,7 +37,7 @@ describe('Population Service', function () {
         let location
 
         beforeEach(async function () {
-          sinon.stub(apiClient, 'find').resolves(mockResponse)
+          apiClient.find = sinon.stub().resolves(mockResponse)
 
           location = await populationService.getById(mockId)
         })
@@ -60,7 +62,7 @@ describe('Population Service', function () {
         }
 
         beforeEach(async function () {
-          sinon.stub(apiClient, 'find').resolves(mockResponse)
+          apiClient.find = sinon.stub().resolves(mockResponse)
 
           await populationService.getById(mockId, {
             include: ['foo', 'bar'],

--- a/common/services/profile.test.js
+++ b/common/services/profile.test.js
@@ -1,11 +1,13 @@
 const proxyquire = require('proxyquire')
 
-const apiClient = require('../lib/api-client')()
+const apiClient = {}
+const ApiClient = sinon.stub().callsFake(req => apiClient)
 
 const unformatStub = sinon.stub()
 
 const profileService = proxyquire('./profile', {
   './profile/profile.unformat': unformatStub,
+  '../lib/api-client': ApiClient,
 })
 describe('Profile Service', function () {
   describe('#create()', function () {
@@ -28,9 +30,9 @@ describe('Profile Service', function () {
 
     context('with person ID', function () {
       beforeEach(async function () {
-        sinon.spy(apiClient, 'one')
-        sinon.spy(apiClient, 'all')
-        sinon.stub(apiClient, 'post').resolves(mockResponse)
+        apiClient.one = sinon.stub().returns(apiClient)
+        apiClient.all = sinon.stub().returns(apiClient)
+        apiClient.post = sinon.stub().resolves(mockResponse)
 
         await profileService.create('#personId', profileData)
       })
@@ -67,8 +69,8 @@ describe('Profile Service', function () {
 
     context('with person ID', function () {
       beforeEach(async function () {
-        sinon.spy(apiClient, 'one')
-        sinon.stub(apiClient, 'patch').resolves(mockResponse)
+        apiClient.one = sinon.stub().returns(apiClient)
+        apiClient.patch = sinon.stub().resolves(mockResponse)
 
         await profileService.update(profileData)
       })

--- a/common/services/single-request.test.js
+++ b/common/services/single-request.test.js
@@ -1,7 +1,15 @@
-const apiClient = require('../lib/api-client')()
+const proxyquire = require('proxyquire')
 
-const moveService = require('./move')
-const singleRequestService = require('./single-request')
+const apiClient = {}
+const ApiClient = sinon.stub().callsFake(req => apiClient)
+
+const moveService = proxyquire('./move', {
+  '../lib/api-client': ApiClient,
+})
+const singleRequestService = proxyquire('./single-request', {
+  '../lib/api-client': ApiClient,
+  './move': moveService,
+})
 
 const mockMove = {
   id: 'b695d0f0-af8e-4b97-891e-92020d6820b9',
@@ -555,7 +563,7 @@ describe('Single request service', function () {
       let move
 
       beforeEach(async function () {
-        sinon.stub(apiClient, 'update').resolves(mockResponse)
+        apiClient.update = sinon.stub().resolves(mockResponse)
       })
 
       context('without data args', function () {
@@ -617,9 +625,9 @@ describe('Single request service', function () {
       let move
 
       beforeEach(async function () {
-        sinon.stub(apiClient, 'all').returns(apiClient)
-        sinon.stub(apiClient, 'one').returns(apiClient)
-        sinon.stub(apiClient, 'post').resolves(mockResponse)
+        apiClient.all = sinon.stub().returns(apiClient)
+        apiClient.one = sinon.stub().returns(apiClient)
+        apiClient.post = sinon.stub().resolves(mockResponse)
       })
 
       context('without comment', function () {

--- a/common/services/youth-risk-assessment.test.js
+++ b/common/services/youth-risk-assessment.test.js
@@ -1,6 +1,7 @@
 const proxyquire = require('proxyquire')
 
-const apiClient = require('../lib/api-client')()
+const apiClient = {}
+const ApiClient = sinon.stub().callsFake(_req => apiClient)
 
 const mockFrameworksVersion = '2.5.3'
 const youthRiskAssessmentService = proxyquire('./youth-risk-assessment', {
@@ -9,6 +10,7 @@ const youthRiskAssessmentService = proxyquire('./youth-risk-assessment', {
       CURRENT_VERSION: mockFrameworksVersion,
     },
   },
+  '../lib/api-client': ApiClient,
 })
 
 const mockRecord = {
@@ -36,7 +38,7 @@ describe('Services', function () {
       let response
 
       beforeEach(async function () {
-        sinon.stub(apiClient, 'create').resolves(mockResponse)
+        apiClient.create = sinon.stub().resolves(mockResponse)
 
         response = await youthRiskAssessmentService.create(mockMoveId)
       })
@@ -63,7 +65,7 @@ describe('Services', function () {
       const mockId = '8567f1a5-2201-4bc2-b655-f6526401303a'
 
       beforeEach(async function () {
-        sinon.stub(apiClient, 'update').resolves({
+        apiClient.update = sinon.stub().resolves({
           data: mockRecord,
         })
       })
@@ -102,7 +104,7 @@ describe('Services', function () {
       const mockId = '8567f1a5-2201-4bc2-b655-f6526401303a'
 
       beforeEach(async function () {
-        sinon.stub(apiClient, 'find').resolves({
+        apiClient.find = sinon.stub().resolves({
           data: mockRecord,
         })
       })
@@ -139,11 +141,11 @@ describe('Services', function () {
       const mockResponses = [{ id: '1' }, { id: '2' }]
 
       beforeEach(async function () {
-        sinon.stub(apiClient, 'patch').resolves({
+        apiClient.patch = sinon.stub().resolves({
           data: [],
         })
-        sinon.spy(apiClient, 'all')
-        sinon.spy(apiClient, 'one')
+        apiClient.all = sinon.stub().returns(apiClient)
+        apiClient.one = sinon.stub().returns(apiClient)
       })
 
       context('without ID', function () {

--- a/server.js
+++ b/server.js
@@ -32,6 +32,8 @@ const sentryEnrichScope = require('./common/middleware/sentry-enrich-scope')
 const sentryRequestId = require('./common/middleware/sentry-request-id')
 const setLocations = require('./common/middleware/set-locations')
 const setPrimaryNavigation = require('./common/middleware/set-primary-navigation')
+const setServices = require('./common/middleware/set-services')
+const setTransactionId = require('./common/middleware/set-transaction-id')
 const setUser = require('./common/middleware/set-user')
 const config = require('./config')
 const i18n = require('./config/i18n')
@@ -51,6 +53,9 @@ const app = express()
 if (config.IS_PRODUCTION) {
   app.enable('trust proxy')
 }
+
+// Ensure we have a useful transaction id
+app.use(setTransactionId)
 
 if (config.SENTRY.DSN) {
   Sentry.init({
@@ -188,6 +193,9 @@ app.use(
 
 // Ensure body processed after reauthentication
 app.use(processOriginalRequestBody())
+
+// Set services
+app.use(setServices)
 
 // Add permission checker
 app.use(setCanAccess)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

[P4-1776] Add groundwork for the req context, to allow passing data from req to headers

## Proposed changes
All of this work was done by Alex, and has been picked from his PR https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/pull/906

The intention of this PR is that it will act as a base PR, and I will make a new PR for each service, to add the request context to them individually. The reasoning behind this is that it should make it easier to understand what's going on in each PR.

### What changed
Added `ApiClient#_originalReq`, which is the current request
Added set-services.js, which sets `request.services`, this contains the functions needed to get service objects with request context via `req.services.move()` for example
Added set-transaction-id.js which sets `request.transactionId` to `req.get('x-request-id') || uuid.v4()`
Changed request-headers.js to take the request and include X-Transaction-Id in the headers

### Why did it change
This has changed so that we can get information about the request (user, headers, etc) more easily, especially in request-headers.js.

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

- [P4-1776](https://dsdmoj.atlassian.net/browse/P4-1776)

## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed

<!--- Delete if changes DO NOT include new environment variables -->
- [ ] Documented in the [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md)
- [ ] Added to [continous integration](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-book-secure-move-frontend)
- [ ] Added to staging environment (deployment repository)
- [ ] Added to preproduction environment (deployment repository)
- [ ] Added to production environment (deployment repository)

### Other considerations

Commit messages with a `fix` or `feat` type are automatically used to generate the [changelog](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/CHANGELOG.md) and
[GitHub release notes](https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/releases) during the release task. Please make sure they will read well on their own in a
summary of changes and that the commit body gives a more detailed description of those changes if necessary.

- [ ] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
- [ ] Update [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md) with any new instructions or tasks
