### PR TITLE
[P4-2557] Add new attributes required for youth moves

### DIFF
--- a/common/lib/api-client/models/location.js
+++ b/common/lib/api-client/models/location.js
@@ -5,6 +5,7 @@ module.exports = {
     location_type: '',
     nomis_agency_id: '',
     can_upload_documents: '',
+    young_offender_institution: '',
     disabled_at: '',
     suppliers: {
       jsonApi: 'hasMany',

--- a/common/lib/api-client/models/profile.js
+++ b/common/lib/api-client/models/profile.js
@@ -1,6 +1,7 @@
 module.exports = {
   fields: {
     assessment_answers: '',
+    requires_youth_risk_assessment: '',
     person: {
       jsonApi: 'hasOne',
       type: 'people',

--- a/test/fixtures/api-client/location.find.json
+++ b/test/fixtures/api-client/location.find.json
@@ -7,6 +7,7 @@
       "key": "axminster_crown_court",
       "title": "Axminster Crown Court",
       "location_type": "court",
+      "young_offender_institution": false,
       "can_upload_documents": false,
       "nomis_agency_id": null,
       "suppliers": [

--- a/test/fixtures/api-client/location.findAll.json
+++ b/test/fixtures/api-client/location.findAll.json
@@ -9,6 +9,7 @@
         "location_type": "court",
         "nomis_agency_id": null,
         "can_upload_documents": true,
+        "young_offender_institution": false,
         "disabled_at": null,
         "suppliers": [
           {
@@ -34,6 +35,7 @@
         "location_type": "court",
         "nomis_agency_id": null,
         "can_upload_documents": false,
+        "young_offender_institution": false,
         "disabled_at": null,
         "suppliers": [],
         "category": {
@@ -51,6 +53,7 @@
         "location_type": "court",
         "nomis_agency_id": null,
         "can_upload_documents": false,
+        "young_offender_institution": false,
         "disabled_at": null,
         "suppliers": [],
         "category": {
@@ -68,6 +71,7 @@
         "location_type": "court",
         "nomis_agency_id": null,
         "can_upload_documents": false,
+        "young_offender_institution": false,
         "disabled_at": null,
         "suppliers": [],
         "category": {
@@ -85,6 +89,7 @@
         "location_type": "court",
         "nomis_agency_id": null,
         "can_upload_documents": false,
+        "young_offender_institution": false,
         "disabled_at": null,
         "suppliers": [],
         "category": {
@@ -102,6 +107,7 @@
         "location_type": "court",
         "nomis_agency_id": null,
         "can_upload_documents": false,
+        "young_offender_institution": false,
         "disabled_at": null,
         "suppliers": [],
         "category": {
@@ -119,6 +125,7 @@
         "location_type": "court",
         "nomis_agency_id": null,
         "can_upload_documents": false,
+        "young_offender_institution": false,
         "disabled_at": null,
         "suppliers": [],
         "category": {
@@ -136,6 +143,7 @@
         "location_type": "court",
         "nomis_agency_id": null,
         "can_upload_documents": false,
+        "young_offender_institution": false,
         "disabled_at": null,
         "suppliers": [
           {
@@ -161,6 +169,7 @@
         "location_type": "court",
         "nomis_agency_id": null,
         "can_upload_documents": true,
+        "young_offender_institution": false,
         "disabled_at": null,
         "suppliers": [],
         "category": {
@@ -178,6 +187,7 @@
         "location_type": "court",
         "nomis_agency_id": null,
         "can_upload_documents": false,
+        "young_offender_institution": false,
         "disabled_at": null,
         "suppliers": [],
         "category": {
@@ -195,6 +205,7 @@
         "location_type": "court",
         "nomis_agency_id": null,
         "can_upload_documents": false,
+        "young_offender_institution": false,
         "disabled_at": null,
         "suppliers": [],
         "category": {
@@ -212,6 +223,7 @@
         "location_type": "court",
         "nomis_agency_id": null,
         "can_upload_documents": false,
+        "young_offender_institution": false,
         "disabled_at": null,
         "suppliers": [],
         "category": {
@@ -229,6 +241,7 @@
         "location_type": "court",
         "nomis_agency_id": null,
         "can_upload_documents": false,
+        "young_offender_institution": false,
         "disabled_at": null,
         "suppliers": [],
         "category": {
@@ -246,6 +259,7 @@
         "location_type": "court",
         "nomis_agency_id": null,
         "can_upload_documents": true,
+        "young_offender_institution": false,
         "disabled_at": null,
         "suppliers": [],
         "category": {
@@ -263,6 +277,7 @@
         "location_type": "court",
         "nomis_agency_id": null,
         "can_upload_documents": false,
+        "young_offender_institution": false,
         "disabled_at": null,
         "suppliers": [],
         "category": {
@@ -280,6 +295,7 @@
         "location_type": "court",
         "nomis_agency_id": null,
         "can_upload_documents": false,
+        "young_offender_institution": false,
         "disabled_at": null,
         "suppliers": [
           {
@@ -305,6 +321,7 @@
         "location_type": "court",
         "nomis_agency_id": null,
         "can_upload_documents": false,
+        "young_offender_institution": false,
         "disabled_at": null,
         "suppliers": [],
         "category": {
@@ -322,6 +339,7 @@
         "location_type": "court",
         "nomis_agency_id": null,
         "can_upload_documents": false,
+        "young_offender_institution": false,
         "disabled_at": null,
         "suppliers": [],
         "category": {
@@ -339,6 +357,7 @@
         "location_type": "court",
         "nomis_agency_id": null,
         "can_upload_documents": true,
+        "young_offender_institution": false,
         "disabled_at": null,
         "suppliers": [],
         "category": {
@@ -356,6 +375,7 @@
         "location_type": "court",
         "nomis_agency_id": null,
         "can_upload_documents": false,
+        "young_offender_institution": false,
         "disabled_at": null,
         "suppliers": [],
         "category": {
@@ -373,6 +393,7 @@
         "location_type": "court",
         "nomis_agency_id": null,
         "can_upload_documents": false,
+        "young_offender_institution": false,
         "disabled_at": null,
         "suppliers": [],
         "category": {
@@ -390,6 +411,7 @@
         "location_type": "court",
         "nomis_agency_id": null,
         "can_upload_documents": false,
+        "young_offender_institution": false,
         "disabled_at": null,
         "suppliers": [],
         "category": {
@@ -407,6 +429,7 @@
         "location_type": "court",
         "nomis_agency_id": null,
         "can_upload_documents": false,
+        "young_offender_institution": false,
         "disabled_at": null,
         "suppliers": [],
         "category": {
@@ -424,6 +447,7 @@
         "location_type": "court",
         "nomis_agency_id": null,
         "can_upload_documents": false,
+        "young_offender_institution": false,
         "disabled_at": null,
         "suppliers": [],
         "category": {
@@ -441,6 +465,7 @@
         "location_type": "court",
         "nomis_agency_id": null,
         "can_upload_documents": false,
+        "young_offender_institution": false,
         "disabled_at": null,
         "suppliers": [],
         "category": {
@@ -458,6 +483,7 @@
         "location_type": "court",
         "nomis_agency_id": null,
         "can_upload_documents": false,
+        "young_offender_institution": false,
         "disabled_at": null,
         "suppliers": [],
         "category": {
@@ -475,6 +501,7 @@
         "location_type": "court",
         "nomis_agency_id": null,
         "can_upload_documents": false,
+        "young_offender_institution": false,
         "disabled_at": null,
         "suppliers": [],
         "category": {
@@ -492,6 +519,7 @@
         "location_type": "court",
         "nomis_agency_id": null,
         "can_upload_documents": false,
+        "young_offender_institution": false,
         "disabled_at": null,
         "suppliers": [],
         "category": {
@@ -509,6 +537,7 @@
         "location_type": "court",
         "nomis_agency_id": null,
         "can_upload_documents": false,
+        "young_offender_institution": false,
         "disabled_at": null,
         "suppliers": [],
         "category": {
@@ -526,6 +555,7 @@
         "location_type": "court",
         "nomis_agency_id": null,
         "can_upload_documents": false,
+        "young_offender_institution": false,
         "disabled_at": null,
         "suppliers": [],
         "category": {
@@ -543,6 +573,7 @@
         "location_type": "court",
         "nomis_agency_id": null,
         "can_upload_documents": false,
+        "young_offender_institution": false,
         "disabled_at": null,
         "suppliers": [],
         "category": {
@@ -560,6 +591,7 @@
         "location_type": "court",
         "nomis_agency_id": null,
         "can_upload_documents": false,
+        "young_offender_institution": false,
         "disabled_at": null,
         "suppliers": [],
         "category": {
@@ -577,6 +609,7 @@
         "location_type": "court",
         "nomis_agency_id": null,
         "can_upload_documents": false,
+        "young_offender_institution": false,
         "disabled_at": null,
         "suppliers": [],
         "category": {
@@ -594,6 +627,7 @@
         "location_type": "court",
         "nomis_agency_id": null,
         "can_upload_documents": false,
+        "young_offender_institution": false,
         "disabled_at": null,
         "suppliers": [],
         "category": {
@@ -611,6 +645,7 @@
         "location_type": "court",
         "nomis_agency_id": null,
         "can_upload_documents": false,
+        "young_offender_institution": false,
         "disabled_at": null,
         "suppliers": [],
         "category": {
@@ -628,6 +663,7 @@
         "location_type": "court",
         "nomis_agency_id": null,
         "can_upload_documents": false,
+        "young_offender_institution": false,
         "disabled_at": null,
         "suppliers": [],
         "category": {
@@ -645,6 +681,7 @@
         "location_type": "court",
         "nomis_agency_id": null,
         "can_upload_documents": false,
+        "young_offender_institution": false,
         "disabled_at": null,
         "suppliers": [],
         "category": {
@@ -662,6 +699,7 @@
         "location_type": "court",
         "nomis_agency_id": null,
         "can_upload_documents": false,
+        "young_offender_institution": false,
         "disabled_at": null,
         "suppliers": [],
         "category": {
@@ -679,6 +717,7 @@
         "location_type": "court",
         "nomis_agency_id": null,
         "can_upload_documents": false,
+        "young_offender_institution": false,
         "disabled_at": null,
         "suppliers": [],
         "category": {
@@ -696,6 +735,7 @@
         "location_type": "court",
         "nomis_agency_id": null,
         "can_upload_documents": false,
+        "young_offender_institution": false,
         "disabled_at": null,
         "suppliers": [],
         "category": {
@@ -713,6 +753,7 @@
         "location_type": "court",
         "nomis_agency_id": null,
         "can_upload_documents": false,
+        "young_offender_institution": false,
         "disabled_at": null,
         "suppliers": [],
         "category": {
@@ -730,6 +771,7 @@
         "location_type": "court",
         "nomis_agency_id": null,
         "can_upload_documents": false,
+        "young_offender_institution": false,
         "disabled_at": null,
         "suppliers": [],
         "category": {
@@ -747,6 +789,7 @@
         "location_type": "court",
         "nomis_agency_id": null,
         "can_upload_documents": false,
+        "young_offender_institution": false,
         "disabled_at": null,
         "suppliers": [],
         "category": {
@@ -764,6 +807,7 @@
         "location_type": "court",
         "nomis_agency_id": null,
         "can_upload_documents": false,
+        "young_offender_institution": false,
         "disabled_at": null,
         "suppliers": [],
         "category": {
@@ -781,6 +825,7 @@
         "location_type": "court",
         "nomis_agency_id": null,
         "can_upload_documents": false,
+        "young_offender_institution": false,
         "disabled_at": null,
         "suppliers": [],
         "category": {
@@ -798,6 +843,7 @@
         "location_type": "court",
         "nomis_agency_id": null,
         "can_upload_documents": false,
+        "young_offender_institution": false,
         "disabled_at": null,
         "suppliers": [],
         "category": {
@@ -815,6 +861,7 @@
         "location_type": "court",
         "nomis_agency_id": null,
         "can_upload_documents": false,
+        "young_offender_institution": false,
         "disabled_at": null,
         "suppliers": [],
         "category": {
@@ -832,6 +879,7 @@
         "location_type": "court",
         "nomis_agency_id": null,
         "can_upload_documents": false,
+        "young_offender_institution": false,
         "disabled_at": null,
         "suppliers": [],
         "category": {
@@ -849,6 +897,7 @@
         "location_type": "court",
         "nomis_agency_id": null,
         "can_upload_documents": false,
+        "young_offender_institution": false,
         "disabled_at": null,
         "suppliers": [],
         "category": {
@@ -866,6 +915,7 @@
         "location_type": "court",
         "nomis_agency_id": null,
         "can_upload_documents": false,
+        "young_offender_institution": false,
         "disabled_at": null,
         "suppliers": [],
         "category": {

--- a/test/fixtures/api-client/profile.create.json
+++ b/test/fixtures/api-client/profile.create.json
@@ -3,6 +3,7 @@
     "id": "b695d0f0-af8e-4b97-891e-92020d6820b9",
     "type": "profiles",
     "attributes": {
+      "requires_youth_risk_assessment": true,
       "assessment_answers": [
         {
           "title": "Violent",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

This adds a new attribute to the locations model (`young_offender_institution`) and a new attribute to the profile model (`requires_youth_risk_assessment `).

### Why did it change

These new attributes are required to add the logic for sending prisoners from a prison that are serving their sentence on the youth estate.

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

- [P4-2557](https://dsdmoj.atlassian.net/browse/P4-2557)