### PR TITLE
[P4-2288] Display categories on population pages

### DIFF
--- a/app/population/controllers/dashboard.js
+++ b/app/population/controllers/dashboard.js
@@ -1,12 +1,12 @@
 function dashboard(req, res) {
-  const { context, dateRange, pagination, resultsAsPopulationTable } = req
+  const { context, dateRange, pagination, resultsAsPopulationTables } = req
   const { period } = req.params
 
   res.render('population/views/dashboard', {
     context,
     pageTitle: 'dashboard::page_title',
     pagination,
-    resultsAsPopulationTable,
+    resultsAsPopulationTables,
     period,
     dateRange,
   })

--- a/app/population/controllers/dashboard.test.js
+++ b/app/population/controllers/dashboard.test.js
@@ -15,7 +15,7 @@ describe('Population controllers', function () {
           nextUrl: '/population/week/2020-06/08',
           prevUrl: '/population/week/20202-05-23',
         },
-        resultsAsPopulationTable: {
+        resultsAsPopulationTables: {
           populationTableData: {},
         },
         params: {
@@ -71,10 +71,10 @@ describe('Population controllers', function () {
           expect(params.pagination).to.deep.equal(mockReq.pagination)
         })
 
-        it('should set resultsAsPopulationTable', function () {
-          expect(params).to.have.property('resultsAsPopulationTable')
-          expect(params.resultsAsPopulationTable).to.deep.equal(
-            mockReq.resultsAsPopulationTable
+        it('should set resultsAsPopulationTables', function () {
+          expect(params).to.have.property('resultsAsPopulationTables')
+          expect(params.resultsAsPopulationTables).to.deep.equal(
+            mockReq.resultsAsPopulationTables
           )
         })
 

--- a/app/population/index.js
+++ b/app/population/index.js
@@ -16,7 +16,7 @@ const {
   redirectBaseUrl,
   setBreadcrumb,
   setPopulation,
-  setResultsAsPopulationTable,
+  setResultsAsPopulationTables,
 } = require('./middleware')
 const { editSteps } = require('./steps')
 
@@ -44,7 +44,7 @@ router.get(
   BASE_PATH,
   setContext('population'),
   setPagination(MOUNTPATH + BASE_PATH),
-  setResultsAsPopulationTable,
+  setResultsAsPopulationTables,
   dashboard
 )
 

--- a/app/population/middleware/index.js
+++ b/app/population/middleware/index.js
@@ -1,11 +1,11 @@
 const redirectBaseUrl = require('./redirect-base-url')
 const setBreadcrumb = require('./set-breadcrumb')
 const setPopulation = require('./set-population')
-const setResultsAsPopulationTable = require('./set-results.population-table')
+const setResultsAsPopulationTables = require('./set-results.population-tables')
 
 module.exports = {
   redirectBaseUrl,
   setBreadcrumb,
   setPopulation,
-  setResultsAsPopulationTable,
+  setResultsAsPopulationTables,
 }

--- a/app/population/middleware/set-population.js
+++ b/app/population/middleware/set-population.js
@@ -4,13 +4,17 @@ async function setPopulation(req, res, next) {
     let transfersIn
     let transfersOut
 
-    const dailyFreeSpace = await req.services.locationsFreeSpaces.getPrisonFreeSpaces(
+    const dailyFreeSpaceByCategory = await req.services.locationsFreeSpaces.getPrisonFreeSpaces(
       {
         dateFrom: date,
         dateTo: date,
         locationIds: locationId,
       }
     )
+
+    const dailyFreeSpace =
+      dailyFreeSpaceByCategory?.[Object.keys(dailyFreeSpaceByCategory)]
+
     req.locationName = dailyFreeSpace?.[0]?.title
 
     const freeSpacePopulation =

--- a/app/population/middleware/set-population.test.js
+++ b/app/population/middleware/set-population.test.js
@@ -4,14 +4,16 @@ const locationsFreeSpacesService = {
 
 const middleware = require('./set-population')
 
-const mockCapacities = [
-  {
-    id: 'ABADCAFE',
-    meta: {
-      populations: [{ id: 'A', free_spaces: 0 }],
+const mockFreeSpaces = {
+  'Category Epsilon': [
+    {
+      id: 'ABADCAFE',
+      meta: {
+        populations: [{ id: 'A', free_spaces: 0 }],
+      },
     },
-  },
-]
+  ],
+}
 
 const mockPopulation = {
   id: 'A',
@@ -64,7 +66,7 @@ describe('Population middleware', function () {
       function () {
         beforeEach(async function () {
           locationsFreeSpacesService.getPrisonFreeSpaces.resolves(
-            mockCapacities
+            mockFreeSpaces
           )
           populationService.getByIdWithMoves
 
@@ -182,7 +184,7 @@ describe('Population middleware', function () {
 
     context('when population service rejects', function () {
       beforeEach(async function () {
-        locationsFreeSpacesService.getPrisonFreeSpaces.resolves(mockCapacities)
+        locationsFreeSpacesService.getPrisonFreeSpaces.resolves(mockFreeSpaces)
         req.services.population.getByIdWithMoves = sinon
           .stub()
           .rejects(mockError)

--- a/app/population/middleware/set-results.population-tables.js
+++ b/app/population/middleware/set-results.population-tables.js
@@ -5,7 +5,7 @@ const {
   locationsToPopulationTable,
 } = require('../../../common/presenters/date-table/locations-to-population-table-component')
 
-async function setResultsPopulationTable(req, res, next) {
+async function setResultsPopulationTables(req, res, next) {
   try {
     const { dateRange, locations, query } = req
 
@@ -22,9 +22,11 @@ async function setResultsPopulationTable(req, res, next) {
       startDate: dateRange[0],
     })(freeSpaces)
 
-    req.resultsAsPopulationTable = decorateAsDateTable({
-      focusDate: res.locals.TODAY,
-      tableComponent: populationTable,
+    req.resultsAsPopulationTables = populationTable.map(groupedPopulation => {
+      return decorateAsDateTable({
+        focusDate: res.locals.TODAY,
+        tableComponent: groupedPopulation,
+      })
     })
 
     next()
@@ -33,4 +35,4 @@ async function setResultsPopulationTable(req, res, next) {
   }
 }
 
-module.exports = setResultsPopulationTable
+module.exports = setResultsPopulationTables

--- a/app/population/middleware/set-results.population-tables.test.js
+++ b/app/population/middleware/set-results.population-tables.test.js
@@ -8,20 +8,23 @@ const locationsToPopulationComponent = {
 
 const proxyquire = require('proxyquire')
 
-const middleware = proxyquire('./set-results.population-table', {
-  '../../../common/services/locations-free-spaces': locationsFreeSpacesService,
+const middleware = proxyquire('./set-results.population-tables', {
   '../../../common/presenters/date-table/date-table-decorator': dateTableDecorator,
   '../../../common/presenters/date-table/locations-to-population-table-component': locationsToPopulationComponent,
 })
 
 const mockLocations = ['ABADCAFE', 'BAADF00D']
 
-const mockPopulationTable = {
-  head: { text: 'Title', date: '2020-06-01' },
-  rows: [{ text: 'Value', date: '2020-06-01' }],
-}
+const mockPopulationTables = [
+  {
+    caption: 'Category Sigma',
+    head: { text: 'Title', date: '2020-06-01' },
+    rows: [{ text: 'Value', date: '2020-06-01' }],
+  },
+]
 
-const mockDateTable = {
+const mockDateTables = {
+  caption: 'Category Sigma',
   head: { text: 'Title', date: '2020-06-01', classes: 'date-stying' },
   rows: [{ text: 'Value', date: '2020-06-01', classes: 'date-styling' }],
 }
@@ -31,16 +34,16 @@ describe('Population middleware', function () {
     locationsFreeSpacesService.getPrisonFreeSpaces.resetHistory()
   })
 
-  describe('#setResultsPopulationTable()', function () {
+  describe('#setResultsPopulationTables()', function () {
     let res
     let req
     let next
 
     beforeEach(function () {
       locationsToPopulationComponent.locationsToPopulationTable.returns(
-        sinon.stub().returns(mockPopulationTable)
+        sinon.stub().returns(mockPopulationTables)
       )
-      dateTableDecorator.decorateAsDateTable.returns(mockDateTable)
+      dateTableDecorator.decorateAsDateTable.returns(mockDateTables)
 
       next = sinon.stub()
       res = {
@@ -88,9 +91,9 @@ describe('Population middleware', function () {
         expect(dateTableDecorator.decorateAsDateTable).to.have.been.calledOnce
       })
 
-      it('should set resultsAsPopulationTable on req', function () {
-        expect(req).to.have.property('resultsAsPopulationTable')
-        expect(req.resultsAsPopulationTable).to.deep.equal(mockDateTable)
+      it('should set resultsAsPopulationTables on req', function () {
+        expect(req).to.have.property('resultsAsPopulationTables')
+        expect(req.resultsAsPopulationTables[0]).to.deep.equal(mockDateTables)
       })
 
       it('should call next', function () {
@@ -107,7 +110,7 @@ describe('Population middleware', function () {
       })
 
       it('should not request properties', function () {
-        expect(req).not.to.have.property('resultsAsPopulationTable')
+        expect(req).not.to.have.property('resultsAsPopulationTables')
       })
 
       it('should call next with error', function () {

--- a/app/population/views/dashboard.njk
+++ b/app/population/views/dashboard.njk
@@ -1,10 +1,14 @@
 {% extends "layouts/collection.njk" %}
 
 {% block pageContent %}
-  {% if resultsAsPopulationTable | length  %}
+  {% if resultsAsPopulationTables | length  %}
     <div class="govuk-grid-row">
       <section class="govuk-grid-column-full govuk-!-margin-bottom-6">
-        {{ govukTable(resultsAsPopulationTable) }}
+      {% for table in resultsAsPopulationTables %}
+        {{ govukTable(table) }}
+      {% else %}
+        <h1>No population to display</h1>
+      {% endfor %}
       </section>
     </div>
   {% endif %}

--- a/app/population/views/dashboard.njk
+++ b/app/population/views/dashboard.njk
@@ -1,16 +1,20 @@
 {% extends "layouts/collection.njk" %}
 
 {% block pageContent %}
-  {% if resultsAsPopulationTables | length  %}
-    <div class="govuk-grid-row">
-      <section class="govuk-grid-column-full govuk-!-margin-bottom-6">
+  <div class="govuk-grid-row">
+    <section class="govuk-grid-column-full govuk-!-margin-bottom-6">
       {% for table in resultsAsPopulationTables %}
         {{ govukTable(table) }}
       {% else %}
-        <h1>No population to display</h1>
+        {{ appMessage({
+          classes: "app-message--muted govuk-!-margin-top-7",
+          allowDismiss: false,
+          content: {
+            html: t("population::no_population")
+          }
+        }) }}
       {% endfor %}
-      </section>
-    </div>
-  {% endif %}
+    </section>
+  </div>
 {% endblock %}
 

--- a/common/assets/scss/components/_all.scss
+++ b/common/assets/scss/components/_all.scss
@@ -1,6 +1,7 @@
 @import "autocomplete";
 @import "date-table";
 @import "icons";
+@import "population-table";
 @import "sortable-table";
 @import "stack-trace";
 @import "sticky-sidebar";

--- a/common/assets/scss/components/_population-table.scss
+++ b/common/assets/scss/components/_population-table.scss
@@ -1,0 +1,3 @@
+.population-table {
+  border-top: 2px solid #313436
+}

--- a/common/lib/api-client/models/index.js
+++ b/common/lib/api-client/models/index.js
@@ -18,7 +18,6 @@ const gender = require('./gender')
 const image = require('./image')
 const journey = require('./journey')
 const location = require('./location')
-const locationsFreeSpaces = require('./locations-free-spaces')
 const move = require('./move')
 const person = require('./person')
 const personEscortRecord = require('./person-escort-record')
@@ -53,7 +52,6 @@ module.exports = {
   image,
   journey,
   location,
-  locations_free_spaces: locationsFreeSpaces,
   move,
   person,
   person_escort_record: personEscortRecord,

--- a/common/lib/api-client/models/location.js
+++ b/common/lib/api-client/models/location.js
@@ -10,6 +10,10 @@ module.exports = {
       jsonApi: 'hasMany',
       type: 'suppliers',
     },
+    category: {
+      jsonApi: 'hasOne',
+      type: 'categories',
+    },
   },
   options: {
     cache: true,

--- a/common/lib/api-client/models/locations-free-spaces.js
+++ b/common/lib/api-client/models/locations-free-spaces.js
@@ -1,5 +1,0 @@
-module.exports = {
-  options: {
-    cache: false,
-  },
-}

--- a/common/presenters/date-table/locations-to-population-table-component.js
+++ b/common/presenters/date-table/locations-to-population-table-component.js
@@ -27,6 +27,8 @@ function locationsToPopulationTable({ query, startDate, dayCount = 5 } = {}) {
     const groupedLocations = locationKeys.map(groupedLocation => {
       return {
         caption: groupedLocation,
+        captionClasses: 'govuk-heading-m',
+        classes: 'population-table',
         head: tableConfig.map(tablePresenters.objectToTableHead(query)),
         rows: locations[groupedLocation].map(
           tablePresenters.objectToTableRow(tableConfig)

--- a/common/presenters/date-table/locations-to-population-table-component.js
+++ b/common/presenters/date-table/locations-to-population-table-component.js
@@ -1,5 +1,5 @@
 const { parseISO, isValid, isDate, addDays } = require('date-fns')
-const { times } = require('lodash')
+const { times, keys } = require('lodash')
 
 const tablePresenters = require('../table')
 
@@ -21,11 +21,20 @@ function locationsToPopulationTable({ query, startDate, dayCount = 5 } = {}) {
 
   tableConfig.unshift(establishmentConfig)
 
-  return function (locations = []) {
-    return {
-      head: tableConfig.map(tablePresenters.objectToTableHead(query)),
-      rows: locations.map(tablePresenters.objectToTableRow(tableConfig)),
-    }
+  return function (locations) {
+    const locationKeys = keys(locations).sort()
+
+    const groupedLocations = locationKeys.map(groupedLocation => {
+      return {
+        caption: groupedLocation,
+        head: tableConfig.map(tablePresenters.objectToTableHead(query)),
+        rows: locations[groupedLocation].map(
+          tablePresenters.objectToTableRow(tableConfig)
+        ),
+      }
+    })
+
+    return groupedLocations
   }
 }
 

--- a/common/presenters/date-table/locations-to-populations-table-component.test.js
+++ b/common/presenters/date-table/locations-to-populations-table-component.test.js
@@ -4,48 +4,84 @@ const i18n = require('../../../config/i18n')
 const tablePresenters = require('../table')
 
 const {
-  locationsToPopulationTable: presenter,
+  locationsToPopulationTable,
 } = require('./locations-to-population-table-component')
 
-const mockLocations = [
-  {
-    id: '54d1c8c3-699e-4198-9218-f923a7f18149',
-    type: 'locations',
-    key: 'wyi',
-    title: 'WETHERBY (HMPYOI)',
-    location_type: 'prison',
-    meta: {
-      populations: [
-        {
-          id: '1bf70844-6b85-4fa6-8437-1c3859f883ee',
-          free_spaces: 2,
-        },
-        {
-          id: '6318fafa-923d-468f-ab5f-dc9cbdd79198',
-          free_spaces: -1,
-        },
-        {
-          id: '06bb368a-d512-406c-9a3f-ef47d75a31c7',
-          free_spaces: 0,
-        },
-        {
-          id: '18a46696-f6ff-4c4e-8fe8-bc3177845a4a',
-          free_spaces: undefined,
-        },
-        {
-          id: 'abccd8db-29fe-47cf-b463-4f71cbea5416',
-          free_spaces: undefined,
-        },
-      ],
+const mockGroupedLocations = {
+  'Category Sigma': [
+    {
+      id: '54d1c8c3-699e-4198-9218-f923a7f18149',
+      type: 'locations',
+      key: 'lor',
+      title: 'Lorem',
+      location_type: 'prison',
+      meta: {
+        populations: [
+          {
+            id: '1bf70844-6b85-4fa6-8437-1c3859f883ee',
+            free_spaces: 2,
+          },
+          {
+            id: '6318fafa-923d-468f-ab5f-dc9cbdd79198',
+            free_spaces: -1,
+          },
+          {
+            id: '06bb368a-d512-406c-9a3f-ef47d75a31c7',
+            free_spaces: 0,
+          },
+          {
+            id: '18a46696-f6ff-4c4e-8fe8-bc3177845a4a',
+            free_spaces: undefined,
+          },
+          {
+            id: 'abccd8db-29fe-47cf-b463-4f71cbea5416',
+            free_spaces: undefined,
+          },
+        ],
+      },
     },
-  },
-]
+  ],
+  'Category Tau': [
+    {
+      id: '34d1c8c3-699e-4198-9218-f923a7f18149',
+      type: 'locations',
+      key: 'ips',
+      title: 'Ipsum',
+      location_type: 'prison',
+      meta: {
+        populations: [
+          {
+            id: '3bf70844-6b85-4fa6-8437-1c3859f883ee',
+            free_spaces: 9,
+          },
+          {
+            id: '3318fafa-923d-468f-ab5f-dc9cbdd79198',
+            free_spaces: 8,
+          },
+          {
+            id: '36bb368a-d512-406c-9a3f-ef47d75a31c7',
+            free_spaces: 7,
+          },
+          {
+            id: '18a46696-f6ff-4c4e-8fe8-bc3177845a4a',
+            free_spaces: 6,
+          },
+          {
+            id: '3bccd8db-29fe-47cf-b463-4f71cbea5416',
+            free_spaces: 5,
+          },
+        ],
+      },
+    },
+  ],
+}
 
 describe('#locationToPopulationTableComponent()', function () {
   let output
 
   beforeEach(function () {
     sinon.stub(i18n, 't').returnsArg(0)
+    i18n.t.resetHistory()
   })
 
   afterEach(function () {
@@ -57,131 +93,141 @@ describe('#locationToPopulationTableComponent()', function () {
       sinon
         .stub(tablePresenters, 'objectToTableHead')
         .returns(sinon.stub().callsFake(arg => arg.head))
-      output = presenter()([])
     })
 
-    it('returns an object with population heads', function () {
-      expect(output.head).to.exist
-      expect(output.head).to.be.an('array')
+    context('with no categories', function () {
+      output = locationsToPopulationTable()({})
+      expect(output).to.deep.equal([])
     })
 
-    it('returns an object with populations', function () {
-      expect(output.rows).to.exist
-      expect(output.rows).to.be.an('array')
-    })
+    context('with an empty category', function () {
+      beforeEach(function () {
+        this.clock = sinon.useFakeTimers(new Date('2020-08-12').getTime())
 
-    describe('table headers', function () {
-      context('with no table data', function () {
-        beforeEach(function () {
-          this.clock = sinon.useFakeTimers(new Date('2020-08-12').getTime())
-
-          output = presenter()()
-        })
-
-        afterEach(function () {
-          this.clock.restore()
-        })
-
-        it('should only have table headers', function () {
-          expect(output.rows.length).to.equal(0)
-        })
-
-        it('should have 6 columns', function () {
-          expect(output.head.length).to.equal(6)
-        })
-
-        it('should have a establishment column', function () {
-          expect(output.head[0]).to.deep.equal({
-            html: 'population::labels.establishment',
-            attributes: { width: '220' },
-          })
-        })
-
-        it('should have 5 day columns starting from "today"', function () {
-          expect(output.head[1])
-            .to.have.property('date')
-            .that.deep.equals(new Date('2020-08-12'))
-          expect(output.head[2])
-            .to.have.property('date')
-            .that.deep.equals(new Date('2020-08-13'))
-          expect(output.head[3])
-            .to.have.property('date')
-            .that.deep.equals(new Date('2020-08-14'))
-          expect(output.head[4])
-            .to.have.property('date')
-            .that.deep.equals(new Date('2020-08-15'))
-          expect(output.head[5])
-            .to.have.property('date')
-            .that.deep.equals(new Date('2020-08-16'))
-        })
+        output = locationsToPopulationTable()({ Empty: [] })
       })
 
-      context('with startDate', function () {
-        beforeEach(function () {
-          output = presenter({
-            startDate: new Date('2020-06-01'),
-          })()
+      afterEach(function () {
+        this.clock.restore()
+      })
+
+      it('returns an object with population heads', function () {
+        expect(output[0].head).to.exist
+        expect(output[0].head).to.be.an('array')
+      })
+
+      it('returns an object with populations', function () {
+        expect(output[0].rows).to.exist
+        expect(output[0].rows).to.be.an('array')
+      })
+
+      describe('table headers', function () {
+        context('with no table data', function () {
+          beforeEach(function () {
+            output = locationsToPopulationTable()({ Empty: [] })
+          })
+
+          it('should only have table headers', function () {
+            expect(output[0].rows.length).to.equal(0)
+          })
+
+          it('should have 6 columns', function () {
+            expect(output[0].head.length).to.equal(6)
+          })
+
+          it('should have a establishment column', function () {
+            expect(output[0].head[0]).to.deep.equal({
+              html: 'population::labels.establishment',
+              attributes: { width: '220' },
+            })
+          })
+
+          it('should have 5 day columns starting from "today"', function () {
+            expect(output[0].head[1])
+              .to.have.property('date')
+              .that.deep.equals(new Date('2020-08-12'))
+            expect(output[0].head[2])
+              .to.have.property('date')
+              .that.deep.equals(new Date('2020-08-13'))
+            expect(output[0].head[3])
+              .to.have.property('date')
+              .that.deep.equals(new Date('2020-08-14'))
+            expect(output[0].head[4])
+              .to.have.property('date')
+              .that.deep.equals(new Date('2020-08-15'))
+            expect(output[0].head[5])
+              .to.have.property('date')
+              .that.deep.equals(new Date('2020-08-16'))
+          })
         })
 
-        it('returns have an establishment column', function () {
-          expect(output.head.length).to.equal(6)
+        context('with startDate', function () {
+          beforeEach(function () {
+            output = locationsToPopulationTable({
+              startDate: new Date('2020-06-01'),
+            })({ Empty: [] })
+          })
 
-          expect(output.head[0]).to.deep.include({
-            html: 'population::labels.establishment',
-            attributes: {
-              width: '220',
-            },
-          })
-        })
+          it('returns have an establishment column', function () {
+            expect(output[0].head.length).to.equal(6)
 
-        it('should have 5 day columns starting from startDate', function () {
-          expect(output.head[1])
-            .to.have.property('date')
-            .that.deep.equals(new Date('2020-06-01'))
-          expect(output.head[2])
-            .to.have.property('date')
-            .that.deep.equals(new Date('2020-06-02'))
-          expect(output.head[3])
-            .to.have.property('date')
-            .that.deep.equals(new Date('2020-06-03'))
-          expect(output.head[4])
-            .to.have.property('date')
-            .that.deep.equals(new Date('2020-06-04'))
-          expect(output.head[5])
-            .to.have.property('date')
-            .that.deep.equals(new Date('2020-06-05'))
-        })
+            expect(output[0].head[0]).to.deep.include({
+              html: 'population::labels.establishment',
+              attributes: {
+                width: '220',
+              },
+            })
+          })
 
-        it('should have day cells with other properties', function () {
-          expect(output.head[1]).to.deep.include({
-            text: 'Day 1',
-            attributes: {
-              width: '80',
-            },
+          it('should have 5 day columns starting from startDate', function () {
+            expect(output[0].head[1])
+              .to.have.property('date')
+              .that.deep.equals(new Date('2020-06-01'))
+            expect(output[0].head[2])
+              .to.have.property('date')
+              .that.deep.equals(new Date('2020-06-02'))
+            expect(output[0].head[3])
+              .to.have.property('date')
+              .that.deep.equals(new Date('2020-06-03'))
+            expect(output[0].head[4])
+              .to.have.property('date')
+              .that.deep.equals(new Date('2020-06-04'))
+            expect(output[0].head[5])
+              .to.have.property('date')
+              .that.deep.equals(new Date('2020-06-05'))
           })
-          expect(output.head[2]).to.deep.include({
-            text: 'Day 2',
-            attributes: {
-              width: '80',
-            },
-          })
-          expect(output.head[3]).to.deep.include({
-            text: 'Day 3',
-            attributes: {
-              width: '80',
-            },
-          })
-          expect(output.head[4]).to.deep.include({
-            text: 'Day 4',
-            attributes: {
-              width: '80',
-            },
-          })
-          expect(output.head[5]).to.deep.include({
-            text: 'Day 5',
-            attributes: {
-              width: '80',
-            },
+
+          it('should have day cells with other properties', function () {
+            expect(output[0].head[1]).to.deep.include({
+              text: 'Day 1',
+              attributes: {
+                width: '80',
+              },
+            })
+            expect(output[0].head[2]).to.deep.include({
+              text: 'Day 2',
+              attributes: {
+                width: '80',
+              },
+            })
+            expect(output[0].head[3]).to.deep.include({
+              text: 'Day 3',
+              attributes: {
+                width: '80',
+              },
+            })
+            expect(output[0].head[4]).to.deep.include({
+              text: 'Day 4',
+              attributes: {
+                width: '80',
+              },
+            })
+            expect(output[0].head[5]).to.deep.include({
+              text: 'Day 5',
+              attributes: {
+                width: '80',
+              },
+            })
           })
         })
       })
@@ -189,133 +235,229 @@ describe('#locationToPopulationTableComponent()', function () {
 
     describe('its behaviour', function () {
       beforeEach(function () {
-        output = presenter({
+        i18n.t.resetHistory()
+
+        output = locationsToPopulationTable({
           startDate: new Date('2020-06-01'),
           focusDate: new Date('2020-06-04'),
-        })(mockLocations)
+        })(mockGroupedLocations)
       })
 
       context('with no options', function () {
-        it('returns one head row with all the cells', function () {
-          expect(output.head.length).to.equal(6)
+        it('returns two tables', function () {
+          expect(output.length).to.be.equal(2)
         })
 
-        it('returns one data row ', function () {
-          expect(output.rows.length).to.equal(1)
-        })
+        context('first table', function () {
+          it('returns one head row with all the cells', function () {
+            expect(output[0].head.length).to.equal(6)
+          })
 
-        it('returns one data row with all the cells', function () {
-          expect(output.rows[0].length).to.equal(6)
-        })
+          it('returns one data row ', function () {
+            expect(output[0].rows.length).to.equal(1)
+          })
 
-        it('returns establishment on first cell', function () {
-          expect(output.rows[0][0]).to.deep.equal({
-            attributes: {
-              scope: 'row',
-            },
-            html: '<a>WETHERBY (HMPYOI)</a>',
+          it('returns one data row with all the cells', function () {
+            expect(output[0].rows[0].length).to.equal(6)
+          })
+
+          it('returns establishment on first cell', function () {
+            expect(output[0].rows[0][0]).to.deep.equal({
+              attributes: {
+                scope: 'row',
+              },
+              html: '<a>Lorem</a>',
+            })
+          })
+
+          it('returns the first capacity for Monday', function () {
+            expect(output[0].rows[0][1].html).to.include(
+              'population::spaces_with_count'
+            )
+            expect(i18n.t).to.have.been.calledWith(
+              'population::spaces_with_count',
+              {
+                count: 2,
+              }
+            )
+          })
+
+          it('returns the second capacity for Tuesday', function () {
+            expect(output[0].rows[0][2].html).to.include(
+              'population::spaces_with_count'
+            )
+            expect(i18n.t).to.have.been.calledWith(
+              'population::spaces_with_count',
+              {
+                count: -1,
+              }
+            )
+          })
+
+          it('returns the third capacity for Wednesday', function () {
+            expect(output[0].rows[0][3].html).to.include(
+              'population::spaces_with_count'
+            )
+            expect(i18n.t).to.have.been.calledWith(
+              'population::spaces_with_count',
+              {
+                count: 0,
+              }
+            )
+          })
+
+          it('returns the fourth capacity for Thursday', function () {
+            expect(output[0].rows[0][4].html).to.include(
+              'population::add_space'
+            )
+            expect(i18n.t).to.have.been.calledWith(
+              'population::spaces_with_count',
+              {
+                count: 2,
+              }
+            )
+          })
+
+          it('returns the fifth capacity for Friday', function () {
+            expect(output[0].rows[0][5].html).to.include(
+              'population::add_space'
+            )
+            expect(i18n.t).to.have.been.calledWith(
+              'population::spaces_with_count',
+              {
+                count: 2,
+              }
+            )
           })
         })
 
-        it('returns the first capacity for Monday', function () {
-          expect(output.rows[0][1].html).to.include(
-            'population::spaces_with_count'
-          )
-          expect(i18n.t).to.have.been.calledWith(
-            'population::spaces_with_count',
-            {
-              count: 2,
-            }
-          )
-        })
+        context('second table', function () {
+          it('returns one head row with all the cells', function () {
+            expect(output[1].head.length).to.equal(6)
+          })
 
-        it('returns the second capacity for Tuesday', function () {
-          expect(output.rows[0][2].html).to.include(
-            'population::spaces_with_count'
-          )
-          expect(i18n.t).to.have.been.calledWith(
-            'population::spaces_with_count',
-            {
-              count: -1,
-            }
-          )
-        })
+          it('returns one data row ', function () {
+            expect(output[1].rows.length).to.equal(1)
+          })
 
-        it('returns the third capacity for Wednesday', function () {
-          expect(output.rows[0][3].html).to.include(
-            'population::spaces_with_count'
-          )
-          expect(i18n.t).to.have.been.calledWith(
-            'population::spaces_with_count',
-            {
-              count: 0,
-            }
-          )
-        })
+          it('returns one data row with all the cells', function () {
+            expect(output[1].rows[0].length).to.equal(6)
+          })
 
-        it('returns the fourth capacity for Thursday', function () {
-          expect(output.rows[0][4].html).to.include('population::add_space')
-          expect(i18n.t).to.have.been.calledWith(
-            'population::spaces_with_count',
-            {
-              count: 2,
-            }
-          )
-        })
+          it('returns establishment on first cell', function () {
+            expect(output[1].rows[0][0]).to.deep.equal({
+              attributes: {
+                scope: 'row',
+              },
+              html: '<a>Ipsum</a>',
+            })
+          })
 
-        it('returns the fifth capacity for Friday', function () {
-          expect(output.rows[0][5].html).to.include('population::add_space')
-          expect(i18n.t).to.have.been.calledWith(
-            'population::spaces_with_count',
-            {
-              count: 2,
-            }
-          )
+          it('returns the first capacity for Monday', function () {
+            expect(output[1].rows[0][1].html).to.include(
+              'population::spaces_with_count'
+            )
+            expect(i18n.t).to.have.been.calledWith(
+              'population::spaces_with_count',
+              {
+                count: 9,
+              }
+            )
+          })
+
+          it('returns the second capacity for Tuesday', function () {
+            expect(output[1].rows[0][2].html).to.include(
+              'population::spaces_with_count'
+            )
+            expect(i18n.t).to.have.been.calledWith(
+              'population::spaces_with_count',
+              {
+                count: 8,
+              }
+            )
+          })
+
+          it('returns the third capacity for Wednesday', function () {
+            expect(output[1].rows[0][3].html).to.include(
+              'population::spaces_with_count'
+            )
+            expect(i18n.t).to.have.been.calledWith(
+              'population::spaces_with_count',
+              {
+                count: 7,
+              }
+            )
+          })
+
+          it('returns the fourth capacity for Thursday', function () {
+            expect(output[1].rows[0][4].html).to.include(
+              'population::spaces_with_count'
+            )
+            expect(i18n.t).to.have.been.calledWith(
+              'population::spaces_with_count',
+              {
+                count: 2,
+              }
+            )
+          })
+
+          it('returns the fifth capacity for Friday', function () {
+            expect(output[1].rows[0][5].html).to.include(
+              'population::spaces_with_count'
+            )
+            expect(i18n.t).to.have.been.calledWith(
+              'population::spaces_with_count',
+              {
+                count: 6,
+              }
+            )
+          })
         })
       })
 
       context('with missing population data', function () {
         beforeEach(function () {
-          const missingData = cloneDeep(mockLocations)
+          const missingGroupedData = cloneDeep(mockGroupedLocations)
+          const missingLocationData = missingGroupedData['Category Sigma']
 
-          delete missingData[0].meta.populations[1].id
-          delete missingData[0].meta.populations[2].free_spaces
-          delete missingData[0].meta.populations[3].id
-          delete missingData[0].meta.populations[3].free_spaces
-          missingData[0].meta.populations[4] = undefined
-          delete missingData[0].meta.populations[5]
+          delete missingLocationData[0].meta.populations[1].id
+          delete missingLocationData[0].meta.populations[2].free_spaces
+          delete missingLocationData[0].meta.populations[3].id
+          delete missingLocationData[0].meta.populations[3].free_spaces
+          missingLocationData[0].meta.populations[4] = undefined
+          delete missingLocationData[0].meta.populations[5]
 
-          output = presenter({
+          output = locationsToPopulationTable({
             query: {
               sortBy: 'date',
               status: 'approved',
             },
-          })(missingData)
+          })(missingGroupedData)
         })
 
         it('returns one head row with all the cells', function () {
-          expect(output.head.length).to.equal(6)
+          expect(output[0].head.length).to.equal(6)
         })
 
         it('returns one data row ', function () {
-          expect(output.rows.length).to.equal(1)
+          expect(output[0].rows.length).to.equal(1)
         })
 
         it('returns one data row with all the cells', function () {
-          expect(output.rows[0].length).to.equal(6)
+          expect(output[0].rows[0].length).to.equal(6)
         })
 
         it('returns establishment on first cell', function () {
-          expect(output.rows[0][0]).to.deep.equal({
+          expect(output[0].rows[0][0]).to.deep.equal({
             attributes: {
               scope: 'row',
             },
-            html: '<a>WETHERBY (HMPYOI)</a>',
+            html: '<a>Lorem</a>',
           })
         })
 
         it('returns the first capacity for Monday', function () {
-          expect(output.rows[0][1].html).to.include(
+          expect(output[0].rows[0][1].html).to.include(
             'population::spaces_with_count'
           )
           expect(i18n.t).to.have.been.calledWith(
@@ -327,7 +469,7 @@ describe('#locationToPopulationTableComponent()', function () {
         })
 
         it('returns the second capacity for Tuesday', function () {
-          expect(output.rows[0][2].html).to.include(
+          expect(output[0].rows[0][2].html).to.include(
             'population::spaces_with_count'
           )
           expect(i18n.t).to.have.been.calledWith(
@@ -339,29 +481,29 @@ describe('#locationToPopulationTableComponent()', function () {
         })
 
         it('returns the third capacity for Wednesday', function () {
-          expect(output.rows[0][3].html).to.include('population::add_space')
+          expect(output[0].rows[0][3].html).to.include('population::add_space')
           expect(i18n.t).to.have.been.calledWith('population::add_space')
         })
 
         it('returns the fourth capacity for Thursday', function () {
-          expect(output.rows[0][4].html).to.include('population::add_space')
+          expect(output[0].rows[0][4].html).to.include('population::add_space')
           expect(i18n.t).to.have.been.calledWith('population::add_space')
         })
 
         it('returns the fifth capacity for Friday', function () {
-          expect(output.rows[0][5].html).to.include('population::add_space')
+          expect(output[0].rows[0][5].html).to.include('population::add_space')
           expect(i18n.t).to.have.been.calledWith('population::add_space')
         })
       })
 
       context('with query', function () {
         beforeEach(function () {
-          output = presenter({
+          output = locationsToPopulationTable({
             query: {
               sortBy: 'date',
               status: 'approved',
             },
-          })(mockLocations)
+          })(mockGroupedLocations)
         })
         it('passes the query to objectToTableHead', function () {
           expect(

--- a/common/services/locations-free-spaces.js
+++ b/common/services/locations-free-spaces.js
@@ -1,4 +1,4 @@
-const { flattenDeep, omitBy, isEmpty } = require('lodash')
+const { flattenDeep, omitBy, isEmpty, groupBy } = require('lodash')
 
 const apiClient = require('../lib/api-client')()
 
@@ -42,8 +42,8 @@ const locationsFreeSpacesService = {
         })
       })
   },
-  getPrisonFreeSpaces({ dateFrom, dateTo, locationIds } = {}) {
-    return locationsFreeSpacesService.getLocationsFreeSpaces({
+  async getPrisonFreeSpaces({ dateFrom, dateTo, locationIds } = {}) {
+    const locations = await locationsFreeSpacesService.getLocationsFreeSpaces({
       dateFrom,
       dateTo,
       filter: omitBy(
@@ -53,7 +53,14 @@ const locationsFreeSpacesService = {
         },
         isEmpty
       ),
+      include: ['category'],
     })
+
+    const groupedLocations = groupBy(locations, value => {
+      return value?.category?.title || 'No Category'
+    })
+
+    return groupedLocations
   },
 }
 

--- a/common/services/locations-free-spaces.test.js
+++ b/common/services/locations-free-spaces.test.js
@@ -12,12 +12,33 @@ const mockLocations = [
   {
     id: '2c952ca0-f750-4ac3-ac76-fb631445f974',
     title: 'Axminster Crown Court',
+    category: {
+      title: 'Category Epsilon',
+    },
   },
   {
     id: '9b56ca31-222b-4522-9d65-4ef429f9081e',
     title: 'Barnstaple Crown Court',
   },
 ]
+
+const mockGroupedLocations = {
+  'Category Epsilon': [
+    {
+      id: '2c952ca0-f750-4ac3-ac76-fb631445f974',
+      title: 'Axminster Crown Court',
+      category: {
+        title: 'Category Epsilon',
+      },
+    },
+  ],
+  'No Category': [
+    {
+      id: '9b56ca31-222b-4522-9d65-4ef429f9081e',
+      title: 'Barnstaple Crown Court',
+    },
+  ],
+}
 
 const dateFrom = '2020-06-01'
 const dateTo = '2020-06-07'
@@ -249,8 +270,10 @@ describe('Locations Free Spaces Service', function () {
   })
 
   describe('#getPrisonFreeSpaces()', function () {
-    const mockResponse = mockLocations
-
+    let mockResponse
+    beforeEach(function () {
+      mockResponse = mockLocations
+    })
     context('by default', function () {
       beforeEach(async function () {
         sinon
@@ -276,7 +299,7 @@ describe('Locations Free Spaces Service', function () {
       })
 
       it('should return first result', function () {
-        expect(locationsFreeSpaces).to.deep.equal(mockResponse)
+        expect(locationsFreeSpaces).to.deep.equal(mockGroupedLocations)
       })
 
       it('should call use provided date params', function () {
@@ -288,6 +311,7 @@ describe('Locations Free Spaces Service', function () {
           filter: {
             'filter[location_type]': 'prison',
           },
+          include: ['category'],
         })
       })
 
@@ -326,7 +350,7 @@ describe('Locations Free Spaces Service', function () {
       })
 
       it('should return first result', function () {
-        expect(locationsFreeSpaces).to.deep.equal(mockResponse)
+        expect(locationsFreeSpaces).to.deep.equal(mockGroupedLocations)
       })
 
       it('should set location_type filter to prison', function () {
@@ -347,6 +371,7 @@ describe('Locations Free Spaces Service', function () {
             'filter[location_id]': 'ABADFEED',
             'filter[location_type]': 'prison',
           },
+          include: ['category'],
         })
       })
 

--- a/locales/en/population.json
+++ b/locales/en/population.json
@@ -39,5 +39,6 @@
   },
   "breadcrumbs": {
     "home": "Population Overview"
-  }
+  },
+  "no_population": "No population to display"
 }

--- a/test/fixtures/api-client/location.find.json
+++ b/test/fixtures/api-client/location.find.json
@@ -17,7 +17,11 @@
           "created_at": "2019-10-09T11:10:53+01:00",
           "updated_at": "2019-10-09T11:10:53+01:00"
         }
-      ]
+      ],
+      "category": {
+        "id": "c923ef88-a476-f1f5-b9bb-2fcc0fe42cb0",
+        "type": "category"
+      }
     }
   }
 }

--- a/test/fixtures/api-client/location.findAll.json
+++ b/test/fixtures/api-client/location.findAll.json
@@ -1,696 +1,896 @@
 {
   "data": [
-      {
-          "id": "398bca42-2ee6-4d2e-ac08-3e5a4b2deb69",
-          "type": "locations",
-          "attributes": {
-              "key": "bedford_county_court",
-              "title": "Bedford County Court",
-              "location_type": "court",
-              "nomis_agency_id": null,
-              "can_upload_documents": true,
-              "disabled_at": null,
-              "suppliers": [
-                {
-                  "id": "3ef88a47-6f1f-5b9b-b2fc-c0fe42cb0c92",
-                  "name": "Serco",
-                  "key": "serco",
-                  "created_at": "2019-10-09T11:10:53+01:00",
-                  "updated_at": "2019-10-09T11:10:53+01:00"
-                }
-              ]
+    {
+      "id": "398bca42-2ee6-4d2e-ac08-3e5a4b2deb69",
+      "type": "locations",
+      "attributes": {
+        "key": "bedford_county_court",
+        "title": "Bedford County Court",
+        "location_type": "court",
+        "nomis_agency_id": null,
+        "can_upload_documents": true,
+        "disabled_at": null,
+        "suppliers": [
+          {
+            "id": "3ef88a47-6f1f-5b9b-b2fc-c0fe42cb0c92",
+            "name": "Serco",
+            "key": "serco",
+            "created_at": "2019-10-09T11:10:53+01:00",
+            "updated_at": "2019-10-09T11:10:53+01:00"
           }
-      },
-      {
-          "id": "98905621-0684-4873-9f0c-c428c24933ea",
-          "type": "locations",
-          "attributes": {
-              "key": "luton_crown_court",
-              "title": "Luton Crown Court",
-              "location_type": "court",
-              "nomis_agency_id": null,
-              "can_upload_documents": false,
-              "disabled_at": null,
-              "suppliers": []
-          }
-      },
-      {
-          "id": "d77fdb81-2a09-4981-a4f2-c6a649768319",
-          "type": "locations",
-          "attributes": {
-              "key": "maidenhead_magistrates_court",
-              "title": "Maidenhead Magistrates Court",
-              "location_type": "court",
-              "nomis_agency_id": null,
-              "can_upload_documents": false,
-              "disabled_at": null,
-              "suppliers": []
-          }
-      },
-      {
-          "id": "ddb11bbb-526b-4769-a9f2-cc82875ca52e",
-          "type": "locations",
-          "attributes": {
-              "key": "newbury_county_court",
-              "title": "Newbury County Court",
-              "location_type": "court",
-              "nomis_agency_id": null,
-              "can_upload_documents": false,
-              "disabled_at": null,
-              "suppliers": []
-          }
-      },
-      {
-          "id": "2d80f632-c831-44a8-9285-be2732fe9a64",
-          "type": "locations",
-          "attributes": {
-              "key": "reading_county_court",
-              "title": "Reading County Court",
-              "location_type": "court",
-              "nomis_agency_id": null,
-              "can_upload_documents": false,
-              "disabled_at": null,
-              "suppliers": []
-          }
-      },
-      {
-          "id": "c6d31f13-ea68-4d47-9260-a2d77b0dbca5",
-          "type": "locations",
-          "attributes": {
-              "key": "windsor_county_court",
-              "title": "Windsor County Court",
-              "location_type": "court",
-              "nomis_agency_id": null,
-              "can_upload_documents": false,
-              "disabled_at": null,
-              "suppliers": []
-          }
-      },
-      {
-          "id": "05085309-2c99-4f87-b9ab-b285b446974b",
-          "type": "locations",
-          "attributes": {
-              "key": "bristol_crown_court",
-              "title": "Bristol Crown Court",
-              "location_type": "court",
-              "nomis_agency_id": null,
-              "can_upload_documents": false,
-              "disabled_at": null,
-              "suppliers": []
-          }
-      },
-      {
-          "id": "dc08582b-c57c-4053-b691-bf3482a00c59",
-          "type": "locations",
-          "attributes": {
-              "key": "cambridge_crown_court",
-              "title": "Cambridge Crown Court",
-              "location_type": "court",
-              "nomis_agency_id": null,
-              "can_upload_documents": false,
-              "disabled_at": null,
-              "suppliers": [
-                {
-                  "id": "3ef88a47-6f1f-5b9b-b2fc-c0fe42cb0c92",
-                  "name": "Serco",
-                  "key": "serco",
-                  "created_at": "2019-10-09T11:10:53+01:00",
-                  "updated_at": "2019-10-09T11:10:53+01:00"
-                }
-              ]
-          }
-      },
-      {
-          "id": "c48c8573-134f-4eba-86cf-ef8bff129045",
-          "type": "locations",
-          "attributes": {
-              "key": "peterborough_crown_court",
-              "title": "Peterborough Crown Court",
-              "location_type": "court",
-              "nomis_agency_id": null,
-              "can_upload_documents": true,
-              "disabled_at": null,
-              "suppliers": []
-          }
-      },
-      {
-          "id": "7d9734a1-81e4-4faf-a4f4-54c84ed3cf85",
-          "type": "locations",
-          "attributes": {
-              "key": "macclesfield_magistrates_court",
-              "title": "Macclesfield Magistrates Court",
-              "location_type": "court",
-              "nomis_agency_id": null,
-              "can_upload_documents": false,
-              "disabled_at": null,
-              "suppliers": []
-          }
-      },
-      {
-          "id": "5c82f67f-25f6-44c2-9fdd-a2ba6d71d964",
-          "type": "locations",
-          "attributes": {
-              "key": "warrington_county_court",
-              "title": "Warrington County Court",
-              "location_type": "court",
-              "nomis_agency_id": null,
-              "can_upload_documents": false,
-              "disabled_at": null,
-              "suppliers": []
-          }
-      },
-      {
-          "id": "747b8928-9f5d-45ee-87ca-595d8287ed74",
-          "type": "locations",
-          "attributes": {
-              "key": "bodmin_magistrates_court",
-              "title": "Bodmin Magistrates Court",
-              "location_type": "court",
-              "nomis_agency_id": null,
-              "can_upload_documents": false,
-              "disabled_at": null,
-              "suppliers": []
-          }
-      },
-      {
-          "id": "73163046-22df-463f-8cc2-f471550e2dc1",
-          "type": "locations",
-          "attributes": {
-              "key": "bude_county_court",
-              "title": "Bude County Court",
-              "location_type": "court",
-              "nomis_agency_id": null,
-              "can_upload_documents": false,
-              "disabled_at": null,
-              "suppliers": []
-          }
-      },
-      {
-          "id": "9e51f929-2880-460c-a7c0-1156a4a9dba3",
-          "type": "locations",
-          "attributes": {
-              "key": "newquay_magistrates_court",
-              "title": "Newquay Magistrates Court",
-              "location_type": "court",
-              "nomis_agency_id": null,
-              "can_upload_documents": true,
-              "disabled_at": null,
-              "suppliers": []
-          }
-      },
-      {
-          "id": "b09cc87d-9330-42ef-a9bb-ad32216358a5",
-          "type": "locations",
-          "attributes": {
-              "key": "penzance_county_court",
-              "title": "Penzance County Court",
-              "location_type": "court",
-              "nomis_agency_id": null,
-              "can_upload_documents": false,
-              "disabled_at": null,
-              "suppliers": []
-          }
-      },
-      {
-          "id": "ea949640-cefe-4d1b-8053-600af97be807",
-          "type": "locations",
-          "attributes": {
-              "key": "darlington_crown_court",
-              "title": "Darlington Crown Court",
-              "location_type": "court",
-              "nomis_agency_id": null,
-              "can_upload_documents": false,
-              "disabled_at": null,
-              "suppliers": [
-                {
-                  "id": "3ef88a47-6f1f-5b9b-b2fc-c0fe42cb0c92",
-                  "name": "Serco",
-                  "key": "serco",
-                  "created_at": "2019-10-09T11:10:53+01:00",
-                  "updated_at": "2019-10-09T11:10:53+01:00"
-                }
-              ]
-          }
-      },
-      {
-          "id": "3287b21e-9691-43f7-a5b7-948b1fa72a75",
-          "type": "locations",
-          "attributes": {
-              "key": "durham_magistrates_court",
-              "title": "Durham Magistrates Court",
-              "location_type": "court",
-              "nomis_agency_id": null,
-              "can_upload_documents": false,
-              "disabled_at": null,
-              "suppliers": []
-          }
-      },
-      {
-          "id": "d8e9cf86-55cd-4412-83b7-3562b7d1f8b6",
-          "type": "locations",
-          "attributes": {
-              "key": "barrow_in_furness_magistrates_court",
-              "title": "Barrow in Furness Magistrates Court",
-              "location_type": "court",
-              "nomis_agency_id": null,
-              "can_upload_documents": false,
-              "disabled_at": null,
-              "suppliers": []
-          }
-      },
-      {
-          "id": "b3707992-da62-4593-896f-983d41315f09",
-          "type": "locations",
-          "attributes": {
-              "key": "carlisle_county_court",
-              "title": "Carlisle County Court",
-              "location_type": "court",
-              "nomis_agency_id": null,
-              "can_upload_documents": true,
-              "disabled_at": null,
-              "suppliers": []
-          }
-      },
-      {
-          "id": "fa7f6393-76e9-43f2-9fb7-3fc82956a4c4",
-          "type": "locations",
-          "attributes": {
-              "key": "chesterfield_crown_court",
-              "title": "Chesterfield Crown Court",
-              "location_type": "court",
-              "nomis_agency_id": null,
-              "can_upload_documents": false,
-              "disabled_at": null,
-              "suppliers": []
-          }
-      },
-      {
-          "id": "8cb9cd00-8e80-4686-b3c3-d14958b8145d",
-          "type": "locations",
-          "attributes": {
-              "key": "derby_county_court",
-              "title": "Derby County Court",
-              "location_type": "court",
-              "nomis_agency_id": null,
-              "can_upload_documents": false,
-              "disabled_at": null,
-              "suppliers": []
-          }
-      },
-      {
-          "id": "2c952ca0-f750-4ac3-ac76-fb631445f974",
-          "type": "locations",
-          "attributes": {
-              "key": "axminster_crown_court",
-              "title": "Axminster Crown Court",
-              "location_type": "court",
-              "nomis_agency_id": null,
-              "can_upload_documents": false,
-              "disabled_at": null,
-              "suppliers": []
-          }
-      },
-      {
-          "id": "9b56ca31-222b-4522-9d65-4ef429f9081e",
-          "type": "locations",
-          "attributes": {
-              "key": "barnstaple_crown_court",
-              "title": "Barnstaple Crown Court",
-              "location_type": "court",
-              "nomis_agency_id": null,
-              "can_upload_documents": false,
-              "disabled_at": null,
-              "suppliers": []
-          }
-      },
-      {
-          "id": "2f03c2fc-2fb7-43bd-be40-eaed19cacb5a",
-          "type": "locations",
-          "attributes": {
-              "key": "exeter_magistrates_court",
-              "title": "Exeter Magistrates Court",
-              "location_type": "court",
-              "nomis_agency_id": null,
-              "can_upload_documents": false,
-              "disabled_at": null,
-              "suppliers": []
-          }
-      },
-      {
-          "id": "f7ef5006-e873-461d-ac32-dccf4a8cabc8",
-          "type": "locations",
-          "attributes": {
-              "key": "plymouth_county_court",
-              "title": "Plymouth County Court",
-              "location_type": "court",
-              "nomis_agency_id": null,
-              "can_upload_documents": false,
-              "disabled_at": null,
-              "suppliers": []
-          }
-      },
-      {
-          "id": "7db3722d-bef0-4208-8a93-05b70dc0761b",
-          "type": "locations",
-          "attributes": {
-              "key": "torquay_county_court",
-              "title": "Torquay County Court",
-              "location_type": "court",
-              "nomis_agency_id": null,
-              "can_upload_documents": false,
-              "disabled_at": null,
-              "suppliers": []
-          }
-      },
-      {
-          "id": "de136fb8-4491-48ea-be48-8f53f335e338",
-          "type": "locations",
-          "attributes": {
-              "key": "weymouth_crown_court",
-              "title": "Weymouth Crown Court",
-              "location_type": "court",
-              "nomis_agency_id": null,
-              "can_upload_documents": false,
-              "disabled_at": null,
-              "suppliers": []
-          }
-      },
-      {
-          "id": "1e95f86c-af05-4f31-9c3c-4a0da0c6da95",
-          "type": "locations",
-          "attributes": {
-              "key": "brighton_county_court",
-              "title": "Brighton County Court",
-              "location_type": "court",
-              "nomis_agency_id": null,
-              "can_upload_documents": false,
-              "disabled_at": null,
-              "suppliers": []
-          }
-      },
-      {
-          "id": "fa1817f6-4d50-4fbb-b491-2ecd95b378ba",
-          "type": "locations",
-          "attributes": {
-              "key": "colchester_county_court",
-              "title": "Colchester County Court",
-              "location_type": "court",
-              "nomis_agency_id": null,
-              "can_upload_documents": false,
-              "disabled_at": null,
-              "suppliers": []
-          }
-      },
-      {
-          "id": "9d5bbb95-b03e-47a0-a07e-ecacb56abed7",
-          "type": "locations",
-          "attributes": {
-              "key": "harlow_magistrates_court",
-              "title": "Harlow Magistrates Court",
-              "location_type": "court",
-              "nomis_agency_id": null,
-              "can_upload_documents": false,
-              "disabled_at": null,
-              "suppliers": []
-          }
-      },
-      {
-          "id": "a288caba-70d2-44a0-bec5-331f8ead9d3f",
-          "type": "locations",
-          "attributes": {
-              "key": "romford_magistrates_court",
-              "title": "Romford Magistrates Court",
-              "location_type": "court",
-              "nomis_agency_id": null,
-              "can_upload_documents": false,
-              "disabled_at": null,
-              "suppliers": []
-          }
-      },
-      {
-          "id": "5ed150fd-4cc1-4b38-ab10-0ac7b44b8a2b",
-          "type": "locations",
-          "attributes": {
-              "key": "cheltenham_crown_court",
-              "title": "Cheltenham Crown Court",
-              "location_type": "court",
-              "nomis_agency_id": null,
-              "can_upload_documents": false,
-              "disabled_at": null,
-              "suppliers": []
-          }
-      },
-      {
-          "id": "a3e4228e-3330-4c64-842e-297af0ab8cc4",
-          "type": "locations",
-          "attributes": {
-              "key": "croydon_magistrates_court",
-              "title": "Croydon Magistrates Court",
-              "location_type": "court",
-              "nomis_agency_id": null,
-              "can_upload_documents": false,
-              "disabled_at": null,
-              "suppliers": []
-          }
-      },
-      {
-          "id": "4eb51a6c-222c-497c-90e0-0e3203443b68",
-          "type": "locations",
-          "attributes": {
-              "key": "kingston_upon_thames_county_court",
-              "title": "Kingston upon Thames County Court",
-              "location_type": "court",
-              "nomis_agency_id": null,
-              "can_upload_documents": false,
-              "disabled_at": null,
-              "suppliers": []
-          }
-      },
-      {
-          "id": "2756e2e3-cd61-4a67-9775-417adb3671f4",
-          "type": "locations",
-          "attributes": {
-              "key": "richmond_crown_court",
-              "title": "Richmond Crown Court",
-              "location_type": "court",
-              "nomis_agency_id": null,
-              "can_upload_documents": false,
-              "disabled_at": null,
-              "suppliers": []
-          }
-      },
-      {
-          "id": "b044ad72-2375-46be-9610-f75c1a539e8a",
-          "type": "locations",
-          "attributes": {
-              "key": "southall_crown_court",
-              "title": "Southall Crown Court",
-              "location_type": "court",
-              "nomis_agency_id": null,
-              "can_upload_documents": false,
-              "disabled_at": null,
-              "suppliers": []
-          }
-      },
-      {
-          "id": "e9f59e9b-afd0-40e7-a1d4-f1786d7a7fc0",
-          "type": "locations",
-          "attributes": {
-              "key": "wimbledon_magistrates_court",
-              "title": "Wimbledon Magistrates Court",
-              "location_type": "court",
-              "nomis_agency_id": null,
-              "can_upload_documents": false,
-              "disabled_at": null,
-              "suppliers": []
-          }
-      },
-      {
-          "id": "881fa099-201c-4b76-9253-df37d6bd1009",
-          "type": "locations",
-          "attributes": {
-              "key": "manchester_county_court",
-              "title": "Manchester County Court",
-              "location_type": "court",
-              "nomis_agency_id": null,
-              "can_upload_documents": false,
-              "disabled_at": null,
-              "suppliers": []
-          }
-      },
-      {
-          "id": "58ec74f4-09c8-4e57-8550-9b460202229b",
-          "type": "locations",
-          "attributes": {
-              "key": "oldham_crown_court",
-              "title": "Oldham Crown Court",
-              "location_type": "court",
-              "nomis_agency_id": null,
-              "can_upload_documents": false,
-              "disabled_at": null,
-              "suppliers": []
-          }
-      },
-      {
-          "id": "10923762-bc17-4ea1-bae3-68ea709ee23e",
-          "type": "locations",
-          "attributes": {
-              "key": "basingstoke_county_court",
-              "title": "Basingstoke County Court",
-              "location_type": "court",
-              "nomis_agency_id": null,
-              "can_upload_documents": false,
-              "disabled_at": null,
-              "suppliers": []
-          }
-      },
-      {
-          "id": "6ca4e72a-499b-474d-9267-8ddc055f983a",
-          "type": "locations",
-          "attributes": {
-              "key": "southampton_county_court",
-              "title": "Southampton County Court",
-              "location_type": "court",
-              "nomis_agency_id": null,
-              "can_upload_documents": false,
-              "disabled_at": null,
-              "suppliers": []
-          }
-      },
-      {
-          "id": "bacd8ed5-378b-4912-a029-bfb789086945",
-          "type": "locations",
-          "attributes": {
-              "key": "watford_crown_court",
-              "title": "Watford Crown Court",
-              "location_type": "court",
-              "nomis_agency_id": null,
-              "can_upload_documents": false,
-              "disabled_at": null,
-              "suppliers": []
-          }
-      },
-      {
-          "id": "979fae93-9aae-43ce-81e0-c64d4ee472ff",
-          "type": "locations",
-          "attributes": {
-              "key": "dover_magistrates_court",
-              "title": "Dover Magistrates Court",
-              "location_type": "court",
-              "nomis_agency_id": null,
-              "can_upload_documents": false,
-              "disabled_at": null,
-              "suppliers": []
-          }
-      },
-      {
-          "id": "f11b377e-a19d-4a91-b98d-a26c4b2e4d84",
-          "type": "locations",
-          "attributes": {
-              "key": "maidstone_crown_court",
-              "title": "Maidstone Crown Court",
-              "location_type": "court",
-              "nomis_agency_id": null,
-              "can_upload_documents": false,
-              "disabled_at": null,
-              "suppliers": []
-          }
-      },
-      {
-          "id": "23b1ac5c-04e3-4ff1-94bc-eb4e7fa477d6",
-          "type": "locations",
-          "attributes": {
-              "key": "blackburn_county_court",
-              "title": "Blackburn County Court",
-              "location_type": "court",
-              "nomis_agency_id": null,
-              "can_upload_documents": false,
-              "disabled_at": null,
-              "suppliers": []
-          }
-      },
-      {
-          "id": "61346c8a-370c-4cbd-9285-cf4e5610bd95",
-          "type": "locations",
-          "attributes": {
-              "key": "burnley_county_court",
-              "title": "Burnley County Court",
-              "location_type": "court",
-              "nomis_agency_id": null,
-              "can_upload_documents": false,
-              "disabled_at": null,
-              "suppliers": []
-          }
-      },
-      {
-          "id": "bdec4256-ce5a-46bd-8583-6234b535b8c7",
-          "type": "locations",
-          "attributes": {
-              "key": "preston_crown_court",
-              "title": "Preston Crown Court",
-              "location_type": "court",
-              "nomis_agency_id": null,
-              "can_upload_documents": false,
-              "disabled_at": null,
-              "suppliers": []
-          }
-      },
-      {
-          "id": "6d6eec6a-3e28-46c5-84ec-269851000ba1",
-          "type": "locations",
-          "attributes": {
-              "key": "grantham_magistrates_court",
-              "title": "Grantham Magistrates Court",
-              "location_type": "court",
-              "nomis_agency_id": null,
-              "can_upload_documents": false,
-              "disabled_at": null,
-              "suppliers": []
-          }
-      },
-      {
-          "id": "1015f73d-0f41-4e85-9f34-0cfd5cfb27f4",
-          "type": "locations",
-          "attributes": {
-              "key": "grimsby_magistrates_court",
-              "title": "Grimsby Magistrates Court",
-              "location_type": "court",
-              "nomis_agency_id": null,
-              "can_upload_documents": false,
-              "disabled_at": null,
-              "suppliers": []
-          }
-      },
-      {
-          "id": "c5c5aeb0-7d2e-4168-a7a9-d55746a58318",
-          "type": "locations",
-          "attributes": {
-              "key": "liverpool_magistrates_court",
-              "title": "Liverpool Magistrates Court",
-              "location_type": "court",
-              "nomis_agency_id": null,
-              "can_upload_documents": false,
-              "disabled_at": null,
-              "suppliers": []
-          }
+        ],
+        "category": {
+          "id": "c923ef88-a476-f1f5-b9bb-2fcc0fe42cb0",
+          "type": "category"
+        }
       }
+    },
+    {
+      "id": "98905621-0684-4873-9f0c-c428c24933ea",
+      "type": "locations",
+      "attributes": {
+        "key": "luton_crown_court",
+        "title": "Luton Crown Court",
+        "location_type": "court",
+        "nomis_agency_id": null,
+        "can_upload_documents": false,
+        "disabled_at": null,
+        "suppliers": [],
+        "category": {
+          "id": "c923ef88-a476-f1f5-b9bb-2fcc0fe42cb0",
+          "type": "category"
+        }
+      }
+    },
+    {
+      "id": "d77fdb81-2a09-4981-a4f2-c6a649768319",
+      "type": "locations",
+      "attributes": {
+        "key": "maidenhead_magistrates_court",
+        "title": "Maidenhead Magistrates Court",
+        "location_type": "court",
+        "nomis_agency_id": null,
+        "can_upload_documents": false,
+        "disabled_at": null,
+        "suppliers": [],
+        "category": {
+          "id": "c923ef88-a476-f1f5-b9bb-2fcc0fe42cb0",
+          "type": "category"
+        }
+      }
+    },
+    {
+      "id": "ddb11bbb-526b-4769-a9f2-cc82875ca52e",
+      "type": "locations",
+      "attributes": {
+        "key": "newbury_county_court",
+        "title": "Newbury County Court",
+        "location_type": "court",
+        "nomis_agency_id": null,
+        "can_upload_documents": false,
+        "disabled_at": null,
+        "suppliers": [],
+        "category": {
+          "id": "c923ef88-a476-f1f5-b9bb-2fcc0fe42cb0",
+          "type": "category"
+        }
+      }
+    },
+    {
+      "id": "2d80f632-c831-44a8-9285-be2732fe9a64",
+      "type": "locations",
+      "attributes": {
+        "key": "reading_county_court",
+        "title": "Reading County Court",
+        "location_type": "court",
+        "nomis_agency_id": null,
+        "can_upload_documents": false,
+        "disabled_at": null,
+        "suppliers": [],
+        "category": {
+          "id": "c923ef88-a476-f1f5-b9bb-2fcc0fe42cb0",
+          "type": "category"
+        }
+      }
+    },
+    {
+      "id": "c6d31f13-ea68-4d47-9260-a2d77b0dbca5",
+      "type": "locations",
+      "attributes": {
+        "key": "windsor_county_court",
+        "title": "Windsor County Court",
+        "location_type": "court",
+        "nomis_agency_id": null,
+        "can_upload_documents": false,
+        "disabled_at": null,
+        "suppliers": [],
+        "category": {
+          "id": "c923ef88-a476-f1f5-b9bb-2fcc0fe42cb0",
+          "type": "category"
+        }
+      }
+    },
+    {
+      "id": "05085309-2c99-4f87-b9ab-b285b446974b",
+      "type": "locations",
+      "attributes": {
+        "key": "bristol_crown_court",
+        "title": "Bristol Crown Court",
+        "location_type": "court",
+        "nomis_agency_id": null,
+        "can_upload_documents": false,
+        "disabled_at": null,
+        "suppliers": [],
+        "category": {
+          "id": "c923ef88-a476-f1f5-b9bb-2fcc0fe42cb0",
+          "type": "category"
+        }
+      }
+    },
+    {
+      "id": "dc08582b-c57c-4053-b691-bf3482a00c59",
+      "type": "locations",
+      "attributes": {
+        "key": "cambridge_crown_court",
+        "title": "Cambridge Crown Court",
+        "location_type": "court",
+        "nomis_agency_id": null,
+        "can_upload_documents": false,
+        "disabled_at": null,
+        "suppliers": [
+          {
+            "id": "3ef88a47-6f1f-5b9b-b2fc-c0fe42cb0c92",
+            "name": "Serco",
+            "key": "serco",
+            "created_at": "2019-10-09T11:10:53+01:00",
+            "updated_at": "2019-10-09T11:10:53+01:00"
+          }
+        ],
+        "category": {
+          "id": "c923ef88-a476-f1f5-b9bb-2fcc0fe42cb0",
+          "type": "category"
+        }
+      }
+    },
+    {
+      "id": "c48c8573-134f-4eba-86cf-ef8bff129045",
+      "type": "locations",
+      "attributes": {
+        "key": "peterborough_crown_court",
+        "title": "Peterborough Crown Court",
+        "location_type": "court",
+        "nomis_agency_id": null,
+        "can_upload_documents": true,
+        "disabled_at": null,
+        "suppliers": [],
+        "category": {
+          "id": "c923ef88-a476-f1f5-b9bb-2fcc0fe42cb0",
+          "type": "category"
+        }
+      }
+    },
+    {
+      "id": "7d9734a1-81e4-4faf-a4f4-54c84ed3cf85",
+      "type": "locations",
+      "attributes": {
+        "key": "macclesfield_magistrates_court",
+        "title": "Macclesfield Magistrates Court",
+        "location_type": "court",
+        "nomis_agency_id": null,
+        "can_upload_documents": false,
+        "disabled_at": null,
+        "suppliers": [],
+        "category": {
+          "id": "c923ef88-a476-f1f5-b9bb-2fcc0fe42cb0",
+          "type": "category"
+        }
+      }
+    },
+    {
+      "id": "5c82f67f-25f6-44c2-9fdd-a2ba6d71d964",
+      "type": "locations",
+      "attributes": {
+        "key": "warrington_county_court",
+        "title": "Warrington County Court",
+        "location_type": "court",
+        "nomis_agency_id": null,
+        "can_upload_documents": false,
+        "disabled_at": null,
+        "suppliers": [],
+        "category": {
+          "id": "c923ef88-a476-f1f5-b9bb-2fcc0fe42cb0",
+          "type": "category"
+        }
+      }
+    },
+    {
+      "id": "747b8928-9f5d-45ee-87ca-595d8287ed74",
+      "type": "locations",
+      "attributes": {
+        "key": "bodmin_magistrates_court",
+        "title": "Bodmin Magistrates Court",
+        "location_type": "court",
+        "nomis_agency_id": null,
+        "can_upload_documents": false,
+        "disabled_at": null,
+        "suppliers": [],
+        "category": {
+          "id": "c923ef88-a476-f1f5-b9bb-2fcc0fe42cb0",
+          "type": "category"
+        }
+      }
+    },
+    {
+      "id": "73163046-22df-463f-8cc2-f471550e2dc1",
+      "type": "locations",
+      "attributes": {
+        "key": "bude_county_court",
+        "title": "Bude County Court",
+        "location_type": "court",
+        "nomis_agency_id": null,
+        "can_upload_documents": false,
+        "disabled_at": null,
+        "suppliers": [],
+        "category": {
+          "id": "c923ef88-a476-f1f5-b9bb-2fcc0fe42cb0",
+          "type": "category"
+        }
+      }
+    },
+    {
+      "id": "9e51f929-2880-460c-a7c0-1156a4a9dba3",
+      "type": "locations",
+      "attributes": {
+        "key": "newquay_magistrates_court",
+        "title": "Newquay Magistrates Court",
+        "location_type": "court",
+        "nomis_agency_id": null,
+        "can_upload_documents": true,
+        "disabled_at": null,
+        "suppliers": [],
+        "category": {
+          "id": "c923ef88-a476-f1f5-b9bb-2fcc0fe42cb0",
+          "type": "category"
+        }
+      }
+    },
+    {
+      "id": "b09cc87d-9330-42ef-a9bb-ad32216358a5",
+      "type": "locations",
+      "attributes": {
+        "key": "penzance_county_court",
+        "title": "Penzance County Court",
+        "location_type": "court",
+        "nomis_agency_id": null,
+        "can_upload_documents": false,
+        "disabled_at": null,
+        "suppliers": [],
+        "category": {
+          "id": "c923ef88-a476-f1f5-b9bb-2fcc0fe42cb0",
+          "type": "category"
+        }
+      }
+    },
+    {
+      "id": "ea949640-cefe-4d1b-8053-600af97be807",
+      "type": "locations",
+      "attributes": {
+        "key": "darlington_crown_court",
+        "title": "Darlington Crown Court",
+        "location_type": "court",
+        "nomis_agency_id": null,
+        "can_upload_documents": false,
+        "disabled_at": null,
+        "suppliers": [
+          {
+            "id": "3ef88a47-6f1f-5b9b-b2fc-c0fe42cb0c92",
+            "name": "Serco",
+            "key": "serco",
+            "created_at": "2019-10-09T11:10:53+01:00",
+            "updated_at": "2019-10-09T11:10:53+01:00"
+          }
+        ],
+        "category": {
+          "id": "c923ef88-a476-f1f5-b9bb-2fcc0fe42cb0",
+          "type": "category"
+        }
+      }
+    },
+    {
+      "id": "3287b21e-9691-43f7-a5b7-948b1fa72a75",
+      "type": "locations",
+      "attributes": {
+        "key": "durham_magistrates_court",
+        "title": "Durham Magistrates Court",
+        "location_type": "court",
+        "nomis_agency_id": null,
+        "can_upload_documents": false,
+        "disabled_at": null,
+        "suppliers": [],
+        "category": {
+          "id": "c923ef88-a476-f1f5-b9bb-2fcc0fe42cb0",
+          "type": "category"
+        }
+      }
+    },
+    {
+      "id": "d8e9cf86-55cd-4412-83b7-3562b7d1f8b6",
+      "type": "locations",
+      "attributes": {
+        "key": "barrow_in_furness_magistrates_court",
+        "title": "Barrow in Furness Magistrates Court",
+        "location_type": "court",
+        "nomis_agency_id": null,
+        "can_upload_documents": false,
+        "disabled_at": null,
+        "suppliers": [],
+        "category": {
+          "id": "c923ef88-a476-f1f5-b9bb-2fcc0fe42cb0",
+          "type": "category"
+        }
+      }
+    },
+    {
+      "id": "b3707992-da62-4593-896f-983d41315f09",
+      "type": "locations",
+      "attributes": {
+        "key": "carlisle_county_court",
+        "title": "Carlisle County Court",
+        "location_type": "court",
+        "nomis_agency_id": null,
+        "can_upload_documents": true,
+        "disabled_at": null,
+        "suppliers": [],
+        "category": {
+          "id": "c923ef88-a476-f1f5-b9bb-2fcc0fe42cb0",
+          "type": "category"
+        }
+      }
+    },
+    {
+      "id": "fa7f6393-76e9-43f2-9fb7-3fc82956a4c4",
+      "type": "locations",
+      "attributes": {
+        "key": "chesterfield_crown_court",
+        "title": "Chesterfield Crown Court",
+        "location_type": "court",
+        "nomis_agency_id": null,
+        "can_upload_documents": false,
+        "disabled_at": null,
+        "suppliers": [],
+        "category": {
+          "id": "c923ef88-a476-f1f5-b9bb-2fcc0fe42cb0",
+          "type": "category"
+        }
+      }
+    },
+    {
+      "id": "8cb9cd00-8e80-4686-b3c3-d14958b8145d",
+      "type": "locations",
+      "attributes": {
+        "key": "derby_county_court",
+        "title": "Derby County Court",
+        "location_type": "court",
+        "nomis_agency_id": null,
+        "can_upload_documents": false,
+        "disabled_at": null,
+        "suppliers": [],
+        "category": {
+          "id": "c923ef88-a476-f1f5-b9bb-2fcc0fe42cb0",
+          "type": "category"
+        }
+      }
+    },
+    {
+      "id": "2c952ca0-f750-4ac3-ac76-fb631445f974",
+      "type": "locations",
+      "attributes": {
+        "key": "axminster_crown_court",
+        "title": "Axminster Crown Court",
+        "location_type": "court",
+        "nomis_agency_id": null,
+        "can_upload_documents": false,
+        "disabled_at": null,
+        "suppliers": [],
+        "category": {
+          "id": "c923ef88-a476-f1f5-b9bb-2fcc0fe42cb0",
+          "type": "category"
+        }
+      }
+    },
+    {
+      "id": "9b56ca31-222b-4522-9d65-4ef429f9081e",
+      "type": "locations",
+      "attributes": {
+        "key": "barnstaple_crown_court",
+        "title": "Barnstaple Crown Court",
+        "location_type": "court",
+        "nomis_agency_id": null,
+        "can_upload_documents": false,
+        "disabled_at": null,
+        "suppliers": [],
+        "category": {
+          "id": "c923ef88-a476-f1f5-b9bb-2fcc0fe42cb0",
+          "type": "category"
+        }
+      }
+    },
+    {
+      "id": "2f03c2fc-2fb7-43bd-be40-eaed19cacb5a",
+      "type": "locations",
+      "attributes": {
+        "key": "exeter_magistrates_court",
+        "title": "Exeter Magistrates Court",
+        "location_type": "court",
+        "nomis_agency_id": null,
+        "can_upload_documents": false,
+        "disabled_at": null,
+        "suppliers": [],
+        "category": {
+          "id": "c923ef88-a476-f1f5-b9bb-2fcc0fe42cb0",
+          "type": "category"
+        }
+      }
+    },
+    {
+      "id": "f7ef5006-e873-461d-ac32-dccf4a8cabc8",
+      "type": "locations",
+      "attributes": {
+        "key": "plymouth_county_court",
+        "title": "Plymouth County Court",
+        "location_type": "court",
+        "nomis_agency_id": null,
+        "can_upload_documents": false,
+        "disabled_at": null,
+        "suppliers": [],
+        "category": {
+          "id": "c923ef88-a476-f1f5-b9bb-2fcc0fe42cb0",
+          "type": "category"
+        }
+      }
+    },
+    {
+      "id": "7db3722d-bef0-4208-8a93-05b70dc0761b",
+      "type": "locations",
+      "attributes": {
+        "key": "torquay_county_court",
+        "title": "Torquay County Court",
+        "location_type": "court",
+        "nomis_agency_id": null,
+        "can_upload_documents": false,
+        "disabled_at": null,
+        "suppliers": [],
+        "category": {
+          "id": "c923ef88-a476-f1f5-b9bb-2fcc0fe42cb0",
+          "type": "category"
+        }
+      }
+    },
+    {
+      "id": "de136fb8-4491-48ea-be48-8f53f335e338",
+      "type": "locations",
+      "attributes": {
+        "key": "weymouth_crown_court",
+        "title": "Weymouth Crown Court",
+        "location_type": "court",
+        "nomis_agency_id": null,
+        "can_upload_documents": false,
+        "disabled_at": null,
+        "suppliers": [],
+        "category": {
+          "id": "c923ef88-a476-f1f5-b9bb-2fcc0fe42cb0",
+          "type": "category"
+        }
+      }
+    },
+    {
+      "id": "1e95f86c-af05-4f31-9c3c-4a0da0c6da95",
+      "type": "locations",
+      "attributes": {
+        "key": "brighton_county_court",
+        "title": "Brighton County Court",
+        "location_type": "court",
+        "nomis_agency_id": null,
+        "can_upload_documents": false,
+        "disabled_at": null,
+        "suppliers": [],
+        "category": {
+          "id": "c923ef88-a476-f1f5-b9bb-2fcc0fe42cb0",
+          "type": "category"
+        }
+      }
+    },
+    {
+      "id": "fa1817f6-4d50-4fbb-b491-2ecd95b378ba",
+      "type": "locations",
+      "attributes": {
+        "key": "colchester_county_court",
+        "title": "Colchester County Court",
+        "location_type": "court",
+        "nomis_agency_id": null,
+        "can_upload_documents": false,
+        "disabled_at": null,
+        "suppliers": [],
+        "category": {
+          "id": "c923ef88-a476-f1f5-b9bb-2fcc0fe42cb0",
+          "type": "category"
+        }
+      }
+    },
+    {
+      "id": "9d5bbb95-b03e-47a0-a07e-ecacb56abed7",
+      "type": "locations",
+      "attributes": {
+        "key": "harlow_magistrates_court",
+        "title": "Harlow Magistrates Court",
+        "location_type": "court",
+        "nomis_agency_id": null,
+        "can_upload_documents": false,
+        "disabled_at": null,
+        "suppliers": [],
+        "category": {
+          "id": "c923ef88-a476-f1f5-b9bb-2fcc0fe42cb0",
+          "type": "category"
+        }
+      }
+    },
+    {
+      "id": "a288caba-70d2-44a0-bec5-331f8ead9d3f",
+      "type": "locations",
+      "attributes": {
+        "key": "romford_magistrates_court",
+        "title": "Romford Magistrates Court",
+        "location_type": "court",
+        "nomis_agency_id": null,
+        "can_upload_documents": false,
+        "disabled_at": null,
+        "suppliers": [],
+        "category": {
+          "id": "c923ef88-a476-f1f5-b9bb-2fcc0fe42cb0",
+          "type": "category"
+        }
+      }
+    },
+    {
+      "id": "5ed150fd-4cc1-4b38-ab10-0ac7b44b8a2b",
+      "type": "locations",
+      "attributes": {
+        "key": "cheltenham_crown_court",
+        "title": "Cheltenham Crown Court",
+        "location_type": "court",
+        "nomis_agency_id": null,
+        "can_upload_documents": false,
+        "disabled_at": null,
+        "suppliers": [],
+        "category": {
+          "id": "c923ef88-a476-f1f5-b9bb-2fcc0fe42cb0",
+          "type": "category"
+        }
+      }
+    },
+    {
+      "id": "a3e4228e-3330-4c64-842e-297af0ab8cc4",
+      "type": "locations",
+      "attributes": {
+        "key": "croydon_magistrates_court",
+        "title": "Croydon Magistrates Court",
+        "location_type": "court",
+        "nomis_agency_id": null,
+        "can_upload_documents": false,
+        "disabled_at": null,
+        "suppliers": [],
+        "category": {
+          "id": "c923ef88-a476-f1f5-b9bb-2fcc0fe42cb0",
+          "type": "category"
+        }
+      }
+    },
+    {
+      "id": "4eb51a6c-222c-497c-90e0-0e3203443b68",
+      "type": "locations",
+      "attributes": {
+        "key": "kingston_upon_thames_county_court",
+        "title": "Kingston upon Thames County Court",
+        "location_type": "court",
+        "nomis_agency_id": null,
+        "can_upload_documents": false,
+        "disabled_at": null,
+        "suppliers": [],
+        "category": {
+          "id": "c923ef88-a476-f1f5-b9bb-2fcc0fe42cb0",
+          "type": "category"
+        }
+      }
+    },
+    {
+      "id": "2756e2e3-cd61-4a67-9775-417adb3671f4",
+      "type": "locations",
+      "attributes": {
+        "key": "richmond_crown_court",
+        "title": "Richmond Crown Court",
+        "location_type": "court",
+        "nomis_agency_id": null,
+        "can_upload_documents": false,
+        "disabled_at": null,
+        "suppliers": [],
+        "category": {
+          "id": "c923ef88-a476-f1f5-b9bb-2fcc0fe42cb0",
+          "type": "category"
+        }
+      }
+    },
+    {
+      "id": "b044ad72-2375-46be-9610-f75c1a539e8a",
+      "type": "locations",
+      "attributes": {
+        "key": "southall_crown_court",
+        "title": "Southall Crown Court",
+        "location_type": "court",
+        "nomis_agency_id": null,
+        "can_upload_documents": false,
+        "disabled_at": null,
+        "suppliers": [],
+        "category": {
+          "id": "c923ef88-a476-f1f5-b9bb-2fcc0fe42cb0",
+          "type": "category"
+        }
+      }
+    },
+    {
+      "id": "e9f59e9b-afd0-40e7-a1d4-f1786d7a7fc0",
+      "type": "locations",
+      "attributes": {
+        "key": "wimbledon_magistrates_court",
+        "title": "Wimbledon Magistrates Court",
+        "location_type": "court",
+        "nomis_agency_id": null,
+        "can_upload_documents": false,
+        "disabled_at": null,
+        "suppliers": [],
+        "category": {
+          "id": "c923ef88-a476-f1f5-b9bb-2fcc0fe42cb0",
+          "type": "category"
+        }
+      }
+    },
+    {
+      "id": "881fa099-201c-4b76-9253-df37d6bd1009",
+      "type": "locations",
+      "attributes": {
+        "key": "manchester_county_court",
+        "title": "Manchester County Court",
+        "location_type": "court",
+        "nomis_agency_id": null,
+        "can_upload_documents": false,
+        "disabled_at": null,
+        "suppliers": [],
+        "category": {
+          "id": "c923ef88-a476-f1f5-b9bb-2fcc0fe42cb0",
+          "type": "category"
+        }
+      }
+    },
+    {
+      "id": "58ec74f4-09c8-4e57-8550-9b460202229b",
+      "type": "locations",
+      "attributes": {
+        "key": "oldham_crown_court",
+        "title": "Oldham Crown Court",
+        "location_type": "court",
+        "nomis_agency_id": null,
+        "can_upload_documents": false,
+        "disabled_at": null,
+        "suppliers": [],
+        "category": {
+          "id": "c923ef88-a476-f1f5-b9bb-2fcc0fe42cb0",
+          "type": "category"
+        }
+      }
+    },
+    {
+      "id": "10923762-bc17-4ea1-bae3-68ea709ee23e",
+      "type": "locations",
+      "attributes": {
+        "key": "basingstoke_county_court",
+        "title": "Basingstoke County Court",
+        "location_type": "court",
+        "nomis_agency_id": null,
+        "can_upload_documents": false,
+        "disabled_at": null,
+        "suppliers": [],
+        "category": {
+          "id": "c923ef88-a476-f1f5-b9bb-2fcc0fe42cb0",
+          "type": "category"
+        }
+      }
+    },
+    {
+      "id": "6ca4e72a-499b-474d-9267-8ddc055f983a",
+      "type": "locations",
+      "attributes": {
+        "key": "southampton_county_court",
+        "title": "Southampton County Court",
+        "location_type": "court",
+        "nomis_agency_id": null,
+        "can_upload_documents": false,
+        "disabled_at": null,
+        "suppliers": [],
+        "category": {
+          "id": "c923ef88-a476-f1f5-b9bb-2fcc0fe42cb0",
+          "type": "category"
+        }
+      }
+    },
+    {
+      "id": "bacd8ed5-378b-4912-a029-bfb789086945",
+      "type": "locations",
+      "attributes": {
+        "key": "watford_crown_court",
+        "title": "Watford Crown Court",
+        "location_type": "court",
+        "nomis_agency_id": null,
+        "can_upload_documents": false,
+        "disabled_at": null,
+        "suppliers": [],
+        "category": {
+          "id": "c923ef88-a476-f1f5-b9bb-2fcc0fe42cb0",
+          "type": "category"
+        }
+      }
+    },
+    {
+      "id": "979fae93-9aae-43ce-81e0-c64d4ee472ff",
+      "type": "locations",
+      "attributes": {
+        "key": "dover_magistrates_court",
+        "title": "Dover Magistrates Court",
+        "location_type": "court",
+        "nomis_agency_id": null,
+        "can_upload_documents": false,
+        "disabled_at": null,
+        "suppliers": [],
+        "category": {
+          "id": "c923ef88-a476-f1f5-b9bb-2fcc0fe42cb0",
+          "type": "category"
+        }
+      }
+    },
+    {
+      "id": "f11b377e-a19d-4a91-b98d-a26c4b2e4d84",
+      "type": "locations",
+      "attributes": {
+        "key": "maidstone_crown_court",
+        "title": "Maidstone Crown Court",
+        "location_type": "court",
+        "nomis_agency_id": null,
+        "can_upload_documents": false,
+        "disabled_at": null,
+        "suppliers": [],
+        "category": {
+          "id": "c923ef88-a476-f1f5-b9bb-2fcc0fe42cb0",
+          "type": "category"
+        }
+      }
+    },
+    {
+      "id": "23b1ac5c-04e3-4ff1-94bc-eb4e7fa477d6",
+      "type": "locations",
+      "attributes": {
+        "key": "blackburn_county_court",
+        "title": "Blackburn County Court",
+        "location_type": "court",
+        "nomis_agency_id": null,
+        "can_upload_documents": false,
+        "disabled_at": null,
+        "suppliers": [],
+        "category": {
+          "id": "c923ef88-a476-f1f5-b9bb-2fcc0fe42cb0",
+          "type": "category"
+        }
+      }
+    },
+    {
+      "id": "61346c8a-370c-4cbd-9285-cf4e5610bd95",
+      "type": "locations",
+      "attributes": {
+        "key": "burnley_county_court",
+        "title": "Burnley County Court",
+        "location_type": "court",
+        "nomis_agency_id": null,
+        "can_upload_documents": false,
+        "disabled_at": null,
+        "suppliers": [],
+        "category": {
+          "id": "c923ef88-a476-f1f5-b9bb-2fcc0fe42cb0",
+          "type": "category"
+        }
+      }
+    },
+    {
+      "id": "bdec4256-ce5a-46bd-8583-6234b535b8c7",
+      "type": "locations",
+      "attributes": {
+        "key": "preston_crown_court",
+        "title": "Preston Crown Court",
+        "location_type": "court",
+        "nomis_agency_id": null,
+        "can_upload_documents": false,
+        "disabled_at": null,
+        "suppliers": [],
+        "category": {
+          "id": "c923ef88-a476-f1f5-b9bb-2fcc0fe42cb0",
+          "type": "category"
+        }
+      }
+    },
+    {
+      "id": "6d6eec6a-3e28-46c5-84ec-269851000ba1",
+      "type": "locations",
+      "attributes": {
+        "key": "grantham_magistrates_court",
+        "title": "Grantham Magistrates Court",
+        "location_type": "court",
+        "nomis_agency_id": null,
+        "can_upload_documents": false,
+        "disabled_at": null,
+        "suppliers": [],
+        "category": {
+          "id": "c923ef88-a476-f1f5-b9bb-2fcc0fe42cb0",
+          "type": "category"
+        }
+      }
+    },
+    {
+      "id": "1015f73d-0f41-4e85-9f34-0cfd5cfb27f4",
+      "type": "locations",
+      "attributes": {
+        "key": "grimsby_magistrates_court",
+        "title": "Grimsby Magistrates Court",
+        "location_type": "court",
+        "nomis_agency_id": null,
+        "can_upload_documents": false,
+        "disabled_at": null,
+        "suppliers": [],
+        "category": {
+          "id": "c923ef88-a476-f1f5-b9bb-2fcc0fe42cb0",
+          "type": "category"
+        }
+      }
+    },
+    {
+      "id": "c5c5aeb0-7d2e-4168-a7a9-d55746a58318",
+      "type": "locations",
+      "attributes": {
+        "key": "liverpool_magistrates_court",
+        "title": "Liverpool Magistrates Court",
+        "location_type": "court",
+        "nomis_agency_id": null,
+        "can_upload_documents": false,
+        "disabled_at": null,
+        "suppliers": [],
+        "category": {
+          "id": "c923ef88-a476-f1f5-b9bb-2fcc0fe42cb0",
+          "type": "category"
+        }
+      }
+    }
   ],
   "links": {
-      "self": "http://localhost:5000/api/v1/reference/locations?filter%5Blocation_type%5D=court&page%5Bnumber%5D=1&page%5Bsize%5D=50&per_page=50",
-      "first": "http://localhost:5000/api/v1/reference/locations?filter%5Blocation_type%5D=court&page%5Bnumber%5D=1&page%5Bsize%5D=50&per_page=50",
-      "prev": null,
-      "next": null,
-      "last": "http://localhost:5000/api/v1/reference/locations?filter%5Blocation_type%5D=court&page%5Bnumber%5D=2&page%5Bsize%5D=50&per_page=50"
+    "self": "http://localhost:5000/api/v1/reference/locations?filter%5Blocation_type%5D=court&page%5Bnumber%5D=1&page%5Bsize%5D=50&per_page=50",
+    "first": "http://localhost:5000/api/v1/reference/locations?filter%5Blocation_type%5D=court&page%5Bnumber%5D=1&page%5Bsize%5D=50&per_page=50",
+    "prev": null,
+    "next": null,
+    "last": "http://localhost:5000/api/v1/reference/locations?filter%5Blocation_type%5D=court&page%5Bnumber%5D=2&page%5Bsize%5D=50&per_page=50"
   },
   "meta": {
-      "pagination": {
-          "per_page": 50,
-          "total_pages": 1,
-          "total_objects": 50,
-          "links": {
-              "first": "/api/v1/reference/locations?filter%5Blocation_type%5D=court&page=1&per_page=50",
-              "last": "/api/v1/reference/locations?filter%5Blocation_type%5D=court&page=2&per_page=50"
-          }
+    "pagination": {
+      "per_page": 50,
+      "total_pages": 1,
+      "total_objects": 50,
+      "links": {
+        "first": "/api/v1/reference/locations?filter%5Blocation_type%5D=court&page=1&per_page=50",
+        "last": "/api/v1/reference/locations?filter%5Blocation_type%5D=court&page=2&per_page=50"
       }
+    }
   }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

PMU users manage the population of establishments via category groups. This PR groups the establishments via these categories.

### What changed

- Categories have been added to the location model
- getPrisonFreeSpaces uses an include of `category`, and the response is grouped by category, with an added caption
- Population dashboard loops over many population tables 

<!--- Describe the changes in detail - the "what"-->

### Why did it change

<!--- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

- [P4-2288](https://dsdmoj.atlassian.net/browse/P4-2288)

## Screenshots
<!--- (Optional) Include screenshots if changes update interfaces or components -->
<!--- Delete/copy as appropriate --->

| Before | After |
| ------ | ----- |
| ![Screenshot_2020-12-15 Population for 14 to 20 Dec 2020 (This week)](https://user-images.githubusercontent.com/196695/102280463-1a267580-3f25-11eb-8510-c70ff54a987b.png) |![Screenshot_2020-12-16 Population for 14 to 20 Dec 2020 (This week)](https://user-images.githubusercontent.com/196695/102371880-9321dd80-3fb6-11eb-8e0c-91674788618a.png)|
| |![Screenshot_2020-12-16 Population for 14 to 20 Dec 2020 (This week)(1)](https://user-images.githubusercontent.com/196695/102387279-1566cd80-3fc8-11eb-9fe4-3bbf4ec80d95.png)|

## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [ ] Chrome
- [x] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed

### Other considerations

Commit messages with a `fix` or `feat` type are automatically used to generate the [changelog](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/CHANGELOG.md) and
[GitHub release notes](https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/releases) during the release task. Please make sure they will read well on their own in a
summary of changes and that the commit body gives a more detailed description of those changes if necessary.

- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
- [ ] Update [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md) with any new instructions or tasks
