### PR TITLE
Ensure profile not null in move get-locals helper

### DIFF
--- a/common/helpers/move/get-locals.js
+++ b/common/helpers/move/get-locals.js
@@ -17,7 +17,7 @@ const getUpdateUrls = require('./get-update-urls')
 function getLocals(req) {
   const { move, canAccess } = req
   const userPermissions = req.session?.user?.permissions
-  const { profile } = move
+  const profile = move.profile || {}
   const { person } = profile
 
   // person

--- a/common/helpers/move/get-locals.test.js
+++ b/common/helpers/move/get-locals.test.js
@@ -296,6 +296,71 @@ describe('Move helpers', function () {
       })
     })
 
+    context('when move doesn’t have a profile', function () {
+      let params
+
+      beforeEach(function () {
+        req.move = {
+          id: 'moveId',
+          status: 'requested',
+        }
+
+        params = getLocals(req)
+      })
+
+      it('should still return the expected locals', function () {
+        expect(Object.keys(params).sort()).to.deep.equal([
+          'additionalInfoSummary',
+          'assessments',
+          'canCancelMove',
+          'courtHearings',
+          'messageBanner',
+          'messageContent',
+          'messageTitle',
+          'move',
+          'moveSummary',
+          'perDetails',
+          'personalDetailsSummary',
+          'tagLists',
+          'updateLinks',
+          'urls',
+        ])
+      })
+    })
+
+    context('when move profile is null', function () {
+      let params
+
+      beforeEach(function () {
+        req.move = {
+          id: 'moveId',
+          status: 'requested',
+          profile: null,
+        }
+
+        params = getLocals(req)
+      })
+
+      it('should still return the expected locals', function () {
+        expect(Object.keys(params).sort()).to.deep.equal([
+          'additionalInfoSummary',
+          'assessments',
+          'canCancelMove',
+          'courtHearings',
+          'messageBanner',
+          'messageContent',
+          'messageTitle',
+          'move',
+          'moveSummary',
+          'perDetails',
+          'personalDetailsSummary',
+          'tagLists',
+          'updateLinks',
+          'urls',
+        ])
+      })
+    })
+
     describe('cancelling a move', function () {
       let params
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Put a guard to ensure `move.profile` is not null

### Why did it change

`person` is retrieved from the `profile` object

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

https://sentry.io/organizations/ministryofjustice/issues/2100728538/?project=2014813&query=is%3Aunresolved#exception

Fixes BOOK-A-SECURE-MOVE-FRONTEND-23

## Screenshots
<!--- (Optional) Include screenshots if changes update interfaces or components -->
<!--- Delete/copy as appropriate --->

n/a

## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed



### Other considerations


- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics

