### PR TITLE
Store transaction ID in Sentry and pass to API calls

### DIFF
--- a/common/lib/api-client/request-headers.js
+++ b/common/lib/api-client/request-headers.js
@@ -17,5 +17,9 @@ module.exports = (req, format = 'application/vnd.api+json') => {
     headers['X-Current-User'] = req.user.username
   }
 
+  if (req && req.transactionId) {
+    headers['X-Transaction-ID'] = req.transactionId
+  }
+
   return headers
 }

--- a/common/lib/api-client/request-headers.test.js
+++ b/common/lib/api-client/request-headers.test.js
@@ -101,5 +101,37 @@ describe('API Client', function () {
         expect('X-Current-User' in headers).to.equal(false)
       })
     })
+
+    context('without request', function () {
+      let headers
+
+      beforeEach(function () {
+        headers = getRequestHeaders(undefined, 'format/foo')
+      })
+
+      it('should not add Current User Header', function () {
+        expect('X-Current-User' in headers).to.equal(false)
+      })
+
+      it('should not add Current User Header', function () {
+        expect('X-Transaction-ID' in headers).to.equal(false)
+      })
+    })
+
+    context('with transaction ID', function () {
+      let headers
+      let req
+
+      beforeEach(function () {
+        req = {
+          transactionId: '12345-aaaaa',
+        }
+        headers = getRequestHeaders(req)
+      })
+
+      it('should add transaction ID header', function () {
+        expect(headers['X-Transaction-ID']).to.equal('12345-aaaaa')
+      })
+    })
   })
 })

--- a/common/middleware/sentry-request-id.js
+++ b/common/middleware/sentry-request-id.js
@@ -1,10 +1,12 @@
 const Sentry = require('@sentry/node')
 
 module.exports = function sentryRequestId(req, res, next) {
-  const requestId = req.headers['x-request-id']
+  // This is defined in a previous middleware and uses the x-request-id if available
+  const transactionId = req.transactionId
 
-  if (requestId) {
-    Sentry.setTag('request_id', requestId)
+  if (transactionId) {
+    Sentry.setTag('request_id', transactionId)
+    Sentry.setTag('transaction_id', transactionId)
   }
 
   next()

--- a/common/middleware/sentry-request-id.test.js
+++ b/common/middleware/sentry-request-id.test.js
@@ -8,13 +8,11 @@ describe('#sentryRequestId', function () {
   beforeEach(function () {
     sinon.stub(Sentry, 'setTag')
     nextSpy = sinon.spy()
-    req = {
-      headers: {},
-    }
+    req = {}
     res = {}
   })
 
-  context('without request header', function () {
+  context('without transaction id', function () {
     beforeEach(function () {
       sentryRequestId(req, res, nextSpy)
     })
@@ -28,9 +26,9 @@ describe('#sentryRequestId', function () {
     })
   })
 
-  context('with request header', function () {
+  context('with transaction id', function () {
     beforeEach(function () {
-      req.headers['x-request-id'] = '12345-aaaaa'
+      req.transactionId = '12345-aaaaa'
       sentryRequestId(req, res, nextSpy)
     })
 
@@ -38,8 +36,15 @@ describe('#sentryRequestId', function () {
       expect(nextSpy).to.be.calledOnceWithExactly()
     })
 
-    it('should set location tags in Sentry', function () {
+    it('should set request ID tag in Sentry', function () {
       expect(Sentry.setTag).to.be.calledWithExactly('request_id', '12345-aaaaa')
+    })
+
+    it('should set transaction ID tag in Sentry', function () {
+      expect(Sentry.setTag).to.be.calledWithExactly(
+        'transaction_id',
+        '12345-aaaaa'
+      )
     })
   })
 })

--- a/common/middleware/set-transaction-id.js
+++ b/common/middleware/set-transaction-id.js
@@ -1,0 +1,8 @@
+const uuid = require('uuid')
+
+const setTransactionId = (req, res, next) => {
+  req.transactionId = req.get('x-request-id') || uuid.v4()
+  next()
+}
+
+module.exports = setTransactionId

--- a/common/middleware/set-transaction-id.test.js
+++ b/common/middleware/set-transaction-id.test.js
@@ -1,0 +1,58 @@
+const proxyquire = require('proxyquire').noCallThru()
+
+const uuid = {}
+
+const setTransactionId = proxyquire('./set-transaction-id', {
+  uuid,
+})
+
+describe('Middleware', function () {
+  describe('#setTranasctionId', function () {
+    let next
+    let req
+    beforeEach(function () {
+      uuid.v4 = sinon.stub().returns('#uuid')
+      next = sinon.spy()
+      req = {
+        get: sinon.stub(),
+      }
+    })
+
+    context('When request has no request id', function () {
+      beforeEach(function () {
+        setTransactionId(req, {}, next)
+      })
+
+      it('should check the x-request-id header', function () {
+        expect(req.get).to.be.calledOnceWithExactly('x-request-id')
+      })
+
+      it('should create an id for the request', function () {
+        expect(uuid.v4).to.be.calledOnceWithExactly()
+      })
+
+      it('should set the transaction id on the request', function () {
+        expect(req.transactionId).to.equal('#uuid')
+      })
+    })
+
+    context('When request has an request id', function () {
+      beforeEach(function () {
+        req.get.returns('#xRequestId')
+        setTransactionId(req, {}, next)
+      })
+
+      it('should check the x-request-id header', function () {
+        expect(req.get).to.be.calledOnceWithExactly('x-request-id')
+      })
+
+      it('should not create an id for the request', function () {
+        expect(uuid.v4).to.not.be.called
+      })
+
+      it('should set the transaction id on the request', function () {
+        expect(req.transactionId).to.equal('#xRequestId')
+      })
+    })
+  })
+})

--- a/server.js
+++ b/server.js
@@ -35,6 +35,7 @@ const setApiClient = require('./common/middleware/set-api-client')
 const setLocations = require('./common/middleware/set-locations')
 const setPrimaryNavigation = require('./common/middleware/set-primary-navigation')
 const setServices = require('./common/middleware/set-services')
+const setTransactionId = require('./common/middleware/set-transaction-id')
 const setUser = require('./common/middleware/set-user')
 const config = require('./config')
 const i18n = require('./config/i18n')
@@ -54,6 +55,9 @@ const app = express()
 if (config.IS_PRODUCTION) {
   app.enable('trust proxy')
 }
+
+// Ensure we have a useful transaction id
+app.use(setTransactionId)
 
 if (config.SENTRY.DSN) {
   Sentry.init({


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

This uses the request ID header to store against sentry issues and also
passes that same value to API calls.

### Why did it change

This allows a particular frontend request can be traced through to particular API calls that might have
errorred.
