### PR TITLE
Remove Person Escort Record feature flag

### DIFF
--- a/app/allocation/controllers/view.js
+++ b/app/allocation/controllers/view.js
@@ -8,10 +8,8 @@ function viewAllocation(req, res) {
   const bannerStatuses = ['cancelled']
   const movesWithoutProfile = moves.filter(move => !move.profile)
   const movesWithProfile = moves.filter(move => move.profile)
-  const personEscortRecordIsEnabled = canAccess('person_escort_record:view')
   const moveToCardComponent = presenters.moveToCardComponent({
     showStatus: false,
-    tagSource: personEscortRecordIsEnabled ? 'personEscortRecord' : '',
   })
 
   const removeUnassignedMoves = move => {

--- a/app/move/views/view.njk
+++ b/app/move/views/view.njk
@@ -117,29 +117,21 @@
       }) }}
     </span>
 
-    {% if personEscortRecordIsEnabled %}
-      <div class="govuk-!-margin-top-2" data-tag-list-source="person-escort-record">
-        {% if not personEscortRecordIsCompleted %}
-          {{ govukInsetText({
-            classes: "govuk-inset-text--compact govuk-!-margin-0",
-            text: t("assessment::incomplete")
-          }) }}
-        {% endif %}
+    <div class="govuk-!-margin-top-2" data-tag-list-source="person-escort-record">
+      {% if not personEscortRecordIsCompleted %}
+        {{ govukInsetText({
+          classes: "govuk-inset-text--compact govuk-!-margin-0",
+          text: t("assessment::incomplete")
+        }) }}
+      {% endif %}
 
-        {% if personEscortRecordIsCompleted and personEscortRecordTagList | length %}
-          {% for tag in personEscortRecordTagList %}
-            {{ appTag(tag) }}
-          {% endfor %}
-        {% endif %}
-      </div>
-    {% elif tagList | length %}
-      {# TODO: Remove surrounding conditional once PER is fully enabled #}
-      <div class="govuk-!-margin-top-2" data-tag-list-source="move-request">
-        {% for tag in tagList %}
+      {% if personEscortRecordIsCompleted and personEscortRecordTagList | length %}
+        {% for tag in personEscortRecordTagList %}
           {{ appTag(tag) }}
         {% endfor %}
-      </div>
-    {% endif %}
+      {% endif %}
+    </div>
+
     {% if importantEventsTagList.length %}
       <div class="govuk-!-margin-top-2" data-tag-list-source="move-important-events">
         {% for tag in importantEventsTagList %}
@@ -212,11 +204,9 @@
         {{ updateLink(updateLinks.personal_details) }}
       </section>
 
-      {% if personEscortRecordIsEnabled and personEscortRecord %}
+      {% if personEscortRecord or (youthRiskAssessment and youthRiskAssessmentIsEnabled) %}
         {% include "move/views/_includes/assessment-summary.njk" %}
-      {% elif youthRiskAssessmentIsEnabled and youthRiskAssessment %}
-        {% include "move/views/_includes/assessment-summary.njk" %}
-      {% elif not personEscortRecordIsEnabled and not move._is_youth_move or not youthRiskAssessmentIsEnabled %}
+      {% else %}
         {% include "move/views/_includes/assessment.njk" %}
       {% endif %}
 

--- a/app/moves/middleware/set-results.moves.js
+++ b/app/moves/middleware/set-results.moves.js
@@ -14,19 +14,9 @@ function setResultsMoves(bodyKey, locationKey) {
         req.services.move.getActive(args),
         req.services.move.getCancelled(args),
       ])
-      const personEscortRecordIsEnabled = req.canAccess(
-        'person_escort_record:view'
-      )
-      const cardTagSource = personEscortRecordIsEnabled
-        ? 'personEscortRecord'
-        : undefined
 
       req.resultsAsCards = {
-        active: presenters.movesByLocation(
-          activeMoves,
-          locationKey,
-          cardTagSource
-        ),
+        active: presenters.movesByLocation(activeMoves, locationKey),
         cancelled: cancelledMoves.map(
           presenters.moveToCardComponent({
             showMeta: false,

--- a/app/moves/middleware/set-results.moves.test.js
+++ b/app/moves/middleware/set-results.moves.test.js
@@ -99,7 +99,6 @@ describe('Moves middleware', function () {
         it('should call movesByLocation presenter without locationKey', function () {
           expect(presenters.movesByLocation).to.be.calledOnceWithExactly(
             mockActiveMoves,
-            undefined,
             undefined
           )
         })
@@ -128,40 +127,8 @@ describe('Moves middleware', function () {
         it('should call movesByLocation presenter with locationKey', function () {
           expect(presenters.movesByLocation).to.be.calledOnceWithExactly(
             mockActiveMoves,
-            mockLocationKey,
-            undefined
+            mockLocationKey
           )
-        })
-      })
-
-      context('with `personEscortRecordFeature`', function () {
-        context('with correct user permission', function () {
-          beforeEach(async function () {
-            req.canAccess.withArgs('person_escort_record:view').returns(true)
-            await middleware(mockBodyKey, mockLocationKey)(req, res, nextSpy)
-          })
-
-          it('should call movesByLocation presenter with locationKey', function () {
-            expect(presenters.movesByLocation).to.be.calledOnceWithExactly(
-              mockActiveMoves,
-              mockLocationKey,
-              'personEscortRecord'
-            )
-          })
-        })
-
-        context('without correct user permission', function () {
-          beforeEach(async function () {
-            await middleware(mockBodyKey, mockLocationKey)(req, res, nextSpy)
-          })
-
-          it('should call movesByLocation presenter with locationKey', function () {
-            expect(presenters.movesByLocation).to.be.calledOnceWithExactly(
-              mockActiveMoves,
-              mockLocationKey,
-              undefined
-            )
-          })
         })
       })
     })

--- a/common/helpers/move/get-locals.js
+++ b/common/helpers/move/get-locals.js
@@ -43,9 +43,9 @@ function getLocals(req) {
   const tagLists = getTagLists(move)
   const assessments = getAssessments(move)
   const tabsUrls = getTabsUrls(move)
+  const perDetails = getPerDetails(move)
   // move, canAccess
   const messageBanner = getMessageBanner(move, canAccess)
-  const perDetails = getPerDetails(move, canAccess)
   // move, canAccess, updateSteps
   const updateUrls = getUpdateUrls(move, canAccess, updateSteps)
   const updateLinks = getUpdateLinks(move, canAccess, updateSteps)

--- a/common/helpers/move/get-locals.test.js
+++ b/common/helpers/move/get-locals.test.js
@@ -176,9 +176,9 @@ describe('Move helpers', function () {
         })
       })
 
-      describe('PER details', function () {
+      describe('Person Escort Record (PER) details', function () {
         it('should get the PER details', function () {
-          expect(getPerDetails).to.be.calledOnceWithExactly(mockMove, canAccess)
+          expect(getPerDetails).to.be.calledOnceWithExactly(mockMove)
         })
 
         it('should set the PER details params', function () {

--- a/common/helpers/move/get-per-details.js
+++ b/common/helpers/move/get-per-details.js
@@ -4,13 +4,10 @@ const presenters = require('../../presenters')
 
 const getMoveUrl = require('./get-move-url')
 
-function getPerDetails(move, canAccess) {
+function getPerDetails(move) {
   const { profile } = move
   const { person_escort_record: personEscortRecord } = profile || {}
-
   const moveUrl = getMoveUrl(move.id)
-
-  const personEscortRecordIsEnabled = canAccess('person_escort_record:view')
   const personEscortRecordIsCompleted =
     !isEmpty(personEscortRecord) &&
     !['not_started', 'in_progress'].includes(personEscortRecord?.status)
@@ -22,7 +19,6 @@ function getPerDetails(move, canAccess) {
 
   const perDetails = {
     personEscortRecord,
-    personEscortRecordIsEnabled,
     personEscortRecordIsCompleted,
     personEscortRecordTagList,
   }

--- a/common/helpers/move/get-per-details.test.js
+++ b/common/helpers/move/get-per-details.test.js
@@ -9,8 +9,6 @@ const presenters = {
 
 const getMoveUrl = sinon.stub().returns('move-url')
 
-const canAccess = sinon.stub().returns(false)
-
 const getPerDetails = proxyquire('./get-per-details', {
   '../../presenters': presenters,
   './get-move-url': getMoveUrl,
@@ -38,22 +36,15 @@ describe('Move helpers', function () {
     beforeEach(function () {
       frameworkFlagsToTagList.resetHistory()
       getMoveUrl.resetHistory()
-      canAccess.resetHistory()
     })
 
     context('when getting the PER details', function () {
       beforeEach(function () {
-        perDetails = getPerDetails(move, canAccess)
+        perDetails = getPerDetails(move)
       })
 
       it('should get the move url', function () {
         expect(getMoveUrl).to.be.calledOnceWithExactly('moveId')
-      })
-
-      it('should get the PER view permission', function () {
-        expect(canAccess).to.be.calledOnceWithExactly(
-          'person_escort_record:view'
-        )
       })
 
       it('should get the framework flag tag list', function () {
@@ -68,38 +59,16 @@ describe('Move helpers', function () {
         perDetails // ?
         expect(perDetails).to.deep.equal({
           personEscortRecord,
-          personEscortRecordIsEnabled: false,
           personEscortRecordIsCompleted: false,
           personEscortRecordTagList: { content: 'framework flag tags' },
         })
       })
     })
 
-    context('when user has no access to PER', function () {
-      beforeEach(function () {
-        perDetails = getPerDetails(move, canAccess)
-      })
-
-      it('should not enable the PER', function () {
-        expect(perDetails.personEscortRecordIsEnabled).to.be.false
-      })
-    })
-
-    context('when user has access to PER', function () {
-      beforeEach(function () {
-        canAccess.returns(true)
-        perDetails = getPerDetails(move, canAccess)
-      })
-
-      it('should enable the PER', function () {
-        expect(perDetails.personEscortRecordIsEnabled).to.be.true
-      })
-    })
-
     context('when the PER is empty', function () {
       beforeEach(function () {
         const moveWithEmptyPER = getMockMove()
-        perDetails = getPerDetails(moveWithEmptyPER, canAccess)
+        perDetails = getPerDetails(moveWithEmptyPER)
       })
 
       it('should not show the PER as completed', function () {
@@ -112,7 +81,7 @@ describe('Move helpers', function () {
         const moveWithNotStartedStatus = getMockMove({
           status: 'not_started',
         })
-        perDetails = getPerDetails(moveWithNotStartedStatus, canAccess)
+        perDetails = getPerDetails(moveWithNotStartedStatus)
       })
 
       it('should not show the PER as completed', function () {
@@ -125,7 +94,7 @@ describe('Move helpers', function () {
         const moveWithInProgressStatus = getMockMove({
           status: 'in_progress',
         })
-        perDetails = getPerDetails(moveWithInProgressStatus, canAccess)
+        perDetails = getPerDetails(moveWithInProgressStatus)
       })
 
       it('should not show the PER as completed', function () {
@@ -138,7 +107,7 @@ describe('Move helpers', function () {
         const moveWithOtherStatus = getMockMove({
           status: 'other',
         })
-        perDetails = getPerDetails(moveWithOtherStatus, canAccess)
+        perDetails = getPerDetails(moveWithOtherStatus)
       })
 
       it('should show the PER as completed', function () {
@@ -152,7 +121,7 @@ describe('Move helpers', function () {
       }
 
       beforeEach(function () {
-        perDetails = getPerDetails(moveWithoutProfile, canAccess)
+        perDetails = getPerDetails(moveWithoutProfile)
       })
 
       it('should get the framework flag tag list with no items', function () {

--- a/common/lib/permissions.js
+++ b/common/lib/permissions.js
@@ -19,6 +19,10 @@ const policePermissions = [
   'move:update:prison_recall',
   'move:update:police_transfer',
   'move:update:video_remand',
+  'person_escort_record:view',
+  'person_escort_record:create',
+  'person_escort_record:update',
+  'person_escort_record:confirm',
 ]
 
 const secureChildrensHomePermissions = [
@@ -39,6 +43,10 @@ const secureChildrensHomePermissions = [
   'move:update:hospital',
   'move:cancel',
   'move:cancel:proposed',
+  'person_escort_record:view',
+  'person_escort_record:create',
+  'person_escort_record:update',
+  'person_escort_record:confirm',
   'youth_risk_assessment:view',
   'youth_risk_assessment:create',
   'youth_risk_assessment:update',
@@ -62,6 +70,10 @@ const secureTrainingCentrePermissions = [
   'move:update:hospital',
   'move:cancel',
   'move:cancel:proposed',
+  'person_escort_record:view',
+  'person_escort_record:create',
+  'person_escort_record:update',
+  'person_escort_record:confirm',
   'youth_risk_assessment:view',
   'youth_risk_assessment:create',
   'youth_risk_assessment:update',
@@ -86,6 +98,10 @@ const prisonPermissions = [
   'move:create:court_appearance',
   'move:create:hospital',
   'move:cancel',
+  'person_escort_record:view',
+  'person_escort_record:create',
+  'person_escort_record:update',
+  'person_escort_record:confirm',
 ]
 const ocaPermissions = [
   'dashboard:view',
@@ -99,6 +115,10 @@ const ocaPermissions = [
   'move:create:prison_transfer',
   'move:create:secure_childrens_home',
   'move:create:secure_training_centre',
+  'person_escort_record:view',
+  'person_escort_record:create',
+  'person_escort_record:update',
+  'person_escort_record:confirm',
 ]
 const pmuPermissions = [
   'allocations:view',
@@ -110,6 +130,7 @@ const pmuPermissions = [
   'moves:view:proposed',
   'move:review',
   'move:view',
+  'person_escort_record:view',
 ]
 const courtPermissions = [
   'dashboard:view',
@@ -117,6 +138,7 @@ const courtPermissions = [
   'moves:view:incoming',
   'moves:download',
   'move:view',
+  'person_escort_record:view',
 ]
 const personEscortRecordAuthorPermissions = [
   'person_escort_record:view',

--- a/common/lib/user.test.js
+++ b/common/lib/user.test.js
@@ -145,6 +145,10 @@ describe('User class', function () {
           'move:update:prison_recall',
           'move:update:police_transfer',
           'move:update:video_remand',
+          'person_escort_record:view',
+          'person_escort_record:create',
+          'person_escort_record:update',
+          'person_escort_record:confirm',
         ]
 
         expect(permissions).to.have.members(policePermissions)
@@ -166,6 +170,10 @@ describe('User class', function () {
           'move:create:court_appearance',
           'move:create:hospital',
           'move:cancel',
+          'person_escort_record:view',
+          'person_escort_record:create',
+          'person_escort_record:update',
+          'person_escort_record:confirm',
         ])
       })
     })
@@ -194,6 +202,10 @@ describe('User class', function () {
           'move:update:hospital',
           'move:cancel',
           'move:cancel:proposed',
+          'person_escort_record:view',
+          'person_escort_record:create',
+          'person_escort_record:update',
+          'person_escort_record:confirm',
           'youth_risk_assessment:view',
           'youth_risk_assessment:create',
           'youth_risk_assessment:update',
@@ -228,6 +240,10 @@ describe('User class', function () {
           'move:update:hospital',
           'move:cancel',
           'move:cancel:proposed',
+          'person_escort_record:view',
+          'person_escort_record:create',
+          'person_escort_record:update',
+          'person_escort_record:confirm',
           'youth_risk_assessment:view',
           'youth_risk_assessment:create',
           'youth_risk_assessment:update',
@@ -251,6 +267,10 @@ describe('User class', function () {
           'move:create:court_appearance',
           'move:create:hospital',
           'move:cancel',
+          'person_escort_record:view',
+          'person_escort_record:create',
+          'person_escort_record:update',
+          'person_escort_record:confirm',
         ])
       })
     })
@@ -273,6 +293,10 @@ describe('User class', function () {
           'move:create:prison_transfer',
           'move:create:secure_childrens_home',
           'move:create:secure_training_centre',
+          'person_escort_record:view',
+          'person_escort_record:create',
+          'person_escort_record:update',
+          'person_escort_record:confirm',
         ])
       })
     })
@@ -293,6 +317,7 @@ describe('User class', function () {
           'moves:view:proposed',
           'move:review',
           'move:view',
+          'person_escort_record:view',
         ])
       })
     })
@@ -327,6 +352,7 @@ describe('User class', function () {
           'moves:view:incoming',
           'moves:download',
           'move:view',
+          'person_escort_record:view',
         ])
       })
     })

--- a/common/presenters/move-to-card-component.js
+++ b/common/presenters/move-to-card-component.js
@@ -8,7 +8,6 @@ function moveToCardComponent({
   showImage = true,
   showMeta = true,
   showTags = true,
-  tagSource,
   showStatus = true,
   hrefSuffix = '',
 } = {}) {
@@ -28,7 +27,6 @@ function moveToCardComponent({
       showImage: isCompact ? false : showImage,
       showMeta: isCompact ? false : showMeta,
       showTags,
-      tagSource,
     })({
       ...profile,
       href,

--- a/common/presenters/move-to-card-component.test.js
+++ b/common/presenters/move-to-card-component.test.js
@@ -56,7 +56,6 @@ describe('Presenters', function () {
               showImage: true,
               showMeta: true,
               showTags: true,
-              tagSource: undefined,
             })
           })
 
@@ -126,28 +125,6 @@ describe('Presenters', function () {
           showImage: true,
           showMeta: true,
           showTags: true,
-          tagSource: undefined,
-        })
-      })
-    })
-
-    context('with tagSource', function () {
-      beforeEach(function () {
-        transformedResponse = moveToCardComponent({
-          tagSource: 'personEscortRecord',
-        })(mockMove)
-      })
-
-      it('should call profile to card component correctly', function () {
-        expect(profileToCardComponentItemStub).to.be.calledWithExactly({
-          ...mockMove.profile,
-          href: '/move/12345/path/to/somewhere',
-        })
-        expect(profileToCardComponentStub).to.be.calledWithExactly({
-          showImage: true,
-          showMeta: true,
-          showTags: true,
-          tagSource: 'personEscortRecord',
         })
       })
     })
@@ -168,7 +145,6 @@ describe('Presenters', function () {
           showImage: false,
           showMeta: true,
           showTags: true,
-          tagSource: undefined,
         })
       })
     })
@@ -189,7 +165,6 @@ describe('Presenters', function () {
           showImage: true,
           showMeta: false,
           showTags: true,
-          tagSource: undefined,
         })
       })
     })
@@ -210,7 +185,6 @@ describe('Presenters', function () {
           showImage: true,
           showMeta: true,
           showTags: false,
-          tagSource: undefined,
         })
       })
     })
@@ -231,7 +205,6 @@ describe('Presenters', function () {
           showImage: true,
           showMeta: true,
           showTags: true,
-          tagSource: undefined,
         })
       })
 
@@ -256,7 +229,6 @@ describe('Presenters', function () {
           showImage: false,
           showMeta: false,
           showTags: false,
-          tagSource: undefined,
         })
       })
 
@@ -291,7 +263,6 @@ describe('Presenters', function () {
           showImage: false,
           showMeta: false,
           showTags: false,
-          tagSource: undefined,
         })
       })
 

--- a/common/presenters/moves-by-location.js
+++ b/common/presenters/moves-by-location.js
@@ -22,11 +22,7 @@ function _emptyToLocation(move) {
   }
 }
 
-module.exports = function movesByLocation(
-  data,
-  locationKey = 'to_location',
-  cardTagSource
-) {
+module.exports = function movesByLocation(data, locationKey = 'to_location') {
   const locations = []
   const groupedByLocation = groupBy(
     data.map(_emptyToLocation),
@@ -35,11 +31,7 @@ module.exports = function movesByLocation(
 
   Object.entries(groupedByLocation).forEach(([locationId, moves]) => {
     locations.push({
-      items: moves.map(
-        moveToCardComponent({
-          tagSource: cardTagSource,
-        })
-      ),
+      items: moves.map(moveToCardComponent()),
       label: i18n.t(`collections::labels.${locationKey}`),
       location: get(moves[0], `${locationKey}.title`),
     })

--- a/common/presenters/moves-by-location.test.js
+++ b/common/presenters/moves-by-location.test.js
@@ -59,21 +59,7 @@ describe('Presenters', function () {
       })
 
       it('should call card presenter', function () {
-        expect(moveToCardComponentStub).to.be.calledWithExactly({
-          tagSource: undefined,
-        })
-      })
-    })
-
-    context('with cardTagSource', function () {
-      beforeEach(function () {
-        movesByLocation(mockMoves, undefined, 'tagSource')
-      })
-
-      it('should call card presenter with source', function () {
-        expect(moveToCardComponentStub).to.be.calledWithExactly({
-          tagSource: 'tagSource',
-        })
+        expect(moveToCardComponentStub).to.be.calledWithExactly()
       })
     })
 

--- a/common/presenters/profile-to-card-component.js
+++ b/common/presenters/profile-to-card-component.js
@@ -1,24 +1,18 @@
-const { filter } = require('lodash')
+const { filter, isEmpty } = require('lodash')
 
 const i18n = require('../../config/i18n')
 const filters = require('../../config/nunjucks/filters')
 
-const assessmentToTagList = require('./assessment-to-tag-list')
 const frameworkFlagsToTagList = require('./framework-flags-to-tag-list')
 
 function profileToCardComponent({
   showImage = true,
   showMeta = true,
   showTags = true,
-  tagSource,
 } = {}) {
   return function item(profile) {
-    const {
-      assessment_answers: assessmentAnswers,
-      href,
-      person = {},
-      person_escort_record: personEscortRecord,
-    } = profile || {}
+    const { href, person = {}, person_escort_record: personEscortRecord } =
+      profile || {}
     const {
       id,
       gender,
@@ -60,36 +54,27 @@ function profileToCardComponent({
     }
 
     if (showTags) {
-      let items
+      // let items
 
-      // TODO: Remove condition once PER is enabled everywhere
-      if (tagSource === 'personEscortRecord') {
-        const { flags, status } = personEscortRecord || {}
-        const isComplete =
-          personEscortRecord && !['not_started', 'in_progress'].includes(status)
+      const { flags, status } = personEscortRecord || {}
+      const isComplete =
+        personEscortRecord && !['not_started', 'in_progress'].includes(status)
 
-        if (isComplete) {
-          items = frameworkFlagsToTagList({
-            flags,
-            hrefPrefix: href,
-            includeLink: true,
-          })
-        } else {
-          card.insetText = {
-            classes: 'govuk-inset-text--compact',
-            text: i18n.t('assessment::incomplete'),
-          }
-        }
-      } else {
-        items = assessmentToTagList(assessmentAnswers, href)
-      }
-
-      if (items) {
+      if (isComplete) {
         card.tags = [
           {
-            items,
+            items: frameworkFlagsToTagList({
+              flags,
+              hrefPrefix: href,
+              includeLink: true,
+            }),
           },
         ]
+      } else if (!isEmpty(person)) {
+        card.insetText = {
+          classes: 'govuk-inset-text--compact',
+          text: i18n.t('assessment::incomplete'),
+        }
       }
     }
 

--- a/common/presenters/profile-to-card-component.test.js
+++ b/common/presenters/profile-to-card-component.test.js
@@ -11,28 +11,6 @@ const profileToCardComponent = proxyquire('./profile-to-card-component', {
 const mockProfile = {
   id: '12345',
   href: '/move/12345',
-  assessment_answers: [
-    {
-      key: 'concealed_items',
-      title: 'Concealed items',
-      category: 'risk',
-    },
-    {
-      key: 'health_issue',
-      title: 'Health issue',
-      category: 'health',
-    },
-    {
-      key: 'other_risks',
-      title: 'Any other risks',
-      category: 'risk',
-    },
-    {
-      key: 'legal_representation',
-      title: 'Solicitor or other legal representation',
-      category: 'court',
-    },
-  ],
   person: {
     id: '12345',
     _fullname: 'Name, Full',
@@ -107,32 +85,16 @@ describe('Presenters', function () {
             })
           })
 
-          it('should contain correct tags', function () {
-            expect(transformedResponse).to.have.property('tags')
-            expect(transformedResponse.tags).to.deep.equal([
-              {
-                items: [
-                  {
-                    href: '/move/12345#concealed-items',
-                    text: 'Concealed items',
-                    classes: 'app-tag--destructive',
-                    sortOrder: 1,
-                  },
-                  {
-                    href: '/move/12345#any-other-risks',
-                    text: 'Any other risks',
-                    classes: 'app-tag--destructive',
-                    sortOrder: 1,
-                  },
-                  {
-                    href: '/move/12345#health-issue',
-                    text: 'Health issue',
-                    classes: '',
-                    sortOrder: 2,
-                  },
-                ],
-              },
-            ])
+          it('should not contain correct tags', function () {
+            expect(transformedResponse).not.to.have.property('tags')
+          })
+
+          it('should contain inset text', function () {
+            expect(transformedResponse).to.have.property('insetText')
+            expect(transformedResponse.insetText).to.deep.equal({
+              classes: 'govuk-inset-text--compact',
+              text: '__translated__',
+            })
           })
 
           it('should contain correct amount of properties', function () {
@@ -161,8 +123,12 @@ describe('Presenters', function () {
             )
           })
 
+          it('should translate inset text', function () {
+            expect(i18n.t).to.be.calledWithExactly('assessment::incomplete')
+          })
+
           it('should translate correct number of times', function () {
-            expect(i18n.t).to.be.callCount(3)
+            expect(i18n.t).to.be.callCount(4)
           })
         })
       })
@@ -229,133 +195,15 @@ describe('Presenters', function () {
         })
       })
 
-      context('with assessment answers', function () {
-        let transformedResponse, mockPersonWithAnswers
-
-        beforeEach(function () {
-          mockPersonWithAnswers = {
-            href: '/move/12345',
-            last_name: 'Jones',
-            first_names: 'Steve',
-            date_of_birth: '',
-            assessment_answers: [
-              {
-                key: 'concealed_items',
-                title: 'Concealed items',
-                comments: 'Penknife found in trouser pockets',
-                date: null,
-                expiry_date: null,
-                assessment_question_id: '942a634a-2e38-49be-bfe6-ac03979620b3',
-                category: 'risk',
-              },
-              {
-                key: 'health_issue',
-                title: 'Health issue',
-                comments: 'Keeps complaining of headaches',
-                date: null,
-                expiry_date: null,
-                assessment_question_id: '5bb4f1a2-b5e3-49af-a2ef-01b0ae33429d',
-                category: 'health',
-              },
-              {
-                key: 'other_risks',
-                title: 'Any other risks',
-                comments: '',
-                date: null,
-                expiry_date: null,
-                assessment_question_id: '94cf7afd-d2c7-489f-b6c2-a6fb68cc9f15',
-                category: 'risk',
-              },
-              {
-                key: 'legal_representation',
-                title: 'Solicitor or other legal representation',
-                comments: '',
-                date: null,
-                expiry_date: null,
-                assessment_question_id: 'f191fe25-11c8-4195-bbcc-99bf508f293d',
-                category: 'court',
-              },
-              {
-                key: 'invalid_answer',
-                title: 'Invalid answer',
-                comments: '',
-                date: null,
-                expiry_date: null,
-                assessment_question_id: 'f1f1fe15-11c8-4195-bbcc-99bf508f293d',
-                category: 'invalid',
-              },
-              {
-                key: 'escape',
-                title: 'Escape',
-                comments: 'Large poster in cell',
-                date: null,
-                expiry_date: null,
-                assessment_question_id: 'f199c4fe-0134-490c-afa9-a11f3c52c32b',
-                category: 'risk',
-              },
-              {
-                key: 'diet_allergy',
-                title: 'Special diet or allergy',
-                comments: 'Vegan',
-                date: null,
-                expiry_date: null,
-                assessment_question_id: '394d3f05-4d25-43ef-8e7e-6d3a0e742888',
-                category: 'health',
-              },
-            ],
-          }
-
-          transformedResponse = profileToCardComponent()(mockPersonWithAnswers)
-        })
-
-        it('should correctly filter', function () {
-          expect(transformedResponse).to.have.property('tags')
-          expect(transformedResponse.tags.length).to.equal(1)
-          expect(transformedResponse.tags[0].items.length).to.equal(5)
-        })
-
-        it('should correctly map and sort', function () {
-          expect(transformedResponse.tags[0].items).to.deep.equal([
-            {
-              href: `${mockPersonWithAnswers.href}#concealed-items`,
-              text: 'Concealed items',
-              classes: 'app-tag--destructive',
-              sortOrder: 1,
-            },
-            {
-              href: `${mockPersonWithAnswers.href}#any-other-risks`,
-              text: 'Any other risks',
-              classes: 'app-tag--destructive',
-              sortOrder: 1,
-            },
-            {
-              href: `${mockPersonWithAnswers.href}#escape`,
-              text: 'Escape',
-              classes: 'app-tag--destructive',
-              sortOrder: 1,
-            },
-            {
-              href: `${mockPersonWithAnswers.href}#health-issue`,
-              text: 'Health issue',
-              classes: '',
-              sortOrder: 2,
-            },
-            {
-              href: `${mockPersonWithAnswers.href}#special-diet-or-allergy`,
-              text: 'Special diet or allergy',
-              classes: '',
-              sortOrder: 2,
-            },
-          ])
-        })
-      })
-
-      context('with Person Escort Record tag source', function () {
-        context('with no Person Escort Record', function () {
+      context('with Person Escort Record', function () {
+        context('with `not_started` PER', function () {
           beforeEach(function () {
-            transformedResponse = profileToCardComponent({
-              tagSource: 'personEscortRecord',
-            })(mockProfile)
+            transformedResponse = profileToCardComponent()({
+              ...mockProfile,
+              person_escort_record: {
+                status: 'not_started',
+              },
+            })
           })
 
           it('should not contain tags', function () {
@@ -377,102 +225,63 @@ describe('Presenters', function () {
           })
         })
 
-        context('with Person Escort Record', function () {
-          context('with `not_started` PER', function () {
-            beforeEach(function () {
-              transformedResponse = profileToCardComponent({
-                tagSource: 'personEscortRecord',
-              })({
-                ...mockProfile,
-                person_escort_record: {
-                  status: 'not_started',
-                },
-              })
-            })
-
-            it('should not contain tags', function () {
-              expect(transformedResponse).not.to.have.property('tags')
-            })
-
-            it('should not contain inset text message', function () {
-              expect(transformedResponse).to.have.property('insetText')
-              expect(transformedResponse.insetText).to.deep.equal({
-                classes: 'govuk-inset-text--compact',
-                text: '__translated__',
-              })
-            })
-
-            it('should translate inset text message', function () {
-              expect(i18n.t).to.have.been.calledWithExactly(
-                'assessment::incomplete'
-              )
+        context('with `in_progress` PER', function () {
+          beforeEach(function () {
+            transformedResponse = profileToCardComponent()({
+              ...mockProfile,
+              person_escort_record: {
+                status: 'in_progress',
+              },
             })
           })
 
-          context('with `in_progress` PER', function () {
-            beforeEach(function () {
-              transformedResponse = profileToCardComponent({
-                tagSource: 'personEscortRecord',
-              })({
-                ...mockProfile,
-                person_escort_record: {
-                  status: 'in_progress',
-                },
-              })
-            })
+          it('should not contain tags', function () {
+            expect(transformedResponse).not.to.have.property('tags')
+          })
 
-            it('should not contain tags', function () {
-              expect(transformedResponse).not.to.have.property('tags')
-            })
-
-            it('should not contain inset text message', function () {
-              expect(transformedResponse).to.have.property('insetText')
-              expect(transformedResponse.insetText).to.deep.equal({
-                classes: 'govuk-inset-text--compact',
-                text: '__translated__',
-              })
-            })
-
-            it('should translate inset text message', function () {
-              expect(i18n.t).to.have.been.calledWithExactly(
-                'assessment::incomplete'
-              )
+          it('should not contain inset text message', function () {
+            expect(transformedResponse).to.have.property('insetText')
+            expect(transformedResponse.insetText).to.deep.equal({
+              classes: 'govuk-inset-text--compact',
+              text: '__translated__',
             })
           })
 
-          context('with `completed` PER', function () {
-            beforeEach(function () {
-              transformedResponse = profileToCardComponent({
-                tagSource: 'personEscortRecord',
-              })({
-                ...mockProfile,
-                person_escort_record: {
-                  status: 'completed',
-                  flags: ['foo', 'bar'],
-                },
-              })
-            })
+          it('should translate inset text message', function () {
+            expect(i18n.t).to.have.been.calledWithExactly(
+              'assessment::incomplete'
+            )
+          })
+        })
 
-            it('should contain tags', function () {
-              expect(transformedResponse).to.have.property('tags')
-              expect(transformedResponse.tags[0]).to.deep.equal({
-                items: ['1', '2', '3'],
-              })
-            })
-
-            it('should call frameworkFlagsToTagList presenter', function () {
-              expect(
-                frameworkFlagsToTagListStub
-              ).to.have.been.calledWithExactly({
+        context('with `completed` PER', function () {
+          beforeEach(function () {
+            transformedResponse = profileToCardComponent()({
+              ...mockProfile,
+              person_escort_record: {
+                status: 'completed',
                 flags: ['foo', 'bar'],
-                hrefPrefix: '/move/12345',
-                includeLink: true,
-              })
+              },
             })
+          })
 
-            it('should not contain inset text message', function () {
-              expect(transformedResponse).not.to.have.property('insetText')
+          it('should contain tags', function () {
+            expect(transformedResponse).to.have.property('tags')
+            expect(transformedResponse.tags[0]).to.deep.equal({
+              items: ['1', '2', '3'],
             })
+          })
+
+          it('should call frameworkFlagsToTagList presenter', function () {
+            expect(frameworkFlagsToTagListStub).to.have.been.calledWithExactly({
+              flags: ['foo', 'bar'],
+              hrefPrefix: '/move/12345',
+              includeLink: true,
+            })
+          })
+
+          it('should not contain inset text message', function () {
+            expect(transformedResponse).not.to.have.property('insetText')
           })
         })
       })
@@ -495,11 +304,6 @@ describe('Presenters', function () {
 
       it('should contain title', function () {
         expect(transformedResponse).to.have.property('title')
-      })
-
-      it('should contain tags', function () {
-        expect(transformedResponse).to.have.property('tags')
-        expect(transformedResponse.tags[0].items.length).to.equal(3)
       })
     })
 
@@ -566,7 +370,6 @@ describe('Presenters', function () {
       classes: 'app-card--placeholder',
       title: { text: '__translated__' },
       meta: { items: [] },
-      tags: [{ items: [] }],
       image_path: undefined,
       image_alt: '__translated__',
     }

--- a/test/e2e/pages/move-detail.js
+++ b/test/e2e/pages/move-detail.js
@@ -216,7 +216,6 @@ class MoveDetailPage extends Page {
 
   async checkAssessment(selector, selectedItems, labelMap) {
     for (const key of selectedItems) {
-      const tag = this.nodes.tags.withText(key.toUpperCase())
       const panel = selector
         .find('.app-tag')
         .withText(key.toUpperCase())
@@ -225,8 +224,6 @@ class MoveDetailPage extends Page {
 
       // check answer panel exists
       await t.expect(panel.exists).ok()
-      // check answer tag exists
-      await t.expect(tag.exists).ok()
 
       // if comment was entered, check it is displayed
       if (comment) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

This set of changes removes and tidies up logic that was written to allow the Person Escort Record to be rolled out on a permission basis.

### Why did it change

This feature is now available to all users so we don't need to hide it behind a permission any longer.

## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [x] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed

### Other considerations

Commit messages with a `fix` or `feat` type are automatically used to generate the [changelog](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/CHANGELOG.md) and
[GitHub release notes](https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/releases) during the release task. Please make sure they will read well on their own in a
summary of changes and that the commit body gives a more detailed description of those changes if necessary.

- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
- [x] Update [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md) with any new instructions or tasks
