### PR TITLE
chore: Whitelist the components URL

### DIFF
--- a/common/middleware/ensure-authenticated.js
+++ b/common/middleware/ensure-authenticated.js
@@ -1,3 +1,5 @@
+const pathToRegexp = require('path-to-regexp')
+
 function _isExpired(authExpiry) {
   if (!authExpiry) {
     return true
@@ -18,7 +20,11 @@ module.exports = function ensureAuthenticated({
       authExpiry -= expiryMargin
     }
 
-    if (whitelist.includes(req.url) || !_isExpired(authExpiry)) {
+    const matchedWhitelists = whitelist.filter(route =>
+      pathToRegexp.match(route)(req.url)
+    )
+
+    if (matchedWhitelists.length > 0 || !_isExpired(authExpiry)) {
       return next()
     }
 

--- a/common/middleware/ensure-authenticated.test.js
+++ b/common/middleware/ensure-authenticated.test.js
@@ -38,6 +38,24 @@ describe('Authentication middleware', function () {
       })
     })
 
+    context('when whitelist url uses a pattern', function () {
+      const whitelist = ['/url', '/bypass-url', '/components/(.*)']
+
+      beforeEach(function () {
+        req.url = '/components/component-name/example'
+
+        ensureAuthenticated({ provider, whitelist })(req, res, nextSpy)
+      })
+
+      it('should call next', function () {
+        expect(nextSpy).to.be.calledOnceWithExactly()
+      })
+
+      it('should not redirect', function () {
+        expect(res.redirect).not.to.be.called
+      })
+    })
+
     context('when there is no access token', function () {
       beforeEach(function () {
         ensureAuthenticated({ provider })(req, res, nextSpy)

--- a/common/middleware/ensure-selected-location.js
+++ b/common/middleware/ensure-selected-location.js
@@ -1,8 +1,14 @@
+const pathToRegexp = require('path-to-regexp')
+
 function ensureSelectedLocation({ locationsMountpath, whitelist = [] } = {}) {
   return (req, res, next) => {
+    const matchedWhitelists = whitelist.filter(route =>
+      pathToRegexp.match(route)(req.url)
+    )
+
     if (
       req.session.hasSelectedLocation ||
-      whitelist.includes(req.url) ||
+      matchedWhitelists.length > 0 ||
       req.url.includes(locationsMountpath)
     ) {
       return next()

--- a/common/middleware/ensure-selected-location.test.js
+++ b/common/middleware/ensure-selected-location.test.js
@@ -53,6 +53,27 @@ describe('Ensure current location middleware', function () {
     })
   })
 
+  context('when whitelist url uses a pattern', function () {
+    const whitelist = ['/url', '/bypass-url', '/components/(.*)']
+
+    beforeEach(function () {
+      req.url = '/components/component-name/example'
+
+      ensureCurrentLocation({
+        locationsMountpath,
+        whitelist,
+      })(req, res, nextSpy)
+    })
+
+    it('should call next', function () {
+      expect(nextSpy).to.be.calledOnceWithExactly()
+    })
+
+    it('should not redirect', function () {
+      expect(res.redirect).not.to.be.called
+    })
+  })
+
   context('when url contains locations mountpath', function () {
     beforeEach(function () {
       req.url = '/locations/location-id'

--- a/config/index.js
+++ b/config/index.js
@@ -127,6 +127,8 @@ module.exports = {
     '/auth/sign-out',
     '/healthcheck',
     '/healthcheck/ping',
+    '/components',
+    '/components/(.*)',
   ],
   AUTH_PROVIDERS: {
     hmpps: {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

This change adds the path to the whitelist so that they authentication
is bypassed.

### Why did it change

Currently the components app is being the global authentication and
location middleware. There is no need for this on environments where
it is enabled.