### PR TITLE
fix: Use correct content for prison recall conflicts

### DIFF
--- a/app/move/controllers/create/save.js
+++ b/app/move/controllers/create/save.js
@@ -150,7 +150,9 @@ class SaveController extends CreateBaseController {
         message: req.t('validation::move_conflict.message', {
           href: `/move/${existingMoveId}`,
           name: values.person._fullname,
-          location: values.to_location.title,
+          location:
+            values.to_location?.title ||
+            req.t('fields::move_type.items.prison_recall.label'),
           date: filters.formatDateWithDay(values.date),
         }),
         instruction: req.t('validation::move_conflict.instructions', {

--- a/app/move/controllers/create/save.test.js
+++ b/app/move/controllers/create/save.test.js
@@ -918,61 +918,131 @@ describe('Move controllers', function () {
         })
 
         context('with `taken` error code', function () {
-          beforeEach(function () {
-            errorMock.errors = [
-              {
-                code: 'taken',
-                meta: {
-                  existing_id: mockExistingMoveId,
+          context('with to location', function () {
+            beforeEach(function () {
+              errorMock.errors = [
+                {
+                  code: 'taken',
+                  meta: {
+                    existing_id: mockExistingMoveId,
+                  },
                 },
-              },
-            ]
-            controller.errorHandler(errorMock, reqMock, resMock, nextSpy)
+              ]
+              controller.errorHandler(errorMock, reqMock, resMock, nextSpy)
+            })
+
+            it('should not call parent error handler', function () {
+              expect(
+                BaseController.prototype.errorHandler
+              ).not.to.have.been.called
+            })
+
+            it('should render a template', function () {
+              expect(resMock.render).to.have.been.calledOnceWithExactly(
+                'action-prevented',
+                {
+                  pageTitle: 'validation::move_conflict.heading',
+                  message: 'validation::move_conflict.message',
+                  instruction: 'validation::move_conflict.instructions',
+                }
+              )
+            })
+
+            it('should translate page title', function () {
+              expect(reqMock.t).to.have.been.calledWithExactly(
+                'validation::move_conflict.heading'
+              )
+            })
+
+            it('should translate message', function () {
+              expect(reqMock.t).to.have.been.calledWithExactly(
+                'validation::move_conflict.message',
+                {
+                  href: '/move/12345',
+                  name: 'DOE, JOHN',
+                  location: 'BRIXTON',
+                  date: '2020-10-10',
+                }
+              )
+            })
+
+            it('should translate instruction', function () {
+              expect(reqMock.t).to.have.been.calledWithExactly(
+                'validation::move_conflict.instructions',
+                {
+                  date_href: 'move-date/edit',
+                  location_href: 'move-details/edit',
+                }
+              )
+            })
           })
 
-          it('should not call parent error handler', function () {
-            expect(
-              BaseController.prototype.errorHandler
-            ).not.to.have.been.called
-          })
-
-          it('should render a template', function () {
-            expect(resMock.render).to.have.been.calledOnceWithExactly(
-              'action-prevented',
-              {
-                pageTitle: 'validation::move_conflict.heading',
-                message: 'validation::move_conflict.message',
-                instruction: 'validation::move_conflict.instructions',
-              }
-            )
-          })
-
-          it('should translate page title', function () {
-            expect(reqMock.t).to.have.been.calledWithExactly(
-              'validation::move_conflict.heading'
-            )
-          })
-
-          it('should translate message', function () {
-            expect(reqMock.t).to.have.been.calledWithExactly(
-              'validation::move_conflict.message',
-              {
-                href: '/move/12345',
-                name: 'DOE, JOHN',
-                location: 'BRIXTON',
+          context('with prison recall', function () {
+            beforeEach(function () {
+              reqMock.sessionModel.toJSON.returns({
                 date: '2020-10-10',
-              }
-            )
-          })
+                person: {
+                  _fullname: 'DOE, JOHN',
+                },
+              })
+              errorMock.errors = [
+                {
+                  code: 'taken',
+                  meta: {
+                    existing_id: mockExistingMoveId,
+                  },
+                },
+              ]
+              controller.errorHandler(errorMock, reqMock, resMock, nextSpy)
+            })
 
-          it('should translate instruction', function () {
-            expect(reqMock.t).to.have.been.calledWithExactly(
-              'validation::move_conflict.instructions',
-              {
-                date_href: 'move-date/edit',
-                location_href: 'move-details/edit',
-              }
-            )
+            it('should not call parent error handler', function () {
+              expect(
+                BaseController.prototype.errorHandler
+              ).not.to.have.been.called
+            })
+
+            it('should render a template', function () {
+              expect(resMock.render).to.have.been.calledOnceWithExactly(
+                'action-prevented',
+                {
+                  pageTitle: 'validation::move_conflict.heading',
+                  message: 'validation::move_conflict.message',
+                  instruction: 'validation::move_conflict.instructions',
+                }
+              )
+            })
+
+            it('should translate page title', function () {
+              expect(reqMock.t).to.have.been.calledWithExactly(
+                'validation::move_conflict.heading'
+              )
+            })
+
+            it('should translate message', function () {
+              expect(reqMock.t).to.have.been.calledWithExactly(
+                'validation::move_conflict.message',
+                {
+                  href: '/move/12345',
+                  name: 'DOE, JOHN',
+                  location: 'fields::move_type.items.prison_recall.label',
+                  date: '2020-10-10',
+                }
+              )
+            })
+
+            it('should translate instruction', function () {
+              expect(reqMock.t).to.have.been.calledWithExactly(
+                'validation::move_conflict.instructions',
+                {
+                  date_href: 'move-date/edit',
+                  location_href: 'move-details/edit',
+                }
+              )
+              expect(reqMock.t).to.have.been.calledWithExactly(
+                'fields::move_type.items.prison_recall.label'
+              )
+            })
           })
         })
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Fixes an issue when prison recall conflicts occur.

### Why did it change

The current error handler for rendering conflicts expects there to
be a to location and a title for that location.

However, for a prison recall move this doesn't exist so this fixes
that issue and uses the label for the prison recall option when
the location doesn't exist.

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

Fixes BOOK-A-SECURE-MOVE-FRONTEND-1F

https://sentry.io/organizations/ministryofjustice/issues/2072489820

## Screenshots
<!--- (Optional) Include screenshots if changes update interfaces or components -->
<!--- Delete/copy as appropriate --->

| Before | After |
| ------ | ----- |
| <kbd>![image](https://user-images.githubusercontent.com/3327997/101360910-31ff5900-3896-11eb-85c1-0e65635cc016.png)</kbd> | <kbd>![image](https://user-images.githubusercontent.com/3327997/101360867-214ee300-3896-11eb-8b60-202e506db24c.png)</kbd> |

## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [x] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed
