### PR TITLE
[P4-2557] Create logic to determine if the person is serving a youth sentence

### DIFF
--- a/app/move/app/new/controllers/base.js
+++ b/app/move/app/new/controllers/base.js
@@ -188,6 +188,38 @@ class CreateBaseController extends FormWizardController {
 
     return false
   }
+
+  requiresYouthAssessment(req) {
+    const {
+      person = {},
+      from_location_type: fromLocationType,
+      is_young_offender_institution: isYoungOffenderInstitution,
+      serving_youth_sentence: servingYouthSentence,
+    } = req.sessionModel.toJSON()
+    const age = filters.calculateAge(person.date_of_birth)
+
+    if (
+      ['secure_training_centre', 'secure_childrens_home'].includes(
+        fromLocationType
+      )
+    ) {
+      return true
+    }
+
+    if (
+      fromLocationType === 'prison' &&
+      isYoungOffenderInstitution &&
+      age < 18
+    ) {
+      return true
+    }
+
+    if (servingYouthSentence === 'yes') {
+      return true
+    }
+
+    return false
+  }
 }
 
 module.exports = CreateBaseController

--- a/app/move/app/new/controllers/base.js
+++ b/app/move/app/new/controllers/base.js
@@ -1,5 +1,6 @@
 const FormWizardController = require('../../../../../common/controllers/form-wizard')
 const presenters = require('../../../../../common/presenters')
+const filters = require('../../../../../config/nunjucks/filters')
 
 class CreateBaseController extends FormWizardController {
   middlewareSetup() {
@@ -157,13 +158,35 @@ class CreateBaseController extends FormWizardController {
       id: currentLocationId,
       location_type: locationType,
       can_upload_documents: canUploadDocuments,
+      young_offender_institution: isYoungOffenderInstitution,
     } = req.session.currentLocation || {}
 
     req.form.values.from_location = currentLocationId
     req.form.values.from_location_type = locationType
     req.form.values.can_upload_documents = canUploadDocuments
+    req.form.values.is_young_offender_institution = isYoungOffenderInstitution
 
     super.saveValues(req, res, next)
+  }
+
+  shouldAskYouthSentenceStep(req) {
+    const fromLocationType = req.sessionModel.get('from_location_type')
+    const isYoungOffenderInstitution = req.sessionModel.get(
+      'is_young_offender_institution'
+    )
+    const { date_of_birth: dateOfBirth } = req.sessionModel.get('person') || {}
+    const age = filters.calculateAge(dateOfBirth)
+
+    if (
+      fromLocationType === 'prison' &&
+      isYoungOffenderInstitution &&
+      age >= 18 &&
+      age <= 19
+    ) {
+      return true
+    }
+
+    return false
   }
 }
 

--- a/app/move/app/new/controllers/base.test.js
+++ b/app/move/app/new/controllers/base.test.js
@@ -922,6 +922,7 @@ describe('Move controllers', function () {
         id: '12345',
         location_type: 'police',
         can_upload_documents: true,
+        young_offender_institution: true,
       }
 
       beforeEach(function () {
@@ -957,6 +958,12 @@ describe('Move controllers', function () {
           )
         })
 
+        it('should set young offender institute value', function () {
+          expect(req.form.values.is_young_offender_institution).to.equal(
+            currentLocationMock.young_offender_institution
+          )
+        })
+
         it('should call parent method', function () {
           expect(
             FormController.prototype.saveValues
@@ -969,22 +976,110 @@ describe('Move controllers', function () {
           controller.saveValues(req, {}, nextSpy)
         })
 
-        it('should set current location ID', function () {
+        it('should not set current location ID', function () {
           expect(req.form.values.from_location).to.be.undefined
         })
 
-        it('should set from location type', function () {
+        it('should not set from location type', function () {
           expect(req.form.values.from_location_type).to.be.undefined
         })
 
-        it('should set can upload documents values', function () {
+        it('should not set can upload documents values', function () {
           expect(req.form.values.can_upload_documents).to.be.undefined
+        })
+
+        it('should not set young offender institute value', function () {
+          expect(req.form.values.is_young_offender_institution).to.be.undefined
         })
 
         it('should call parent method', function () {
           expect(
             FormController.prototype.saveValues
           ).to.be.calledOnceWithExactly(req, {}, nextSpy)
+        })
+      })
+    })
+
+    describe('#shouldAskYouthSentenceStep', function () {
+      const mockDate = new Date('2020-12-25')
+      let mockReq
+
+      beforeEach(function () {
+        this.clock = sinon.useFakeTimers(mockDate.getTime())
+        mockReq = {
+          sessionModel: {
+            get: sinon.stub(),
+          },
+        }
+      })
+
+      afterEach(function () {
+        this.clock.restore()
+      })
+
+      context('with non-prison move', function () {
+        beforeEach(function () {
+          mockReq.sessionModel.get
+            .withArgs('from_location_type')
+            .returns('police')
+        })
+
+        it('should return false', function () {
+          expect(controller.shouldAskYouthSentenceStep(mockReq)).to.be.false
+        })
+      })
+
+      context('with prison move', function () {
+        beforeEach(function () {
+          mockReq.sessionModel.get
+            .withArgs('from_location_type')
+            .returns('prison')
+        })
+
+        context('without YOI', function () {
+          it('should return false', function () {
+            expect(controller.shouldAskYouthSentenceStep(mockReq)).to.be.false
+          })
+        })
+
+        context('with YOI', function () {
+          beforeEach(function () {
+            mockReq.sessionModel.get
+              .withArgs('is_young_offender_institution')
+              .returns(true)
+          })
+
+          context('when in age bracket', function () {
+            it('should return true', function () {
+              mockReq.sessionModel.get
+                .withArgs('person')
+                .returns({ date_of_birth: '2002-10-10' })
+              expect(controller.shouldAskYouthSentenceStep(mockReq)).to.be.true
+            })
+
+            it('should return true', function () {
+              mockReq.sessionModel.get
+                .withArgs('person')
+                .returns({ date_of_birth: '2001-10-10' })
+              expect(controller.shouldAskYouthSentenceStep(mockReq)).to.be.true
+            })
+          })
+
+          context('when not in age bracket', function () {
+            it('should return false', function () {
+              mockReq.sessionModel.get
+                .withArgs('person')
+                .returns({ date_of_birth: '2010-10-10' })
+              expect(controller.shouldAskYouthSentenceStep(mockReq)).to.be.false
+            })
+
+            it('should return false', function () {
+              mockReq.sessionModel.get
+                .withArgs('person')
+                .returns({ date_of_birth: '1990-10-10' })
+              expect(controller.shouldAskYouthSentenceStep(mockReq)).to.be.false
+            })
+          })
         })
       })
     })

--- a/app/move/app/new/controllers/base.test.js
+++ b/app/move/app/new/controllers/base.test.js
@@ -1083,5 +1083,133 @@ describe('Move controllers', function () {
         })
       })
     })
+
+    describe('#requiresYouthAssessment', function () {
+      const mockDate = new Date('2020-12-25')
+      let mockReq
+
+      beforeEach(function () {
+        this.clock = sinon.useFakeTimers(mockDate.getTime())
+        mockReq = {
+          sessionModel: {
+            toJSON: sinon.stub(),
+          },
+        }
+      })
+
+      afterEach(function () {
+        this.clock.restore()
+      })
+
+      context('with youth move', function () {
+        it('should return true', function () {
+          mockReq.sessionModel.toJSON.returns({
+            person: {
+              id: '12345',
+            },
+            from_location_type: 'secure_childrens_home',
+            is_young_offender_institution: false,
+          })
+          expect(controller.requiresYouthAssessment(mockReq)).to.be.true
+        })
+
+        it('should return true', function () {
+          mockReq.sessionModel.toJSON.returns({
+            person: {
+              id: '12345',
+            },
+            from_location_type: 'secure_training_centre',
+            is_young_offender_institution: false,
+          })
+          expect(controller.requiresYouthAssessment(mockReq)).to.be.true
+        })
+      })
+
+      context('with under 18 YOI move', function () {
+        it('should return true', function () {
+          mockReq.sessionModel.toJSON.returns({
+            person: {
+              id: '12345',
+              date_of_birth: '2005-12-25',
+            },
+            from_location_type: 'prison',
+            is_young_offender_institution: true,
+          })
+          expect(controller.requiresYouthAssessment(mockReq)).to.be.true
+        })
+      })
+
+      context('with under 18 prison move', function () {
+        it('should return false', function () {
+          mockReq.sessionModel.toJSON.returns({
+            person: {
+              id: '12345',
+              date_of_birth: '2005-12-25',
+            },
+            from_location_type: 'prison',
+            is_young_offender_institution: false,
+          })
+          expect(controller.requiresYouthAssessment(mockReq)).to.be.false
+        })
+      })
+
+      context('with over 18 prison move', function () {
+        it('should return false', function () {
+          mockReq.sessionModel.toJSON.returns({
+            person: {
+              id: '12345',
+              date_of_birth: '1990-12-25',
+            },
+            from_location_type: 'prison',
+            is_young_offender_institution: true,
+          })
+          expect(controller.requiresYouthAssessment(mockReq)).to.be.false
+        })
+      })
+
+      context('with serving youth sentence move', function () {
+        it('should return true', function () {
+          mockReq.sessionModel.toJSON.returns({
+            person: {
+              id: '12345',
+              date_of_birth: '2002-12-25',
+            },
+            from_location_type: 'prison',
+            is_young_offender_institution: true,
+            serving_youth_sentence: 'yes',
+          })
+          expect(controller.requiresYouthAssessment(mockReq)).to.be.true
+        })
+      })
+
+      context('without serving youth sentence move', function () {
+        it('should return false', function () {
+          mockReq.sessionModel.toJSON.returns({
+            person: {
+              id: '12345',
+              date_of_birth: '2002-12-25',
+            },
+            from_location_type: 'prison',
+            is_young_offender_institution: true,
+            serving_youth_sentence: 'no',
+          })
+          expect(controller.requiresYouthAssessment(mockReq)).to.be.false
+        })
+      })
+
+      context('with police move', function () {
+        it('should return false', function () {
+          mockReq.sessionModel.toJSON.returns({
+            person: {
+              id: '12345',
+              date_of_birth: '2005-12-25',
+            },
+            from_location_type: 'police',
+            is_young_offender_institution: false,
+          })
+          expect(controller.requiresYouthAssessment(mockReq)).to.be.false
+        })
+      })
+    })
   })
 })

--- a/app/move/app/new/controllers/save.js
+++ b/app/move/app/new/controllers/save.js
@@ -46,6 +46,7 @@ class SaveController extends CreateBaseController {
 
       await profileService.update({
         ...data.profile,
+        requires_youth_risk_assessment: this.requiresYouthAssessment(req),
         assessment_answers: assessment,
         documents,
       })

--- a/app/move/app/new/controllers/save.test.js
+++ b/app/move/app/new/controllers/save.test.js
@@ -91,6 +91,9 @@ describe('Move controllers', function () {
       let req, nextSpy, courtHearingService, profileService, moveService
 
       beforeEach(function () {
+        sinon
+          .stub(BaseController.prototype, 'requiresYouthAssessment')
+          .returns(true)
         courtHearingService = {
           create: sinon.stub().resolvesArg(0),
         }
@@ -136,6 +139,7 @@ describe('Move controllers', function () {
           it('should patch profile', function () {
             expect(profileService.update).to.be.calledOnceWithExactly({
               ...mockValues.profile,
+              requires_youth_risk_assessment: true,
               assessment_answers: mockValues.assessment,
               documents: mockValues.documents,
             })
@@ -198,6 +202,7 @@ describe('Move controllers', function () {
             it('should patch profile', function () {
               expect(profileService.update).to.be.calledOnceWithExactly({
                 ...mockValuesWithHearings.profile,
+                requires_youth_risk_assessment: true,
                 assessment_answers: mockValuesWithHearings.assessment,
                 documents: mockValuesWithHearings.documents,
               })

--- a/app/move/app/new/steps.js
+++ b/app/move/app/new/steps.js
@@ -2,6 +2,7 @@ const { FEATURE_FLAGS } = require('../../../../config')
 
 const {
   Assessment,
+  Base,
   CourtHearings,
   Document,
   Hospital,
@@ -137,6 +138,12 @@ module.exports = {
         value: true,
         next: 'personal-details',
       },
+      {
+        fn: Base.prototype.shouldAskYouthSentenceStep,
+        next: FEATURE_FLAGS.YOUTH_RISK_ASSESSMENT
+          ? 'serving-youth-sentence'
+          : 'move-details',
+      },
       'move-details',
     ],
     fields: ['people'],
@@ -144,7 +151,15 @@ module.exports = {
   '/personal-details': {
     controller: PersonalDetails,
     pageTitle: 'moves::steps.personal_details.heading',
-    next: 'move-details',
+    next: [
+      {
+        fn: Base.prototype.shouldAskYouthSentenceStep,
+        next: FEATURE_FLAGS.YOUTH_RISK_ASSESSMENT
+          ? 'serving-youth-sentence'
+          : 'move-details',
+      },
+      'move-details',
+    ],
     fields: [
       'police_national_computer',
       'last_name',
@@ -154,6 +169,11 @@ module.exports = {
       'gender',
       'gender_additional_information',
     ],
+  },
+  '/serving-youth-sentence': {
+    pageTitle: 'moves::steps.serving_youth_sentence.heading',
+    fields: ['serving_youth_sentence'],
+    next: 'move-details',
   },
   // OCA journey
   '/move-date-range': {

--- a/app/move/fields/index.js
+++ b/app/move/fields/index.js
@@ -36,6 +36,7 @@ const prisonRecallComments = require('./prison-recall-comments')
 const prisonTransferComments = require('./prison-transfer-comments')
 const prisonTransferType = require('./prison-transfer-type')
 const reviewFields = require('./review')
+const servingYouthSentence = require('./serving-youth-sentence')
 const shouldSaveCourtHearings = require('./should-save-court-hearings')
 const specialVehicleCheck = require('./special-vehicle-check')
 const timeDue = require('./time-due')
@@ -104,6 +105,7 @@ const createFields = {
     isRequired: true,
     isExplicit: true,
   }),
+  serving_youth_sentence: servingYouthSentence,
   should_save_court_hearings: shouldSaveCourtHearings,
   time_due: timeDue,
   to_location: toLocation,

--- a/app/move/fields/serving-youth-sentence.js
+++ b/app/move/fields/serving-youth-sentence.js
@@ -1,0 +1,23 @@
+const servingYouthSentence = {
+  validate: 'required',
+  component: 'govukRadios',
+  name: 'serving_youth_sentence',
+  fieldset: {
+    legend: {
+      text: 'fields::serving_youth_sentence.label',
+      classes: 'govuk-visually-hidden govuk-fieldset__legend--m',
+    },
+  },
+  items: [
+    {
+      value: 'yes',
+      text: 'Yes',
+    },
+    {
+      value: 'no',
+      text: 'No',
+    },
+  ],
+}
+
+module.exports = servingYouthSentence

--- a/locales/en/fields.json
+++ b/locales/en/fields.json
@@ -63,6 +63,9 @@
     "label": "Security category",
     "uncategorised": "Pending category"
   },
+  "serving_youth_sentence": {
+    "label": "Is this person serving their sentence in the Secure Youth Estate?"
+  },
   "from_location": {
     "label": "Move from",
     "short_label": "From"

--- a/locales/en/moves.json
+++ b/locales/en/moves.json
@@ -21,6 +21,9 @@
     "personal_details": {
       "heading": "Personal details"
     },
+    "serving_youth_sentence": {
+      "heading": "Is this person serving their sentence in the Secure Youth Estate?"
+    },
     "move_date": {
       "heading": "When is this person moving?"
     },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

This set of changes introduces logic within the move creation journey to ask if a prisoner is serving their sentence in the youth estate.

This check only occurs when the location is marked as a `prison` and also a `young_offender_institution` and the person is between 18 and 19. 

This moves the logic for determining if a youth risk assessment should be shown to the profile, where the attribute `requires_youth_risk_assessment` is set when creating the move.

In some scenarios this can be determined automatically, in others the extra question needs to be asked.

#### Logic

- if coming from `secure_childrens_home` - **true**
- if coming from `secure_training_centre` - **true**
- if coming from `prison`
  - if `young_offender_institution`
    - if under 18 - **true**
    - if over 18 - **false**
    - if serving on secure youth estate - **true**
    - if serving **not** on secure youth estate - **false**
  - else - **false**
- else - **false**

### Why did it change

Currently, all establishment that can hold young offenders (HMYOI or HMP/YOI) are marked as a `prison` location type within the API. This means in certain circumstances we can't tell if the person being moved is serving their sentence in the youth estate.

That requires us to ask the user creating the move in this scenarios.

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

- [P4-2557](https://dsdmoj.atlassian.net/browse/P4-2557)

## Screenshots
<!--- (Optional) Include screenshots if changes update interfaces or components -->
<!--- Delete/copy as appropriate --->

#### YOI

When over 18

<kbd>![overage-prison](https://user-images.githubusercontent.com/3327997/102344806-5c3ad000-3f94-11eb-9172-b652f996272d.gif)</kbd>

When under 18

<kbd>![underage-yoi](https://user-images.githubusercontent.com/3327997/102344886-74aaea80-3f94-11eb-93a3-969b80bcaa53.gif)</kbd>

When 18 or 19

<kbd>![agecheck-yoi](https://user-images.githubusercontent.com/3327997/102344940-87252400-3f94-11eb-90f1-6a5df0815b1c.gif)</kbd>

### Secure Childrens Home or Secure Training Centre

<kbd>![youth-estate](https://user-images.githubusercontent.com/3327997/102344920-81c7d980-3f94-11eb-9160-1d8b0996df93.gif)</kbd>

## Checklists

### Testing

#### Automated testing

- [ ] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [x] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed

### Other considerations

Commit messages with a `fix` or `feat` type are automatically used to generate the [changelog](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/CHANGELOG.md) and
[GitHub release notes](https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/releases) during the release task. Please make sure they will read well on their own in a
summary of changes and that the commit body gives a more detailed description of those changes if necessary.

- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
- [x] Update [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md) with any new instructions or tasks
