### PR TITLE
fix: Prevent metrics error from recent dep upgrade

### DIFF
--- a/common/lib/metrics.js
+++ b/common/lib/metrics.js
@@ -170,8 +170,11 @@ const summaryRoute = (req, res, next) => {
 
   const contentType = promster.getContentType()
   res.setHeader('Content-Type', contentType)
-  const summary = promster.getSummary()
-  res.end(summary)
+
+  promster
+    .getSummary()
+    .then(result => res.end(result))
+    .catch(next)
 }
 
 module.exports = {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

This change adjusts the controller handling the response to expect a promise from now on.

### Why did it change

The recent dependency bump for promster included a breaking change,
even though the version didn't show a major version change:
https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/pull/1188

The call to get the summary became a promise. 

Fixes BOOK-A-SECURE-MOVE-FRONTEND-2A

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

https://sentry.io/organizations/ministryofjustice/issues/2109959785