### PR TITLE
Use approval endpoint for approving single requests

### DIFF
--- a/common/lib/api-client/models/approve.js
+++ b/common/lib/api-client/models/approve.js
@@ -1,0 +1,9 @@
+module.exports = {
+  fields: {
+    timestamp: '',
+    date: '',
+  },
+  options: {
+    collectionPath: 'approve',
+  },
+}

--- a/common/lib/api-client/models/index.js
+++ b/common/lib/api-client/models/index.js
@@ -1,5 +1,6 @@
 const allocation = require('./allocation')
 const allocationComplexCase = require('./allocation-complex-case')
+const approve = require('./approve')
 const assessmentQuestion = require('./assessment-question')
 const cancel = require('./cancel')
 const category = require('./category')
@@ -34,6 +35,7 @@ const youthRiskAssessment = require('./youth-risk-assessment')
 module.exports = {
   allocation,
   allocation_complex_case: allocationComplexCase,
+  approve,
   assessment_question: assessmentQuestion,
   cancel,
   category,

--- a/common/services/single-request.js
+++ b/common/services/single-request.js
@@ -136,11 +136,14 @@ const singleRequestService = {
       return Promise.reject(new Error(noMoveIdMessage))
     }
 
+    const timestamp = dateFunctions.formatISO(new Date())
+
     return apiClient
-      .update('move', {
-        id,
+      .one('move', id)
+      .all('approve')
+      .post({
+        timestamp,
         date,
-        status: 'requested',
       })
       .then(response => response.data)
   },

--- a/common/services/single-request.test.js
+++ b/common/services/single-request.test.js
@@ -555,7 +555,9 @@ describe('Single request service', function () {
       let move
 
       beforeEach(async function () {
-        sinon.stub(apiClient, 'update').resolves(mockResponse)
+        sinon.stub(apiClient, 'all').returns(apiClient)
+        sinon.stub(apiClient, 'one').returns(apiClient)
+        sinon.stub(apiClient, 'post').resolves(mockResponse)
       })
 
       context('without data args', function () {
@@ -564,10 +566,11 @@ describe('Single request service', function () {
         })
 
         it('should call update method with data', function () {
-          expect(apiClient.update).to.be.calledOnceWithExactly('move', {
-            id: mockId,
+          expect(apiClient.one).to.be.calledOnceWithExactly('move', mockId)
+          expect(apiClient.all).to.be.calledOnceWithExactly('approve')
+          expect(apiClient.post).to.be.calledOnceWithExactly({
             date: undefined,
-            status: 'requested',
+            timestamp: sinon.match.string,
           })
         })
 
@@ -584,10 +587,11 @@ describe('Single request service', function () {
         })
 
         it('should call update method with data', function () {
-          expect(apiClient.update).to.be.calledOnceWithExactly('move', {
-            id: mockId,
+          expect(apiClient.one).to.be.calledOnceWithExactly('move', mockId)
+          expect(apiClient.all).to.be.calledOnceWithExactly('approve')
+          expect(apiClient.post).to.be.calledOnceWithExactly({
             date: '2020-10-10',
-            status: 'requested',
+            timestamp: sinon.match.string,
           })
         })
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

This changes the current approval action to use the "events" endpoints
on a move rather than relying on a `PATCH`.

### Why did it change

When a `PATCH` is called it doesn't trigger the necessary events
and actions in the background so this change ensures all frontend
status changes are using the correct endpoints.

## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Internet Explorer
