### PR TITLE
Use correct content for framework assessment

### DIFF
--- a/common/controllers/framework/framework-overview.js
+++ b/common/controllers/framework/framework-overview.js
@@ -1,3 +1,5 @@
+const { snakeCase } = require('lodash')
+
 const presenters = require('../../presenters')
 
 function frameworkOverview(req, res) {
@@ -10,8 +12,10 @@ function frameworkOverview(req, res) {
     frameworkSections: assessment._framework?.sections,
     sectionProgress: assessment.meta?.section_progress,
   })
+  const i18nContext = snakeCase(assessment.framework?.name || '')
 
   res.render('framework-overview', {
+    i18nContext,
     moveId,
     taskList,
     fullname,

--- a/common/controllers/framework/framework-overview.test.js
+++ b/common/controllers/framework/framework-overview.test.js
@@ -47,7 +47,7 @@ describe('Framework controllers', function () {
         })
 
         it('should pass correct number of params to template', function () {
-          expect(Object.keys(params)).to.have.length(3)
+          expect(Object.keys(params)).to.have.length(4)
         })
 
         it('should set moveId', function () {
@@ -63,6 +63,11 @@ describe('Framework controllers', function () {
         it('should not set fullname', function () {
           expect(params).to.have.property('fullname')
           expect(params.fullname).to.be.undefined
+        })
+
+        it('should not set i18nContext', function () {
+          expect(params).to.have.property('i18nContext')
+          expect(params.i18nContext).to.equal('')
         })
       })
 
@@ -84,6 +89,9 @@ describe('Framework controllers', function () {
             ...mockReq,
             assessment: {
               _framework: mockFramework,
+              framework: {
+                name: 'person-escort-record',
+              },
               meta: {
                 section_progress: [
                   {
@@ -136,6 +144,11 @@ describe('Framework controllers', function () {
         it('should set fullname', function () {
           expect(params).to.have.property('fullname')
           expect(params.fullname).to.equal('John Doe')
+        })
+
+        it('should set i18nContext', function () {
+          expect(params).to.have.property('i18nContext')
+          expect(params.i18nContext).to.equal('person_escort_record')
         })
       })
     })

--- a/common/controllers/framework/framework-section.js
+++ b/common/controllers/framework/framework-section.js
@@ -1,4 +1,4 @@
-const { filter } = require('lodash')
+const { filter, snakeCase } = require('lodash')
 
 const presenters = require('../../presenters')
 const FormWizardController = require('../form-wizard')
@@ -9,6 +9,12 @@ class FrameworkSectionController extends FormWizardController {
     this.use(this.setSectionSummary)
     this.use(this.setMoveId)
     this.use(this.setEditableStatus)
+    this.use(this.seti18nContext)
+  }
+
+  seti18nContext(req, res, next) {
+    res.locals.i18nContext = snakeCase(req.assessment?.framework?.name || '')
+    next()
   }
 
   setMoveId(req, res, next) {

--- a/common/controllers/framework/framework-section.js
+++ b/common/controllers/framework/framework-section.js
@@ -23,7 +23,11 @@ class FrameworkSectionController extends FormWizardController {
   }
 
   setEditableStatus(req, res, next) {
-    res.locals.isEditable = req.assessment.editable
+    const { editable, framework } = req.assessment
+
+    res.locals.isEditable =
+      editable && req.canAccess(`${snakeCase(framework.name)}:update`)
+
     next()
   }
 

--- a/common/controllers/framework/framework-section.test.js
+++ b/common/controllers/framework/framework-section.test.js
@@ -154,21 +154,66 @@ describe('Framework controllers', function () {
           assessment: {
             id: '12345',
             editable: true,
+            framework: {
+              name: 'person-escort-record',
+            },
           },
+          canAccess: sinon.stub().returns(true),
         }
         mockRes = {
           locals: {},
         }
-
-        controller.setEditableStatus(mockReq, mockRes, nextSpy)
       })
 
-      it('should set isEditable to false', function () {
-        expect(mockRes.locals.isEditable).to.equal(true)
+      context('when Person Escort Record is not editable', function () {
+        beforeEach(function () {
+          mockReq.assessment.editable = false
+
+          controller.setEditableStatus(mockReq, mockRes, nextSpy)
+        })
+
+        it('should set isEditable to false', function () {
+          expect(mockRes.locals.isEditable).to.equal(false)
+        })
+
+        it('should call next without error', function () {
+          expect(nextSpy).to.be.calledOnceWithExactly()
+        })
       })
 
-      it('should call next without error', function () {
-        expect(nextSpy).to.be.calledOnceWithExactly()
+      context('when Person Escort Record is editable', function () {
+        beforeEach(function () {
+          controller.setEditableStatus(mockReq, mockRes, nextSpy)
+        })
+
+        it('should set isEditable to true', function () {
+          expect(mockRes.locals.isEditable).to.equal(true)
+        })
+
+        it('should call next without error', function () {
+          expect(nextSpy).to.be.calledOnceWithExactly()
+        })
+      })
+
+      context("when user doesn't have permission", function () {
+        beforeEach(function () {
+          mockReq.canAccess.returns(false)
+          controller.setEditableStatus(mockReq, mockRes, nextSpy)
+        })
+
+        it('should check permissions correctly', function () {
+          expect(mockReq.canAccess).to.be.calledOnceWithExactly(
+            'person_escort_record:update'
+          )
+        })
+
+        it('should set isEditable to false', function () {
+          expect(mockRes.locals.isEditable).to.equal(false)
+        })
+
+        it('should call next without error', function () {
+          expect(nextSpy).to.be.calledOnceWithExactly()
+        })
       })
     })
 

--- a/common/controllers/framework/framework-section.test.js
+++ b/common/controllers/framework/framework-section.test.js
@@ -15,6 +15,7 @@ describe('Framework controllers', function () {
         sinon.stub(controller, 'setSectionSummary')
         sinon.stub(controller, 'setMoveId')
         sinon.stub(controller, 'setEditableStatus')
+        sinon.stub(controller, 'seti18nContext')
         sinon.stub(controller, 'use')
 
         controller.middlewareLocals()
@@ -43,8 +44,60 @@ describe('Framework controllers', function () {
         )
       })
 
+      it('should call set i18n context', function () {
+        expect(controller.use).to.have.been.calledWithExactly(
+          controller.seti18nContext
+        )
+      })
+
       it('should call correct number of middleware', function () {
-        expect(controller.use).to.be.callCount(3)
+        expect(controller.use).to.be.callCount(4)
+      })
+    })
+
+    describe('#seti18nContext', function () {
+      let mockReq, mockRes, nextSpy
+
+      beforeEach(function () {
+        nextSpy = sinon.spy()
+        mockReq = {}
+        mockRes = {
+          locals: {},
+        }
+      })
+
+      context('without an assessment', function () {
+        beforeEach(function () {
+          controller.seti18nContext(mockReq, mockRes, nextSpy)
+        })
+
+        it('should not set move ID', function () {
+          expect(mockRes.locals.i18nContext).to.equal('')
+        })
+
+        it('should call next without error', function () {
+          expect(nextSpy).to.be.calledOnceWithExactly()
+        })
+      })
+
+      context('with an assessment', function () {
+        beforeEach(function () {
+          mockReq.assessment = {
+            framework: {
+              name: 'person-escort-record',
+            },
+          }
+
+          controller.seti18nContext(mockReq, mockRes, nextSpy)
+        })
+
+        it('should set move ID', function () {
+          expect(mockRes.locals.i18nContext).to.equal('person_escort_record')
+        })
+
+        it('should call next without error', function () {
+          expect(nextSpy).to.be.calledOnceWithExactly()
+        })
       })
     })
 

--- a/common/controllers/framework/framework-step.js
+++ b/common/controllers/framework/framework-step.js
@@ -77,6 +77,12 @@ class FrameworkStepController extends FormWizardController {
     this.use(this.setPageTitleLocals)
     this.use(this.setSyncStatusBanner)
     this.use(this.setPrefillBanner)
+    this.use(this.seti18nContext)
+  }
+
+  seti18nContext(req, res, next) {
+    res.locals.i18nContext = snakeCase(req.assessment?.framework?.name || '')
+    next()
   }
 
   setPageTitleLocals(req, res, next) {

--- a/common/controllers/framework/framework-step.test.js
+++ b/common/controllers/framework/framework-step.test.js
@@ -82,6 +82,7 @@ describe('Framework controllers', function () {
         sinon.stub(controller, 'setPageTitleLocals')
         sinon.stub(controller, 'setSyncStatusBanner')
         sinon.stub(controller, 'setPrefillBanner')
+        sinon.stub(controller, 'seti18nContext')
         sinon.stub(controller, 'use')
 
         controller.middlewareLocals()
@@ -110,8 +111,60 @@ describe('Framework controllers', function () {
         )
       })
 
+      it('should call set i18n context', function () {
+        expect(controller.use).to.have.been.calledWithExactly(
+          controller.seti18nContext
+        )
+      })
+
       it('should call correct number of middleware', function () {
-        expect(controller.use).to.be.callCount(3)
+        expect(controller.use).to.be.callCount(4)
+      })
+    })
+
+    describe('#seti18nContext', function () {
+      let mockReq, mockRes, nextSpy
+
+      beforeEach(function () {
+        nextSpy = sinon.spy()
+        mockReq = {}
+        mockRes = {
+          locals: {},
+        }
+      })
+
+      context('without an assessment', function () {
+        beforeEach(function () {
+          controller.seti18nContext(mockReq, mockRes, nextSpy)
+        })
+
+        it('should not set move ID', function () {
+          expect(mockRes.locals.i18nContext).to.equal('')
+        })
+
+        it('should call next without error', function () {
+          expect(nextSpy).to.be.calledOnceWithExactly()
+        })
+      })
+
+      context('with an assessment', function () {
+        beforeEach(function () {
+          mockReq.assessment = {
+            framework: {
+              name: 'person-escort-record',
+            },
+          }
+
+          controller.seti18nContext(mockReq, mockRes, nextSpy)
+        })
+
+        it('should set move ID', function () {
+          expect(mockRes.locals.i18nContext).to.equal('person_escort_record')
+        })
+
+        it('should call next without error', function () {
+          expect(nextSpy).to.be.calledOnceWithExactly()
+        })
       })
     })
 

--- a/common/helpers/frameworks/render-previous-answer-to-field.js
+++ b/common/helpers/frameworks/render-previous-answer-to-field.js
@@ -23,7 +23,7 @@ function renderPreviousAnswerToField({ responses = [] } = {}) {
 
     hintContent += `
       <span class="app-form-group__message-text">
-        ${i18n.t('person-escort-record::prefilled_message')}
+        ${i18n.t('assessment::prefilled_message')}
       </span>
     `
 

--- a/common/helpers/frameworks/render-previous-answer-to-field.test.js
+++ b/common/helpers/frameworks/render-previous-answer-to-field.test.js
@@ -87,14 +87,12 @@ describe('#renderPreviousAnswerToField', function () {
       it('should append message to hint content', function () {
         expect(output[1].hint).to.deep.equal({
           html:
-            '\n      <span class="app-form-group__message-text">\n        person-escort-record::prefilled_message\n      </span>\n    ',
+            '\n      <span class="app-form-group__message-text">\n        assessment::prefilled_message\n      </span>\n    ',
         })
       })
 
       it('should translate keys', function () {
-        expect(i18n.t).to.be.calledWithExactly(
-          'person-escort-record::prefilled_message'
-        )
+        expect(i18n.t).to.be.calledWithExactly('assessment::prefilled_message')
       })
     })
 
@@ -122,7 +120,7 @@ describe('#renderPreviousAnswerToField', function () {
       it('should append message to existing hint content', function () {
         expect(output[1].hint).to.deep.equal({
           html:
-            'EXISTING_HINT\n      <span class="app-form-group__message-text">\n        person-escort-record::prefilled_message\n      </span>\n    ',
+            'EXISTING_HINT\n      <span class="app-form-group__message-text">\n        assessment::prefilled_message\n      </span>\n    ',
         })
       })
     })

--- a/common/presenters/framework-to-task-list-component.js
+++ b/common/presenters/framework-to-task-list-component.js
@@ -24,7 +24,7 @@ function frameworkToTaskListComponent({
         text: name,
         href: `${baseUrl}${key}${deepLinkToFirstStep ? '/start' : ''}`,
         tag: {
-          text: i18n.t(`person-escort-record::statuses.${status}`),
+          text: i18n.t(`assessment::statuses.${status}`),
           classes: tagClasses[status] || tagClasses.default,
         },
       }

--- a/common/presenters/framework-to-task-list-component.test.js
+++ b/common/presenters/framework-to-task-list-component.test.js
@@ -133,13 +133,13 @@ describe('Presenters', function () {
 
           it('should translate status', function () {
             expect(i18n.t).to.be.calledWithExactly(
-              'person-escort-record::statuses.completed'
+              'assessment::statuses.completed'
             )
           })
 
           it('should return correct tag class', function () {
             expect(output.items[0].tag).to.deep.equal({
-              text: 'person-escort-record::statuses.completed',
+              text: 'assessment::statuses.completed',
               classes: '',
             })
           })
@@ -156,13 +156,13 @@ describe('Presenters', function () {
 
           it('should translate status', function () {
             expect(i18n.t).to.be.calledWithExactly(
-              'person-escort-record::statuses.in_progress'
+              'assessment::statuses.in_progress'
             )
           })
 
           it('should return correct tag class', function () {
             expect(output.items[1].tag).to.deep.equal({
-              text: 'person-escort-record::statuses.in_progress',
+              text: 'assessment::statuses.in_progress',
               classes: 'govuk-tag--blue',
             })
           })
@@ -179,13 +179,13 @@ describe('Presenters', function () {
 
           it('should translate status', function () {
             expect(i18n.t).to.be.calledWithExactly(
-              'person-escort-record::statuses.not_started'
+              'assessment::statuses.not_started'
             )
           })
 
           it('should return correct tag class', function () {
             expect(output.items[2].tag).to.deep.equal({
-              text: 'person-escort-record::statuses.not_started',
+              text: 'assessment::statuses.not_started',
               classes: 'govuk-tag--grey',
             })
           })

--- a/common/templates/framework-overview.njk
+++ b/common/templates/framework-overview.njk
@@ -1,12 +1,12 @@
 {% extends "layouts/two-column.njk" %}
 
 {% block customGtagConfig %}
-  gtag('set', {'page_title': 'Person Escort Record'});
+  gtag('set', {'page_title': '{{ t(i18nContext) }}'});
 {% endblock %}
 
 {% block pageTitle %}
-  {{ t("person-escort-record::page_title", {
-    context: "with_name",
+  {{ t("assessment::page_title_with_name", {
+    context: i18nContext,
     name: fullname
   }) }} – {{ SERVICE_NAME }}
 {% endblock %}
@@ -26,8 +26,8 @@
   <header class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <span class="govuk-caption-xl">
-        {{ t("person-escort-record::heading", {
-          context: "with_name"
+        {{ t("assessment::page_title_with_name", {
+          context: i18nContext
         }) }}
       </span>
       <h1 class="govuk-heading-xl">

--- a/common/templates/framework-section.njk
+++ b/common/templates/framework-section.njk
@@ -4,7 +4,7 @@
   {{ t("person-escort-record::section_overview", {
     section: sectionTitle
   }) }}
-  – {{ t("person-escort-record::page_title") }}
+  – {{ t("assessment::page_title", { context: i18nContext }) }}
   – {{ SERVICE_NAME }}
 {% endblock %}
 

--- a/common/templates/framework-section.njk
+++ b/common/templates/framework-section.njk
@@ -49,7 +49,7 @@
             {{ step.pageTitle }}
           </h2>
 
-          {% if canAccess('person_escort_record:update') and isEditable %}
+          {% if isEditable %}
             <p class="app-!-position-top-right">
               <a href="{{ step.stepUrl }}" class="govuk-link">
                 <strong>{{ t("actions::change", {

--- a/common/templates/framework-section.njk
+++ b/common/templates/framework-section.njk
@@ -1,7 +1,7 @@
 {% extends "layouts/base.njk" %}
 
 {% block pageTitle %}
-  {{ t("person-escort-record::section_overview", {
+  {{ t("assessment::section_overview", {
     section: sectionTitle
   }) }}
   – {{ t("assessment::page_title", { context: i18nContext }) }}
@@ -27,7 +27,7 @@
   <header class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-l govuk-!-margin-bottom-9">
-        {{ t("person-escort-record::section_overview", {
+        {{ t("assessment::section_overview", {
           section: sectionTitle
         }) }}
       </h1>
@@ -38,7 +38,7 @@
     <div class="govuk-grid-column-three-quarters">
       {% if not isEditable %}
         {{ govukWarningText({
-          text: t("person-escort-record::locked"),
+          text: t("assessment::locked"),
           iconFallbackText: "Warning"
         }) }}
       {% endif %}
@@ -73,7 +73,7 @@
   {% if PERSON_ESCORT_RECORD_FEEDBACK_URL %}
     {{ appFeedbackPrompt({
       content: {
-        html: t("person-escort-record::feedback_prompt", {
+        html: t("assessment::feedback_prompt", {
           url: PERSON_ESCORT_RECORD_FEEDBACK_URL
         })
       }

--- a/common/templates/framework-step.njk
+++ b/common/templates/framework-step.njk
@@ -6,13 +6,13 @@
   {% if syncFailures.length > 0 %}
     {% set html %}
       <p class="govuk-!-margin-bottom-3">
-        {{ t("person-escort-record::sync_status.failed.message") }}
+        {{ t("assessment::sync_status.failed.message") }}
       </p>
 
       <ul>
         {% for type in syncFailures %}
           <li>
-            {{ t("person-escort-record::sync_status.failed.resource_types." + type) }}
+            {{ t("assessment::sync_status.failed.resource_types." + type) }}
           </li>
         {% endfor %}
       </ul>
@@ -22,7 +22,7 @@
       allowDismiss: false,
       classes: "app-message--warning govuk-!-margin-bottom-4",
       title: {
-        text: t("person-escort-record::sync_status.failed.title")
+        text: t("assessment::sync_status.failed.title")
       },
       content: {
         html: html
@@ -35,8 +35,9 @@
       allowDismiss: false,
       classes: "govuk-!-margin-bottom-4",
       title: {
-        text: t("person-escort-record::prefilled_banner.title", {
-          date: prefilledSourceDate | formatDateWithRelativeDay + " at " + prefilledSourceDate | formatTime
+        text: t("assessment::prefilled_banner.title", {
+          date: prefilledSourceDate | formatDateWithRelativeDay + " at " + prefilledSourceDate | formatTime,
+          context: i18nContext
         })
       }
     }) }}

--- a/common/templates/framework-step.njk
+++ b/common/templates/framework-step.njk
@@ -48,7 +48,7 @@
 {% block pageTitle %}
   {{ t(options.pageTitle) }}
   – {{ t(frameworkSection) }}
-  – {{ t("person-escort-record::page_title") }}
+  – {{ t("assessment::page_title", { context: i18nContext }) }}
   – {{ SERVICE_NAME }}
 {% endblock %}
 

--- a/locales/en/assessment.json
+++ b/locales/en/assessment.json
@@ -1,6 +1,13 @@
 {
   "page_title": "$t({{context}})",
   "page_title_with_name": "$t({{context}}) for {{name}}",
+  "section_overview": "{{section}} overview",
+  "locked": "A Person Escort Record cannot be updated once it has been confirmed or once the move has started.",
+  "statuses": {
+    "not_started": "Not started",
+    "in_progress": "In progress",
+    "completed": "Completed"
+  },
   "heading": {
     "text": "Information",
     "text_risk": "Risk information",
@@ -32,8 +39,24 @@
       }
     }
   },
+  "sync_status": {
+    "failed": {
+      "title": "Some NOMIS information could not be included",
+      "message": "The following information could not be included. Check NOMIS for the most up to date information:",
+      "resource_types": {
+        "alerts": "alerts",
+        "personal_care_needs": "personal care needs",
+        "reasonable_adjustments": "reasonable adjustments"
+      }
+    }
+  },
   "view_previous_assessment": "View information provided when move was requested",
   "view_previous_assessment_framework": "View information provided in youth risk assessment",
   "incomplete": "Warnings will display once a Person Escort Record has been completed",
-  "section_incomplete": "Warnings will display once this section has been completed"
+  "section_incomplete": "Warnings will display once this section has been completed",
+  "prefilled_banner": {
+    "title": "Some answers on this page need to be reviewed. They are from the last $t({{context}}) confirmed on {{date}}."
+  },
+  "prefilled_message": "This answer needs to be reviewed",
+  "feedback_prompt": "This is a new feature — <a href=\"{{url}}\">give us your feedback</a> to help us improve it"
 }

--- a/locales/en/assessment.json
+++ b/locales/en/assessment.json
@@ -1,4 +1,6 @@
 {
+  "page_title": "$t({{context}})",
+  "page_title_with_name": "$t({{context}}) for {{name}}",
   "heading": {
     "text": "Information",
     "text_risk": "Risk information",

--- a/locales/en/person-escort-record.json
+++ b/locales/en/person-escort-record.json
@@ -1,26 +1,5 @@
 {
-  "section_overview": "{{section}} overview",
-  "locked": "A Person Escort Record cannot be updated once it has been confirmed or once the move has started.",
-  "statuses": {
-    "not_started": "Not started",
-    "in_progress": "In progress",
-    "completed": "Completed"
-  },
-  "sync_status": {
-    "failed": {
-      "title": "Some NOMIS information could not be included",
-      "message": "The following information could not be included. Check NOMIS for the most up to date information:",
-      "resource_types": {
-        "alerts": "alerts",
-        "personal_care_needs": "personal care needs",
-        "reasonable_adjustments": "reasonable adjustments"
-      }
-    }
-  },
-  "prefilled_banner": {
-    "title": "Some answers on this page need to be reviewed. They are from the last Person Escort Record confirmed on {{date}}."
-  },
-  "prefilled_message": "This answer needs to be reviewed",
+  "heading": "Person Escort Record",
   "journeys": {
     "confirm": {
       "heading":"Confirm and complete this Person Escort Record",
@@ -51,6 +30,5 @@
     "property_handover": {
       "heading": "Property and cash handover"
     }
-  },
-  "feedback_prompt": "This is a new feature — <a href=\"{{url}}\">give us your feedback</a> to help us improve it"
+  }
 }

--- a/locales/en/person-escort-record.json
+++ b/locales/en/person-escort-record.json
@@ -1,8 +1,4 @@
 {
-  "page_title": "Person Escort Record",
-  "page_title_with_name": "Person Escort Record for {{name}}",
-  "heading": "Person Escort Record",
-  "heading_with_name": "Person Escort Record for",
   "section_overview": "{{section}} overview",
   "locked": "A Person Escort Record cannot be updated once it has been confirmed or once the move has started.",
   "statuses": {

--- a/locales/en/youth-risk-assessment.json
+++ b/locales/en/youth-risk-assessment.json
@@ -1,8 +1,5 @@
 {
-  "page_title": "Youth risk assessment",
-  "page_title_with_name": "Youth risk assessment for {{name}}",
   "heading": "Youth risk assessment",
-  "heading_with_name": "Youth risk assessment for",
   "journeys": {
     "confirm": {
       "heading":"Confirm and complete this youth risk assessment",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

This set of changes moves some of the Person Escort Record specific content keys to the generic namespace so that they can be shared between the two.

### Why did it change

Some of the Youth Risk Assessment pages are currently using the Person Escort Record content when they need to be using
youth risk assessment specific content.

## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [x] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed
