### PR TITLE
[IM-28] Protect assign journey with extra checks

### DIFF
--- a/app/allocation/controllers/assign-to-allocation.js
+++ b/app/allocation/controllers/assign-to-allocation.js
@@ -1,0 +1,12 @@
+function assignToAllocation(req, res) {
+  const { allocation } = req
+  const movesWithoutProfile = allocation.moves.filter(move => !move.profile)
+
+  if (movesWithoutProfile.length) {
+    return res.redirect(`/move/${movesWithoutProfile[0].id}/assign`)
+  }
+
+  res.redirect(`/allocation/${allocation.id}`)
+}
+
+module.exports = assignToAllocation

--- a/app/allocation/controllers/assign-to-allocation.test.js
+++ b/app/allocation/controllers/assign-to-allocation.test.js
@@ -1,0 +1,72 @@
+const controller = require('./assign-to-allocation')
+
+describe('Allocation controllers', function () {
+  describe('#assignToAllocation', function () {
+    let mockReq
+    let mockRes
+
+    beforeEach(function () {
+      mockReq = {
+        allocation: {
+          id: '__allocation_id__',
+          moves: [],
+        },
+      }
+      mockRes = {
+        redirect: sinon.stub(),
+      }
+    })
+
+    context('with moves to be assigned', function () {
+      it('should redirect to next move to be assigned', function () {
+        mockReq.allocation.moves = [
+          {
+            id: '_move_1',
+            profile: {
+              id: '_profile_1',
+            },
+          },
+          {
+            id: '_move_2',
+          },
+          {
+            id: '_move_3',
+          },
+        ]
+        controller(mockReq, mockRes)
+        expect(mockRes.redirect).to.have.been.calledOnceWithExactly(
+          '/move/_move_2/assign'
+        )
+      })
+    })
+
+    context('when allocation is full', function () {
+      it('should redirect back to allocation', function () {
+        mockReq.allocation.moves = [
+          {
+            id: '_move_1',
+            profile: {
+              id: '_profile_1',
+            },
+          },
+          {
+            id: '_move_2',
+            profile: {
+              id: '_profile_2',
+            },
+          },
+          {
+            id: '_move_3',
+            profile: {
+              id: '_profile_3',
+            },
+          },
+        ]
+        controller(mockReq, mockRes)
+        expect(mockRes.redirect).to.have.been.calledOnceWithExactly(
+          '/allocation/__allocation_id__'
+        )
+      })
+    })
+  })
+})

--- a/app/allocation/controllers/index.js
+++ b/app/allocation/controllers/index.js
@@ -1,9 +1,11 @@
+const assignToAllocation = require('./assign-to-allocation')
 const CancelController = require('./cancel')
 const createControllers = require('./create')
 const RemoveMoveController = require('./remove-move')
 const viewAllocation = require('./view')
 
 module.exports = {
+  assignToAllocation,
   CancelController,
   createControllers,
   RemoveMoveController,

--- a/app/allocation/controllers/view.js
+++ b/app/allocation/controllers/view.js
@@ -39,9 +39,6 @@ function viewAllocation(req, res) {
       context: allocation.cancellation_reason,
       comment: allocation.cancellation_reason_comment,
     }),
-    unassignedMoveId: movesWithoutProfile.length
-      ? movesWithoutProfile[0].id
-      : undefined,
     totalCount: totalSlots,
     remainingCount: movesWithoutProfile.length,
     addedCount: movesWithProfile.length,

--- a/app/allocation/controllers/view.test.js
+++ b/app/allocation/controllers/view.test.js
@@ -169,10 +169,6 @@ describe('Allocation controllers', function () {
           expect(locals.messageTitle).to.be.undefined
         })
 
-        it('should create unassigned move ID', function () {
-          expect(locals.unassignedMoveId).to.equal('123')
-        })
-
         it('should order moves without person first', function () {
           const ordered = locals.moves.map(move => move.id)
           expect(ordered).to.deep.equal(['789', '123', '011', '456'])
@@ -187,7 +183,7 @@ describe('Allocation controllers', function () {
         })
 
         it('should contain correct number of locals', function () {
-          expect(Object.keys(locals)).to.have.length(11)
+          expect(Object.keys(locals)).to.have.length(10)
         })
       })
 
@@ -228,49 +224,6 @@ describe('Allocation controllers', function () {
         expect(mockReq.t).to.be.calledWithExactly('statuses::cancelled', {
           context: 'allocation',
         })
-      })
-    })
-
-    context('when all moves have been filled', function () {
-      let locals
-
-      beforeEach(function () {
-        mockReq.allocation.moves = [
-          {
-            id: '123',
-            profile: {
-              person: {
-                first_names: 'James',
-                last_name: 'Stevens',
-              },
-            },
-          },
-          {
-            id: '456',
-            profile: {
-              person: {
-                first_names: 'Andrew',
-                last_name: 'Collins',
-              },
-            },
-          },
-          {
-            id: '789',
-            profile: {
-              person: {
-                first_names: 'John',
-                last_name: 'Doe',
-              },
-            },
-          },
-        ]
-
-        controller(mockReq, mockRes)
-        locals = mockRes.render.firstCall.lastArg
-      })
-
-      it('should not create an unassigned move ID', function () {
-        expect(locals.unassignedMoveId).to.be.undefined
       })
     })
 

