### PR TITLE
build: Add tasks folder to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,6 +46,7 @@ COPY --chown=node:node server.js .
 COPY --chown=node:node locales locales
 COPY --chown=node:node common common
 COPY --chown=node:node app app
+COPY --chown=node:node tasks tasks
 
 EXPOSE 3000
 CMD [ "node", "start.js" ]


### PR DESCRIPTION
The tasks need to be called in some environments to do actions like
clearing cache.

To have access to this we need this copied across in the container.