### PR TITLE
Set expected dates within test blocks so they use mock dates

### DIFF
--- a/common/parsers/index.test.js
+++ b/common/parsers/index.test.js
@@ -11,16 +11,21 @@ const getExpectedDate = (
   return expectedDate
 }
 
-const marchCurrentYear = getExpectedDate()
-const octoberCurrentYear = getExpectedDate(undefined, '3 October')
-const march2019 = getExpectedDate(2019)
-const october2019 = getExpectedDate(2019, '3 October')
-
 describe('Parsers', function () {
   describe('#date', function () {
+    let marchCurrentYear
+    let octoberCurrentYear
+    let march2019
+    let october2019
+
     beforeEach(function () {
       const mockDate = new Date('2020-06-01')
       this.clock = sinon.useFakeTimers(mockDate.getTime())
+
+      marchCurrentYear = getExpectedDate()
+      octoberCurrentYear = getExpectedDate(undefined, '3 October')
+      march2019 = getExpectedDate(2019)
+      october2019 = getExpectedDate(2019, '3 October')
     })
 
     afterEach(function () {


### PR DESCRIPTION




<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

This change moves the variables so that they are set within mochas test
blocks and will therefore use the mocked dates correctly.

### Why did it change

The expected dates for these tests were set outside the test blocks
which means they don't use the mock dates used by the tests.

This worked up until we changed year to 2021.
