### PR TITLE
fix: Set current user header only when the username is present

### DIFF
--- a/common/lib/api-client/request-headers.js
+++ b/common/lib/api-client/request-headers.js
@@ -13,7 +13,7 @@ module.exports = (req, format = 'application/vnd.api+json') => {
     'Idempotency-Key': uuid.v4(),
   }
 
-  if (req && req.user) {
+  if (req && req.user && req.user.username) {
     headers['X-Current-User'] = req.user.username
   }
 

--- a/common/lib/api-client/request-headers.test.js
+++ b/common/lib/api-client/request-headers.test.js
@@ -85,5 +85,21 @@ describe('API Client', function () {
         expect(headers['Idempotency-Key']).to.equal('#uuid')
       })
     })
+
+    context('when there is no username', function () {
+      let headers
+      let req
+
+      beforeEach(function () {
+        req = {
+          user: {},
+        }
+        headers = getRequestHeaders(req, 'format/foo')
+      })
+
+      it('should not add Current User Header', function () {
+        expect('X-Current-User' in headers).to.equal(false)
+      })
+    })
   })
 })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Added an extra check before setting the `X-Current-User` header.
<!--- Describe the changes in detail - the "what"-->

### Why did it change
In development we can set options to bypass SSO, which means a user object exists without a username.
<!--- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

- [P4-1776]()

## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed

### Other considerations

Commit messages with a `fix` or `feat` type are automatically used to generate the [changelog](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/CHANGELOG.md) and
[GitHub release notes](https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/releases) during the release task. Please make sure they will read well on their own in a
summary of changes and that the commit body gives a more detailed description of those changes if necessary.

- [ ] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
- [ ] Update [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md) with any new instructions or tasks
