### PR TITLE
fix: Ensure radio/checkboxes within add another keep same name

### DIFF
--- a/common/helpers/field/reduce-add-another-fields.test.js
+++ b/common/helpers/field/reduce-add-another-fields.test.js
@@ -45,10 +45,10 @@ describe('Field helpers', function () {
           skip: true,
           prefix: 'foo[0]',
           name: 'foo[0][baz]',
-          id: 'foo-0--baz-',
+          id: 'foo-0--baz',
           attributes: {
             'data-name': 'foo[%index%][baz]',
-            'data-id': 'foo-%index%--baz-',
+            'data-id': 'foo-%index%--baz',
           },
         })
       })
@@ -59,22 +59,22 @@ describe('Field helpers', function () {
             {
               attributes: {
                 'data-name': 'foo[%index%][bar]',
-                'data-id': 'foo-%index%--bar-',
+                'data-id': 'foo-%index%--bar',
                 attr: 'value',
               },
             },
             {
               attributes: {
-                'data-name': 'foo[%index%][bar][2]',
-                'data-id': 'foo-%index%--bar--2-',
+                'data-name': 'foo[%index%][bar]',
+                'data-id': 'foo-%index%--bar-2',
               },
             },
           ],
           skip: true,
           prefix: 'foo[0]',
           name: 'foo[0][bar]',
-          id: 'foo-0--bar-',
-          idPrefix: 'foo-0--bar-',
+          id: 'foo-0--bar',
+          idPrefix: 'foo-0--bar',
         })
       })
     })
@@ -96,10 +96,10 @@ describe('Field helpers', function () {
           skip: true,
           prefix: 'foo[1]',
           name: 'foo[1][baz]',
-          id: 'foo-1--baz-',
+          id: 'foo-1--baz',
           attributes: {
             'data-name': 'foo[%index%][baz]',
-            'data-id': 'foo-%index%--baz-',
+            'data-id': 'foo-%index%--baz',
           },
         })
       })
@@ -110,22 +110,22 @@ describe('Field helpers', function () {
             {
               attributes: {
                 'data-name': 'foo[%index%][bar]',
-                'data-id': 'foo-%index%--bar-',
+                'data-id': 'foo-%index%--bar',
                 attr: 'value',
               },
             },
             {
               attributes: {
-                'data-name': 'foo[%index%][bar][2]',
-                'data-id': 'foo-%index%--bar--2-',
+                'data-name': 'foo[%index%][bar]',
+                'data-id': 'foo-%index%--bar-2',
               },
             },
           ],
           skip: true,
           prefix: 'foo[1]',
           name: 'foo[1][bar]',
-          id: 'foo-1--bar-',
-          idPrefix: 'foo-1--bar-',
+          id: 'foo-1--bar',
+          idPrefix: 'foo-1--bar',
         })
       })
     })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

This is a fix to ensure that when items are added using JavaScript
and that item contains radios or checkboxes, that the data name does
not receive an index.

### Why did it change

This causes each item to use a different field name and means in some
cases the form submits these values as an array instead of a string.

## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [x] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed
