### PR TITLE
Display person category on move record page [P4 2461]

### DIFF
--- a/common/helpers/move/get-locals.js
+++ b/common/helpers/move/get-locals.js
@@ -21,7 +21,19 @@ function getLocals(req) {
   const { person } = profile
 
   // person
-  const personalDetailsSummary = presenters.personToSummaryListComponent(person)
+  // NB. category for move is actually on the move's profile
+  // since it's a snapshot rather than the current live value
+  // Merging the category into the person for now but could mix in
+  // during transformations or pass profile as extra param to presenter
+  const personWithProfileCategory = person
+    ? {
+        ...person,
+        category: profile.category,
+      }
+    : undefined
+  const personalDetailsSummary = presenters.personToSummaryListComponent(
+    personWithProfileCategory
+  )
   // move
   const additionalInfoSummary = presenters.moveToAdditionalInfoListComponent(
     move

--- a/common/helpers/move/get-locals.test.js
+++ b/common/helpers/move/get-locals.test.js
@@ -54,6 +54,7 @@ const mockPerson = {
 const mockProfile = {
   assessment_answers: mockAssessmentAnswers,
   person: mockPerson,
+  category: '__mock-category__',
 }
 const mockMove = {
   id: 'moveId',
@@ -123,14 +124,20 @@ describe('Move helpers', function () {
       })
 
       describe('personal details', function () {
+        const mockPersonWithProfileCategory = {
+          ...mockPerson,
+          category: '__mock-category__',
+        }
         it('should get the personal details summary', function () {
           expect(personToSummaryListComponent).to.be.calledOnceWithExactly(
-            mockPerson
+            mockPersonWithProfileCategory
           )
         })
         it('should set the personal details summary param', function () {
           expect(params).to.have.property('personalDetailsSummary')
-          expect(params.personalDetailsSummary).to.deep.equal(mockPerson)
+          expect(params.personalDetailsSummary).to.deep.equal(
+            mockPersonWithProfileCategory
+          )
         })
       })
 

--- a/common/lib/api-client/models/profile.js
+++ b/common/lib/api-client/models/profile.js
@@ -17,5 +17,9 @@ module.exports = {
       jsonApi: 'hasOne',
       type: 'youth_risk_assessments',
     },
+    category: {
+      jsonApi: 'hasOne',
+      type: 'categories',
+    },
   },
 }

--- a/common/presenters/person-to-summary-list-component.js
+++ b/common/presenters/person-to-summary-list-component.js
@@ -68,6 +68,17 @@ module.exports = function personToSummaryListComponent(props) {
     },
   ]
 
+  if (props.prison_number) {
+    rows.push({
+      key: {
+        text: i18n.t('fields::category.label'),
+      },
+      value: {
+        text: props.category?.title ?? i18n.t('fields::category.uncategorised'),
+      },
+    })
+  }
+
   return {
     classes: 'govuk-!-font-size-16',
     rows,

--- a/common/presenters/person-to-summary-list-component.test.js
+++ b/common/presenters/person-to-summary-list-component.test.js
@@ -21,7 +21,7 @@ const mockPerson = {
 describe('Presenters', function () {
   describe('#personToSummaryListComponent()', function () {
     beforeEach(function () {
-      sinon.stub(i18n, 't').returns('__translated__')
+      sinon.stub(i18n, 't').returnsArg(0)
       sinon.stub(filters, 'formatDate').returns('18 Jun 1960')
       sinon.stub(filters, 'calculateAge').returns(50)
     })
@@ -46,34 +46,32 @@ describe('Presenters', function () {
         })
 
         it('should contain correct number of rows', function () {
-          expect(transformedResponse.rows.length).to.equal(6)
+          expect(transformedResponse.rows.length).to.equal(7)
         })
 
         it('should contain identifiers first', function () {
           const row1 = transformedResponse.rows[0]
           const row2 = transformedResponse.rows[1]
           const row3 = transformedResponse.rows[2]
-
           expect(row1).to.deep.equal({
-            key: { html: '__translated__' },
+            key: { html: 'fields::police_national_computer.label' },
             value: { text: mockPerson.police_national_computer },
           })
           expect(row2).to.deep.equal({
-            key: { html: '__translated__' },
+            key: { html: 'fields::prison_number.label' },
             value: { text: mockPerson.prison_number },
           })
           expect(row3).to.deep.equal({
-            key: { html: '__translated__' },
+            key: { html: 'fields::criminal_records_office.label' },
             value: { text: mockPerson.criminal_records_office },
           })
         })
 
         it('should contain date of birth', function () {
           const row = transformedResponse.rows[3]
-
           expect(row).to.deep.equal({
-            key: { text: '__translated__' },
-            value: { text: '18 Jun 1960 (__translated__ 50)' },
+            key: { text: 'fields::date_of_birth.label' },
+            value: { text: '18 Jun 1960 (age 50)' },
           })
         })
 
@@ -81,7 +79,7 @@ describe('Presenters', function () {
           const row = transformedResponse.rows[4]
 
           expect(row).to.deep.equal({
-            key: { text: '__translated__' },
+            key: { text: 'fields::gender.label' },
             value: {
               text: `${mockPerson.gender.title} — ${mockPerson.gender_additional_information}`,
             },
@@ -92,7 +90,7 @@ describe('Presenters', function () {
           const row = transformedResponse.rows[5]
 
           expect(row).to.deep.equal({
-            key: { text: '__translated__' },
+            key: { text: 'fields::ethnicity.label' },
             value: { text: mockPerson.ethnicity.title },
           })
         })
@@ -133,8 +131,20 @@ describe('Presenters', function () {
           )
         })
 
+        it('should translate category label', function () {
+          expect(i18n.t.getCall(7)).to.be.calledWithExactly(
+            'fields::category.label'
+          )
+        })
+
+        it('should translate category uncategorised', function () {
+          expect(i18n.t.getCall(8)).to.be.calledWithExactly(
+            'fields::category.uncategorised'
+          )
+        })
+
         it('should translate correct number of times', function () {
-          expect(i18n.t).to.be.callCount(7)
+          expect(i18n.t).to.be.callCount(9)
         })
       })
     })
@@ -153,7 +163,7 @@ describe('Presenters', function () {
           const row = transformedResponse.rows[0]
 
           expect(row).to.deep.equal({
-            key: { text: '__translated__' },
+            key: { text: 'fields::date_of_birth.label' },
             value: { text: '' },
           })
         })
@@ -162,7 +172,7 @@ describe('Presenters', function () {
           const row = transformedResponse.rows[1]
 
           expect(row).to.deep.equal({
-            key: { text: '__translated__' },
+            key: { text: 'fields::gender.label' },
             value: { text: '' },
           })
         })
@@ -171,7 +181,7 @@ describe('Presenters', function () {
           const row = transformedResponse.rows[2]
 
           expect(row).to.deep.equal({
-            key: { text: '__translated__' },
+            key: { text: 'fields::ethnicity.label' },
             value: { text: '' },
           })
         })
@@ -195,9 +205,54 @@ describe('Presenters', function () {
           const row = transformedResponse.rows[1]
 
           expect(row).to.deep.equal({
-            key: { text: '__translated__' },
+            key: { text: 'fields::gender.label' },
             value: { text: 'Male' },
           })
+        })
+      })
+    })
+
+    describe('when person has category', function () {
+      let transformedResponse
+      let row
+
+      describe('and has a prison number', function () {
+        beforeEach(function () {
+          transformedResponse = personToSummaryListComponent({
+            id: '12345',
+            prison_number: 'AA/183716',
+            category: {
+              title: 'Category X',
+            },
+          })
+          row = transformedResponse.rows.filter(
+            row => row.key.text === 'fields::category.label'
+          )[0]
+        })
+
+        it('should return the person’s category', function () {
+          expect(row).to.deep.equal({
+            key: { text: 'fields::category.label' },
+            value: { text: 'Category X' },
+          })
+        })
+      })
+
+      describe('and has no prison number', function () {
+        beforeEach(function () {
+          transformedResponse = personToSummaryListComponent({
+            id: '12345',
+            category: {
+              title: 'Category X',
+            },
+          })
+          row = transformedResponse.rows.filter(
+            row => row.key.text === 'fields::category.label'
+          )[0]
+        })
+
+        it('should not return the person’s category', function () {
+          expect(row).to.be.undefined
         })
       })
     })

--- a/common/services/move.js
+++ b/common/services/move.js
@@ -241,7 +241,11 @@ class MoveService extends BaseService {
 
   getById(id) {
     return this._getById(id, {
-      include: [...this.defaultInclude(), 'important_events'],
+      include: [
+        ...this.defaultInclude(),
+        'important_events',
+        'profile.category',
+      ],
     })
   }
 

--- a/common/services/move.test.js
+++ b/common/services/move.test.js
@@ -976,7 +976,11 @@ describe('Move Service', function () {
       })
       it('should call find method with data', function () {
         expect(moveService._getById).to.be.calledOnceWithExactly(mockId, {
-          include: [...moveService.defaultInclude(), 'important_events'],
+          include: [
+            ...moveService.defaultInclude(),
+            'important_events',
+            'profile.category',
+          ],
         })
       })
       it('should return move', function () {

--- a/locales/en/fields.json
+++ b/locales/en/fields.json
@@ -59,6 +59,10 @@
   "ethnicity": {
     "label": "Ethnicity"
   },
+  "category": {
+    "label": "Security category",
+    "uncategorised": "Pending category"
+  },
   "from_location": {
     "label": "Move from",
     "short_label": "From"

--- a/test/fixtures/api-client/profile.create.json
+++ b/test/fixtures/api-client/profile.create.json
@@ -99,6 +99,9 @@
       },
       "documents": {
         "data": []
+      },
+      "category": {
+        "data": null
       }
     }
   },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Adds person’s category to personal summary details if the person has a prison number



### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

- [P4-2461 - Display the person's category on their record page](https://dsdmoj.atlassian.net/browse/P4-2461)

## Screenshots
<!--- (Optional) Include screenshots if changes update interfaces or components -->
<!--- Delete/copy as appropriate --->

<kbd>![Move_details_for_CASEDY__DOMSANIGH_–_Book_a_secure_move](https://user-images.githubusercontent.com/4856/102611446-d438ff80-4126-11eb-8ec4-932006ab758f.png)</kbd>

## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed


### Other considerations

- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics

