### PR TITLE
fix: Use correct link to population edit page

### DIFF
--- a/common/presenters/date-table/population-helpers.js
+++ b/common/presenters/date-table/population-helpers.js
@@ -1,4 +1,5 @@
 const { format } = require('date-fns')
+const { isNil } = require('lodash')
 
 const i18n = require('../../../config/i18n')
 
@@ -38,15 +39,15 @@ const establishmentConfig = {
 const freeSpaceCellContent = function ({ date, populationIndex = 0 }) {
   return data => {
     const { id: locationId } = data
-    const { free_spaces: count } =
+    const { free_spaces: freeSpaces } =
       data?.meta?.populations?.[populationIndex] || {}
 
-    const link =
-      count === undefined
-        ? i18n.t('population::add_space')
-        : i18n.t('population::spaces_with_count', { count })
+    const hasNoFreeSpaces = isNil(freeSpaces)
+    const link = hasNoFreeSpaces
+      ? i18n.t('population::add_space')
+      : i18n.t('population::spaces_with_count', { count: freeSpaces })
 
-    const editQuicklink = count === undefined ? '/edit' : ''
+    const editQuicklink = hasNoFreeSpaces ? '/edit' : ''
 
     const url = `/population/day/${format(
       date,

--- a/common/presenters/date-table/population-helpers.test.js
+++ b/common/presenters/date-table/population-helpers.test.js
@@ -13,6 +13,8 @@ const mockLocation = {
       {
         id: '1bf70844-6b85-4fa6-8437-1c3859f883ee',
         free_spaces: 2,
+        transfers_in: 3,
+        transfers_out: 4,
       },
       {
         id: '6318fafa-923d-468f-ab5f-dc9cbdd79198',
@@ -23,12 +25,16 @@ const mockLocation = {
         free_spaces: 0,
       },
       {
-        id: '18a46696-f6ff-4c4e-8fe8-bc3177845a4a',
+        id: undefined,
         free_spaces: undefined,
+        transfers_in: 3,
+        transfers_out: 4,
       },
       {
-        id: 'abccd8db-29fe-47cf-b463-4f71cbea5416',
-        free_spaces: undefined,
+        id: null,
+        free_spaces: null,
+        transfers_in: 3,
+        transfers_out: 4,
       },
     ],
   },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes
A regression was introduced in a recent refactor which broke the deep linking into the edit screen.

### What changed

The API returns `null`, and the previous test was comparing against `undefined`. This code now used `lodash`'s `isNil` to handle all cases.

<!--- Describe the changes in detail - the "what"-->

### Why did it change

<!--- Describe the reason these changes were made - the "why" -->

## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [ ] Chrome
- [x] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed

### Other considerations

Commit messages with a `fix` or `feat` type are automatically used to generate the [changelog](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/CHANGELOG.md) and
[GitHub release notes](https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/releases) during the release task. Please make sure they will read well on their own in a
summary of changes and that the commit body gives a more detailed description of those changes if necessary.

- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
