### PR TITLE
Reverse order of items in move timeline

### DIFF
--- a/common/presenters/events-to-timeline-component.js
+++ b/common/presenters/events-to-timeline-component.js
@@ -64,39 +64,41 @@ const getFlagClasses = eventTypePrefix => {
 const eventsToTimelineComponent = (move = {}) => {
   const { timeline_events: moveEvents } = move
 
-  const items = addTriggeredEvents(moveEvents).map(moveEvent => {
-    const event = setEventDetails(moveEvent, move)
+  const items = addTriggeredEvents(moveEvents)
+    .map(moveEvent => {
+      const event = setEventDetails(moveEvent, move)
 
-    const { details, event_type: eventType } = event
-    const eventTypePrefix = `events::${eventType}`
+      const { details, event_type: eventType } = event
+      const eventTypePrefix = `events::${eventType}`
 
-    const labelClasses = getLabelClasses(eventTypePrefix)
+      const labelClasses = getLabelClasses(eventTypePrefix)
 
-    const flagClasses = getFlagClasses(eventTypePrefix)
+      const flagClasses = getFlagClasses(eventTypePrefix)
 
-    const heading = i18n.t(`${eventTypePrefix}.heading`, details)
-    const description = i18n
-      .t(`${eventTypePrefix}.description`, details)
-      .replace(/^<br>/, '')
-    // Some strings that get added together are prefixed with a <br>.
-    // This enables them to be used as the first item or where a previous string doesn't get output
-    // and not insert additional space without having to make the <br> conditional
+      const heading = i18n.t(`${eventTypePrefix}.heading`, details)
+      const description = i18n
+        .t(`${eventTypePrefix}.description`, details)
+        .replace(/^<br>/, '')
+      // Some strings that get added together are prefixed with a <br>.
+      // This enables them to be used as the first item or where a previous string doesn't get output
+      // and not insert additional space without having to make the <br> conditional
 
-    // TODO: when we have user info for event, update the following with something like
-    // const byline = i18n.t('events::byline', details)
-    const byline = ''
+      // TODO: when we have user info for event, update the following with something like
+      // const byline = i18n.t('events::byline', details)
+      const byline = ''
 
-    const timestamp = event.occurred_at
+      const timestamp = event.occurred_at
 
-    return getItem({
-      ...flagClasses,
-      labelClasses,
-      heading,
-      description,
-      timestamp,
-      byline,
+      return getItem({
+        ...flagClasses,
+        labelClasses,
+        heading,
+        description,
+        timestamp,
+        byline,
+      })
     })
-  })
+    .reverse()
   return { items }
 }
 

--- a/common/presenters/events-to-timeline-component.test.js
+++ b/common/presenters/events-to-timeline-component.test.js
@@ -98,6 +98,67 @@ describe('Presenters', function () {
       })
     })
 
+    context('when transforming events', function () {
+      const mockEvents = [
+        {
+          event_type: 'foo',
+          occurred_at: '2020-10-03',
+          details: {
+            hello: 'world',
+          },
+        },
+        {
+          event_type: 'bar',
+          occurred_at: '2020-10-04',
+          details: {
+            goodbye: 'columbus',
+          },
+        },
+      ]
+      const mockMove = {
+        id: 'move2',
+        timeline_events: mockEvents,
+      }
+      beforeEach(function () {
+        transformedResponse = eventsToTimelineComponent(mockMove)
+      })
+
+      it('should add triggered events if needed', function () {
+        expect(addTriggeredEvents).to.be.calledOnceWithExactly(mockEvents)
+      })
+
+      it('should set the event details', function () {
+        expect(setEventDetails.callCount).to.equal(2)
+        expect(setEventDetails).to.be.calledWithExactly(mockEvents[0], mockMove)
+        expect(setEventDetails).to.be.calledWithExactly(mockEvents[1], mockMove)
+      })
+
+      it('should return the events in reverse order', function () {
+        expect(transformedResponse).to.deep.equal({
+          items: [
+            {
+              container: { classes: undefined },
+              header: { classes: undefined },
+              classes: undefined,
+              label: { html: 'events::bar.heading', classes: undefined },
+              html: 'events::bar.description',
+              datetime: { timestamp: '2020-10-04', type: 'datetime' },
+              byline: { html: '' },
+            },
+            {
+              container: { classes: undefined },
+              header: { classes: undefined },
+              classes: undefined,
+              label: { html: 'events::foo.heading', classes: undefined },
+              html: 'events::foo.description',
+              datetime: { timestamp: '2020-10-03', type: 'datetime' },
+              byline: { html: '' },
+            },
+          ],
+        })
+      })
+    })
+
     context('when event is a triggered status change', function () {
       beforeEach(function () {
         i18n.exists.onCall(0).returns(true)

--- a/test/e2e/_routes.js
+++ b/test/e2e/_routes.js
@@ -19,6 +19,7 @@ export const incomingMoves = `${E2E.BASE_URL}/moves/incoming`
 export const outgoingMoves = `${E2E.BASE_URL}/moves/outgoing`
 export const newMove = `${E2E.BASE_URL}/move/new`
 export const getMove = id => `${E2E.BASE_URL}/move/${id}`
+export const getTimeline = id => `${E2E.BASE_URL}/move/${id}/timeline`
 export const getUpdateMove = (id, page) =>
   `${E2E.BASE_URL}/move/${id}/edit/${getUpdatePageStub(page)}`
 export const newAllocation = `${E2E.BASE_URL}/allocation/new`

--- a/test/e2e/move.timeline.test.js
+++ b/test/e2e/move.timeline.test.js
@@ -1,0 +1,17 @@
+import { expectStatusCode } from './_helpers'
+import { createMove } from './_move'
+import { policeUser } from './_roles'
+import { home, getTimeline } from './_routes'
+import { moveTimelinePage } from './pages'
+
+fixture('Move timeline').beforeEach(async t => {
+  await t.useRole(policeUser).navigateTo(home)
+  await createMove()
+})
+
+test('Check timeline exists', async t => {
+  const timelineUrl = getTimeline(t.ctx.move.id)
+  await expectStatusCode(timelineUrl, 200)
+  // there should be the actual proposed event and a corresponding auto-inserted triggered event
+  await t.expect(moveTimelinePage.nodes.timelineItems.count).eql(2)
+})

--- a/test/e2e/pages/index.js
+++ b/test/e2e/pages/index.js
@@ -3,6 +3,7 @@ import CancelMovePage from './cancel-move'
 import CreateMovePage from './create-move'
 import DashboardPage from './dashboard'
 import MoveDetailPage from './move-detail'
+import MoveTimelinePage from './move-timeline'
 import MovesDashboardPage from './moves-dashboard'
 import Page from './page'
 import UpdateMovePage from './update-move'
@@ -10,6 +11,7 @@ import UpdateMovePage from './update-move'
 const page = new Page()
 const allocationJourney = new AllocationJourney()
 const moveDetailPage = new MoveDetailPage()
+const moveTimelinePage = new MoveTimelinePage()
 const movesDashboardPage = new MovesDashboardPage()
 const createMovePage = new CreateMovePage()
 const cancelMovePage = new CancelMovePage()
@@ -19,6 +21,7 @@ export {
   page,
   allocationJourney,
   moveDetailPage,
+  moveTimelinePage,
   movesDashboardPage,
   createMovePage,
   cancelMovePage,

--- a/test/e2e/pages/move-timeline.js
+++ b/test/e2e/pages/move-timeline.js
@@ -1,0 +1,17 @@
+import { Selector } from 'testcafe'
+
+import MoveDetailPage from './move-detail'
+
+class MoveTimelinePage extends MoveDetailPage {
+  constructor() {
+    super()
+
+    this.nodes = {
+      ...this.nodes,
+      timeline: Selector('.app-timeline'),
+      timelineItems: Selector('.app-timeline__item'),
+    }
+  }
+}
+
+export default MoveTimelinePage


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

- Reverses order in which timeline items are output
- Adds basic e2e tests for move timeline
  - ensures that timeline view can be rendered
  - ensures that minimal events exist on page


### Why did it change

Reverse order is as per design.

Tests are good, but more to the point, ensuring that the timeline view can be rendered would have caught the infinite loop bug in the model `transformResource` method.

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

n/a

## Screenshots
<!--- (Optional) Include screenshots if changes update interfaces or components -->
<!--- Delete/copy as appropriate --->

| After | Before |
| ------ | ----- |
| <kbd>![Move_details_for_SCHMITT__ERICH_–_Book_a_secure_move](https://user-images.githubusercontent.com/4856/100391127-6e2af200-302a-11eb-88d5-334218883f06.png)</kbd> | <kbd>![Move_details_for_SCHMITT__ERICH_–_Book_a_secure_move](https://user-images.githubusercontent.com/4856/100391209-a29eae00-302a-11eb-8e57-3d55c6d0b739.png)</kbd> |

## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed


### Other considerations

- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics

