### PR TITLE
Use context for locked assessment text

### DIFF
--- a/common/templates/framework-section.njk
+++ b/common/templates/framework-section.njk
@@ -38,7 +38,7 @@
     <div class="govuk-grid-column-three-quarters">
       {% if not isEditable %}
         {{ govukWarningText({
-          text: t("assessment::locked"),
+          text: t("assessment::locked", { context: i18nContext }),
           iconFallbackText: "Warning"
         }) }}
       {% endif %}

--- a/locales/en/assessment.json
+++ b/locales/en/assessment.json
@@ -2,7 +2,7 @@
   "page_title": "$t({{context}})",
   "page_title_with_name": "$t({{context}}) for {{name}}",
   "section_overview": "{{section}} overview",
-  "locked": "A Person Escort Record cannot be updated once it has been confirmed or once the move has started.",
+  "locked": "A $t({{context}}) cannot be updated once it has been confirmed or once the move has started.",
   "statuses": {
     "not_started": "Not started",
     "in_progress": "In progress",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

This text was currently specific to the Person Escort Record but is
used by both assessment.

### Why did it change

It needs to be set using a context so that it is dynamic based on which
is being viewed.