### PR TITLE
Make filter remove icons show up properly [P4-2567]

### DIFF
--- a/webpack.config.production.js
+++ b/webpack.config.production.js
@@ -9,7 +9,7 @@ module.exports = {
   module: {
     rules: [
       {
-        test: /\.(woff(2)?|ttf|eot|svg)(\?v=\d+\.\d+\.\d+)?$/,
+        test: /\.(woff(2)?|ttf|eot)(\?v=\d+\.\d+\.\d+)?$/,
         use: [
           {
             loader: 'file-loader',


### PR DESCRIPTION
SVG files were being double processed by webpack, once as images, and once as fonts.

This resulted in the svg files looking like:

  export default __webpack_public_path__ + "icon-tag-remove-cross.aa3a837b.svg";

There are no SVG font assets, so this simply removes svg from the font config

<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Updated webpack production config to not process svg as fonts.

### Why did it change

SVG files were being created as an unexecuted line of javascript and so not rendering when requested.

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

- [P4-2567 - 'X' icon no longer showing in filter tag](https://dsdmoj.atlassian.net/browse/P4-2567)

## Screenshots
<!--- (Optional) Include screenshots if changes update interfaces or components -->
<!--- Delete/copy as appropriate --->

| After | Before |
| ------ | ----- |
| <kbd>![Single_requests_sent_7_to_13_Dec_2020__This_week_](https://user-images.githubusercontent.com/4856/101673289-e348ef00-3a4e-11eb-91f6-8af18f005a0d.png)</kbd> | <kbd>![Single_requests_sent_7_to_13_Dec_2020__This_week_](https://user-images.githubusercontent.com/4856/101673368-feb3fa00-3a4e-11eb-82fe-29a26d43d9e7.png)</kbd> |

## Checklists

### Testing

#### Automated testing

- [ ] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed

### Other considerations

- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
