### PR TITLE
Use mutation in API client transform layer

### DIFF
--- a/app/allocation/controllers/view.js
+++ b/app/allocation/controllers/view.js
@@ -47,7 +47,7 @@ function viewAllocation(req, res) {
     addedCount: movesWithProfile.length,
     moves: sortBy(
       moves.filter(removeUnassignedMoves),
-      'profile.person.fullname'
+      'profile.person._fullname'
     )
       .reverse()
       .map(move => ({

--- a/app/allocation/controllers/view.test.js
+++ b/app/allocation/controllers/view.test.js
@@ -49,7 +49,7 @@ describe('Allocation controllers', function () {
             person: {
               first_names: 'John',
               last_name: 'Doe',
-              fullname: 'John Doe',
+              _fullname: 'John Doe',
             },
           },
         },
@@ -60,7 +60,7 @@ describe('Allocation controllers', function () {
             person: {
               first_names: 'Phil',
               last_name: 'Jones',
-              fullname: 'Phil Jones',
+              _fullname: 'Phil Jones',
             },
           },
         },
@@ -291,7 +291,7 @@ describe('Allocation controllers', function () {
               person: {
                 first_names: 'Phil',
                 last_name: 'Jones',
-                fullname: 'Phil Jones',
+                _fullname: 'Phil Jones',
               },
             },
             removeMoveHref: undefined,
@@ -301,7 +301,7 @@ describe('Allocation controllers', function () {
                 person: {
                   first_names: 'Phil',
                   last_name: 'Jones',
-                  fullname: 'Phil Jones',
+                  _fullname: 'Phil Jones',
                 },
               },
             },
@@ -312,7 +312,7 @@ describe('Allocation controllers', function () {
               person: {
                 first_names: 'John',
                 last_name: 'Doe',
-                fullname: 'John Doe',
+                _fullname: 'John Doe',
               },
             },
             removeMoveHref: undefined,
@@ -322,7 +322,7 @@ describe('Allocation controllers', function () {
                 person: {
                   first_names: 'John',
                   last_name: 'Doe',
-                  fullname: 'John Doe',
+                  _fullname: 'John Doe',
                 },
               },
             },

--- a/app/allocation/views/view.njk
+++ b/app/allocation/views/view.njk
@@ -126,7 +126,7 @@
             {{ govukButton({
               href: "/move/" + move.id + "/unassign",
               html: t("actions::remove_person", {
-                name: move.profile.person.fullname
+                name: move.profile.person._fullname
               }),
               classes: "govuk-button--secondary"
             })}}

--- a/app/move/controllers/assign/save.js
+++ b/app/move/controllers/assign/save.js
@@ -45,7 +45,7 @@ class SaveController extends PersonAssignBase {
         pageTitle: req.t('validation::assign_conflict.heading'),
         message: req.t('validation::assign_conflict.message', {
           href: `/move/${existingMoveId}`,
-          name: person.fullname,
+          name: person._fullname,
           location: req.move.allocation.to_location.title,
           date: filters.formatDateWithDay(req.move.date),
         }),

--- a/app/move/controllers/assign/save.test.js
+++ b/app/move/controllers/assign/save.test.js
@@ -176,7 +176,7 @@ describe('Assign controllers', function () {
             get: sinon
               .stub()
               .withArgs('person')
-              .returns({ fullname: 'DOE, JOHN' }),
+              .returns({ _fullname: 'DOE, JOHN' }),
           },
           move: {
             id: '12345',

--- a/app/move/controllers/cancel.test.js
+++ b/app/move/controllers/cancel.test.js
@@ -9,7 +9,7 @@ const mockMove = {
   id: '123456789',
   profile: {
     person: {
-      fullname: 'Full name',
+      _fullname: 'Full name',
     },
   },
 }

--- a/app/move/controllers/create/base.test.js
+++ b/app/move/controllers/create/base.test.js
@@ -583,7 +583,7 @@ describe('Move controllers', function () {
         additional_information: 'Additional information',
         person: {
           first_names: 'Mr',
-          fullname: 'Benn, Mr',
+          _fullname: 'Benn, Mr',
           last_name: 'Benn',
         },
       }

--- a/app/move/controllers/create/save.js
+++ b/app/move/controllers/create/save.js
@@ -148,7 +148,7 @@ class SaveController extends CreateBaseController {
         pageTitle: req.t('validation::move_conflict.heading'),
         message: req.t('validation::move_conflict.message', {
           href: `/move/${existingMoveId}`,
-          name: values.person.fullname,
+          name: values.person._fullname,
           location: values.to_location.title,
           date: filters.formatDateWithDay(values.date),
         }),

--- a/app/move/controllers/create/save.test.js
+++ b/app/move/controllers/create/save.test.js
@@ -20,7 +20,7 @@ const controller = new Controller({ route: '/' })
 
 const mockPerson = {
   id: '3333',
-  fullname: 'Full name',
+  _fullname: 'Full name',
 }
 const mockProfile = {
   id: '2222',
@@ -868,7 +868,7 @@ describe('Move controllers', function () {
             toJSON: sinon.stub().returns({
               date: '2020-10-10',
               person: {
-                fullname: 'DOE, JOHN',
+                _fullname: 'DOE, JOHN',
               },
               to_location: {
                 title: 'BRIXTON',

--- a/app/move/controllers/review.js
+++ b/app/move/controllers/review.js
@@ -134,7 +134,7 @@ class ReviewController extends FormWizardController {
         }),
         message: req.t('validation::move_conflict.message', {
           href: `/move/${existingMoveId}`,
-          name: req.move.profile.person.fullname,
+          name: req.move.profile.person._fullname,
           location: req.move.to_location.title,
           date: filters.formatDateWithDay(moveDate),
         }),

--- a/app/move/controllers/review.test.js
+++ b/app/move/controllers/review.test.js
@@ -13,7 +13,7 @@ const controller = new ReviewController({ route: '/' })
 const mockMove = {
   id: '123456789',
   person: {
-    fullname: 'Full name',
+    _fullname: 'Full name',
   },
 }
 
@@ -661,7 +661,7 @@ describe('Move controllers', function () {
             },
             profile: {
               person: {
-                fullname: 'DOE, JOHN',
+                _fullname: 'DOE, JOHN',
               },
             },
           },

--- a/app/move/controllers/unassign.js
+++ b/app/move/controllers/unassign.js
@@ -35,7 +35,7 @@ class UnassignController extends FormWizardController {
       message: req.t('validation::unassign_ineligible.message'),
       instruction: req.t('validation::unassign_ineligible.instructions', {
         move_href: `/move/${id}`,
-        name: profile?.person?.fullname,
+        name: profile?.person?._fullname,
       }),
     })
   }

--- a/app/move/controllers/unassign.test.js
+++ b/app/move/controllers/unassign.test.js
@@ -141,7 +141,7 @@ describe('Move controllers', function () {
             },
             profile: {
               person: {
-                fullname: 'DOE, JOHN',
+                _fullname: 'DOE, JOHN',
               },
             },
           },

--- a/app/move/controllers/update/base.js
+++ b/app/move/controllers/update/base.js
@@ -157,7 +157,7 @@ class UpdateBaseController extends CreateBaseController {
         message: req.t('validation::move_conflict.message', {
           context: 'update',
           href: `/move/${existingMoveId}`,
-          name: move.profile.person.fullname,
+          name: move.profile.person._fullname,
           date: filters.formatDateWithDay(move.date),
         }),
         instruction: req.t('validation::move_conflict.instructions', {

--- a/app/move/controllers/update/base.test.js
+++ b/app/move/controllers/update/base.test.js
@@ -274,7 +274,7 @@ describe('Move controllers', function () {
             },
             profile: {
               person: {
-                fullname: 'DOE, JOHN',
+                _fullname: 'DOE, JOHN',
               },
             },
           }),

--- a/app/move/views/assign/no-special-vehicle.njk
+++ b/app/move/views/assign/no-special-vehicle.njk
@@ -3,11 +3,11 @@
 {% set pageTitle = t("validation::assign_needs_special_vehicle.heading") %}
 
 {% set message = t("validation::assign_needs_special_vehicle.message", {
-  name: person.fullname
+  name: person._fullname
 }) %}
 
 {% set instruction = t("validation::assign_needs_special_vehicle.instructions", {
-  name: person.fullname,
+  name: person._fullname,
   allocationHref: "/move/" + move.id + "/assign",
   moveHref: "/move/new"
 }) %}

--- a/app/move/views/cancel.njk
+++ b/app/move/views/cancel.njk
@@ -5,7 +5,7 @@
 {% endblock %}
 
 {% block innerPageTitle %}
-  {{ t("moves::cancel.page_title", { name: move.profile.person._fullname | upper }) }}
+  {{ t("moves::cancel.page_title", { name: move.profile.person._fullname }) }}
 {% endblock %}
 
 {% block beforeContent %}
@@ -21,7 +21,7 @@
   {% if move.status != "proposed" %}
     {{ govukWarningText({
       html: t("moves::cancel.warning", {
-        name: move.profile.person._fullname | upper
+        name: move.profile.person._fullname
       }),
       iconFallbackText: "Warning"
     }) }}

--- a/app/move/views/cancel.njk
+++ b/app/move/views/cancel.njk
@@ -5,7 +5,7 @@
 {% endblock %}
 
 {% block innerPageTitle %}
-  {{ t("moves::cancel.page_title", { name: move.profile.person.fullname | upper }) }}
+  {{ t("moves::cancel.page_title", { name: move.profile.person._fullname | upper }) }}
 {% endblock %}
 
 {% block beforeContent %}
@@ -21,7 +21,7 @@
   {% if move.status != "proposed" %}
     {{ govukWarningText({
       html: t("moves::cancel.warning", {
-        name: move.profile.person.fullname | upper
+        name: move.profile.person._fullname | upper
       }),
       iconFallbackText: "Warning"
     }) }}

--- a/app/move/views/confirmation.njk
+++ b/app/move/views/confirmation.njk
@@ -7,7 +7,7 @@
 {% block pageTitle %}
   {{ t("moves::confirmation.page_title", {
     context: "assign" if move.allocation else move.status,
-    name: move.profile.person._fullname | upper
+    name: move.profile.person._fullname
   }) }}
 {% endblock %}
 
@@ -44,7 +44,7 @@
           count: move.allocation.moves_count,
           href: "/move/" + move.id,
           allocationHref: "/allocation/" + move.allocation.id,
-          name: move.profile.person._fullname | upper,
+          name: move.profile.person._fullname,
           location: location,
           date: move.date | formatDateWithDay,
           supplier: move.supplier.name or t("supplier_fallback")
@@ -63,7 +63,7 @@
       {% if savedHearings|length %}
         {{ govukInsetText({
           html: t("moves::confirmation.saved_to_nomis", {
-            name: move.profile.person._fullname | upper,
+            name: move.profile.person._fullname,
             date: move.date | formatDateWithDay,
             cases: savedHearings | oxfordJoin,
             count: savedHearings.length

--- a/app/move/views/confirmation.njk
+++ b/app/move/views/confirmation.njk
@@ -7,7 +7,7 @@
 {% block pageTitle %}
   {{ t("moves::confirmation.page_title", {
     context: "assign" if move.allocation else move.status,
-    name: move.profile.person.fullname | upper
+    name: move.profile.person._fullname | upper
   }) }}
 {% endblock %}
 
@@ -44,7 +44,7 @@
           count: move.allocation.moves_count,
           href: "/move/" + move.id,
           allocationHref: "/allocation/" + move.allocation.id,
-          name: move.profile.person.fullname | upper,
+          name: move.profile.person._fullname | upper,
           location: location,
           date: move.date | formatDateWithDay,
           supplier: move.supplier.name or t("supplier_fallback")
@@ -63,7 +63,7 @@
       {% if savedHearings|length %}
         {{ govukInsetText({
           html: t("moves::confirmation.saved_to_nomis", {
-            name: move.profile.person.fullname | upper,
+            name: move.profile.person._fullname | upper,
             date: move.date | formatDateWithDay,
             cases: savedHearings | oxfordJoin,
             count: savedHearings.length

--- a/app/move/views/create/move-not-supported.njk
+++ b/app/move/views/create/move-not-supported.njk
@@ -1,7 +1,7 @@
 {% extends "layouts/action-prevented.njk" %}
 
 {% set actionPreventedTitle = t("validation::move_not_supported.heading", {
-  name: person.fullname
+  name: person._fullname
 }) %}
 
 {% set actionPreventedMessage = t("validation::move_not_supported.message", {

--- a/app/move/views/create/timetable.njk
+++ b/app/move/views/create/timetable.njk
@@ -4,7 +4,7 @@
   {% if timetable.rows.length %}
     <h2 class="govuk-heading-m govuk-!-margin-bottom-2">
       {{ t("moves::steps.timetable.subheading", {
-        name: person.fullname | upper,
+        name: person._fullname | upper,
         date: values.date | formatDateWithDay
       }) }}
     </h2>

--- a/app/move/views/create/timetable.njk
+++ b/app/move/views/create/timetable.njk
@@ -4,7 +4,7 @@
   {% if timetable.rows.length %}
     <h2 class="govuk-heading-m govuk-!-margin-bottom-2">
       {{ t("moves::steps.timetable.subheading", {
-        name: person._fullname | upper,
+        name: person._fullname,
         date: values.date | formatDateWithDay
       }) }}
     </h2>

--- a/app/move/views/review.njk
+++ b/app/move/views/review.njk
@@ -5,12 +5,12 @@
 {% endblock %}
 
 {% block innerPageTitle %}
-  {{ t("moves::review.page_title", { name: move.profile.person._fullname | upper }) }}
+  {{ t("moves::review.page_title", { name: move.profile.person._fullname }) }}
 {% endblock %}
 
 {% block pageHeading %}
   <h1 class="govuk-heading-xl govuk-!-margin-bottom-1">
-    {{ t("moves::review.page_title", { name: move.profile.person._fullname | upper }) }}
+    {{ t("moves::review.page_title", { name: move.profile.person._fullname }) }}
   </h1>
   <span class="govuk-caption-xl govuk-!-margin-bottom-8">
     {{ t("moves::move_reference", {

--- a/app/move/views/review.njk
+++ b/app/move/views/review.njk
@@ -5,12 +5,12 @@
 {% endblock %}
 
 {% block innerPageTitle %}
-  {{ t("moves::review.page_title", { name: move.profile.person.fullname | upper }) }}
+  {{ t("moves::review.page_title", { name: move.profile.person._fullname | upper }) }}
 {% endblock %}
 
 {% block pageHeading %}
   <h1 class="govuk-heading-xl govuk-!-margin-bottom-1">
-    {{ t("moves::review.page_title", { name: move.profile.person.fullname | upper }) }}
+    {{ t("moves::review.page_title", { name: move.profile.person._fullname | upper }) }}
   </h1>
   <span class="govuk-caption-xl govuk-!-margin-bottom-8">
     {{ t("moves::move_reference", {

--- a/app/move/views/unassign.njk
+++ b/app/move/views/unassign.njk
@@ -12,7 +12,7 @@
 {% block contentMain %}
   <p class="govuk-lede">
     {{ t("allocation::unassign.detail", {
-      name: person.fullname,
+      name: person._fullname,
       href: '/allocation/' + allocation.id,
       count: allocation.moves_count,
       from_location: move.from_location.title,

--- a/app/move/views/view.njk
+++ b/app/move/views/view.njk
@@ -1,7 +1,7 @@
 {% extends "layouts/two-column.njk" %}
 
 {% set additionalContainerClass = "sticky-sidebar-container" %}
-{% set name = (move.profile.person.fullname | upper) or t("awaiting_person") %}
+{% set name = (move.profile.person._fullname | upper) or t("awaiting_person") %}
 
 {% block customGtagConfig %}
   gtag('set', {'page_title': 'Move details'});
@@ -357,9 +357,9 @@
           {{ name }}
         </h3>
 
-        {% if move.profile.person.image_url %}
+        {% if move.profile.person._image_url %}
           <div class="govuk-!-width-one-half govuk-!-margin-bottom-3">
-            <img src="{{ move.profile.person.image_url }}" alt="{{ name }}">
+            <img src="{{ move.profile.person._image_url }}" alt="{{ name }}">
           </div>
         {% endif %}
 

--- a/app/move/views/view.njk
+++ b/app/move/views/view.njk
@@ -1,7 +1,7 @@
 {% extends "layouts/two-column.njk" %}
 
 {% set additionalContainerClass = "sticky-sidebar-container" %}
-{% set name = (move.profile.person._fullname | upper) or t("awaiting_person") %}
+{% set name = move.profile.person._fullname or t("awaiting_person") %}
 
 {% block customGtagConfig %}
   gtag('set', {'page_title': 'Move details'});

--- a/app/person-escort-record/controllers/print-record.js
+++ b/app/person-escort-record/controllers/print-record.js
@@ -28,8 +28,8 @@ function printRecord(req, res) {
   const moveId = move?.id
   const pickupLocation = move?.from_location?.title
   const moveType = move?.move_type
-  const fullname = profile?.person?.fullname
-  const imageUrl = profile?.person?.image_url
+  const fullname = profile?.person?._fullname
+  const imageUrl = profile?.person?._image_url
   const moveSummary = presenters.moveToSummaryListComponent(move)
   const personalDetailsSummary = presenters.personToSummaryListComponent(
     profile?.person

--- a/app/person-escort-record/views/print-record.njk
+++ b/app/person-escort-record/views/print-record.njk
@@ -15,7 +15,7 @@
 {% block pageTitle %}
   {{ t("person-escort-record::page_title", {
     context: "with_name",
-    name: fullname | upper
+    name: fullname
   }) }}
   – {{ SERVICE_NAME }}
 {% endblock %}
@@ -112,7 +112,7 @@
         <div class="app-!-float-left govuk-grid-column-three-quarters-at-mobile">
           <header class="govuk-!-margin-bottom-4">
             <h1 class="govuk-heading-l govuk-!-margin-bottom-0">
-              {{ fullname | upper }}
+              {{ fullname }}
             </h1>
             <span class="govuk-caption-l">
               {{ t("moves::move_reference", {

--- a/common/controllers/framework/framework-overview.js
+++ b/common/controllers/framework/framework-overview.js
@@ -4,7 +4,7 @@ function frameworkOverview(req, res) {
   const { originalUrl, assessment = {}, move } = req
   const moveId = move?.id
   const profile = move?.profile || assessment.profile
-  const fullname = profile?.person?.fullname
+  const fullname = profile?.person?._fullname
   const taskList = presenters.frameworkToTaskListComponent({
     baseUrl: `${originalUrl}/`,
     frameworkSections: assessment._framework?.sections,

--- a/common/controllers/framework/framework-overview.test.js
+++ b/common/controllers/framework/framework-overview.test.js
@@ -98,7 +98,7 @@ describe('Framework controllers', function () {
               },
               profile: {
                 person: {
-                  fullname: 'John Doe',
+                  _fullname: 'John Doe',
                 },
               },
             },
@@ -149,7 +149,7 @@ describe('Framework controllers', function () {
               id: '12345',
               profile: {
                 person: {
-                  fullname: 'James Stevens',
+                  _fullname: 'James Stevens',
                 },
               },
             },

--- a/common/lib/api-client/README.md
+++ b/common/lib/api-client/README.md
@@ -1,0 +1,70 @@
+# API client
+
+The internal API client is based on top of the [JSON:API devour client](https://github.com/twg/devour).
+
+This module exports a singleton to avoid creating a new devour instance with each use.
+
+## Middelware
+
+This library uses [middleware modules](./middleware) to take care of things like authentication and data
+transformation in a single layer.
+
+## Models
+
+[Models](./models) are defined as objects that are passed to the `devour.define`  method. The take the following form:
+
+```javascript
+module.exports = {
+  fields: {
+    // defines model attributes and relationships
+    // passed to `define` as second argument
+    ...
+  },
+  options: {
+    // defines devour options and custom application options used within middleware
+    // passed to `define` as third argument
+    ...
+  }
+}
+```
+
+### Custom options
+
+The following custom options have been created to be used within middleware.
+
+- `cache` - set to `true` to cache responses for this resource endpoint
+
+## Data transformation
+
+Devour doesn't support an easy way to transform the data once it has been deserialized.
+
+A [helper function](./transformers/transform-resource.js) has been created so that a transform method can be passed to it when
+using the `deserializer` option on a model.
+
+This transform method **should mutate** the data passed to it rather than return a new
+object to avoid issues with devour cache.
+
+### Naming convention
+
+To avoid conflicts with API attributes or relationships (old and potentially new) custom
+properties that are added in the transformation layer should contain an underscore (`_`)
+prefix. For example:
+
+```javascript
+// model
+const { transformResource, exampleTransformer } = require('../transformers')
+
+module.exports = {
+  fields: {
+    foo: '',
+  },
+  options: {
+    deserializer: transformResource(exampleTransformer),
+  }
+}
+
+// transformer
+module.exports = function exampleTransformer(data) {
+  data._fizz = 'buzz'
+}
+```

--- a/common/lib/api-client/transformers/assessment.transformer.js
+++ b/common/lib/api-client/transformers/assessment.transformer.js
@@ -1,17 +1,12 @@
 const frameworksService = require('../../../services/frameworks')
 
 module.exports = function assessmentTransformer(data = {}) {
-  if (!data.framework) {
-    return data
-  }
+  if (data.framework) {
+    const framework = frameworksService.getFramework({
+      framework: data.framework.name,
+      version: data.framework.version,
+    })
 
-  const framework = frameworksService.getFramework({
-    framework: data.framework.name,
-    version: data.framework.version,
-  })
-
-  return {
-    ...data,
-    _framework: framework,
+    data._framework = framework
   }
 }

--- a/common/lib/api-client/transformers/assessment.transformer.test.js
+++ b/common/lib/api-client/transformers/assessment.transformer.test.js
@@ -5,7 +5,7 @@ const transformer = require('./assessment.transformer')
 describe('API Client', function () {
   describe('Transformers', function () {
     describe('#assessmentTransformer', function () {
-      let output, item, mockFramework
+      let item, mockFramework
 
       beforeEach(function () {
         mockFramework = {
@@ -24,7 +24,7 @@ describe('API Client', function () {
               version: '1.1.0',
             },
           }
-          output = transformer(item)
+          transformer(item)
         })
 
         it('should get correct framework', function () {
@@ -37,8 +37,12 @@ describe('API Client', function () {
         })
 
         it('should add custom properties', function () {
-          expect(output).to.deep.equal({
-            ...item,
+          expect(item).to.deep.equal({
+            id: '12345',
+            framework: {
+              name: 'framework-name',
+              version: '1.1.0',
+            },
             _framework: mockFramework,
           })
         })
@@ -49,7 +53,7 @@ describe('API Client', function () {
           item = {
             id: '12345',
           }
-          output = transformer(item)
+          transformer(item)
         })
 
         it('should not get framework', function () {
@@ -57,7 +61,9 @@ describe('API Client', function () {
         })
 
         it('should not add custom properties', function () {
-          expect(output).to.deep.equal(item)
+          expect(item).to.deep.equal({
+            id: '12345',
+          })
         })
       })
     })

--- a/common/lib/api-client/transformers/person.transformer.js
+++ b/common/lib/api-client/transformers/person.transformer.js
@@ -1,7 +1,4 @@
 module.exports = function personTransformer(data) {
-  return {
-    ...data,
-    image_url: `/person/${data.id}/image`,
-    fullname: [data.last_name, data.first_names].filter(Boolean).join(', '),
-  }
+  data.image_url = `/person/${data.id}/image`
+  data.fullname = [data.last_name, data.first_names].filter(Boolean).join(', ')
 }

--- a/common/lib/api-client/transformers/person.transformer.js
+++ b/common/lib/api-client/transformers/person.transformer.js
@@ -1,4 +1,7 @@
 module.exports = function personTransformer(data) {
   data._image_url = `/person/${data.id}/image`
-  data._fullname = [data.last_name, data.first_names].filter(Boolean).join(', ')
+  data._fullname = [data.last_name, data.first_names]
+    .filter(Boolean)
+    .join(', ')
+    .toUpperCase()
 }

--- a/common/lib/api-client/transformers/person.transformer.js
+++ b/common/lib/api-client/transformers/person.transformer.js
@@ -1,4 +1,4 @@
 module.exports = function personTransformer(data) {
-  data.image_url = `/person/${data.id}/image`
-  data.fullname = [data.last_name, data.first_names].filter(Boolean).join(', ')
+  data._image_url = `/person/${data.id}/image`
+  data._fullname = [data.last_name, data.first_names].filter(Boolean).join(', ')
 }

--- a/common/lib/api-client/transformers/person.transformer.test.js
+++ b/common/lib/api-client/transformers/person.transformer.test.js
@@ -19,8 +19,8 @@ describe('API Client', function () {
           id: '12345',
           first_names: 'Foo',
           last_name: 'Bar',
-          image_url: '/person/12345/image',
-          fullname: 'Bar, Foo',
+          _image_url: '/person/12345/image',
+          _fullname: 'Bar, Foo',
         })
       })
     })

--- a/common/lib/api-client/transformers/person.transformer.test.js
+++ b/common/lib/api-client/transformers/person.transformer.test.js
@@ -20,7 +20,7 @@ describe('API Client', function () {
           first_names: 'Foo',
           last_name: 'Bar',
           _image_url: '/person/12345/image',
-          _fullname: 'Bar, Foo',
+          _fullname: 'BAR, FOO',
         })
       })
     })

--- a/common/lib/api-client/transformers/person.transformer.test.js
+++ b/common/lib/api-client/transformers/person.transformer.test.js
@@ -3,7 +3,7 @@ const transformer = require('./person.transformer')
 describe('API Client', function () {
   describe('Transformers', function () {
     describe('#personTransformer', function () {
-      let output, item
+      let item
 
       beforeEach(function () {
         item = {
@@ -11,12 +11,14 @@ describe('API Client', function () {
           first_names: 'Foo',
           last_name: 'Bar',
         }
-        output = transformer(item)
+        transformer(item)
       })
 
       it('should add custom properties', function () {
-        expect(output).to.deep.equal({
-          ...item,
+        expect(item).to.deep.equal({
+          id: '12345',
+          first_names: 'Foo',
+          last_name: 'Bar',
           image_url: '/person/12345/image',
           fullname: 'Bar, Foo',
         })

--- a/common/lib/api-client/transformers/transform-resource.js
+++ b/common/lib/api-client/transformers/transform-resource.js
@@ -1,4 +1,4 @@
-const { cloneDeep, remove } = require('lodash')
+const { cloneDeep } = require('lodash')
 
 module.exports = function transformResource(transformer) {
   return function deserializer(item, included) {
@@ -15,23 +15,10 @@ module.exports = function transformResource(transformer) {
       included
     )
 
-    if (!transformer) {
-      return deserializedData
+    if (transformer) {
+      transformer(deserializedData)
     }
 
-    const transformedData = transformer(deserializedData)
-
-    // we need to clear the cache the old time from the cache to avoid
-    // the original resource being loaded
-    // the cache is a collection and doesn't allow an item to be updated
-    // clearing doesn't work, so remove matching item
-    remove(
-      this.deserialize.cache._cache,
-      i => i.id === item.id && i.type === item.type
-    )
-    // set the new transformed data to the cache for future deserializations
-    this.deserialize.cache.set(item.type, item.id, transformedData)
-
-    return transformedData
+    return deserializedData
   }
 }

--- a/common/lib/api-client/transformers/transform-resource.test.js
+++ b/common/lib/api-client/transformers/transform-resource.test.js
@@ -70,9 +70,8 @@ describe('API Client', function () {
         let transformer
 
         beforeEach(function () {
-          transformer = sinon.stub().returns({
-            ...item,
-            _fizz: 'buzz',
+          transformer = sinon.stub().callsFake(data => {
+            data._fizz = 'buzz'
           })
 
           _this.models.book.options.deserializer = transformer
@@ -93,11 +92,12 @@ describe('API Client', function () {
           })
         })
 
-        it('should not mutate original item', function () {
+        it('should mutate original item', function () {
           expect(item).to.deep.equal({
             id: '12345',
             type: 'book',
             foo: 'bar',
+            _fizz: 'buzz',
           })
         })
 
@@ -105,23 +105,6 @@ describe('API Client', function () {
           expect(_this.deserialize.resource).to.have.been.calledWithExactly(
             item,
             included
-          )
-        })
-
-        it('should remove item from devour cache', function () {
-          expect(_this.deserialize.cache._cache).to.deep.equal([])
-        })
-
-        it('should set devour cache', function () {
-          expect(_this.deserialize.cache.set).to.have.been.calledWithExactly(
-            'book',
-            '12345',
-            {
-              id: '12345',
-              type: 'book',
-              foo: 'bar',
-              _fizz: 'buzz',
-            }
           )
         })
 

--- a/common/presenters/move-to-card-component.test.js
+++ b/common/presenters/move-to-card-component.test.js
@@ -8,7 +8,7 @@ const mockMove = {
   status: 'requested',
   profile: {
     person: {
-      fullname: 'Name, Full',
+      _fullname: 'Name, Full',
     },
   },
 }

--- a/common/presenters/profile-to-card-component.js
+++ b/common/presenters/profile-to-card-component.js
@@ -29,7 +29,7 @@ function profileToCardComponent({
     const card = {
       href,
       title: {
-        text: fullname ? fullname.toUpperCase() : i18n.t('awaiting_person'),
+        text: fullname || i18n.t('awaiting_person'),
       },
     }
 
@@ -85,9 +85,7 @@ function profileToCardComponent({
 
     if (showImage) {
       card.image_path = imageUrl
-      card.image_alt = fullname
-        ? fullname.toUpperCase()
-        : i18n.t('awaiting_person')
+      card.image_alt = fullname || i18n.t('awaiting_person')
     }
 
     return card

--- a/common/presenters/profile-to-card-component.js
+++ b/common/presenters/profile-to-card-component.js
@@ -22,8 +22,8 @@ function profileToCardComponent({
     const {
       id,
       gender,
-      fullname,
-      image_url: imageUrl,
+      _fullname: fullname,
+      _image_url: imageUrl,
       date_of_birth: dateOfBirth,
     } = person
     const card = {

--- a/common/presenters/profile-to-card-component.test.js
+++ b/common/presenters/profile-to-card-component.test.js
@@ -69,7 +69,7 @@ describe('Presenters', function () {
           it('should contain a title', function () {
             expect(transformedResponse).to.have.property('title')
             expect(transformedResponse.title).to.deep.equal({
-              text: mockProfile.person._fullname.toUpperCase(),
+              text: mockProfile.person._fullname,
             })
           })
 
@@ -87,7 +87,7 @@ describe('Presenters', function () {
           it('should contain image alt', function () {
             expect(transformedResponse).to.have.property('image_alt')
             expect(transformedResponse.image_alt).to.equal(
-              mockProfile.person._fullname.toUpperCase()
+              mockProfile.person._fullname
             )
           })
 

--- a/common/presenters/profile-to-card-component.test.js
+++ b/common/presenters/profile-to-card-component.test.js
@@ -35,8 +35,8 @@ const mockProfile = {
   ],
   person: {
     id: '12345',
-    fullname: 'Name, Full',
-    image_url: '/path/to/image.jpg',
+    _fullname: 'Name, Full',
+    _image_url: '/path/to/image.jpg',
     date_of_birth: '2000-10-10',
     gender: {
       title: 'Male',
@@ -69,7 +69,7 @@ describe('Presenters', function () {
           it('should contain a title', function () {
             expect(transformedResponse).to.have.property('title')
             expect(transformedResponse.title).to.deep.equal({
-              text: mockProfile.person.fullname.toUpperCase(),
+              text: mockProfile.person._fullname.toUpperCase(),
             })
           })
 
@@ -80,14 +80,14 @@ describe('Presenters', function () {
           it('should contain an image path', function () {
             expect(transformedResponse).to.have.property('image_path')
             expect(transformedResponse.image_path).to.equal(
-              mockProfile.person.image_url
+              mockProfile.person._image_url
             )
           })
 
           it('should contain image alt', function () {
             expect(transformedResponse).to.have.property('image_alt')
             expect(transformedResponse.image_alt).to.equal(
-              mockProfile.person.fullname.toUpperCase()
+              mockProfile.person._fullname.toUpperCase()
             )
           })
 

--- a/common/presenters/single-requests-to-table-component.test.js
+++ b/common/presenters/single-requests-to-table-component.test.js
@@ -38,7 +38,7 @@ const mockMoves = [
           value: 'A5075DA',
         },
       ],
-      fullname: 'DOE, JOHN',
+      _fullname: 'DOE, JOHN',
     },
     from_location: {
       id: '54d1c8c3-699e-4198-9218-f923a7f18149',
@@ -83,7 +83,7 @@ const mockMoves = [
           value: 'A5075DY',
         },
       ],
-      fullname: 'DOE, JANE',
+      _fullname: 'DOE, JANE',
     },
     from_location: {
       id: '54d1c8c3-699e-4198-9218-f923a7f18149',
@@ -131,7 +131,7 @@ const mockApprovedMoves = [
           value: 'A5075DA',
         },
       ],
-      fullname: 'DOE, JOHN',
+      _fullname: 'DOE, JOHN',
     },
     from_location: {
       id: '54d1c8c3-699e-4198-9218-f923a7f18149',

--- a/common/templates/form-wizard.njk
+++ b/common/templates/form-wizard.njk
@@ -105,7 +105,7 @@
   </form>
 {% endblock %}
 
-{% set sidebarHeading = sidebarHeading or (person.fullname | upper) or t("awaiting_person") %}
+{% set sidebarHeading = sidebarHeading or (person._fullname | upper) or t("awaiting_person") %}
 
 {% block contentSidebar %}
   {% if person.id or move.id and not options.hideSidebar %}
@@ -116,9 +116,9 @@
             {{ sidebarHeading }}
           </h3>
 
-          {% if person.image_url %}
+          {% if person._image_url %}
             <div class="govuk-!-width-one-half govuk-!-margin-bottom-3">
-              <img src="{{ person.image_url }}" alt="{{ person.fullname | upper }}">
+              <img src="{{ person._image_url }}" alt="{{ person._fullname | upper }}">
             </div>
           {% endif %}
 

--- a/common/templates/form-wizard.njk
+++ b/common/templates/form-wizard.njk
@@ -105,7 +105,7 @@
   </form>
 {% endblock %}
 
-{% set sidebarHeading = sidebarHeading or (person._fullname | upper) or t("awaiting_person") %}
+{% set sidebarHeading = sidebarHeading or person._fullname or t("awaiting_person") %}
 
 {% block contentSidebar %}
   {% if person.id or move.id and not options.hideSidebar %}
@@ -118,7 +118,7 @@
 
           {% if person._image_url %}
             <div class="govuk-!-width-one-half govuk-!-margin-bottom-3">
-              <img src="{{ person._image_url }}" alt="{{ person._fullname | upper }}">
+              <img src="{{ person._image_url }}" alt="{{ person._fullname }}">
             </div>
           {% endif %}
 

--- a/common/templates/framework-overview.njk
+++ b/common/templates/framework-overview.njk
@@ -7,7 +7,7 @@
 {% block pageTitle %}
   {{ t("person-escort-record::page_title", {
     context: "with_name",
-    name: fullname | upper
+    name: fullname
   }) }} – {{ SERVICE_NAME }}
 {% endblock %}
 
@@ -31,7 +31,7 @@
         }) }}
       </span>
       <h1 class="govuk-heading-xl">
-        {{ fullname | upper }}
+        {{ fullname }}
       </h1>
     </div>
   </header>

--- a/locales/en/events.json
+++ b/locales/en/events.json
@@ -28,7 +28,7 @@
   "incident_location_vehicle_false": "{{location.title}}",
   "incident_escaped": "$t(events::person) escaped from $t(events::select_incident_location_vehicle) $t(events::incident_reported_classified)",
   "no_events": "No events",
-  "person": "{{person.fullname, uppercase}}",
+  "person": "{{person._fullname, uppercase}}",
   "JourneyAdmitThroughOuterGate": {
     "heading": "Admitted through outer gate",
     "description": "Vehicle {{journey.vehicle.registration}} admitted through outer gate of {{journey.to_location.title}}"

--- a/locales/en/events.json
+++ b/locales/en/events.json
@@ -28,7 +28,7 @@
   "incident_location_vehicle_false": "{{location.title}}",
   "incident_escaped": "$t(events::person) escaped from $t(events::select_incident_location_vehicle) $t(events::incident_reported_classified)",
   "no_events": "No events",
-  "person": "{{person._fullname, uppercase}}",
+  "person": "{{person._fullname}}",
   "JourneyAdmitThroughOuterGate": {
     "heading": "Admitted through outer gate",
     "description": "Vehicle {{journey.vehicle.registration}} admitted through outer gate of {{journey.to_location.title}}"

--- a/locales/en/validation.json
+++ b/locales/en/validation.json
@@ -23,34 +23,33 @@
   "default_with_label": "{{label}} is required",
   "generic": "something went wrong",
   "prisonNumber": "Enter a prison number in the correct format",
-  "name": "{{name, uppercase}}",
   "move_conflict": {
     "heading": "This move cannot be created",
     "heading_update": "This move cannot be updated",
     "heading_review": "This move cannot be requested for this date",
-    "message": "A move <a href=\"{{href}}\">already exists</a> for <strong>$t(validation::name)</strong> to <strong>{{location}}</strong> on <strong>{{date}}</strong>.",
-    "message_update": "A move <a href=\"{{href}}\">already exists</a> for <strong>$t(validation::name)</strong> on <strong>{{date}}</strong>.",
+    "message": "A move <a href=\"{{href}}\">already exists</a> for <strong>{{name}}</strong> to <strong>{{location}}</strong> on <strong>{{date}}</strong>.",
+    "message_update": "A move <a href=\"{{href}}\">already exists</a> for <strong>{{name}}</strong> on <strong>{{date}}</strong>.",
     "instructions": "If you still need to move this person try <a href=\"{{date_href}}\">changing the date</a> or <a href=\"{{location_href}}\">the destination</a>.",
     "instructions_review": "If you still need to move this person try <a href=\"{{date_href}}\">changing the date</a>."
   },
   "move_not_supported": {
-    "heading": "$t(validation::name) cannot be moved using this service",
+    "heading": "{{name}} cannot be moved using this service",
     "message": "As this person is a Category {{category}} prisoner, they cannot be moved using this service."
   },
   "assign_conflict": {
     "heading": "This person cannot be added to this allocation",
-    "message": "A move <a href=\"{{href}}\">already exists</a> for <strong>$t(validation::name)</strong> to <strong>{{location}}</strong> on <strong>{{date}}</strong>.",
+    "message": "A move <a href=\"{{href}}\">already exists</a> for <strong>{{name}}</strong> to <strong>{{location}}</strong> on <strong>{{date}}</strong>.",
     "instructions": "Try <a href=\"{{assign_href}}\">adding a different person</a>."
   },
   "assign_needs_special_vehicle": {
     "heading": "This person cannot be added to this allocation",
-    "message": "<strong>$t(validation::name)</strong> needs a special vehicle and cannot be part of an allocation move.",
-    "instructions": "<a href=\"{{allocationHref}}\">Add a different person</a> or <a href=\"{{moveHref}}\">create a single request</a> for <strong>$t(validation::name)</strong> if they still need to move."
+    "message": "<strong>{{name}}</strong> needs a special vehicle and cannot be part of an allocation move.",
+    "instructions": "<a href=\"{{allocationHref}}\">Add a different person</a> or <a href=\"{{moveHref}}\">create a single request</a> for <strong>{{name}}</strong> if they still need to move."
   },
   "unassign_ineligible": {
     "heading": "This person cannot be removed from this allocation",
     "message": "A person cannot be removed once the move is in transit or completed.",
-    "instructions": "View the <a href=\"{{move_href}}\"><strong>move for $t(validation::name)</strong></a>."
+    "instructions": "View the <a href=\"{{move_href}}\"><strong>move for {{name}}</strong></a>."
   },
   "LIMIT_FILE_SIZE": "must be smaller than 50MB",
   "LIMIT_PART_COUNT": "has too many parts",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

The API client library uses a mutation method when deserializing response
data and storing it into its local cache.

This will now mutate the data passed to the transform methods and
also doesn't need to mess with the library's cache.

### Why did it change

The initial implementation of the local transformers were built to
return a fresh set of data rather than mutate the original object as
it is often a better approach and causes less side-effects.

However, because the original library mutates and the stores nested
resources within a cache layer, when our application would return fresh
objects it would lead to incorrect data being returned when parent
objects were given a transformer.
