### PR TITLE
refactor: Separate request ID and transaction ID in Sentry tags

### DIFF
--- a/common/middleware/sentry-request-id.js
+++ b/common/middleware/sentry-request-id.js
@@ -1,11 +1,15 @@
 const Sentry = require('@sentry/node')
 
 module.exports = function sentryRequestId(req, res, next) {
+  const requestId = req.get('x-request-id')
   // This is defined in a previous middleware and uses the x-request-id if available
   const transactionId = req.transactionId
 
+  if (requestId) {
+    Sentry.setTag('request_id', requestId)
+  }
+
   if (transactionId) {
-    Sentry.setTag('request_id', transactionId)
     Sentry.setTag('transaction_id', transactionId)
   }
 

--- a/common/middleware/sentry-request-id.test.js
+++ b/common/middleware/sentry-request-id.test.js
@@ -8,11 +8,13 @@ describe('#sentryRequestId', function () {
   beforeEach(function () {
     sinon.stub(Sentry, 'setTag')
     nextSpy = sinon.spy()
-    req = {}
+    req = {
+      get: sinon.stub(),
+    }
     res = {}
   })
 
-  context('without transaction id', function () {
+  context('without any ids', function () {
     beforeEach(function () {
       sentryRequestId(req, res, nextSpy)
     })
@@ -36,8 +38,45 @@ describe('#sentryRequestId', function () {
       expect(nextSpy).to.be.calledOnceWithExactly()
     })
 
+    it('should set transaction ID tag in Sentry', function () {
+      expect(Sentry.setTag).to.be.calledOnceWithExactly(
+        'transaction_id',
+        '12345-aaaaa'
+      )
+    })
+  })
+
+  context('with request id', function () {
+    beforeEach(function () {
+      req.get.withArgs('x-request-id').returns('67890-bbbbb')
+      sentryRequestId(req, res, nextSpy)
+    })
+
+    it('should call next', function () {
+      expect(nextSpy).to.be.calledOnceWithExactly()
+    })
+
     it('should set request ID tag in Sentry', function () {
-      expect(Sentry.setTag).to.be.calledWithExactly('request_id', '12345-aaaaa')
+      expect(Sentry.setTag).to.be.calledOnceWithExactly(
+        'request_id',
+        '67890-bbbbb'
+      )
+    })
+  })
+
+  context('with both ids', function () {
+    beforeEach(function () {
+      req.transactionId = '12345-aaaaa'
+      req.get.withArgs('x-request-id').returns('67890-bbbbb')
+      sentryRequestId(req, res, nextSpy)
+    })
+
+    it('should call next', function () {
+      expect(nextSpy).to.be.calledOnceWithExactly()
+    })
+
+    it('should set request ID tag in Sentry', function () {
+      expect(Sentry.setTag).to.be.calledWithExactly('request_id', '67890-bbbbb')
     })
 
     it('should set transaction ID tag in Sentry', function () {
@@ -45,6 +84,10 @@ describe('#sentryRequestId', function () {
         'transaction_id',
         '12345-aaaaa'
       )
+    })
+
+    it('should set correct number of tags', function () {
+      expect(Sentry.setTag).to.be.calledTwice
     })
   })
 })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

This change separates the two variables and allows them to be set
independently.

### Why did it change

Before we were always using the transaction ID for Sentry tags.

But in the case where the request ID doesn't exist, we don't want
to set it in Sentry, we'd rather leave it unset which shows there
was no request ID available.

## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [x] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed
