### PR TITLE
Refactor: Use transfers from locations_free_spaces service

### DIFF
--- a/app/population/middleware/set-population.js
+++ b/app/population/middleware/set-population.js
@@ -1,8 +1,6 @@
 async function setPopulation(req, res, next) {
   try {
     const { locationId, date } = req.params
-    let transfersIn
-    let transfersOut
 
     const dailyFreeSpaceByCategory = await req.services.locationsFreeSpaces.getPrisonFreeSpaces(
       {
@@ -19,32 +17,21 @@ async function setPopulation(req, res, next) {
 
     const freeSpacePopulation =
       dailyFreeSpace?.[0]?.meta?.populations?.[0] || {}
-    const { id: populationId } = freeSpacePopulation
+    const {
+      id: populationId,
+      transfers_in: transfersIn,
+      transfers_out: transfersOut,
+    } = freeSpacePopulation
+
+    req.transfers = {
+      transfersIn,
+      transfersOut,
+    }
 
     if (populationId) {
       req.population = await req.services.population.getByIdWithMoves(
         populationId
       )
-
-      transfersIn = req.population.moves_to.length
-      transfersOut = req.population.moves_from.length
-    } else {
-      const options = { dateRange: [date, date], isAggregation: true }
-      ;[transfersIn, transfersOut] = await Promise.all([
-        req.services.move.getActive({
-          ...options,
-          toLocationId: locationId,
-        }),
-        req.services.move.getActive({
-          ...options,
-          fromLocationId: locationId,
-        }),
-      ])
-    }
-
-    req.transfers = {
-      transfersIn,
-      transfersOut,
     }
 
     req.locationId = locationId


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes
Now that transfers are returned on the locations_free_spaces service, there is no longer an need for extra requests to retrieve this information.

### What changed

This PR removes the calls to load transfers and replaces them with the information from the locations_free_spaces request


## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [ ] Chrome
- [x] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed

### Other considerations

Commit messages with a `fix` or `feat` type are automatically used to generate the [changelog](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/CHANGELOG.md) and
[GitHub release notes](https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/releases) during the release task. Please make sure they will read well on their own in a
summary of changes and that the commit body gives a more detailed description of those changes if necessary.

- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
- [ ] Update [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md) with any new instructions or tasks
