### PR TITLE
chore: Add support for split pagination modifier

### DIFF
--- a/common/components/pagination/_pagination.scss
+++ b/common/components/pagination/_pagination.scss
@@ -97,3 +97,31 @@
     }
   }
 }
+
+.app-pagination--split {
+  @include govuk-clearfix;
+
+  .app-pagination__list-item--prev {
+    float: left;
+    width: 49%;
+  }
+
+  .app-pagination__list-item--next {
+    float: right;
+    width: 49%;
+    text-align: right;
+
+    .app-pagination__link-text {
+      margin-left: 0;
+      margin-right: govuk-spacing(2);
+    }
+
+    .app-pagination__link-icon {
+      float: right;
+    }
+    .app-pagination__link-label {
+      margin-left: 0;
+      margin-right: 25px;
+    }
+  }
+}

--- a/common/components/pagination/pagination.yaml
+++ b/common/components/pagination/pagination.yaml
@@ -73,13 +73,6 @@ examples:
       next:
         href: "/next-day"
         text: "Next day"
-  - name: inline variation
-    data:
-      classes: app-pagination--inline
-      previous:
-        href: "/previous-page"
-      next:
-        href: "/next-page"
   - name: with items
     data:
       previous:
@@ -93,27 +86,6 @@ examples:
           text: "two"
         - href: "/page-3"
           text: "three"
-  - name: with items with class
-    data:
-      previous:
-        href: "/previous-page"
-      next:
-        href: "/next-page"
-      items:
-        - href: "/page-1"
-          text: "one"
-          classes: "item-class"
-  - name: with items with attributes
-    data:
-      previous:
-        href: "/previous-page"
-      next:
-        href: "/next-page"
-      items:
-        - href: "/page-1"
-          text: "one"
-          attributes:
-            data-foo: "bar"
   - name: with inline items
     data:
       classes: app-pagination--inline
@@ -128,3 +100,19 @@ examples:
           text: "2"
         - href: "/page-3"
           text: "3"
+  - name: inline variation
+    data:
+      classes: app-pagination--inline
+      previous:
+        href: "/previous-page"
+      next:
+        href: "/next-page"
+  - name: split variation
+    data:
+      classes: app-pagination--split
+      previous:
+        href: "/previous-page"
+        label: "1 of 300"
+      next:
+        href: "/next-page"
+        label: "3 of 300"

--- a/common/components/pagination/template.test.js
+++ b/common/components/pagination/template.test.js
@@ -184,60 +184,72 @@ describe('Pagination component', function () {
       expect($itemLink.attr('href')).to.equal('/page-3')
     })
   })
-})
 
-context('with items with class', function () {
-  let $, $component, items
+  context('with items with class', function () {
+    let $, $component, items
 
-  beforeEach(function () {
-    $ = renderComponentHtmlToCheerio(
-      'pagination',
-      examples['with items with class']
-    )
-    $component = $('.app-pagination')
-    items = $component.find('.app-pagination__list-item')
+    beforeEach(function () {
+      $ = renderComponentHtmlToCheerio('pagination', {
+        items: [
+          {
+            href: '/page-1',
+            text: 'one',
+            classes: 'item-class',
+          },
+        ],
+      })
+      $component = $('.app-pagination')
+      items = $component.find('.app-pagination__list-item')
+    })
+
+    it('should render correct number of items', function () {
+      const $items = $component.find('.app-pagination__list-item')
+      expect($items.length).to.equal(1)
+    })
+
+    it('should render item class', function () {
+      const $item = $(items[0])
+      const $itemText = $item.find('.app-pagination__link-text')
+      const $itemLink = $item.find('a')
+
+      expect($itemText.text().trim()).to.equal('one')
+      expect($itemLink.attr('href')).to.equal('/page-1')
+      expect($item.hasClass('item-class')).to.be.true
+    })
   })
 
-  it('should render correct number of items', function () {
-    const $items = $component.find('.app-pagination__list-item')
-    expect($items.length).to.equal(3)
-  })
+  context('with items with attributes', function () {
+    let $, $component, items
 
-  it('should render item class', function () {
-    const $item = $(items[1])
-    const $itemText = $item.find('.app-pagination__link-text')
-    const $itemLink = $item.find('a')
+    beforeEach(function () {
+      $ = renderComponentHtmlToCheerio('pagination', {
+        items: [
+          {
+            href: '/page-1',
+            text: 'one',
+            attributes: {
+              'data-foo': 'bar',
+            },
+          },
+        ],
+      })
+      $component = $('.app-pagination')
+      items = $component.find('.app-pagination__list-item')
+    })
 
-    expect($itemText.text().trim()).to.equal('one')
-    expect($itemLink.attr('href')).to.equal('/page-1')
-    expect($item.hasClass('item-class')).to.be.true
-  })
-})
+    it('should render correct number of items', function () {
+      const $items = $component.find('.app-pagination__list-item')
+      expect($items.length).to.equal(1)
+    })
 
-context('with items with attributes', function () {
-  let $, $component, items
+    it('should render item class', function () {
+      const $item = $(items[0])
+      const $itemText = $item.find('.app-pagination__link-text')
+      const $itemLink = $item.find('a')
 
-  beforeEach(function () {
-    $ = renderComponentHtmlToCheerio(
-      'pagination',
-      examples['with items with attributes']
-    )
-    $component = $('.app-pagination')
-    items = $component.find('.app-pagination__list-item')
-  })
-
-  it('should render correct number of items', function () {
-    const $items = $component.find('.app-pagination__list-item')
-    expect($items.length).to.equal(3)
-  })
-
-  it('should render item class', function () {
-    const $item = $(items[1])
-    const $itemText = $item.find('.app-pagination__link-text')
-    const $itemLink = $item.find('a')
-
-    expect($itemText.text().trim()).to.equal('one')
-    expect($itemLink.attr('href')).to.equal('/page-1')
-    expect($item.attr('data-foo')).to.equal('bar')
+      expect($itemText.text().trim()).to.equal('one')
+      expect($itemLink.attr('href')).to.equal('/page-1')
+      expect($item.attr('data-foo')).to.equal('bar')
+    })
   })
 })


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Add a modifier to the pagination component to allow it to be split across the container element.

Also includes a tidy up to the examples. Examples should only show visual changes. Custom options are document in the yaml files and should be tested within creating visual examples that will be rendered in the component explorer.

### Why did it change

This allows pagination to be displayed on either side of the container
element and will be used to pagination results in a collection.

## Screenshots
<!--- (Optional) Include screenshots if changes update interfaces or components -->
<!--- Delete/copy as appropriate --->

<kbd>![image](https://user-images.githubusercontent.com/3327997/103294355-06354600-49f2-11eb-8b50-e9baaa9aa893.png)</kbd>

[**DEMO**](https://booksecuremove-pr-1202.herokuapp.com/components/pagination)

## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [x] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed
