### PR TITLE
test: Pin codeclimate test coverage reporter

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -136,9 +136,6 @@ jobs:
           command: |
             ./cc-test-reporter after-build
           when: always
-      - run:
-          name: Build the app
-          command: NODE_ENV=production npm run build
       - store_test_results:
           path: reports
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,7 +120,7 @@ jobs:
           name: Setup Code Climate test-reporter
           # download test reporter as a static binary
           command: |
-            curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+            curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-0.8.0-linux-amd64 > ./cc-test-reporter
             chmod +x ./cc-test-reporter
       - run:
           name: Notify CodeClimate before build


### PR DESCRIPTION
The latest tag is having some issues with the latest release of the
code climate test coverage reporter.

The quickest way out of it is to pin the version instead of using
`latest`.

See this thread for more information:
https://github.com/codeclimate/test-reporter/issues/449