### PR TITLE
[P4-2548] fix: Update edit population heading and button

### DIFF
--- a/app/population/controllers/edit.js
+++ b/app/population/controllers/edit.js
@@ -6,8 +6,8 @@ const populationService = require('../../../common/services/population')
 class DetailsController extends FormWizardController {
   middlewareLocals() {
     super.middlewareLocals()
-    this.use(this.setTitleText)
     this.use(this.setCancelUrl)
+    this.use(this.setPageTitle)
   }
 
   setInitialValues(req, res, next) {
@@ -60,7 +60,7 @@ class DetailsController extends FormWizardController {
     next()
   }
 
-  setTitleText(req, res, next) {
+  setPageTitle(req, res, next) {
     req.form.options.pageTitle = req.population
       ? 'population::edit.page_title_update'
       : 'population::edit.page_title_new'

--- a/app/population/controllers/edit.js
+++ b/app/population/controllers/edit.js
@@ -6,7 +6,7 @@ const populationService = require('../../../common/services/population')
 class DetailsController extends FormWizardController {
   middlewareLocals() {
     super.middlewareLocals()
-    this.use(this.setButtonText)
+    this.use(this.setTitleText)
     this.use(this.setCancelUrl)
   }
 
@@ -50,21 +50,20 @@ class DetailsController extends FormWizardController {
     }
   }
 
-  setButtonText(req, res, next) {
-    const buttonText = req.population
-      ? 'actions::change_numbers'
-      : 'actions::add_numbers'
-    req.form.options.buttonText = req.form.options.buttonText || buttonText
-
-    next()
-  }
-
   setCancelUrl(req, res, next) {
     if (req.population) {
       res.locals.cancelUrl = `/population/day/${req.date}/${req.locationId}`
     } else {
       res.locals.cancelUrl = `/population/week/${req.date}`
     }
+
+    next()
+  }
+
+  setTitleText(req, res, next) {
+    req.form.options.pageTitle = req.population
+      ? 'population::edit.page_title_update'
+      : 'population::edit.page_title_new'
 
     next()
   }

--- a/app/population/controllers/edit.test.js
+++ b/app/population/controllers/edit.test.js
@@ -64,7 +64,7 @@ describe('Population controllers', function () {
       it('should call set button text method', function () {
         expect(
           controllerInstance.use.getCall(0)
-        ).to.have.been.calledWithExactly(controllerInstance.setButtonText)
+        ).to.have.been.calledWithExactly(controllerInstance.setTitleText)
       })
 
       it('should call set cancel url method', function () {
@@ -215,37 +215,6 @@ describe('Population controllers', function () {
       })
     })
 
-    describe('setButtonText', function () {
-      context('with an existing population', function () {
-        beforeEach(function () {
-          req.population = {}
-          controllerInstance.setButtonText(req, res, next)
-        })
-        it('should use change text', function () {
-          expect(req.form.options.buttonText).to.equal(
-            'actions::change_numbers'
-          )
-        })
-
-        it('should call next', function () {
-          expect(next).to.have.been.calledWith()
-        })
-      })
-
-      context('with an new population', function () {
-        beforeEach(async function () {
-          await controllerInstance.setButtonText(req, res, next)
-        })
-        it('should use add text', function () {
-          expect(req.form.options.buttonText).to.equal('actions::add_numbers')
-        })
-
-        it('should call next', function () {
-          expect(next).to.have.been.calledWith()
-        })
-      })
-    })
-
     describe('setCancelUrl', function () {
       context('with an existing population', function () {
         beforeEach(function () {
@@ -272,6 +241,39 @@ describe('Population controllers', function () {
         })
         it('should use add text', function () {
           expect(res.locals.cancelUrl).to.equal('/population/week/2020-06-01')
+        })
+
+        it('should call next', function () {
+          expect(next).to.have.been.calledWith()
+        })
+      })
+    })
+
+    describe('setTitleText', function () {
+      context('with an existing population', function () {
+        beforeEach(function () {
+          req.population = {}
+          controllerInstance.setTitleText(req, res, next)
+        })
+        it('should use change text', function () {
+          expect(req.form.options.pageTitle).to.equal(
+            'population::edit.page_title_update'
+          )
+        })
+
+        it('should call next', function () {
+          expect(next).to.have.been.calledWith()
+        })
+      })
+
+      context('with an new population', function () {
+        beforeEach(async function () {
+          await controllerInstance.setTitleText(req, res, next)
+        })
+        it('should use add text', function () {
+          expect(req.form.options.pageTitle).to.equal(
+            'population::edit.page_title_new'
+          )
         })
 
         it('should call next', function () {

--- a/app/population/controllers/edit.test.js
+++ b/app/population/controllers/edit.test.js
@@ -61,22 +61,23 @@ describe('Population controllers', function () {
           .calledOnce
       })
 
-      it('should call set button text method', function () {
-        expect(
-          controllerInstance.use.getCall(0)
-        ).to.have.been.calledWithExactly(controllerInstance.setTitleText)
-      })
-
       it('should call set cancel url method', function () {
         expect(
-          controllerInstance.use.getCall(1)
+          controllerInstance.use.getCall(0)
         ).to.have.been.calledWithExactly(controllerInstance.setCancelUrl)
+      })
+
+      it('should call set page title method', function () {
+        expect(
+          controllerInstance.use.getCall(1)
+        ).to.have.been.calledWithExactly(controllerInstance.setPageTitle)
       })
 
       it('should call correct number of middleware', function () {
         expect(controllerInstance.use).to.be.callCount(2)
       })
     })
+
     describe('setInitialValues', function () {
       context('on first page visit', function () {
         beforeEach(async function () {
@@ -249,11 +250,11 @@ describe('Population controllers', function () {
       })
     })
 
-    describe('setTitleText', function () {
+    describe('setPageTitle', function () {
       context('with an existing population', function () {
         beforeEach(function () {
           req.population = {}
-          controllerInstance.setTitleText(req, res, next)
+          controllerInstance.setPageTitle(req, res, next)
         })
         it('should use change text', function () {
           expect(req.form.options.pageTitle).to.equal(
@@ -268,7 +269,7 @@ describe('Population controllers', function () {
 
       context('with an new population', function () {
         beforeEach(async function () {
-          await controllerInstance.setTitleText(req, res, next)
+          await controllerInstance.setPageTitle(req, res, next)
         })
         it('should use add text', function () {
           expect(req.form.options.pageTitle).to.equal(

--- a/app/population/steps/edit.js
+++ b/app/population/steps/edit.js
@@ -11,7 +11,6 @@ module.exports = {
   },
   '/details': {
     controller: EditController,
-    pageTitle: 'population::free_space_details.page_title',
     fields: [
       'operational_capacity',
       'usable_capacity',
@@ -22,5 +21,6 @@ module.exports = {
       'out_of_area_courts',
       'discharges',
     ],
+    buttonText: 'actions::save_and_calculate',
   },
 }

--- a/locales/en/actions.json
+++ b/locales/en/actions.json
@@ -50,6 +50,5 @@
   "add_item": "Add {{name}}",
   "add_item_with_items": "Add another {{name}}",
   "remove_item": "Remove <span class=\"govuk-visually-hidden\">{{name}} {{index}}</span>",
-  "add_numbers": "Add numbers",
-  "change_numbers": "Change numbers"
+  "save_and_calculate": "Save and calculate"
 }

--- a/locales/en/population.json
+++ b/locales/en/population.json
@@ -33,7 +33,8 @@
   "labels": {
     "establishment": "Establishment"
   },
-  "free_space_details": {
-    "page_title": "Population Details"
+  "edit": {
+    "page_title_new": "Add numbers",
+    "page_title_update": "Change numbers"
   }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes
If adding new population details, use "Add numbers" as a page title, if editing existing population details use "Change numbers" as a page title.

Change the button text to "Calculate and save" in both instances

### What changed

<!--- Describe the changes in detail - the "what"-->

### Why did it change

<!--- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

- [P4-2548](https://dsdmoj.atlassian.net/browse/P4-2548)

## Screenshots
<!--- (Optional) Include screenshots if changes update interfaces or components -->
<!--- Delete/copy as appropriate --->

| Before | After |
| ------ | ----- |
| ![Screenshot_2020-12-03 Population Details - create_population](https://user-images.githubusercontent.com/196695/101016069-2f33f980-3560-11eb-9b27-a61b2bf69e0f.png) | ![Screenshot_2020-12-03 Change numbers - create_population](https://user-images.githubusercontent.com/196695/101016097-365b0780-3560-11eb-907b-7907e49b6a62.png) |
| ![Screenshot_2020-12-03 Population Details - create_population(1)](https://user-images.githubusercontent.com/196695/101016131-407d0600-3560-11eb-9ca4-a4406ac5e35a.png) | ![Screenshot_2020-12-03 Add numbers - create_population](https://user-images.githubusercontent.com/196695/101016141-44108d00-3560-11eb-866e-eced6967ea63.png) |

## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [ ] Chrome
- [x] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed

### Other considerations

Commit messages with a `fix` or `feat` type are automatically used to generate the [changelog](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/CHANGELOG.md) and
[GitHub release notes](https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/releases) during the release task. Please make sure they will read well on their own in a
summary of changes and that the commit body gives a more detailed description of those changes if necessary.

- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
- [ ] Update [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md) with any new instructions or tasks
