### PR TITLE
Add breadcrumbs to Person Escort Record and Youth Risk Assessment

### DIFF
--- a/app/person-escort-record/index.js
+++ b/app/person-escort-record/index.js
@@ -9,7 +9,9 @@ const { uuidRegex } = require('../../common/helpers/url')
 const { defineFormWizard } = require('../../common/lib/framework-form-wizard')
 const {
   setAssessment,
+  setBreadcrumbs,
   setFrameworkSection,
+  setSectionBreadcrumb,
   setRecord,
 } = require('../../common/middleware/framework')
 const { protectRoute } = require('../../common/middleware/permissions')
@@ -27,6 +29,7 @@ router.use(newApp.mountpath, newApp.router)
 router.use(protectRoute('person_escort_record:view'))
 router.use(setRecord('personEscortRecord', 'personEscortRecord', 'getById'))
 router.use(setAssessment('personEscortRecord'))
+router.use(setBreadcrumbs)
 
 // Define sub-apps
 router.use(confirmApp.mountpath, confirmApp.router)
@@ -34,7 +37,7 @@ router.use(confirmApp.mountpath, confirmApp.router)
 // Define routes
 router.get('/', frameworkOverviewController)
 router.get('/print', printRecordController)
-router.use('/:section', defineFormWizard)
+router.use('/:section', setSectionBreadcrumb, defineFormWizard)
 
 // Export
 module.exports = {

--- a/app/youth-risk-assessment/index.js
+++ b/app/youth-risk-assessment/index.js
@@ -9,8 +9,10 @@ const { uuidRegex } = require('../../common/helpers/url')
 const { defineFormWizard } = require('../../common/lib/framework-form-wizard')
 const {
   setAssessment,
+  setBreadcrumbs,
   setFrameworkSection,
   setRecord,
+  setSectionBreadcrumb,
 } = require('../../common/middleware/framework')
 const { protectRoute } = require('../../common/middleware/permissions')
 
@@ -27,13 +29,14 @@ router.use(protectRoute('youth_risk_assessment:view'))
 // router.use(setPersonEscortRecord)
 router.use(setRecord('youthRiskAssessment', 'youthRiskAssessment', 'getById'))
 router.use(setAssessment('youthRiskAssessment'))
+router.use(setBreadcrumbs)
 
 // Define sub-apps
 router.use(confirmApp.mountpath, confirmApp.router)
 
 // Define routes
 router.get('/', frameworkOverviewController)
-router.use('/:section', defineFormWizard)
+router.use('/:section', setSectionBreadcrumb, defineFormWizard)
 
 // Export
 module.exports = {

--- a/common/controllers/framework/framework-step.js
+++ b/common/controllers/framework/framework-step.js
@@ -75,6 +75,7 @@ class FrameworkStepController extends FormWizardController {
     this.use(this.setSyncStatusBanner)
     this.use(this.setPrefillBanner)
     this.use(this.seti18nContext)
+    this.use(this.setBreadcrumb)
     this.use(setMoveWithSummary)
   }
 
@@ -85,6 +86,14 @@ class FrameworkStepController extends FormWizardController {
 
   setPageTitleLocals(req, res, next) {
     res.locals.frameworkSection = req.frameworkSection.name
+    next()
+  }
+
+  setBreadcrumb(req, res, next) {
+    res.breadcrumb({
+      text: req.form.options.pageTitle,
+    })
+
     next()
   }
 

--- a/common/controllers/framework/framework-step.test.js
+++ b/common/controllers/framework/framework-step.test.js
@@ -85,6 +85,7 @@ describe('Framework controllers', function () {
         sinon.stub(controller, 'setSyncStatusBanner')
         sinon.stub(controller, 'setPrefillBanner')
         sinon.stub(controller, 'seti18nContext')
+        sinon.stub(controller, 'setBreadcrumb')
         sinon.stub(controller, 'use')
 
         controller.middlewareLocals()
@@ -119,6 +120,12 @@ describe('Framework controllers', function () {
         )
       })
 
+      it('should call set breadcrumbs', function () {
+        expect(controller.use).to.have.been.calledWithExactly(
+          controller.setBreadcrumb
+        )
+      })
+
       it('should call set move summary', function () {
         expect(controller.use).to.have.been.calledWithExactly(
           setMoveWithSummary
@@ -126,7 +133,7 @@ describe('Framework controllers', function () {
       })
 
       it('should call correct number of middleware', function () {
-        expect(controller.use).to.be.callCount(5)
+        expect(controller.use).to.be.callCount(6)
       })
     })
 
@@ -173,6 +180,35 @@ describe('Framework controllers', function () {
         it('should call next without error', function () {
           expect(nextSpy).to.be.calledOnceWithExactly()
         })
+      })
+    })
+
+    describe('#setBreadcrumb', function () {
+      let mockReq, mockRes, nextSpy
+
+      beforeEach(function () {
+        nextSpy = sinon.spy()
+        mockReq = {
+          form: {
+            options: {
+              pageTitle: 'Step title',
+            },
+          },
+        }
+        mockRes = {
+          breadcrumb: sinon.stub().returnsThis(),
+        }
+        controller.setBreadcrumb(mockReq, mockRes, nextSpy)
+      })
+
+      it('should set breadcrumb item', function () {
+        expect(mockRes.breadcrumb).to.have.been.calledOnceWithExactly({
+          text: 'Step title',
+        })
+      })
+
+      it('should call next without error', function () {
+        expect(nextSpy).to.be.calledOnceWithExactly()
       })
     })
 

--- a/common/middleware/framework/index.js
+++ b/common/middleware/framework/index.js
@@ -1,9 +1,13 @@
 const setAssessment = require('./set-assessment')
+const setBreadcrumbs = require('./set-breadcrumbs')
 const setFrameworkSection = require('./set-framework-section')
 const setRecord = require('./set-record')
+const setSectionBreadcrumb = require('./set-section-breadcrumb')
 
 module.exports = {
   setAssessment,
+  setBreadcrumbs,
   setFrameworkSection,
   setRecord,
+  setSectionBreadcrumb,
 }

--- a/common/middleware/framework/set-breadcrumbs.js
+++ b/common/middleware/framework/set-breadcrumbs.js
@@ -1,0 +1,28 @@
+const { snakeCase } = require('lodash')
+
+function setBreadcrumbs(req, res, next) {
+  const { assessment = {}, move } = req
+  const moveId = move?.id || assessment?.move?.id
+  const profile = move?.profile || assessment?.profile
+  const frameworkName = assessment.framework.name
+
+  res
+    .breadcrumb({
+      text: req.t('moves::detail.page_title', {
+        name: profile.person._fullname,
+      }),
+      href: `/move/${moveId}`,
+    })
+    .breadcrumb({
+      text: req.t('assessment::page_title', {
+        context: snakeCase(frameworkName),
+      }),
+      href: move
+        ? `/move/${moveId}/${frameworkName}`
+        : `/${frameworkName}/${assessment.id}`,
+    })
+
+  next()
+}
+
+module.exports = setBreadcrumbs

--- a/common/middleware/framework/set-breadcrumbs.test.js
+++ b/common/middleware/framework/set-breadcrumbs.test.js
@@ -1,0 +1,123 @@
+const middleware = require('./set-breadcrumbs')
+
+describe('Framework middleware', function () {
+  describe('#setBreacrumbs', function () {
+    let mockReq, mockRes, nextSpy
+
+    beforeEach(function () {
+      nextSpy = sinon.spy()
+      mockReq = {
+        t: sinon.stub().returnsArg(0),
+      }
+      mockRes = {
+        breadcrumb: sinon.stub().returnsThis(),
+      }
+    })
+
+    context('when move exists on request', function () {
+      beforeEach(function () {
+        mockReq.assessment = {
+          id: '__assessment_12345__',
+          framework: {
+            name: 'assessment-name',
+          },
+        }
+        mockReq.move = {
+          id: '__move_12345__',
+          profile: {
+            person: {
+              _fullname: 'DOE, JOHN',
+            },
+          },
+        }
+        middleware(mockReq, mockRes, nextSpy)
+      })
+
+      it('should set move breadcrumb item', function () {
+        expect(mockRes.breadcrumb).to.have.been.calledWithExactly({
+          text: 'moves::detail.page_title',
+          href: '/move/__move_12345__',
+        })
+      })
+
+      it('should set assessment breadcrumb item', function () {
+        expect(mockRes.breadcrumb).to.have.been.calledWithExactly({
+          text: 'assessment::page_title',
+          href: '/move/__move_12345__/assessment-name',
+        })
+      })
+
+      it('should translate correctly', function () {
+        expect(mockReq.t).to.have.been.calledWithExactly(
+          'moves::detail.page_title',
+          {
+            name: 'DOE, JOHN',
+          }
+        )
+        expect(mockReq.t).to.have.been.calledWithExactly(
+          'assessment::page_title',
+          {
+            context: 'assessment_name',
+          }
+        )
+      })
+
+      it('should call next without error', function () {
+        expect(nextSpy).to.be.calledOnceWithExactly()
+      })
+    })
+
+    context('when no move exists on request', function () {
+      beforeEach(function () {
+        mockReq.assessment = {
+          id: '__assessment_12345__',
+          framework: {
+            name: 'assessment-name',
+          },
+          profile: {
+            person: {
+              _fullname: 'DOE, JOHN',
+            },
+          },
+          move: {
+            id: '__move_12345__',
+          },
+        }
+        middleware(mockReq, mockRes, nextSpy)
+      })
+
+      it('should set move breadcrumb item', function () {
+        expect(mockRes.breadcrumb).to.have.been.calledWithExactly({
+          text: 'moves::detail.page_title',
+          href: '/move/__move_12345__',
+        })
+      })
+
+      it('should set assessment breadcrumb item', function () {
+        expect(mockRes.breadcrumb).to.have.been.calledWithExactly({
+          text: 'assessment::page_title',
+          href: '/assessment-name/__assessment_12345__',
+        })
+      })
+
+      it('should translate correctly', function () {
+        expect(mockReq.t).to.have.been.calledWithExactly(
+          'moves::detail.page_title',
+          {
+            name: 'DOE, JOHN',
+          }
+        )
+        expect(mockReq.t).to.have.been.calledWithExactly(
+          'assessment::page_title',
+          {
+            context: 'assessment_name',
+          }
+        )
+      })
+
+      it('should call next without error', function () {
+        expect(nextSpy).to.be.calledOnceWithExactly()
+      })
+    })
+  })
+})

--- a/common/middleware/framework/set-section-breadcrumb.js
+++ b/common/middleware/framework/set-section-breadcrumb.js
@@ -1,0 +1,10 @@
+function setSectionBreadcrumb(req, res, next) {
+  res.breadcrumb({
+    text: req.frameworkSection.name,
+    href: req.baseUrl,
+  })
+
+  next()
+}
+
+module.exports = setSectionBreadcrumb

--- a/common/middleware/framework/set-section-breadcrumb.test.js
+++ b/common/middleware/framework/set-section-breadcrumb.test.js
@@ -1,0 +1,32 @@
+const middleware = require('./set-section-breadcrumb')
+
+describe('Framework middleware', function () {
+  describe('#setSectionBreadcrumb', function () {
+    let mockReq, mockRes, nextSpy
+
+    beforeEach(function () {
+      nextSpy = sinon.spy()
+      mockReq = {
+        baseUrl: '/base-url',
+        frameworkSection: {
+          name: 'Framework name',
+        },
+      }
+      mockRes = {
+        breadcrumb: sinon.stub().returnsThis(),
+      }
+      middleware(mockReq, mockRes, nextSpy)
+    })
+
+    it('should set breadcrumb item', function () {
+      expect(mockRes.breadcrumb).to.have.been.calledOnceWithExactly({
+        text: 'Framework name',
+        href: '/base-url',
+      })
+    })
+
+    it('should call next without error', function () {
+      expect(nextSpy).to.be.calledOnceWithExactly()
+    })
+  })
+})

--- a/common/templates/framework-overview.njk
+++ b/common/templates/framework-overview.njk
@@ -11,17 +11,6 @@
   }) }} – {{ SERVICE_NAME }}
 {% endblock %}
 
-{% block beforeContent %}
-  {% if moveId %}
-    {{ govukBackLink({
-      text: t("actions::back_to_move"),
-      href: "/move/" + moveId
-    }) }}
-  {% endif %}
-
-  {{ super() }}
-{% endblock %}
-
 {% block contentHeader %}
   <header class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">

--- a/common/templates/framework-section.njk
+++ b/common/templates/framework-section.njk
@@ -8,21 +8,6 @@
   – {{ SERVICE_NAME }}
 {% endblock %}
 
-{% macro backLink() %}
-  {% if moveId %}
-    {{ govukBackLink({
-      text: t("actions::back_to_move"),
-      href: "/move/" + moveId
-    }) }}
-  {% endif %}
-{% endmacro %}
-
-{% block beforeContent %}
-  {{ backLink() }}
-
-  {{ super() }}
-{% endblock %}
-
 {% block content %}
   <header class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
@@ -72,8 +57,6 @@
     </div>
 
   </div>
-
-  {{ backLink() }}
 {% endblock %}
 
 {% block footer %}

--- a/locales/en/moves.json
+++ b/locales/en/moves.json
@@ -108,7 +108,7 @@
     }
   },
   "detail": {
-    "page_title": "Move details for {{name}}",
+    "page_title": "Move for {{name}}",
     "court_hearings": {
       "heading": "Court hearing",
       "heading_plural": "Court hearings",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

This change adds a breadcrumb for the assessment sections and steps.

### Why did it change

This makes navigating around the assessments easier and gives users
an anchor when going through steps/sections.

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

- [P4-XXXX]()

## Screenshots
<!--- (Optional) Include screenshots if changes update interfaces or components -->
<!--- Delete/copy as appropriate --->

| Before | After |
| ------ | ----- |
| <kbd>![image](https://user-images.githubusercontent.com/3327997/102901122-82b5ab00-446d-11eb-8a47-50359608550a.png)</kbd> | <kbd>![image](https://user-images.githubusercontent.com/3327997/102900704-f905dd80-446c-11eb-8011-f661d5d5f881.png)</kbd> |


## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [x] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed
