### PR TITLE
Extract router subapp loading to its own module for reuse

### DIFF
--- a/app/router.js
+++ b/app/router.js
@@ -1,29 +1,3 @@
-const fs = require('fs')
+const mount = require('../common/lib/mount')
 
-const debug = require('debug')('app:router')
-const router = require('express').Router()
-
-const subApps = fs.readdirSync(__dirname, { withFileTypes: true })
-
-const appRouters = subApps
-  .filter(dirent => dirent.isDirectory())
-  .map(({ name }) => {
-    const subApp = require(`./${name}`)
-    debug('Loading app:', name)
-
-    if (subApp.router && !subApp.skip) {
-      debug('Loading router:', name)
-
-      if (subApp.mountpath) {
-        return router.use(subApp.mountpath, subApp.router)
-      }
-
-      return router.use(subApp.router)
-    }
-
-    debug('Skipping router:', name)
-
-    return (req, res, next) => next()
-  })
-
-module.exports = appRouters
+module.exports = mount(__dirname)

--- a/common/lib/mount.js
+++ b/common/lib/mount.js
@@ -1,0 +1,37 @@
+const fs = require('fs')
+const path = require('path')
+
+const debug = require('debug')('app:mount')
+const express = require('express')
+
+const mount = dir => {
+  const router = express.Router()
+  const subApps = fs.readdirSync(dir, { withFileTypes: true })
+
+  const appRouters = subApps
+    .filter(dirent => dirent.isDirectory())
+    .filter(({ name }) => fs.existsSync(path.resolve(dir, name, 'index.js')))
+    // eslint-disable-next-line array-callback-return
+    .map(({ name }) => {
+      debug('Loading app:', name)
+
+      const subApp = require(path.resolve(dir, name))
+
+      if (subApp.router && !subApp.skip) {
+        debug('Loading router:', name)
+
+        if (subApp.mountpath) {
+          return router.use(subApp.mountpath, subApp.router)
+        }
+
+        return router.use(subApp.router)
+      } else {
+        debug('Skipping router:', name)
+      }
+    })
+    .filter(used => used)
+
+  return appRouters.length ? appRouters : (req, res, next) => next()
+}
+
+module.exports = mount

--- a/common/lib/mount.test.js
+++ b/common/lib/mount.test.js
@@ -1,0 +1,111 @@
+const path = require('path')
+
+const proxyquire = require('proxyquire')
+
+const use = sinon.stub().returnsArg(0)
+const express = {
+  Router: sinon.stub().returns({ use }),
+}
+
+const mount = proxyquire('./mount', {
+  express,
+})
+
+const mountPath = testpath =>
+  mount(path.resolve(__dirname, `../../test/fixtures/mount/${testpath}`))
+
+describe('subapp mounter', function () {
+  let mounts
+  beforeEach(function () {
+    express.Router.resetHistory()
+    use.resetHistory()
+  })
+
+  describe('when there is a subapp', function () {
+    beforeEach(function () {
+      mounts = mountPath('default')
+    })
+
+    it('should use the subapp', function () {
+      expect(use).to.be.calledOnceWithExactly('app1')
+    })
+
+    it('should return the used middleware', function () {
+      expect(mounts).to.deep.equal(['app1'])
+    })
+  })
+
+  describe('when there is a subapp with a mountpath', function () {
+    beforeEach(function () {
+      mounts = mountPath('mountpath')
+    })
+
+    it('should use the subapp', function () {
+      expect(use).to.be.calledOnceWithExactly('/app1', 'app1')
+    })
+
+    it('should return the used middleware', function () {
+      expect(mounts).to.deep.equal(['/app1'])
+    })
+  })
+
+  describe('when there are multiple subapps', function () {
+    beforeEach(function () {
+      mounts = mountPath('multiple')
+    })
+
+    it('should use the subapp', function () {
+      expect(use.callCount).to.equal(2)
+      expect(use).to.be.calledWithExactly('app1')
+      expect(use).to.be.calledWithExactly('app2')
+    })
+
+    it('should return the used middleware', function () {
+      expect(mounts).to.deep.equal(['app1', 'app2'])
+    })
+  })
+
+  describe('when there is a skippable subapp', function () {
+    beforeEach(function () {
+      mounts = mountPath('skip')
+    })
+
+    it('should only use the non-skipped subapps', function () {
+      expect(use).to.be.calledOnceWithExactly('app2')
+    })
+
+    it('should return the used middleware', function () {
+      expect(mounts).to.deep.equal(['app2'])
+    })
+  })
+
+  describe('when there is a missing router', function () {
+    beforeEach(function () {
+      mounts = mountPath('missing')
+    })
+
+    it('should only use the non-missing subapps', function () {
+      expect(use).to.be.calledOnceWithExactly('app2')
+    })
+
+    it('should return the used middleware', function () {
+      expect(mounts).to.deep.equal(['app2'])
+    })
+  })
+
+  describe('when there are no subapps', function () {
+    beforeEach(function () {
+      mounts = mountPath('empty')
+    })
+
+    it('should not attempt to use any subapps', function () {
+      expect(use).to.not.be.called
+    })
+
+    it('should return a noop middleware', function () {
+      const next = sinon.stub()
+      mounts('req', 'res', next)
+      expect(next).to.be.calledOnceWithExactly()
+    })
+  })
+})

--- a/test/fixtures/mount/default/app1/index.js
+++ b/test/fixtures/mount/default/app1/index.js
@@ -1,0 +1,3 @@
+module.exports = {
+  router: 'app1',
+}

--- a/test/fixtures/mount/empty/.gitkeep
+++ b/test/fixtures/mount/empty/.gitkeep
@@ -1,0 +1,1 @@
+# empty file

--- a/test/fixtures/mount/missing/app1/.gitkeep
+++ b/test/fixtures/mount/missing/app1/.gitkeep
@@ -1,0 +1,1 @@
+# empty file

--- a/test/fixtures/mount/missing/app2/index.js
+++ b/test/fixtures/mount/missing/app2/index.js
@@ -1,0 +1,3 @@
+module.exports = {
+  router: 'app2',
+}

--- a/test/fixtures/mount/mountpath/app1/index.js
+++ b/test/fixtures/mount/mountpath/app1/index.js
@@ -1,0 +1,4 @@
+module.exports = {
+  router: 'app1',
+  mountpath: '/app1',
+}

--- a/test/fixtures/mount/multiple/app1/index.js
+++ b/test/fixtures/mount/multiple/app1/index.js
@@ -1,0 +1,3 @@
+module.exports = {
+  router: 'app1',
+}

--- a/test/fixtures/mount/multiple/app2/index.js
+++ b/test/fixtures/mount/multiple/app2/index.js
@@ -1,0 +1,3 @@
+module.exports = {
+  router: 'app2',
+}

--- a/test/fixtures/mount/skip/app1/index.js
+++ b/test/fixtures/mount/skip/app1/index.js
@@ -1,0 +1,4 @@
+module.exports = {
+  router: 'app1',
+  skip: true,
+}

--- a/test/fixtures/mount/skip/app2/index.js
+++ b/test/fixtures/mount/skip/app2/index.js
@@ -1,0 +1,3 @@
+module.exports = {
+  router: 'app2',
+}


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Extract router subapp loading to its own module for reuse

### Why did it change

- adds tests
- enables empty folders to not cause the app to crash
- streamlines the returning of noop middleware

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

n/a

## Screenshots
<!--- (Optional) Include screenshots if changes update interfaces or components -->
<!--- Delete/copy as appropriate --->

n/a

## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed

### Other considerations

- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
