### PR TITLE
fix: Use session.user.fullname for updated_by

### DIFF
--- a/app/population/controllers/edit.js
+++ b/app/population/controllers/edit.js
@@ -30,14 +30,14 @@ class DetailsController extends FormWizardController {
         await populationService.update({
           id: req.population.id,
           ...data,
-          updated_by: 'user.fullname',
+          updated_by: req.session.user.fullname,
         })
       } else {
         await populationService.create({
           location: req.locationId,
           date: req.date,
           ...data,
-          updated_by: 'user.fullname',
+          updated_by: req.session.user.fullname,
         })
       }
 

--- a/app/population/controllers/edit.test.js
+++ b/app/population/controllers/edit.test.js
@@ -14,15 +14,17 @@ describe('Population controllers', function () {
     let next
     let controllerInstance
     let sessionData
-    let username
 
     beforeEach(function () {
-      username = 'user.fullname'
       sessionData = { key: 'value' }
       req = {
         date: '2020-06-01',
         locationId: 'DEADBEEF',
-
+        session: {
+          user: {
+            fullname: 'Lorem Ipsum',
+          },
+        },
         sessionModel: {
           toJSON: sinon.stub().returns(sessionData),
           reset: sinon.fake(),
@@ -130,7 +132,7 @@ describe('Population controllers', function () {
           expect(mockPopulationService.create).to.have.been.calledWith({
             location: req.locationId,
             date: req.date,
-            updated_by: username,
+            updated_by: req.session.user.fullname,
             ...sessionData,
           })
         })
@@ -181,7 +183,7 @@ describe('Population controllers', function () {
 
           expect(mockPopulationService.update).to.have.been.calledWith({
             id: req.population.id,
-            updated_by: username,
+            updated_by: req.session.user.fullname,
             ...sessionData,
           })
         })


### PR DESCRIPTION

## Proposed changes

### What changed
Use the fullname of the user when updating, not the string "user.fullname"

<!--- Describe the changes in detail - the "what"-->

### Why did it change

<!--- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

- [P4-XXXX]()

## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [ ] Chrome
- [x] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed

### Other considerations

Commit messages with a `fix` or `feat` type are automatically used to generate the [changelog](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/CHANGELOG.md) and
[GitHub release notes](https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/releases) during the release task. Please make sure they will read well on their own in a
summary of changes and that the commit body gives a more detailed description of those changes if necessary.

- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
- [ ] Update [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md) with any new instructions or tasks
