### PR TITLE
Catch API errors that are generated in the end-to-end tests

### DIFF
--- a/test/e2e/move.update.sch.test.js
+++ b/test/e2e/move.update.sch.test.js
@@ -3,7 +3,6 @@ import {
   checkUpdatePagesAccessible,
   checkUpdateDocuments,
   createMove,
-  checkCancelLink,
 } from './_move'
 import { schUser } from './_roles'
 import { home } from './_routes'
@@ -47,10 +46,6 @@ test.meta('hasDocument', 'true')(
   }
 )
 
-test('User should be able to cancel move', async () => {
-  await checkCancelLink()
-})
-
 fixture(
   'Existing move from Secure Training Centre (STC) to Hospital'
 ).beforeEach(async t => {
@@ -82,10 +77,6 @@ test.meta('hasDocument', 'true')(
   }
 )
 
-test('User should be able to cancel move', async () => {
-  await checkCancelLink()
-})
-
 fixture('Existing move from Secure Children Home (SCH) to Prison').beforeEach(
   async t => {
     await t.useRole(schUser).navigateTo(home)
@@ -115,10 +106,6 @@ test.meta('hasDocument', 'true')(
     )
   }
 )
-
-test('User should be able to cancel move', async () => {
-  await checkCancelLink()
-})
 
 fixture(
   'Existing move from Secure Children Home (SCH) to Secure Training Centre (STC)'
@@ -150,10 +137,6 @@ test.meta('hasDocument', 'true')(
   }
 )
 
-test('User should be able to cancel move', async () => {
-  await checkCancelLink()
-})
-
 fixture(
   'Existing move from Secure Children Home (SCH) to Secure Children Home (SCH)'
 ).beforeEach(async t => {
@@ -183,7 +166,3 @@ test.meta('hasDocument', 'true')(
     )
   }
 )
-
-test('User should be able to cancel move', async () => {
-  await checkCancelLink()
-})


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Catch API errors that occur when running end-to-end tests and log them to Sentry.

### Why did it change

Currently in some scenarios the API may return a `422` when we
create a dynamic fixture.

It's hard to debug to see what extactly went wrong so this change
adds the ability to catch those errors and log them to Sentry so that
they can be investigated.

## Screenshots

<kbd>![image](https://user-images.githubusercontent.com/3327997/101631997-24c0a680-3a1d-11eb-8ab8-bcd9b4481ff4.png)</kbd>

<kbd>![image](https://user-images.githubusercontent.com/3327997/101632042-34d88600-3a1d-11eb-9744-d5434d6b29ba.png)</kbd>

<kbd>![image](https://user-images.githubusercontent.com/3327997/101632073-43bf3880-3a1d-11eb-9ffd-80bb9bb6599b.png)</kbd>
