### PR TITLE
fix: Make sure error response exists first before using in debugging

### DIFF
--- a/common/lib/api-client/middleware/request.js
+++ b/common/lib/api-client/middleware/request.js
@@ -47,11 +47,11 @@ function requestMiddleware({ cacheExpiry = 60, useRedisCache = false } = {}) {
           return res
         })
         .catch(error => {
-          debug(
-            `${error.response.status} ${error.response.statusText}`,
-            `(${req.method} ${url})`,
-            error
-          )
+          const debugMessage = error.response
+            ? `${error.response.status} ${error.response.statusText}`
+            : error.message
+          debug(debugMessage, `(${req.method} ${url})`, error)
+
           // record error
           const duration = clientTimer()
           clientMetrics.recordError(req, error, duration)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

This uses optional chaining to ensure the parent property exists
before trying to use the nested property.

### Why did it change

The debugger was updated to use the response code and text from the
error. But it seems in some cases the response doesn't exist.

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

https://sentry.io/organizations/ministryofjustice/issues/2118879002/?project=2014813

Fixes BOOK-A-SECURE-MOVE-FRONTEND-2F
