### PR TITLE
refactor: Update controllers to use population service from req

### DIFF
--- a/app/population/controllers/edit.js
+++ b/app/population/controllers/edit.js
@@ -1,7 +1,6 @@
 const { omit } = require('lodash')
 
 const FormWizardController = require('../../../common/controllers/form-wizard')
-const populationService = require('../../../common/services/population')
 
 class DetailsController extends FormWizardController {
   middlewareLocals() {
@@ -27,13 +26,13 @@ class DetailsController extends FormWizardController {
       const data = omit(sessionModel, ['csrf-secret', 'errors', 'errorValues'])
 
       if (req.population) {
-        await populationService.update({
+        await req.services.population.update({
           id: req.population.id,
           ...data,
           updated_by: req.session.user.fullname,
         })
       } else {
-        await populationService.create({
+        await req.services.population.create({
           location: req.locationId,
           date: req.date,
           ...data,

--- a/app/population/controllers/edit.test.js
+++ b/app/population/controllers/edit.test.js
@@ -1,11 +1,11 @@
-const proxyquire = require('proxyquire')
-const mockPopulationService = {}
+const mockPopulationService = {
+  create: sinon.stub(),
+  update: sinon.stub(),
+}
 
 const FormWizardController = require('../../../common/controllers/form-wizard')
 
-const Controller = proxyquire('./edit', {
-  '../../../common/services/population': mockPopulationService,
-})
+const Controller = require('./edit')
 
 describe('Population controllers', function () {
   describe('#edit()', function () {
@@ -38,6 +38,9 @@ describe('Population controllers', function () {
           options: {
             fullPath: '/details',
           },
+        },
+        services: {
+          population: mockPopulationService,
         },
       }
       res = {
@@ -121,10 +124,6 @@ describe('Population controllers', function () {
 
     describe('successHandler', function () {
       context('creating a new population', function () {
-        beforeEach(function () {
-          mockPopulationService.create = sinon.stub()
-        })
-
         it('should call create on the population service', async function () {
           await controllerInstance.successHandler(req, res, next)
 
@@ -159,7 +158,7 @@ describe('Population controllers', function () {
 
         it('should call next on failure', async function () {
           const error = new Error('Failure')
-          mockPopulationService.create.rejects(error)
+          req.services.population.create = sinon.stub().rejects(error)
 
           await controllerInstance.successHandler(req, res, next)
 
@@ -174,8 +173,6 @@ describe('Population controllers', function () {
           req.population = {
             id: 'ABADCAFE',
           }
-
-          mockPopulationService.update = sinon.stub()
         })
 
         it('should call update on the population service', async function () {
@@ -207,7 +204,7 @@ describe('Population controllers', function () {
 
         it('should call next on failure', async function () {
           const error = new Error('Failure')
-          mockPopulationService.update.rejects(error)
+          req.services.population.update = sinon.stub().rejects(error)
 
           await controllerInstance.successHandler(req, res, next)
 

--- a/app/population/middleware/set-population.js
+++ b/app/population/middleware/set-population.js
@@ -1,5 +1,4 @@
 const locationsFreeSpacesService = require('../../../common/services/locations-free-spaces')
-const populationService = require('../../../common/services/population')
 
 async function setPopulation(req, res, next) {
   try {
@@ -20,7 +19,9 @@ async function setPopulation(req, res, next) {
     const { id: populationId } = freeSpacePopulation
 
     if (populationId) {
-      req.population = await populationService.getByIdWithMoves(populationId)
+      req.population = await req.services.population.getByIdWithMoves(
+        populationId
+      )
 
       transfersIn = req.population.moves_to.length
       transfersOut = req.population.moves_from.length


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Make use of the new setServices middleware for the population service. Part of the work to enable request context in services.
<!--- Describe the changes in detail - the "what"-->

### Why did it change
All services need to be moved to this pattern in preparation for being refactored to take the request context.
<!--- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

- [P4-1776](https://dsdmoj.atlassian.net/browse/P4-1776)

## Checklists

### Testing

#### Automated testing

- [ ] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed

### Other considerations

Commit messages with a `fix` or `feat` type are automatically used to generate the [changelog](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/CHANGELOG.md) and
[GitHub release notes](https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/releases) during the release task. Please make sure they will read well on their own in a
summary of changes and that the commit body gives a more detailed description of those changes if necessary.

- [ ] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
- [ ] Update [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md) with any new instructions or tasks
