### PR TITLE
Extend assessment transformer

### DIFF
--- a/common/helpers/frameworks/index.js
+++ b/common/helpers/frameworks/index.js
@@ -1,5 +1,7 @@
 const appendResponseToField = require('./append-response-to-field')
 const mapFieldFromName = require('./map-field-from-name')
+const mapItemToSection = require('./map-item-to-section')
+const mapQuestionToResponse = require('./map-question-to-response')
 const reduceResponsesToFormValues = require('./reduce-responses-to-form-values')
 const renderNomisMappingsToField = require('./render-nomis-mappings-to-field')
 const renderPreviousAnswerToField = require('./render-previous-answer-to-field')
@@ -9,6 +11,8 @@ const setValidationRules = require('./set-validation-rules')
 module.exports = {
   appendResponseToField,
   mapFieldFromName,
+  mapQuestionToResponse,
+  mapItemToSection,
   reduceResponsesToFormValues,
   renderNomisMappingsToField,
   renderPreviousAnswerToField,

--- a/common/helpers/frameworks/map-item-to-section.js
+++ b/common/helpers/frameworks/map-item-to-section.js
@@ -1,0 +1,28 @@
+const { find } = require('lodash')
+
+module.exports = function mapItemToSection({ meta = {}, responses = [] } = {}) {
+  return section => {
+    const sectionProgress = find(meta.section_progress, {
+      key: section.key,
+    })
+    const sectionResponses = responses.filter(
+      response => response.question.section === section.key
+    )
+    const sectionQuestions = sectionResponses.reduce((acc, response) => {
+      const question = response._question
+
+      if (question) {
+        acc[question.name] = question
+      }
+
+      return acc
+    }, {})
+
+    return {
+      ...section,
+      progress: sectionProgress ? sectionProgress.status : undefined,
+      questions: sectionQuestions,
+      responses: sectionResponses,
+    }
+  }
+}

--- a/common/helpers/frameworks/map-item-to-section.test.js
+++ b/common/helpers/frameworks/map-item-to-section.test.js
@@ -1,0 +1,162 @@
+const helper = require('./map-item-to-section')
+
+describe('Helpers', function () {
+  describe('Frameworks Helpers', function () {
+    describe('#mapItemToSection', function () {
+      const mockSection = {
+        foo: 'bar',
+        key: 'section-one',
+      }
+      let output
+
+      context('without item', function () {
+        beforeEach(function () {
+          output = helper()(mockSection)
+        })
+
+        it('should append default values', function () {
+          expect(output).to.deep.equal({
+            foo: 'bar',
+            key: 'section-one',
+            progress: undefined,
+            questions: {},
+            responses: [],
+          })
+        })
+      })
+
+      context('with item', function () {
+        const mockItem = {
+          meta: {
+            section_progress: [
+              {
+                key: 'section-one',
+                status: 'completed',
+              },
+              {
+                key: 'section-two',
+                status: 'completed',
+              },
+            ],
+          },
+          responses: [
+            {
+              _question: {
+                name: 'question-one',
+                description: 'question-one',
+              },
+              question: {
+                section: 'section-one',
+              },
+            },
+            {
+              _question: {
+                name: 'question-two',
+                description: 'question-two',
+              },
+              question: {
+                section: 'section-one',
+              },
+            },
+            {
+              _question: {
+                name: 'question-three',
+                description: 'question-three',
+              },
+              question: {
+                section: 'section-two',
+              },
+            },
+            {
+              _question: {
+                name: 'question-four',
+                description: 'question-four',
+              },
+              question: {
+                section: 'section-two',
+              },
+            },
+          ],
+        }
+
+        context('with section key', function () {
+          beforeEach(function () {
+            output = helper(mockItem)({
+              ...mockSection,
+              key: 'section-one',
+            })
+          })
+
+          it('should append correct number of keys', function () {
+            expect(Object.keys(output)).to.have.length(5)
+          })
+
+          it('should append responses for this section', function () {
+            expect(output.responses).to.deep.equal([
+              {
+                _question: {
+                  name: 'question-one',
+                  description: 'question-one',
+                },
+                question: {
+                  section: 'section-one',
+                },
+              },
+              {
+                _question: {
+                  name: 'question-two',
+                  description: 'question-two',
+                },
+                question: {
+                  section: 'section-one',
+                },
+              },
+            ])
+          })
+
+          it('should append questions for this section', function () {
+            expect(output.questions).to.deep.equal({
+              'question-one': {
+                name: 'question-one',
+                description: 'question-one',
+              },
+              'question-two': {
+                name: 'question-two',
+                description: 'question-two',
+              },
+            })
+          })
+
+          it('should append progress for this section', function () {
+            expect(output.progress).to.equal('completed')
+          })
+        })
+
+        context('when question does not exist', function () {
+          beforeEach(function () {
+            output = helper(mockItem)({
+              ...mockSection,
+              key: 'non-existent',
+            })
+          })
+
+          it('should append correct number of keys', function () {
+            expect(Object.keys(output)).to.have.length(5)
+          })
+
+          it('should not append responses for this section', function () {
+            expect(output.responses).to.deep.equal([])
+          })
+
+          it('should not append any questions for this section', function () {
+            expect(output.questions).to.deep.equal({})
+          })
+
+          it('should not append progress for this section', function () {
+            expect(output.progress).to.equal(undefined)
+          })
+        })
+      })
+    })
+  })
+})

--- a/common/helpers/frameworks/map-question-to-response.js
+++ b/common/helpers/frameworks/map-question-to-response.js
@@ -1,0 +1,12 @@
+const { get } = require('lodash')
+
+module.exports = function mapQuestionToResponse({ questions = {} } = {}) {
+  return response => {
+    const question = questions[get(response, 'question.key')]
+
+    return {
+      ...response,
+      _question: question,
+    }
+  }
+}

--- a/common/helpers/frameworks/map-question-to-response.test.js
+++ b/common/helpers/frameworks/map-question-to-response.test.js
@@ -1,0 +1,79 @@
+const helper = require('./map-question-to-response')
+
+describe('Helpers', function () {
+  describe('Frameworks Helpers', function () {
+    describe('#mapQuestionToResponse', function () {
+      const mockResponse = {
+        foo: 'bar',
+      }
+      let response
+
+      context('without options', function () {
+        beforeEach(function () {
+          response = helper()(mockResponse)
+        })
+
+        it('should append undefined question', function () {
+          expect(response).to.deep.equal({
+            _question: undefined,
+            foo: 'bar',
+          })
+        })
+      })
+
+      context('with questions', function () {
+        const mockQuestions = {
+          'question-one': {
+            id: 'question-one',
+            question: 'What is life?',
+          },
+        }
+
+        context('when question exists', function () {
+          beforeEach(function () {
+            response = helper({ questions: mockQuestions })({
+              ...mockResponse,
+              question: {
+                key: 'question-one',
+              },
+            })
+          })
+
+          it('should append question', function () {
+            expect(response).to.deep.equal({
+              _question: {
+                id: 'question-one',
+                question: 'What is life?',
+              },
+              foo: 'bar',
+              question: {
+                key: 'question-one',
+              },
+            })
+          })
+        })
+
+        context('when question does not exist', function () {
+          beforeEach(function () {
+            response = helper({ questions: mockQuestions })({
+              ...mockResponse,
+              question: {
+                key: 'non-existent',
+              },
+            })
+          })
+
+          it('should append undefined question', function () {
+            expect(response).to.deep.equal({
+              _question: undefined,
+              foo: 'bar',
+              question: {
+                key: 'non-existent',
+              },
+            })
+          })
+        })
+      })
+    })
+  })
+})

--- a/common/lib/api-client/transformers/assessment.transformer.js
+++ b/common/lib/api-client/transformers/assessment.transformer.js
@@ -1,3 +1,7 @@
+const { mapValues } = require('lodash')
+
+const mapItemToSection = require('../../../helpers/frameworks/map-item-to-section')
+const mapQuestionToResponse = require('../../../helpers/frameworks/map-question-to-response')
 const frameworksService = require('../../../services/frameworks')
 
 module.exports = function assessmentTransformer(data = {}) {
@@ -6,6 +10,10 @@ module.exports = function assessmentTransformer(data = {}) {
       framework: data.framework.name,
       version: data.framework.version,
     })
+
+    data.responses = data.responses.map(mapQuestionToResponse(framework))
+
+    framework.sections = mapValues(framework.sections, mapItemToSection(data))
 
     data._framework = framework
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

This extends the transformer for the assessment resource.

It includes some additions to each section of the framework to make it
easier to work with this resource within the application.

It adds:
- section progress
- responses for a particular section
- questions for a particular section
- framework question to each response

### Why did it change

This allows some transformation that takes place within the app to
visualise responses or questions to happen a little easier.

It tries to bring together the content from the framework and the values
returned by the API into the one object.

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

- [P4-2444](https://dsdmoj.atlassian.net/browse/P4-2444)

## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [x] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed

### Other considerations

Commit messages with a `fix` or `feat` type are automatically used to generate the [changelog](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/CHANGELOG.md) and
[GitHub release notes](https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/releases) during the release task. Please make sure they will read well on their own in a
summary of changes and that the commit body gives a more detailed description of those changes if necessary.

- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
- [x] Update [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md) with any new instructions or tasks
