### PR TITLE
refactor: Update controllers to use youth risk assessment service from req

### DIFF
--- a/app/youth-risk-assessment/app/confirm/controllers.js
+++ b/app/youth-risk-assessment/app/confirm/controllers.js
@@ -1,10 +1,9 @@
 const ConfirmAssessmentController = require('../../../../common/controllers/framework/confirm-assessment')
-const youthRiskAssessmentService = require('../../../../common/services/youth-risk-assessment')
 
 class ConfirmYouthRiskAssessmentController extends ConfirmAssessmentController {
   async saveValues(req, res, next) {
     try {
-      await youthRiskAssessmentService.confirm(req.assessment.id)
+      await req.services.youthRiskAssessment.confirm(req.assessment.id)
       next()
     } catch (err) {
       next(err)

--- a/app/youth-risk-assessment/app/confirm/controllers.test.js
+++ b/app/youth-risk-assessment/app/confirm/controllers.test.js
@@ -1,5 +1,3 @@
-const youthRiskAssessmentService = require('../../../../common/services/youth-risk-assessment')
-
 const { ConfirmYouthRiskAssessmentController } = require('./controllers')
 
 const controller = new ConfirmYouthRiskAssessmentController({ route: '/' })
@@ -8,21 +6,25 @@ describe('Youth risk assessment controllers', function () {
   describe('ConfirmYouthRiskAssessmentController', function () {
     describe('#saveValues', function () {
       const mockPERId = 'c756d3fb-d5c0-4cf4-9416-6691a89570f2'
-      let req, nextSpy
+      let req, nextSpy, youthRiskAssessmentService
 
       beforeEach(function () {
-        sinon.stub(youthRiskAssessmentService, 'confirm')
+        youthRiskAssessmentService = {
+          confirm: sinon.stub().resolves({}),
+        }
         nextSpy = sinon.spy()
         req = {
           assessment: {
             id: mockPERId,
+          },
+          services: {
+            youthRiskAssessment: youthRiskAssessmentService,
           },
         }
       })
 
       context('when save is successful', function () {
         beforeEach(async function () {
-          youthRiskAssessmentService.confirm.resolves({})
           await controller.saveValues(req, {}, nextSpy)
         })
 
@@ -41,7 +43,9 @@ describe('Youth risk assessment controllers', function () {
         const errorMock = new Error('Problem')
 
         beforeEach(async function () {
-          youthRiskAssessmentService.confirm.throws(errorMock)
+          req.services.youthRiskAssessment.confirm = sinon
+            .stub()
+            .throws(errorMock)
           await controller.saveValues(req, {}, nextSpy)
         })
 

--- a/app/youth-risk-assessment/app/new/controllers.js
+++ b/app/youth-risk-assessment/app/new/controllers.js
@@ -1,12 +1,11 @@
 const { get } = require('lodash')
 
 const NewAssessmentController = require('../../../../common/controllers/framework/new-assessment')
-const youthRiskAssessmentService = require('../../../../common/services/youth-risk-assessment')
 
 class NewYouthRiskAssessmentController extends NewAssessmentController {
   async saveValues(req, res, next) {
     try {
-      req.record = await youthRiskAssessmentService.create(req.move.id)
+      req.record = await req.services.youthRiskAssessment.create(req.move.id)
       next()
     } catch (err) {
       const apiErrorCode = get(err, 'errors[0].code')

--- a/app/youth-risk-assessment/app/new/controllers.test.js
+++ b/app/youth-risk-assessment/app/new/controllers.test.js
@@ -1,5 +1,3 @@
-const youthRiskAssessmentService = require('../../../../common/services/youth-risk-assessment')
-
 const { NewYouthRiskAssessmentController } = require('./controllers')
 
 const controller = new NewYouthRiskAssessmentController({ route: '/' })
@@ -8,21 +6,25 @@ describe('Youth risk assessment controllers', function () {
   describe('NewYouthRiskAssessmentController', function () {
     describe('#saveValues', function () {
       const mockMoveId = 'c756d3fb-d5c0-4cf4-9416-6691a89570f2'
-      let req, nextSpy
+      let req, nextSpy, youthRiskAssessmentService
 
       beforeEach(function () {
-        sinon.stub(youthRiskAssessmentService, 'create')
+        youthRiskAssessmentService = {
+          create: sinon.stub().resolves({}),
+        }
         nextSpy = sinon.spy()
         req = {
           move: {
             id: mockMoveId,
+          },
+          services: {
+            youthRiskAssessment: youthRiskAssessmentService,
           },
         }
       })
 
       context('when save is successful', function () {
         beforeEach(async function () {
-          youthRiskAssessmentService.create.resolves({})
           await controller.saveValues(req, {}, nextSpy)
         })
 
@@ -55,7 +57,9 @@ describe('Youth risk assessment controllers', function () {
 
             sinon.stub(controller, 'successHandler')
 
-            youthRiskAssessmentService.create.throws(errorMock)
+            req.services.youthRiskAssessment.create = sinon
+              .stub()
+              .throws(errorMock)
             await controller.saveValues(req, {}, nextSpy)
           })
 
@@ -75,7 +79,9 @@ describe('Youth risk assessment controllers', function () {
           const errorMock = new Error('Problem')
 
           beforeEach(async function () {
-            youthRiskAssessmentService.create.throws(errorMock)
+            req.services.youthRiskAssessment.create = sinon
+              .stub()
+              .throws(errorMock)
             await controller.saveValues(req, {}, nextSpy)
           })
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Make use of the new setServices middleware for the youth risk assessment service. Part of the work to enable request context in services.
<!--- Describe the changes in detail - the "what"-->

### Why did it change
All services need to be moved to this pattern in preparation for being refactored to take the request context.
<!--- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

- [P4-1776](https://dsdmoj.atlassian.net/browse/P4-1776)

## Checklists

### Testing

#### Automated testing

- [ ] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed

### Other considerations

Commit messages with a `fix` or `feat` type are automatically used to generate the [changelog](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/CHANGELOG.md) and
[GitHub release notes](https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/releases) during the release task. Please make sure they will read well on their own in a
summary of changes and that the commit body gives a more detailed description of those changes if necessary.

- [ ] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
- [ ] Update [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md) with any new instructions or tasks
