### PR TITLE
refactor: Rename pagination to be date specific

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -39,7 +39,7 @@ There are a variety of generic middleware that are provided from within the [com
 - `setActions` - sets potential actions during the routing setup phase
 - `setContext` - sets the `context` used by [i18next](https://www.i18next.com/translation-function/context) to specific content within a generalised template
 - `setDateRange` - sets the `dateRange` used by the weekly views
-- `setPagination` - sets the pagination object used for day/week pagination. Note: This is not for numeric pagination of table data.
+- `setDatePagination` - sets the pagination object used for day/week pagination. Note: This is not for numeric pagination of table data.
 
 ## Orchestration
 
@@ -54,4 +54,4 @@ There are also three specific kinds of orchestration middleware used by this app
 - [Services](../common/services) are the only part of application that should have knowledge of the backend services. This means that  API specific properties, e.g. `filter[from_location]` should contained within this service and exposed in a different way, such as a paremter of `fromLocationId`. This also allows the rest of the application to maintain a consistency, while the API is changed and upgraded.
 - Properties should be added to `req` as needed, and other middleware functions can use these properties as required. `res.locals` should be reserved only for data that will definitely be rendered in some way - often data on the `req` object can replace this usage.
 - Filter properties are used for the filter component and not for specific filtering of service data. If non-configurable data filtering is required, this can usually be more carefully hidden behind a service convenience method.
- 
+

--- a/app/allocations/index.js
+++ b/app/allocations/index.js
@@ -6,8 +6,8 @@ const {
   redirectView,
   setActions,
   setContext,
+  setDatePagination,
   setDateRange,
-  setPagination,
 } = require('../../common/middleware/collection')
 const { protectRoute } = require('../../common/middleware/permissions')
 
@@ -36,7 +36,7 @@ router.get(
   COLLECTION_PATH,
   setActions(ACTIONS),
   setContext('allocations'),
-  setPagination(MOUNTPATH + COLLECTION_PATH),
+  setDatePagination(MOUNTPATH + COLLECTION_PATH),
   [
     setBodyAllocations,
     setResultsAllocations,

--- a/app/moves/constants.js
+++ b/app/moves/constants.js
@@ -1,7 +1,7 @@
 const { dateRegex, uuidRegex } = require('../../common/helpers/url')
 const {
   setActions,
-  setPagination,
+  setDatePagination,
 } = require('../../common/middleware/collection')
 
 const actions = [
@@ -20,7 +20,7 @@ const COLLECTION_VIEW_PATH = '/:view(outgoing|incoming|requested)'
 
 const COLLECTION_MIDDLEWARE = [
   setActions(actions),
-  setPagination(MOUNTPATH + COLLECTION_BASE_PATH + COLLECTION_VIEW_PATH),
+  setDatePagination(MOUNTPATH + COLLECTION_BASE_PATH + COLLECTION_VIEW_PATH),
 ]
 
 const DEFAULTS = {

--- a/app/population/index.js
+++ b/app/population/index.js
@@ -5,7 +5,7 @@ const FormWizardController = require('../../common/controllers/form-wizard')
 const {
   setContext,
   setDateRange,
-  setPagination,
+  setDatePagination,
 } = require('../../common/middleware/collection')
 const wizard = require('../../common/middleware/unique-form-wizard')
 
@@ -43,7 +43,7 @@ router.use(DAILY_PATH, setBreadcrumb, dailyRouter)
 router.get(
   BASE_PATH,
   setContext('population'),
-  setPagination(MOUNTPATH + BASE_PATH),
+  setDatePagination(MOUNTPATH + BASE_PATH),
   setResultsAsPopulationTables,
   dashboard
 )

--- a/common/controllers/collection/render-as-cards.js
+++ b/common/controllers/collection/render-as-cards.js
@@ -1,5 +1,5 @@
 module.exports = function listAsCards(req, res) {
-  const { actions, context, pagination, params, resultsAsCards } = req
+  const { actions, context, datePagination, params, resultsAsCards } = req
   const { dateRange, locationId, period } = params
   const canViewMove = req.canAccess('move:view')
   const template =
@@ -8,7 +8,7 @@ module.exports = function listAsCards(req, res) {
     actions,
     context,
     dateRange,
-    pagination,
+    datePagination,
     period,
     resultsAsCards,
   }

--- a/common/controllers/collection/render-as-cards.test.js
+++ b/common/controllers/collection/render-as-cards.test.js
@@ -22,7 +22,7 @@ describe('Collection controllers', function () {
         canAccess: sinon.stub().returns(false),
         actions: ['1', '2'],
         context: 'listContext',
-        pagination: mockPagination,
+        datePagination: mockPagination,
         params: {
           dateRange: ['2020-10-01', '2020-10-10'],
           period: 'day',
@@ -68,6 +68,12 @@ describe('Collection controllers', function () {
         const params = res.render.args[0][1]
         expect(params).to.have.property('dateRange')
         expect(params.dateRange).to.deep.equal(req.params.dateRange)
+      })
+
+      it('should contain datePagination property', function () {
+        const params = res.render.args[0][1]
+        expect(params).to.have.property('datePagination')
+        expect(params.datePagination).to.deep.equal(req.datePagination)
       })
 
       it('should contain period property', function () {

--- a/common/controllers/collection/render-as-table.js
+++ b/common/controllers/collection/render-as-table.js
@@ -1,15 +1,15 @@
 const { sumBy } = require('lodash')
 
 module.exports = function listAsTable(req, res) {
-  const { actions, context, filter, pagination, resultsAsTable } = req
+  const { actions, datePagination, context, filter, resultsAsTable } = req
   const { dateRange, period } = req.params
 
   res.render('collection-as-table', {
     actions,
     context,
+    datePagination,
     dateRange,
     filter,
-    pagination,
     period,
     resultsAsTable,
     activeStatus: req.query.status,

--- a/common/middleware/collection/index.js
+++ b/common/middleware/collection/index.js
@@ -2,14 +2,14 @@ const redirectDefaultQuery = require('./redirect-default-query')
 const redirectView = require('./redirect-view')
 const setActions = require('./set-actions')
 const setContext = require('./set-context')
+const setDatePagination = require('./set-date-pagination')
 const setDateRange = require('./set-date-range')
-const setPagination = require('./set-pagination')
 
 module.exports = {
   redirectDefaultQuery,
   redirectView,
   setActions,
   setContext,
+  setDatePagination,
   setDateRange,
-  setPagination,
 }

--- a/common/middleware/collection/set-date-pagination.js
+++ b/common/middleware/collection/set-date-pagination.js
@@ -5,7 +5,7 @@ const { DATE_FORMATS } = require('../../../config')
 const dateHelpers = require('../../helpers/date')
 const urlHelpers = require('../../helpers/url')
 
-function setPagination(route) {
+function setDatePagination(route) {
   return function handlePagination(req, res, next) {
     const { date, period } = req.params
 
@@ -14,7 +14,7 @@ function setPagination(route) {
     const prevDate = dateHelpers.getRelativeDate(date, -interval)
     const nextDate = dateHelpers.getRelativeDate(date, interval)
 
-    req.pagination = {
+    req.datePagination = {
       todayUrl: urlHelpers.compileFromRoute(route, req, { date: today }),
       nextUrl: urlHelpers.compileFromRoute(route, req, { date: nextDate }),
       prevUrl: urlHelpers.compileFromRoute(route, req, { date: prevDate }),
@@ -27,4 +27,4 @@ function setPagination(route) {
   }
 }
 
-module.exports = setPagination
+module.exports = setDatePagination

--- a/common/middleware/collection/set-date-pagination.test.js
+++ b/common/middleware/collection/set-date-pagination.test.js
@@ -2,14 +2,14 @@ const proxyquire = require('proxyquire')
 
 const urlHelpers = require('../../helpers/url')
 
-const middleware = proxyquire('./set-pagination', {
+const middleware = proxyquire('./set-date-pagination', {
   '../../../app/date-select/constants': {
     MOUNTPATH: '/datejumper',
   },
 })
 
 describe('Moves middleware', function () {
-  describe('#setPagination()', function () {
+  describe('#setDatePagination()', function () {
     const mockToday = '2020-10-10'
     const mockDate = '2019-10-10'
     const mockRoute = '/moves/:date/:locationId?'
@@ -42,10 +42,10 @@ describe('Moves middleware', function () {
           middleware(mockRoute)(req, res, nextSpy)
         })
         it('should contain pagination on req', function () {
-          expect(req).to.have.property('pagination')
+          expect(req).to.have.property('datePagination')
         })
         it('should set today link', function () {
-          expect(req.pagination.todayUrl).to.equal(mockRoute)
+          expect(req.datePagination.todayUrl).to.equal(mockRoute)
           expect(urlHelpers.compileFromRoute).to.be.calledWithExactly(
             mockRoute,
             req,
@@ -55,7 +55,7 @@ describe('Moves middleware', function () {
           )
         })
         it('should set next link', function () {
-          expect(req.pagination.nextUrl).to.equal(mockRoute)
+          expect(req.datePagination.nextUrl).to.equal(mockRoute)
           expect(urlHelpers.compileFromRoute).to.be.calledWithExactly(
             mockRoute,
             req,
@@ -65,7 +65,7 @@ describe('Moves middleware', function () {
           )
         })
         it('should set previous link', function () {
-          expect(req.pagination.prevUrl).to.equal(mockRoute)
+          expect(req.datePagination.prevUrl).to.equal(mockRoute)
           expect(urlHelpers.compileFromRoute).to.be.calledWithExactly(
             mockRoute,
             req,
@@ -75,7 +75,7 @@ describe('Moves middleware', function () {
           )
         })
         it('should set date select link', function () {
-          expect(req.pagination.dateSelectUrl).to.equal(
+          expect(req.datePagination.dateSelectUrl).to.equal(
             '/datejumper?referrer=/foo%3Fbar%3Dbaz'
           )
         })
@@ -90,10 +90,10 @@ describe('Moves middleware', function () {
           middleware(mockRoute)(req, res, nextSpy)
         })
         it('should contain pagination on req', function () {
-          expect(req).to.have.property('pagination')
+          expect(req).to.have.property('datePagination')
         })
         it('should set today link', function () {
-          expect(req.pagination.todayUrl).to.equal(mockRoute)
+          expect(req.datePagination.todayUrl).to.equal(mockRoute)
           expect(urlHelpers.compileFromRoute).to.be.calledWithExactly(
             mockRoute,
             req,
@@ -103,7 +103,7 @@ describe('Moves middleware', function () {
           )
         })
         it('should set next link', function () {
-          expect(req.pagination.nextUrl).to.equal(mockRoute)
+          expect(req.datePagination.nextUrl).to.equal(mockRoute)
           expect(urlHelpers.compileFromRoute).to.be.calledWithExactly(
             mockRoute,
             req,
@@ -113,7 +113,7 @@ describe('Moves middleware', function () {
           )
         })
         it('should set previous link', function () {
-          expect(req.pagination.prevUrl).to.equal(mockRoute)
+          expect(req.datePagination.prevUrl).to.equal(mockRoute)
           expect(urlHelpers.compileFromRoute).to.be.calledWithExactly(
             mockRoute,
             req,
@@ -133,10 +133,10 @@ describe('Moves middleware', function () {
           middleware(mockRoute)(req, res, nextSpy)
         })
         it('should contain pagination on req', function () {
-          expect(req).to.have.property('pagination')
+          expect(req).to.have.property('datePagination')
         })
         it('should set today link', function () {
-          expect(req.pagination.todayUrl).to.equal(mockRoute)
+          expect(req.datePagination.todayUrl).to.equal(mockRoute)
           expect(urlHelpers.compileFromRoute).to.be.calledWithExactly(
             mockRoute,
             req,
@@ -146,7 +146,7 @@ describe('Moves middleware', function () {
           )
         })
         it('should set next link', function () {
-          expect(req.pagination.nextUrl).to.equal(mockRoute)
+          expect(req.datePagination.nextUrl).to.equal(mockRoute)
           expect(urlHelpers.compileFromRoute).to.be.calledWithExactly(
             mockRoute,
             req,
@@ -156,7 +156,7 @@ describe('Moves middleware', function () {
           )
         })
         it('should set previous link', function () {
-          expect(req.pagination.prevUrl).to.equal(mockRoute)
+          expect(req.datePagination.prevUrl).to.equal(mockRoute)
           expect(urlHelpers.compileFromRoute).to.be.calledWithExactly(
             mockRoute,
             req,

--- a/common/templates/layouts/collection.njk
+++ b/common/templates/layouts/collection.njk
@@ -36,25 +36,25 @@
         </h1>
 
         {% block dateNavigation %}
-          {% if pagination %}
+          {% if datePagination %}
             {{ appPagination({
               classes: "app-pagination--inline app-print--hide",
               previous: {
-                href: pagination.prevUrl,
+                href: datePagination.prevUrl,
                 text: t("actions::previous", { context: period })
               },
               next: {
-                href: pagination.nextUrl,
+                href: datePagination.nextUrl,
                 text: t("actions::next", { context: period })
               },
               items: [{
-                href: pagination.todayUrl,
+                href: datePagination.todayUrl,
                 text: t("actions::current", { context: period }),
                 attributes: {
                   'data-pagination-action': 'today'
                 }
               },{
-                href: pagination.dateSelectUrl,
+                href: datePagination.dateSelectUrl,
                 text: t("actions::date_select"),
                 attributes: {
                   'data-pagination-action': 'date-select'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

This change makes the date pagination used for rendering resources
within a collection specific to the type of pagination it is - date.

### Why did it change

There is some future work to introduce pagination to cycle through
pages so this separation will allow that work to be introduced more
easily.
