### PR TITLE
[P4-2557] fix: Check for profile in base create controller

### DIFF
--- a/app/move/app/new/controllers/assessment.js
+++ b/app/move/app/new/controllers/assessment.js
@@ -30,22 +30,13 @@ class AssessmentController extends CreateBaseController {
     this.use(this.setPreviousAssessment)
   }
 
-  async setPreviousAssessment(req, res, next) {
+  setPreviousAssessment(req, res, next) {
     const {
       assessmentCategory,
       customAssessmentGroupings = [],
       showPreviousAssessment,
     } = req.form.options
-
-    const profileService = req.services.profile
-
-    let profile = req.getProfile()
-
-    if (!profile.id) {
-      const person = req.getPerson()
-      profile = await profileService.create(person.id, {})
-      req.sessionModel.set('profile', profile)
-    }
+    const profile = req.getProfile()
 
     if (showPreviousAssessment) {
       const customAssessmentKeys = customAssessmentGroupings

--- a/app/move/app/new/controllers/assessment.test.js
+++ b/app/move/app/new/controllers/assessment.test.js
@@ -268,27 +268,6 @@ describe('Move controllers', function () {
         nextSpy = sinon.spy()
       })
 
-      context('when no profile exists', function () {
-        beforeEach(async function () {
-          req.getProfile.returns({})
-          await controller.setPreviousAssessment(req, res, nextSpy)
-        })
-
-        it('should create a profile', function () {
-          expect(profileService.create).to.be.calledOnceWithExactly(
-            '#person',
-            {}
-          )
-        })
-
-        it('should stash the profile on the session', function () {
-          expect(req.sessionModel.set).to.be.calledOnceWithExactly(
-            'profile',
-            mockProfile
-          )
-        })
-      })
-
       context('when the step should show previous assessment', function () {
         beforeEach(function () {
           req.form.options.showPreviousAssessment = true

--- a/app/move/app/new/controllers/base.js
+++ b/app/move/app/new/controllers/base.js
@@ -5,6 +5,7 @@ class CreateBaseController extends FormWizardController {
   middlewareSetup() {
     super.middlewareSetup()
     this.use(this.setModels)
+    this.use(this.setProfile)
   }
 
   middlewareChecks() {
@@ -41,6 +42,29 @@ class CreateBaseController extends FormWizardController {
     this._setModels(req)
     this._addModelMethods(req)
     next()
+  }
+
+  async setProfile(req, res, next) {
+    const person = req.sessionModel.get('person') || {}
+
+    if (!person.id) {
+      return next()
+    }
+
+    const profile = req.sessionModel.get('profile') || {}
+
+    if (profile.person?.id === person.id) {
+      return next()
+    }
+
+    try {
+      const result = await req.services.profile.create(person.id, {})
+      req.sessionModel.set('profile', result)
+
+      next()
+    } catch (error) {
+      next(error)
+    }
   }
 
   async checkMoveSupported(req, res, next) {

--- a/app/move/app/new/controllers/document.test.js
+++ b/app/move/app/new/controllers/document.test.js
@@ -3,8 +3,6 @@ const FormError = require('hmpo-form-wizard/lib/error')
 const multer = require('multer')
 const proxyquire = require('proxyquire').noCallThru()
 
-const FormWizardController = require('../../../../../common/controllers/form-wizard')
-
 function MulterStub() {}
 
 MulterStub.prototype.array = sinon.stub()
@@ -63,7 +61,7 @@ describe('Move controllers', function () {
 
     describe('#middlewareSetup()', function () {
       beforeEach(function () {
-        sinon.stub(FormWizardController.prototype, 'middlewareSetup')
+        sinon.stub(BaseController.prototype, 'middlewareSetup')
         sinon.stub(controller, 'use')
         sinon.stub(controller, 'setNextStep')
 
@@ -71,8 +69,7 @@ describe('Move controllers', function () {
       })
 
       it('should call parent method', function () {
-        expect(FormWizardController.prototype.middlewareSetup).to.have.been
-          .calledOnce
+        expect(BaseController.prototype.middlewareSetup).to.have.been.calledOnce
       })
 
       it('should setup multer middleware', function () {
@@ -80,13 +77,13 @@ describe('Move controllers', function () {
       })
 
       it('should call setNextStep middleware', function () {
-        expect(controller.use.getCall(2)).to.have.been.calledWith(
+        expect(controller.use.getCall(1)).to.have.been.calledWith(
           controller.setNextStep
         )
       })
 
       it('should call correct number of middleware', function () {
-        expect(controller.use.callCount).to.equal(3)
+        expect(controller.use.callCount).to.equal(2)
       })
     })
 

--- a/app/move/app/new/controllers/save.js
+++ b/app/move/app/new/controllers/save.js
@@ -28,21 +28,8 @@ class SaveController extends CreateBaseController {
         'errorValues',
         'assessment',
         'documents',
-        'person',
       ])
-
-      const person = req.getPerson()
-      const profile = {
-        ...req.getProfile(),
-        person,
-      }
-
-      const moveData = {
-        ...data,
-        profile,
-      }
-
-      const move = await req.services.move.create(moveData)
+      const move = await req.services.move.create(data)
 
       await Promise.all([
         // create hearings
@@ -58,7 +45,7 @@ class SaveController extends CreateBaseController {
       ])
 
       await profileService.update({
-        ...profile,
+        ...data.profile,
         assessment_answers: assessment,
         documents,
       })

--- a/app/move/app/new/controllers/save.test.js
+++ b/app/move/app/new/controllers/save.test.js
@@ -9,13 +9,6 @@ const Controller = require('./save')
 
 const controller = new Controller({ route: '/' })
 
-const mockPerson = {
-  id: '3333',
-  _fullname: 'Full name',
-}
-const mockProfile = {
-  id: '2222',
-}
 const mockMove = {
   id: '4444',
   date: '2019-10-10',
@@ -26,7 +19,10 @@ const mockMove = {
   from_location: {
     location_type: 'police',
   },
-  person: mockPerson,
+  person: {
+    id: '3333',
+    _fullname: 'Full name',
+  },
 }
 const mockDocuments = [
   {
@@ -46,11 +42,17 @@ const mockValues = {
   to_location: 'Court',
   from_location: 'Prison',
   person: {
+    id: '__person_1__',
     first_names: 'Steve',
     last_name: 'Smith',
   },
   profile: {
-    id: '__profile',
+    id: '__profile_3__',
+    person: {
+      id: '__person_1__',
+      first_names: 'Steve',
+      last_name: 'Smith',
+    },
   },
   assessment: {
     court: [
@@ -100,8 +102,6 @@ describe('Move controllers', function () {
         }
         nextSpy = sinon.spy()
         req = {
-          getProfile: sinon.stub().returns(mockProfile),
-          getPerson: sinon.stub().returns(mockPerson),
           form: {
             values: {},
           },
@@ -128,21 +128,14 @@ describe('Move controllers', function () {
               reference: '',
               to_location: 'Court',
               from_location: 'Prison',
-              profile: {
-                ...mockProfile,
-                person: mockPerson,
-              },
+              person: mockValues.person,
+              profile: mockValues.profile,
             })
-          })
-
-          it('should fetch profile', function () {
-            expect(req.getProfile).to.be.calledOnceWithExactly()
           })
 
           it('should patch profile', function () {
             expect(profileService.update).to.be.calledOnceWithExactly({
-              ...mockProfile,
-              person: mockPerson,
+              ...mockValues.profile,
               assessment_answers: mockValues.assessment,
               documents: mockValues.documents,
             })
@@ -196,22 +189,15 @@ describe('Move controllers', function () {
                 reference: '',
                 to_location: 'Court',
                 from_location: 'Prison',
-                profile: {
-                  ...mockProfile,
-                  person: mockPerson,
-                },
+                person: mockValues.person,
+                profile: mockValues.profile,
                 court_hearings: mockValuesWithHearings.court_hearings,
               })
             })
 
-            it('should fetch profile', function () {
-              expect(req.getProfile).to.be.calledOnceWithExactly()
-            })
-
             it('should patch profile', function () {
               expect(profileService.update).to.be.calledOnceWithExactly({
-                ...mockProfile,
-                person: mockPerson,
+                ...mockValuesWithHearings.profile,
                 assessment_answers: mockValuesWithHearings.assessment,
                 documents: mockValuesWithHearings.documents,
               })
@@ -270,10 +256,8 @@ describe('Move controllers', function () {
                 reference: '',
                 to_location: 'Court',
                 from_location: 'Prison',
-                profile: {
-                  ...mockProfile,
-                  person: mockPerson,
-                },
+                person: mockValuesWithHearings.person,
+                profile: mockValuesWithHearings.profile,
                 court_hearings: mockValuesWithHearings.court_hearings,
                 should_save_court_hearings: shouldSaveCourtHearingsFalseValue,
               })

--- a/common/services/profile.js
+++ b/common/services/profile.js
@@ -51,7 +51,7 @@ class ProfileService extends BaseService {
     return this.apiClient
       .one('person', personId)
       .all('profile')
-      .post(data)
+      .post(data, { include: ['person'] })
       .then(response => response.data)
   }
 

--- a/common/services/profile.test.js
+++ b/common/services/profile.test.js
@@ -40,7 +40,9 @@ describe('Profile Service', function () {
       it('should call create endpoint with data', function () {
         expect(apiClient.one).to.be.calledOnceWithExactly('person', '#personId')
         expect(apiClient.all).to.be.calledOnceWithExactly('profile')
-        expect(apiClient.post).to.be.calledOnceWithExactly(profileData)
+        expect(apiClient.post).to.be.calledOnceWithExactly(profileData, {
+          include: ['person'],
+        })
       })
     })
   })


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Moves profile creation to the base controller.

Fixes issue where changing the person wouldn't create a new profile.

### Why did it change

Currently we check if a profile exists within the assessment controller.

This is done as part of setting the previous assessment.

However, we are introducing different flows to the journey which will
mean these steps are never seen, and therefore the profile is never
created.

This leads to an error when saving the move as the profile doesn't
exist.

This also addresses a bug where if a user tries to change the person,
a new profile is not created as we don't validate that the profile is
for the currently selected person.

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

- [P4-2557](https://dsdmoj.atlassian.net/browse/P4-2557)

## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [x] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed
