### PR TITLE
[P4-2562] [P4-2570] Youth risk assessment updates

### DIFF
--- a/app/move/controllers/view/view.locals.js
+++ b/app/move/controllers/view/view.locals.js
@@ -69,9 +69,12 @@ function getViewLocals(req) {
   ).map(section => {
     return {
       ...section,
-      previousAssessment: move._is_youth_move
-        ? find(youthAssessmentSections, { key: section.key })
-        : find(assessment, { frameworksSection: section.key }),
+      previousAssessment:
+        move._is_youth_move &&
+        youthRiskAssessment &&
+        FEATURE_FLAGS.YOUTH_RISK_ASSESSMENT
+          ? find(youthAssessmentSections, { key: section.key })
+          : find(assessment, { frameworksSection: section.key }),
     }
   })
   const combinedSections = perAssessmentSections.reduce((acc, section) => {
@@ -86,7 +89,9 @@ function getViewLocals(req) {
   const combinedAssessmentSections = [
     ...perAssessmentSections,
     ...youthAssessmentSections.filter(
-      section => !combinedSections.includes(section.key)
+      section =>
+        FEATURE_FLAGS.YOUTH_RISK_ASSESSMENT &&
+        !combinedSections.includes(section.key)
     ),
   ]
 
@@ -103,11 +108,9 @@ function getViewLocals(req) {
     youthRiskAssessment,
     youthRiskAssessmentIsEnabled: FEATURE_FLAGS.YOUTH_RISK_ASSESSMENT,
     assessmentSections:
-      move._is_youth_move &&
-      FEATURE_FLAGS.YOUTH_RISK_ASSESSMENT &&
-      (youthRiskAssessment?.status !== 'confirmed' || !personEscortRecord)
-        ? sortBy(youthAssessmentSections, 'order')
-        : sortBy(combinedAssessmentSections, 'order'),
+      personEscortRecord || !move._is_youth_move
+        ? sortBy(combinedAssessmentSections, 'order')
+        : sortBy(youthAssessmentSections, 'order'),
     moveSummary: presenters.moveToMetaListComponent(move, updateActions),
     personalDetailsSummary: presenters.personToSummaryListComponent(person),
     additionalInfoSummary: presenters.moveToAdditionalInfoListComponent(move),

--- a/app/move/views/view.njk
+++ b/app/move/views/view.njk
@@ -246,6 +246,16 @@
     }) }}
   {% endif %}
 
+  {% if canAccess("youth_risk_assessment:view") and youthRiskAssessment %}
+    <p class="govuk-!-margin-bottom-2">
+      <a href="{{ move.id }}/youth-risk-assessment">
+        {{ t("actions::view_assessment", {
+          context: "youth_risk_assessment"
+        }) }}
+      </a>
+    </p>
+  {% endif %}
+
   {% if canCancelMove %}
     <p class="govuk-!-margin-bottom-0">
       <a href="{{ move.id }}/cancel" class="app-link--destructive">

--- a/common/lib/permissions.js
+++ b/common/lib/permissions.js
@@ -74,6 +74,8 @@ const supplierPermissions = [
   'moves:view:incoming',
   'moves:download',
   'move:view',
+  'person_escort_record:view',
+  'youth_risk_assessment:view',
 ]
 const prisonPermissions = [
   'moves:view:outgoing',

--- a/common/lib/user.test.js
+++ b/common/lib/user.test.js
@@ -309,6 +309,8 @@ describe('User class', function () {
           'moves:view:incoming',
           'moves:download',
           'move:view',
+          'person_escort_record:view',
+          'youth_risk_assessment:view',
         ])
       })
     })