--- a/app/allocation/index.js
+++ b/app/allocation/index.js
@@ -5,7 +5,11 @@ const wizard = require('../../common/middleware/unique-form-wizard')
 const { setMove } = require('../move/middleware')
 
 const { cancelConfig, removeMoveConfig, createConfig } = require('./config')
-const { createControllers, viewAllocation } = require('./controllers')
+const {
+  createControllers,
+  viewAllocation,
+  assignToAllocation,
+} = require('./controllers')
 const { cancelFields, createFields } = require('./fields')
 const { setAllocation } = require('./middleware')
 const { cancelSteps, removeMoveSteps, createSteps } = require('./steps')
@@ -38,6 +42,7 @@ router.use(
 )
 
 router.get('/:allocationId', protectRoute('allocations:view'), viewAllocation)
+router.get('/:allocationId/assign', assignToAllocation)
 
 // Export
 module.exports = {

--- a/app/allocation/views/view.njk
+++ b/app/allocation/views/view.njk
@@ -107,7 +107,7 @@
         </p>
 
         {{ govukButton({
-          href: "/move/" + unassignedMoveId + "/assign",
+          href: "/allocation/" + allocation.id + "/assign",
           html: t("actions::add_person", {
             context: "another" if addedCount !== 0
           })

--- a/app/move/controllers/assign/base.js
+++ b/app/move/controllers/assign/base.js
@@ -8,6 +8,24 @@ class AssignBaseController extends CreateBaseController {
     this.use(this.setCancelUrl)
   }
 
+  middlewareChecks() {
+    super.middlewareChecks()
+    this.use(this.checkNoProfileExists)
+  }
+
+  checkNoProfileExists(req, res, next) {
+    if (req.move.profile) {
+      return res.redirect(`/allocation/${req.move.allocation.id}/assign`)
+    }
+
+    next()
+  }
+
+  // override create method as no location is required to assign
+  checkCurrentLocation(req, res, next) {
+    next()
+  }
+
   setCancelUrl(req, res, next) {
     const allocationId = req.move.allocation.id
     res.locals.cancelUrl = `/allocation/${allocationId}`

--- a/app/move/controllers/create/base.js
+++ b/app/move/controllers/create/base.js
@@ -130,7 +130,7 @@ class CreateBaseController extends FormWizardController {
       id: currentLocationId,
       location_type: locationType,
       can_upload_documents: canUploadDocuments,
-    } = req.session.currentLocation
+    } = req.session.currentLocation || {}
 
     req.form.values.from_location = currentLocationId
     req.form.values.from_location_type = locationType

--- a/app/move/controllers/create/base.test.js
+++ b/app/move/controllers/create/base.test.js
@@ -748,36 +748,62 @@ describe('Move controllers', function () {
           form: {
             values: {},
           },
-          session: {
-            currentLocation: currentLocationMock,
-          },
+          session: {},
         }
         nextSpy = sinon.spy()
-        controller.saveValues(req, {}, nextSpy)
       })
 
-      it('should set current location ID', function () {
-        expect(req.form.values.from_location).to.equal(currentLocationMock.id)
+      context('with location', function () {
+        beforeEach(function () {
+          req.session.currentLocation = currentLocationMock
+          controller.saveValues(req, {}, nextSpy)
+        })
+
+        it('should set current location ID', function () {
+          expect(req.form.values.from_location).to.equal(currentLocationMock.id)
+        })
+
+        it('should set from location type', function () {
+          expect(req.form.values.from_location_type).to.equal(
+            currentLocationMock.location_type
+          )
+        })
+
+        it('should set can upload documents values', function () {
+          expect(req.form.values.can_upload_documents).to.equal(
+            currentLocationMock.can_upload_documents
+          )
+        })
+
+        it('should call parent method', function () {
+          expect(
+            FormController.prototype.saveValues
+          ).to.be.calledOnceWithExactly(req, {}, nextSpy)
+        })
       })
 
-      it('should set from location type', function () {
-        expect(req.form.values.from_location_type).to.equal(
-          currentLocationMock.location_type
-        )
-      })
+      context('without location', function () {
+        beforeEach(function () {
+          controller.saveValues(req, {}, nextSpy)
+        })
 
-      it('should set can upload documents values', function () {
-        expect(req.form.values.can_upload_documents).to.equal(
-          currentLocationMock.can_upload_documents
-        )
-      })
+        it('should set current location ID', function () {
+          expect(req.form.values.from_location).to.be.undefined
+        })
 
-      it('should call parent method', function () {
-        expect(FormController.prototype.saveValues).to.be.calledOnceWithExactly(
-          req,
-          {},
-          nextSpy
-        )
+        it('should set from location type', function () {
+          expect(req.form.values.from_location_type).to.be.undefined
+        })
+
+        it('should set can upload documents values', function () {
+          expect(req.form.values.can_upload_documents).to.be.undefined
+        })
+
+        it('should call parent method', function () {
+          expect(
+            FormController.prototype.saveValues
+          ).to.be.calledOnceWithExactly(req, {}, nextSpy)
+        })
       })
     })
   })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

This change includes two fixes to prevent a circular structure error. It:

- prevents the assign journey being completed when a move already has a profile
- handles the deciding of the next move to assign using a redirect route instead of on page load of the allocation

### Why did it change

See Jira ticket for more information.

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

- [IM-28](https://dsdmoj.atlassian.net/browse/IM-28)

Fixes BOOK-A-SECURE-MOVE-FRONTEND-T
https://sentry.io/organizations/ministryofjustice/issues/1920836995

## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [x] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed
