### PR TITLE
refactor: Extract row & cell functions into helper

### DIFF
--- a/common/presenters/date-table/locations-to-population-table-component.js
+++ b/common/presenters/date-table/locations-to-population-table-component.js
@@ -1,63 +1,9 @@
-const { parseISO, isValid, isDate, addDays, format } = require('date-fns')
+const { parseISO, isValid, isDate, addDays } = require('date-fns')
 const { times } = require('lodash')
 
-const i18n = require('../../../config/i18n')
 const tablePresenters = require('../table')
 
-const freeSpaceCellContent = function ({ date, populationIndex = 0 }) {
-  return data => {
-    const { id: locationId } = data
-    const { free_spaces: count } =
-      data?.meta?.populations?.[populationIndex] || {}
-
-    const link =
-      count === undefined
-        ? i18n.t('population::add_space')
-        : i18n.t('population::spaces_with_count', { count })
-
-    const editQuicklink = count === undefined ? '/edit' : ''
-
-    const url = `/population/day/${format(
-      date,
-      'yyyy-MM-dd'
-    )}/${locationId}${editQuicklink}`
-
-    return `<a href="${url}">${link}</a>`
-  }
-}
-
-const dayConfig = function ({ date, populationIndex = 0 }) {
-  return {
-    head: {
-      date,
-      attributes: {
-        width: '80',
-      },
-      text: `Day ${populationIndex + 1}`,
-    },
-    row: {
-      date,
-      html: data => freeSpaceCellContent({ date, populationIndex })(data),
-    },
-  }
-}
-
-const establishmentConfig = {
-  head: {
-    html: 'population::labels.establishment',
-    attributes: {
-      width: '220',
-    },
-  },
-  row: {
-    attributes: {
-      scope: 'row',
-    },
-    html: data => {
-      return `<a>${data.title}</a>`
-    },
-  },
-}
+const { dayConfig, establishmentConfig } = require('./population-helpers')
 
 function locationsToPopulationTable({ query, startDate, dayCount = 5 } = {}) {
   let startDateAsDate = isDate(startDate) ? startDate : parseISO(startDate)
@@ -85,6 +31,4 @@ function locationsToPopulationTable({ query, startDate, dayCount = 5 } = {}) {
 
 module.exports = {
   locationsToPopulationTable,
-  freeSpaceCellContent,
-  dayConfig,
 }

--- a/common/presenters/date-table/locations-to-populations-table-component.test.js
+++ b/common/presenters/date-table/locations-to-populations-table-component.test.js
@@ -5,8 +5,6 @@ const tablePresenters = require('../table')
 
 const {
   locationsToPopulationTable: presenter,
-  freeSpaceCellContent,
-  dayConfig,
 } = require('./locations-to-population-table-component')
 
 const mockLocations = [
@@ -52,107 +50,6 @@ describe('#locationToPopulationTableComponent()', function () {
 
   afterEach(function () {
     i18n.t.restore()
-  })
-
-  describe('freeSpaceCellContent', function () {
-    beforeEach(function () {
-      output = presenter({
-        startDate: new Date('2020-06-01'),
-        focusDate: new Date('2020-06-04'),
-      })(mockLocations)
-    })
-
-    let result
-    context('with population count', function () {
-      beforeEach(function () {
-        result = freeSpaceCellContent({
-          date: new Date(2020, 5, 1),
-          populationIndex: 1,
-        })(mockLocations[0])
-      })
-      it('should display as spaces_with_count', function () {
-        expect(result).to.contain('>population::spaces_with_count<')
-      })
-      it('should link to daily overview page', function () {
-        expect(result).to.contain(
-          `a href="/population/day/2020-06-01/${mockLocations[0].id}"`
-        )
-      })
-    })
-
-    context('without population count', function () {
-      beforeEach(function () {
-        result = freeSpaceCellContent({
-          date: new Date(2020, 5, 1),
-          populationIndex: 4,
-        })(mockLocations[0])
-      })
-
-      it('should display as add_space', function () {
-        expect(result).to.contain('>population::add_space<')
-      })
-      it('should link to daily edit page', function () {
-        expect(result).to.contain(
-          `a href="/population/day/2020-06-01/${mockLocations[0].id}/edit"`
-        )
-      })
-    })
-    context('with invalid population', function () {
-      beforeEach(function () {
-        result = freeSpaceCellContent({
-          date: new Date(2020, 5, 1),
-          populationIndex: 4,
-        })({
-          ...mockLocations[0],
-          meta: {},
-        })
-      })
-
-      it('should display as add_space', function () {
-        expect(result).to.contain('>population::add_space<')
-      })
-      it('should link to daily edit page', function () {
-        expect(result).to.contain(
-          `a href="/population/day/2020-06-01/${mockLocations[0].id}/edit"`
-        )
-      })
-    })
-  })
-
-  describe('dayConfig', function () {
-    let result
-    beforeEach(function () {
-      result = dayConfig({ date: '2020-01-01', populationIndex: 0 })
-    })
-    context('head', function () {
-      it('should contain a date', function () {
-        expect(result.head.date).to.equal('2020-01-01')
-      })
-      it('should contain other table properties', function () {
-        expect(result.head).to.deep.include({
-          attributes: {
-            width: '80',
-          },
-          text: 'Day 1',
-        })
-      })
-    })
-    context('row', function () {
-      it('should contain a date', function () {
-        expect(result.row.date).to.equal('2020-01-01')
-      })
-      it('should contain html render', function () {
-        expect(result.row.html).to.be.a('function')
-      })
-
-      it('should render cell content with html', function () {
-        result = dayConfig({ date: new Date(2020, 0, 1), populationIndex: 0 })
-
-        const renderedResult = result.row.html(mockLocations[0])
-        expect(renderedResult).to.contain('>population::spaces_with_count<')
-      })
-      it('should display as spaces_with_count', function () {})
-    })
   })
 
   describe('locationsToPopulationTable', function () {

--- a/common/presenters/date-table/population-helpers.js
+++ b/common/presenters/date-table/population-helpers.js
@@ -1,0 +1,64 @@
+const { format } = require('date-fns')
+
+const i18n = require('../../../config/i18n')
+
+const dayConfig = function ({ date, populationIndex = 0 }) {
+  return {
+    head: {
+      date,
+      attributes: {
+        width: '80',
+      },
+      text: `Day ${populationIndex + 1}`,
+    },
+    row: {
+      date,
+      html: data => freeSpaceCellContent({ date, populationIndex })(data),
+    },
+  }
+}
+
+const establishmentConfig = {
+  head: {
+    html: 'population::labels.establishment',
+    attributes: {
+      width: '220',
+    },
+  },
+  row: {
+    attributes: {
+      scope: 'row',
+    },
+    html: data => {
+      return `<a>${data.title}</a>`
+    },
+  },
+}
+
+const freeSpaceCellContent = function ({ date, populationIndex = 0 }) {
+  return data => {
+    const { id: locationId } = data
+    const { free_spaces: count } =
+      data?.meta?.populations?.[populationIndex] || {}
+
+    const link =
+      count === undefined
+        ? i18n.t('population::add_space')
+        : i18n.t('population::spaces_with_count', { count })
+
+    const editQuicklink = count === undefined ? '/edit' : ''
+
+    const url = `/population/day/${format(
+      date,
+      'yyyy-MM-dd'
+    )}/${locationId}${editQuicklink}`
+
+    return `<a href="${url}">${link}</a>`
+  }
+}
+
+module.exports = {
+  dayConfig,
+  establishmentConfig,
+  freeSpaceCellContent,
+}

--- a/common/presenters/date-table/population-helpers.test.js
+++ b/common/presenters/date-table/population-helpers.test.js
@@ -1,0 +1,139 @@
+const i18n = require('../../../config/i18n')
+
+const { dayConfig, freeSpaceCellContent } = require('./population-helpers')
+
+const mockLocation = {
+  id: '54d1c8c3-699e-4198-9218-f923a7f18149',
+  type: 'locations',
+  key: 'wyi',
+  title: 'WETHERBY (HMPYOI)',
+  location_type: 'prison',
+  meta: {
+    populations: [
+      {
+        id: '1bf70844-6b85-4fa6-8437-1c3859f883ee',
+        free_spaces: 2,
+      },
+      {
+        id: '6318fafa-923d-468f-ab5f-dc9cbdd79198',
+        free_spaces: -1,
+      },
+      {
+        id: '06bb368a-d512-406c-9a3f-ef47d75a31c7',
+        free_spaces: 0,
+      },
+      {
+        id: '18a46696-f6ff-4c4e-8fe8-bc3177845a4a',
+        free_spaces: undefined,
+      },
+      {
+        id: 'abccd8db-29fe-47cf-b463-4f71cbea5416',
+        free_spaces: undefined,
+      },
+    ],
+  },
+}
+
+describe('population helpers', function () {
+  beforeEach(function () {
+    sinon.stub(i18n, 't').returnsArg(0)
+  })
+
+  afterEach(function () {
+    i18n.t.restore()
+  })
+
+  describe('freeSpaceCellContent', function () {
+    let result
+    context('with population count', function () {
+      beforeEach(function () {
+        result = freeSpaceCellContent({
+          date: new Date(2020, 5, 1),
+          populationIndex: 1,
+        })(mockLocation)
+      })
+      it('should display as spaces_with_count', function () {
+        expect(result).to.contain('>population::spaces_with_count<')
+      })
+      it('should link to daily overview page', function () {
+        expect(result).to.contain(
+          `a href="/population/day/2020-06-01/${mockLocation.id}"`
+        )
+      })
+    })
+
+    context('without population count', function () {
+      beforeEach(function () {
+        result = freeSpaceCellContent({
+          date: new Date(2020, 5, 1),
+          populationIndex: 4,
+        })(mockLocation)
+      })
+
+      it('should display as add_space', function () {
+        expect(result).to.contain('>population::add_space<')
+      })
+      it('should link to daily edit page', function () {
+        expect(result).to.contain(
+          `a href="/population/day/2020-06-01/${mockLocation.id}/edit"`
+        )
+      })
+    })
+    context('with invalid population', function () {
+      beforeEach(function () {
+        result = freeSpaceCellContent({
+          date: new Date(2020, 5, 1),
+          populationIndex: 4,
+        })({
+          ...mockLocation,
+          meta: {},
+        })
+      })
+
+      it('should display as add_space', function () {
+        expect(result).to.contain('>population::add_space<')
+      })
+      it('should link to daily edit page', function () {
+        expect(result).to.contain(
+          `a href="/population/day/2020-06-01/${mockLocation.id}/edit"`
+        )
+      })
+    })
+  })
+
+  describe('dayConfig', function () {
+    let result
+    beforeEach(function () {
+      result = dayConfig({ date: '2020-01-01', populationIndex: 0 })
+    })
+    context('head', function () {
+      it('should contain a date', function () {
+        expect(result.head.date).to.equal('2020-01-01')
+      })
+      it('should contain other table properties', function () {
+        expect(result.head).to.deep.include({
+          attributes: {
+            width: '80',
+          },
+          text: 'Day 1',
+        })
+      })
+    })
+    context('row', function () {
+      it('should contain a date', function () {
+        expect(result.row.date).to.equal('2020-01-01')
+      })
+      it('should contain html render', function () {
+        expect(result.row.html).to.be.a('function')
+      })
+
+      it('should render cell content with html', function () {
+        result = dayConfig({ date: new Date(2020, 0, 1), populationIndex: 0 })
+
+        const renderedResult = result.row.html(mockLocation)
+        expect(renderedResult).to.contain('>population::spaces_with_count<')
+      })
+      it('should display as spaces_with_count', function () {})
+    })
+  })
+})


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

This PR separates out the row and cell related functions from the ones that construct a population table. This will make it easier to iterate in future PRs.

### What changed

The `dayConfig`, `establishmentConfig` and `freeSpaceCellContent` functions have been moved into a separate file, along with their tests.

## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [ ] Chrome
- [x] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed

### Other considerations

Commit messages with a `fix` or `feat` type are automatically used to generate the [changelog](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/CHANGELOG.md) and
[GitHub release notes](https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/releases) during the release task. Please make sure they will read well on their own in a
summary of changes and that the commit body gives a more detailed description of those changes if necessary.

- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
- [ ] Update [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md) with any new instructions or tasks