--- a/common/presenters/message-banner/move-to-message-banner-component.js
+++ b/common/presenters/message-banner/move-to-message-banner-component.js
@@ -13,11 +13,12 @@ function moveToMessageBannerComponent({ move = {}, moveUrl, canAccess } = {}) {
 
   const assessmentType =
     // TODO: Remove once enabled
-    FEATURE_FLAGS.YOUTH_RISK_ASSESSMENT &&
-    move._is_youth_move &&
-    move.profile?.youth_risk_assessment?.status !== 'confirmed'
-      ? 'youth_risk_assessment'
-      : 'person_escort_record'
+    move.profile?.person_escort_record ||
+    !move._is_youth_move ||
+    move.profile?.youth_risk_assessment?.status === 'confirmed' ||
+    !FEATURE_FLAGS.YOUTH_RISK_ASSESSMENT
+      ? 'person_escort_record'
+      : 'youth_risk_assessment'
   const assessment = move.profile[assessmentType]
   const baseUrl = `${moveUrl}/${kebabCase(assessmentType)}`
   const context = assessmentType

--- a/common/presenters/message-banner/move-to-message-banner-component.test.js
+++ b/common/presenters/message-banner/move-to-message-banner-component.test.js
@@ -258,7 +258,7 @@ describe('Presenters', function () {
               })
             })
 
-            it('should return unconfirmed banner', function () {
+            it('should return start PER banner', function () {
               expect(output).to.deep.equal('__assessmentToStartBanner__')
             })
 
@@ -266,6 +266,42 @@ describe('Presenters', function () {
               expect(
                 assessmentToStartBannerStub
               ).to.have.been.calledOnceWithExactly({
+                baseUrl: '/move/12345/person-escort-record',
+                context: 'person_escort_record',
+                canAccess: mockArgs.canAccess,
+              })
+            })
+          })
+
+          context('when PER exists', function () {
+            beforeEach(function () {
+              output = presenter({
+                ...mockArgs,
+                move: {
+                  ...mockMove,
+                  profile: {
+                    youth_risk_assessment: null,
+                    person_escort_record: {
+                      id: '_per_12345',
+                      status: 'in_progress',
+                    },
+                  },
+                },
+              })
+            })
+
+            it('should return PER banner', function () {
+              expect(output).to.deep.equal('__assessmentToUnconfirmedBanner__')
+            })
+
+            it('should call presenter', function () {
+              expect(
+                assessmentToUnconfirmedBannerStub
+              ).to.have.been.calledOnceWithExactly({
+                assessment: {
+                  id: '_per_12345',
+                  status: 'in_progress',
+                },
                 baseUrl: '/move/12345/person-escort-record',
                 context: 'person_escort_record',
                 canAccess: mockArgs.canAccess,

--- a/locales/en/actions.json
+++ b/locales/en/actions.json
@@ -45,6 +45,7 @@
   "review": "Review",
   "start_assessment": "Start $t({{context}})",
   "print_assessment": "Print $t({{context}})",
+  "view_assessment": "View $t({{context}})",
   "provide_confirmation": "Provide confirmation",
   "confirm_and_complete_record": "Confirm and complete record",
   "add_item": "Add {{name}}",

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -38,7 +38,8 @@
     },
     "completed": {
       "heading": "$t({{context}}) has been completed",
-      "content": "Once you are confident the information provided is correct and won’t change, provide your confirmation that this record is correct in order to print it.",
+      "content": "Once you are confident the information provided is correct and won’t change, provide your confirmation that this record is correct.",
+      "content_person_escort_record": "Once you are confident the information provided is correct and won’t change, provide your confirmation that this record is correct in order to print it",
       "uneditable": "A $t({{context}}) cannot be confirmed once the move has started."
     },
     "confirmed": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

This set of changes includes:

- content tweak to youth banner
- permission updates for all roles and suppliers
- logic update to handle existing PERs when youth feature is enabled

### Why did it change

These changes came as a result of feedback from users and the business.

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

- [P4-2562](https://dsdmoj.atlassian.net/browse/P4-2562)
- [P4-2570](https://dsdmoj.atlassian.net/browse/P4-2570)

## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [x] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed

### Other considerations

Commit messages with a `fix` or `feat` type are automatically used to generate the [changelog](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/CHANGELOG.md) and
[GitHub release notes](https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/releases) during the release task. Please make sure they will read well on their own in a
summary of changes and that the commit body gives a more detailed description of those changes if necessary.

- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
- [x] Update [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md) with any new instructions or tasks
