### PR TITLE
refactor: Update document service to class with req object

### DIFF
--- a/common/services/document.js
+++ b/common/services/document.js
@@ -1,8 +1,8 @@
 const FormData = require('form-data')
 
-const apiClient = require('../lib/api-client')()
+const BaseService = require('./base')
 
-const documentService = {
+class DocumentService extends BaseService {
   create(file, data) {
     const formData = new FormData()
     formData.append('data[attributes][file]', data, {
@@ -10,10 +10,10 @@ const documentService = {
       knownLength: file.size,
     })
 
-    return apiClient
+    return this.apiClient
       .create('document', formData)
       .then(response => response.data)
-  },
+  }
 }
 
-module.exports = documentService
+module.exports = DocumentService

--- a/common/services/document.test.js
+++ b/common/services/document.test.js
@@ -4,10 +4,12 @@ function MockFormData() {}
 
 MockFormData.prototype.append = sinon.stub()
 
-const documentService = proxyquire('./document', {
+const apiClient = require('../lib/api-client')()
+
+const DocumentService = proxyquire('./document', {
   'form-data': MockFormData,
 })
-const apiClient = require('../lib/api-client')()
+const documentService = new DocumentService({ apiClient })
 
 describe('Document Service', function () {
   describe('#create()', function () {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Converts document service to class which takes the req object on isntantiation.
<!--- Describe the changes in detail - the "what"-->

### Why did it change
Enables the service to access the api client that was instantiated in the request cycle and has access to the req object.
<!--- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

- [P4-1776](https://dsdmoj.atlassian.net/browse/P4-1776)

## Checklists

### Testing

#### Automated testing

- [ ] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed

### Other considerations

Commit messages with a `fix` or `feat` type are automatically used to generate the [changelog](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/CHANGELOG.md) and
[GitHub release notes](https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/releases) during the release task. Please make sure they will read well on their own in a
summary of changes and that the commit body gives a more detailed description of those changes if necessary.

- [ ] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
- [ ] Update [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md) with any new instructions or tasks
