### PR TITLE
Handle conditional fields triggered by radio within add another

### DIFF
--- a/common/components/add-another/add-another.js
+++ b/common/components/add-another/add-another.js
@@ -27,6 +27,19 @@ MOJFrontend.AddAnother.prototype.updateAttributes = function (index, item) {
     if (label) {
       label.htmlFor = el.id
     }
+
+    // ensure conditionally revealed inputs correctly targetted
+    const ariaControls = $el.attr('aria-controls')
+
+    if (ariaControls) {
+      const $ariaControlled = $el.parent().next()
+
+      if ($ariaControlled.attr('id') === ariaControls) {
+        const correctConditionalId = 'conditional-' + el.id
+        $el.attr('aria-controls', correctConditionalId)
+        $ariaControlled.attr('id', correctConditionalId)
+      }
+    }
   })
 
   this.updateContent(index, item)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Ensure that conditionally revealed blocks triggered by radio button have correct `aria-controls` value associated with them

### Why did it change

Clicking on radio in an added item would trigger the corresponding block in the first item to be revealed

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

n/a

## Screenshots
<!--- (Optional) Include screenshots if changes update interfaces or components -->
<!--- Delete/copy as appropriate --->

| After | Before |
| ------ | ----- |
| <kbd>![after](https://user-images.githubusercontent.com/4856/102341470-cc932280-3f8f-11eb-95ca-23e5a3496612.gif)</kbd> | <kbd>![before](https://user-images.githubusercontent.com/4856/102341492-d3ba3080-3f8f-11eb-8094-680f0c95f6c9.gif)</kbd> |

## Checklists

### Testing

#### Automated testing

- [ ] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed


### Other considerations

- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
