### PR TITLE
fix: Quick fix for broken population adding

### DIFF
--- a/app/population/controllers/daily.js
+++ b/app/population/controllers/daily.js
@@ -13,6 +13,7 @@ async function daily(req, res) {
     locationId: locationId,
     spaces,
     transfers,
+    editPath: `/population/day/${date}/${locationId}/edit`,
   })
 }
 

--- a/app/population/controllers/daily.test.js
+++ b/app/population/controllers/daily.test.js
@@ -56,7 +56,7 @@ describe('Population controllers', function () {
         })
 
         it('should pass correct number of params to template', function () {
-          expect(Object.keys(params)).to.have.length(4)
+          expect(Object.keys(params)).to.have.length(5)
         })
 
         it('should set date', function () {
@@ -67,6 +67,13 @@ describe('Population controllers', function () {
         it('should set locationId', function () {
           expect(params).to.have.property('locationId')
           expect(params.locationId).to.deep.equal(mockReq.params.locationId)
+        })
+
+        it('should set editPath', function () {
+          expect(params).to.have.property('editPath')
+          expect(params.editPath).to.equal(
+            '/population/day/2020-07-29/C0DEC0DE/edit'
+          )
         })
 
         it('should set spaces', function () {

--- a/app/population/views/daily.njk
+++ b/app/population/views/daily.njk
@@ -48,7 +48,7 @@
           <p>{{ t("population::daily_view.free_space_description") }}</p>
           <p><b>{{  t("population::daily_view.labels.last_updated") }} {{  spaces.details.updated_at | formatDateWithTimeAndDay }}</b></p>
           <p class="govuk-!-margin-bottom-0">
-            <a href="{{ locationId }}/edit" class="govuk-link govuk-link--no-visited-state">
+            <a href="{{ editPath }}" class="govuk-link govuk-link--no-visited-state">
               {{ t("population::daily_view.actions.change_numbers", {
                 context: "with_visually_hidden_text"
               }) | safe }}
@@ -57,7 +57,7 @@
         {%  else %}
           <div>
             {{ govukButton({
-              href: "",
+              href: editPath,
               html: t("population::daily_view.actions.add_numbers"),
               classes: "govuk-button"
             })}}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Recent refactoring broke the link to quick edit from the population grid. This PR fixes an existing bug with "add numbers" on the daily page. Another PR will restore the quit edit functionality.

<!--- Describe the changes in detail - the "what"-->

### Why did it change

A lack of E2E tests meant this wasn't caught on previous PRs.

## Checklists

### Testing

#### Automated testing

- [] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [ ] Chrome
- [x] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed


### Other considerations

Commit messages with a `fix` or `feat` type are automatically used to generate the [changelog](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/CHANGELOG.md) and
[GitHub release notes](https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/releases) during the release task. Please make sure they will read well on their own in a
summary of changes and that the commit body gives a more detailed description of those changes if necessary.

- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
- [ ] Update [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md) with any new instructions or tasks
