### PR TITLE
[P4-2595] Group moves by vehicle on incoming and outgoing dashboards

### DIFF
--- a/app/moves/constants.js
+++ b/app/moves/constants.js
@@ -26,8 +26,8 @@ const COLLECTION_MIDDLEWARE = [
 const DEFAULTS = {
   QUERY: {
     requested: { status: 'pending' },
-    outgoing: { status: 'active' },
-    incoming: { status: 'active' },
+    outgoing: { status: 'active', group_by: 'location' },
+    incoming: { status: 'active', group_by: 'location' },
   },
   TIME_PERIOD: {
     requested: 'week',

--- a/app/moves/middleware/set-results.moves.js
+++ b/app/moves/middleware/set-results.moves.js
@@ -4,6 +4,8 @@ const presenters = require('../../../common/presenters')
 
 function setResultsMoves(bodyKey, locationKey) {
   return async function handleResults(req, res, next) {
+    const { group_by: groupBy } = req.query
+
     try {
       if (!req.session?.currentLocation) {
         return next()
@@ -12,7 +14,18 @@ function setResultsMoves(bodyKey, locationKey) {
       const args = omitBy(req.body[bodyKey], isUndefined)
       const activeMoves = await req.services.move.getActive(args)
 
-      req.resultsAsCards = presenters.movesByLocation(activeMoves, locationKey)
+      if (groupBy === 'vehicle') {
+        req.resultsAsCards = presenters.movesByVehicle({
+          moves: activeMoves,
+          context: locationKey === 'from_location' ? 'incoming' : 'outgoing',
+          showLocations: !req.session?.currentLocation,
+        })
+      } else {
+        req.resultsAsCards = presenters.movesByLocation(
+          activeMoves,
+          locationKey
+        )
+      }
 
       next()
     } catch (error) {

--- a/common/presenters/index.js
+++ b/common/presenters/index.js
@@ -25,6 +25,7 @@ const moveToSummaryListComponent = require('./move-to-summary-list-component')
 const moveToTimelineComponent = require('./move-to-timeline-component')
 const moveTypesToFilterComponent = require('./move-type-for-filter')
 const movesByLocation = require('./moves-by-location')
+const movesByVehicle = require('./moves-by-vehicle')
 const personToSummaryListComponent = require('./person-to-summary-list-component')
 const populationToGrid = require('./population-to-grid')
 const profileToCardComponent = require('./profile-to-card-component')
@@ -52,6 +53,7 @@ module.exports = {
   frameworkStepToSummary,
   frameworkToTaskListComponent,
   movesByLocation,
+  movesByVehicle,
   moveToAdditionalInfoListComponent,
   moveToCardComponent,
   moveToImportantEventsTagListComponent,

--- a/common/presenters/moves-by-vehicle.js
+++ b/common/presenters/moves-by-vehicle.js
@@ -1,0 +1,95 @@
+const { isToday, parseISO } = require('date-fns')
+const { isEmpty, get, groupBy, orderBy, sortBy } = require('lodash')
+
+const i18n = require('../../config/i18n')
+const filters = require('../../config/nunjucks/filters')
+const componentService = require('../services/component')
+
+const moveToCardComponent = require('./move-to-card-component')
+
+module.exports = function movesByVehicle({
+  moves,
+  context = 'outgoing',
+  showLocations = false,
+} = {}) {
+  const groups = []
+  const grouped = groupBy(moves, '_vehicleRegistration')
+  const expectedTimeProperty =
+    context === 'outgoing' ? '_expectedCollectionTime' : '_expectedArrivalTime'
+
+  Object.entries(grouped).forEach(([group, groupedItems]) => {
+    const vehicleRegistration = groupedItems[0]._vehicleRegistration
+    const sortedByTime = sortBy(groupedItems, expectedTimeProperty)
+    const expectedTime = get(sortedByTime[0], expectedTimeProperty)
+    const isComplete = groupedItems.every(
+      move => move[context === 'outgoing' ? '_hasLeftCustody' : '_hasArrived']
+    )
+    const showRelativeTime = !isComplete && isToday(parseISO(expectedTime))
+    const items = sortBy(groupedItems, 'profile.person._fullname').map(
+      moveToCardComponent({
+        showToLocation: showLocations || context === 'outgoing',
+        showFromLocation: showLocations || context === 'incoming',
+      })
+    )
+    const timeData = {
+      datetime: expectedTime,
+      text: filters.formatTime(expectedTime),
+    }
+    const timeComponent = componentService.getComponent('appTime', timeData)
+
+    let timeHTML = expectedTime
+      ? timeComponent
+      : i18n.t('collections::labels.no_expected_time')
+
+    if (showRelativeTime) {
+      timeHTML += componentService.getComponent('appTime', {
+        ...timeData,
+        relative: true,
+        displayAsTag: true,
+        imminentOffset: 60,
+      })
+    }
+
+    if (isComplete) {
+      timeHTML += componentService.getComponent('govukTag', {
+        html: i18n.t('collections::labels.complete', {
+          context: context,
+        }),
+        classes: 'govuk-tag--green',
+      })
+    }
+
+    groups.push({
+      expectedTime,
+      items,
+      isComplete,
+      hasVehicle: !isEmpty(vehicleRegistration),
+      vehicleRegistration,
+      header: [
+        {
+          label: i18n.t('collections::labels.vehicle_registration'),
+          value:
+            vehicleRegistration ||
+            i18n.t('collections::labels.awaiting_vehicle'),
+          classes: 'govuk-grid-column-one-quarter',
+        },
+        {
+          label: i18n.t('collections::labels.expected_time', { context }),
+          value: timeHTML,
+          classes: 'govuk-grid-column-one-half',
+        },
+        {
+          label: i18n.t('people'),
+          value: items.length,
+          classes: 'govuk-grid-column-one-quarter',
+        },
+      ],
+    })
+  })
+
+  return orderBy(
+    groups,
+    ['isComplete', 'hasVehicle', 'expectedTime', 'vehicleRegistration'],
+    ['asc', 'desc', 'asc', 'asc']
+  )
+}

--- a/common/presenters/moves-by-vehicle.test.js
+++ b/common/presenters/moves-by-vehicle.test.js
@@ -1,0 +1,743 @@
+const proxyquire = require('proxyquire')
+
+const i18n = require('../../config/i18n')
+const filters = require('../../config/nunjucks/filters')
+const componentService = require('../services/component')
+const moveToCardComponentStub = sinon
+  .stub()
+  .callsFake(() => sinon.stub().returnsArg(0))
+const movesByVehicle = proxyquire('./moves-by-vehicle', {
+  './move-to-card-component': moveToCardComponentStub,
+})
+
+describe('Presenters', function () {
+  describe('#movesByVehicle()', function () {
+    beforeEach(function () {
+      sinon.stub(i18n, 't').returnsArg(0)
+      sinon.stub(filters, 'formatTime').returnsArg(0)
+      sinon.stub(componentService, 'getComponent').returnsArg(0)
+      moveToCardComponentStub.resetHistory()
+    })
+
+    context('without moves', function () {
+      it('should return empty array', function () {
+        const moves = movesByVehicle()
+        expect(moves).to.deep.equal([])
+      })
+    })
+
+    context('with moves', function () {
+      let output
+
+      describe('grouping', function () {
+        const mockMoves = [
+          {
+            id: 'id_1',
+          },
+          {
+            id: 'id_2',
+            _vehicleRegistration: 'GH12 AUQ',
+          },
+          {
+            id: 'id_3',
+            _vehicleRegistration: 'BD19 OGS',
+          },
+          {
+            id: 'id_4',
+          },
+          {
+            id: 'id_5',
+            _vehicleRegistration: 'BD19 OGS',
+          },
+          {
+            id: 'id_6',
+            _vehicleRegistration: 'LM45 AMA',
+          },
+          {
+            id: 'id_6',
+            _vehicleRegistration: 'BD19 OGS',
+          },
+        ]
+
+        beforeEach(function () {
+          output = movesByVehicle({ moves: mockMoves })
+        })
+
+        it('should contain correct number of groups', function () {
+          expect(output).to.have.length(4)
+        })
+
+        it('should return correct groups', function () {
+          const registrations = output.map(group => group.vehicleRegistration)
+          expect(registrations).to.deep.equal([
+            'BD19 OGS',
+            'GH12 AUQ',
+            'LM45 AMA',
+            undefined,
+          ])
+        })
+
+        it('should return correct number in each group', function () {
+          const items = output.map(group => group.items.length)
+          expect(items).to.deep.equal([3, 1, 1, 2])
+        })
+
+        it('should return correct items for each group', function () {
+          const items = output.map(group => group.items.map(move => move.id))
+          expect(items).to.deep.equal([
+            ['id_3', 'id_5', 'id_6'],
+            ['id_2'],
+            ['id_6'],
+            ['id_1', 'id_4'],
+          ])
+        })
+
+        describe('headers', function () {
+          it('should set vehicle registration header', function () {
+            expect(
+              output.every(
+                group =>
+                  group.header[0].label ===
+                  'collections::labels.vehicle_registration'
+              )
+            ).to.be.true
+
+            expect(
+              output.every(
+                group =>
+                  group.header[0].classes === 'govuk-grid-column-one-quarter'
+              )
+            ).to.be.true
+
+            const items = output.map(group => group.header[0].value)
+            expect(items).to.deep.equal([
+              'BD19 OGS',
+              'GH12 AUQ',
+              'LM45 AMA',
+              'collections::labels.awaiting_vehicle',
+            ])
+          })
+
+          it('should set expected time header', function () {
+            expect(
+              output.every(
+                group =>
+                  group.header[1].label === 'collections::labels.expected_time'
+              )
+            ).to.be.true
+
+            expect(
+              output.every(
+                group =>
+                  group.header[1].classes === 'govuk-grid-column-one-half'
+              )
+            ).to.be.true
+
+            const items = output.map(group => group.header[1].value)
+            expect(items).to.deep.equal([
+              'collections::labels.no_expected_time',
+              'collections::labels.no_expected_time',
+              'collections::labels.no_expected_time',
+              'collections::labels.no_expected_time',
+            ])
+          })
+
+          it('should set people header', function () {
+            expect(
+              output.every(group => group.header[2].label === 'people')
+            ).to.be.true
+
+            expect(
+              output.every(
+                group =>
+                  group.header[2].classes === 'govuk-grid-column-one-quarter'
+              )
+            ).to.be.true
+
+            const items = output.map(group => group.header[2].value)
+            expect(items).to.deep.equal([3, 1, 1, 2])
+          })
+        })
+      })
+
+      describe('group ordering', function () {
+        context('with outgoing context', function () {
+          const mockMoves = [
+            {
+              id: 'id_1',
+              _vehicleRegistration: 'XT19 GQM',
+            },
+            {
+              id: 'id_2',
+              _vehicleRegistration: 'GH12 AUQ',
+            },
+            {
+              id: 'id_3',
+              _vehicleRegistration: 'LM45 AMA',
+              _hasLeftCustody: true,
+              _expectedCollectionTime: '2019-10-10T16:00:00Z',
+            },
+            {
+              id: 'id_4',
+            },
+            {
+              id: 'id_5',
+              _vehicleRegistration: 'BD19 OGS',
+              _hasLeftCustody: true,
+              _expectedCollectionTime: '2019-10-10T14:00:00Z',
+            },
+            {
+              id: 'id_6',
+              _vehicleRegistration: 'LM45 AMA',
+              _hasLeftCustody: true,
+              _expectedCollectionTime: '2019-10-10T16:00:00Z',
+            },
+            {
+              id: 'id_7',
+              _vehicleRegistration: 'BD19 OGS',
+              _hasLeftCustody: true,
+              _expectedCollectionTime: '2019-10-10T14:00:00Z',
+            },
+            {
+              id: 'id_8',
+              _vehicleRegistration: 'AY16 PAM',
+              _expectedCollectionTime: '2019-10-10T14:00:00Z',
+            },
+            {
+              id: 'id_9',
+              _vehicleRegistration: 'IQ20 RNA',
+              _expectedCollectionTime: '2019-10-10T10:00:00Z',
+            },
+          ]
+
+          beforeEach(function () {
+            output = movesByVehicle({ moves: mockMoves })
+          })
+
+          it('should order groups correctly', function () {
+            const registrations = output.map(group => group.vehicleRegistration)
+            expect(registrations).to.deep.equal([
+              'IQ20 RNA',
+              'AY16 PAM',
+              'GH12 AUQ',
+              'XT19 GQM',
+              undefined,
+              'BD19 OGS',
+              'LM45 AMA',
+            ])
+          })
+        })
+
+        context('with incoming context', function () {
+          const mockMoves = [
+            {
+              id: 'id_1',
+              _vehicleRegistration: 'XT19 GQM',
+            },
+            {
+              id: 'id_2',
+              _vehicleRegistration: 'GH12 AUQ',
+            },
+            {
+              id: 'id_3',
+              _vehicleRegistration: 'LM45 AMA',
+              _hasArrived: true,
+              _expectedCollectionTime: '2019-10-10T16:00:00Z',
+            },
+            {
+              id: 'id_4',
+            },
+            {
+              id: 'id_5',
+              _vehicleRegistration: 'BD19 OGS',
+              _hasArrived: true,
+              _expectedCollectionTime: '2019-10-10T14:00:00Z',
+            },
+            {
+              id: 'id_6',
+              _vehicleRegistration: 'LM45 AMA',
+              _hasArrived: false,
+              _expectedCollectionTime: '2019-10-10T16:00:00Z',
+            },
+            {
+              id: 'id_7',
+              _vehicleRegistration: 'BD19 OGS',
+              _hasArrived: true,
+              _expectedCollectionTime: '2019-10-10T14:00:00Z',
+            },
+            {
+              id: 'id_8',
+              _vehicleRegistration: 'AY16 PAM',
+              _expectedCollectionTime: '2019-10-10T14:00:00Z',
+            },
+            {
+              id: 'id_9',
+              _vehicleRegistration: 'IQ20 RNA',
+              _expectedCollectionTime: '2019-10-10T10:00:00Z',
+            },
+          ]
+
+          beforeEach(function () {
+            output = movesByVehicle({ moves: mockMoves, context: 'incoming' })
+          })
+
+          it('should order groups correctly', function () {
+            const registrations = output.map(group => group.vehicleRegistration)
+            expect(registrations).to.deep.equal([
+              'AY16 PAM',
+              'GH12 AUQ',
+              'IQ20 RNA',
+              'LM45 AMA',
+              'XT19 GQM',
+              undefined,
+              'BD19 OGS',
+            ])
+          })
+        })
+      })
+
+      context('with outgoing context', function () {
+        const mockMoves = [
+          {
+            id: 'id_1',
+            _hasLeftCustody: true,
+            _hasArrived: false,
+            _expectedCollectionTime: '2020-10-10T10:50:00Z',
+            _expectedArrivalTime: '2020-10-10T13:30:00Z',
+          },
+        ]
+
+        beforeEach(function () {
+          output = movesByVehicle({ moves: mockMoves, context: 'outgoing' })
+        })
+
+        it('should call presenter with both locations enabled', function () {
+          expect(moveToCardComponentStub).to.be.calledWithExactly({
+            showToLocation: true,
+            showFromLocation: false,
+          })
+        })
+
+        it('should use correct time property', function () {
+          expect(output[0].expectedTime).to.equal('2020-10-10T10:50:00Z')
+        })
+
+        it('should set complete correctly', function () {
+          expect(output[0].isComplete).to.be.true
+        })
+      })
+
+      context('with incoming context', function () {
+        const mockMoves = [
+          {
+            id: 'id_1',
+            _hasLeftCustody: true,
+            _hasArrived: false,
+            _expectedCollectionTime: '2020-10-10T10:50:00Z',
+            _expectedArrivalTime: '2020-10-10T13:30:00Z',
+          },
+        ]
+
+        beforeEach(function () {
+          output = movesByVehicle({ moves: mockMoves, context: 'incoming' })
+        })
+
+        it('should call presenter with both locations enabled', function () {
+          expect(moveToCardComponentStub).to.be.calledWithExactly({
+            showToLocation: false,
+            showFromLocation: true,
+          })
+        })
+
+        it('should use correct time property', function () {
+          expect(output[0].expectedTime).to.equal('2020-10-10T13:30:00Z')
+        })
+
+        it('should set complete correctly', function () {
+          expect(output[0].isComplete).to.be.false
+        })
+      })
+
+      context('with show locations enabled', function () {
+        const mockMoves = [
+          {
+            id: 'id_1',
+          },
+        ]
+
+        beforeEach(function () {
+          output = movesByVehicle({ moves: mockMoves, showLocations: true })
+        })
+
+        it('should call presenter with both locations enabled', function () {
+          expect(moveToCardComponentStub).to.be.calledWithExactly({
+            showToLocation: true,
+            showFromLocation: true,
+          })
+        })
+      })
+
+      context('with no vehicle registration', function () {
+        const mockMoves = [
+          {
+            id: 'id_1',
+          },
+        ]
+
+        beforeEach(function () {
+          output = movesByVehicle({ moves: mockMoves })
+        })
+
+        it('should set group with undefined vehicle registration', function () {
+          expect(output[0].vehicleRegistration).to.be.undefined
+        })
+
+        it('should use fallback for vehicle header', function () {
+          const items = output.map(group => group.header[0].value)
+          expect(items).to.deep.equal(['collections::labels.awaiting_vehicle'])
+        })
+      })
+
+      describe('move ordering', function () {
+        const mockMoves = [
+          {
+            id: 'id_1',
+            profile: {
+              person: {
+                _fullname: 'SMITH, JOHN',
+              },
+            },
+          },
+          {
+            id: 'id_2',
+            profile: {
+              person: {
+                _fullname: 'MILLAR, PAUL',
+              },
+            },
+          },
+          {
+            id: 'id_3',
+            profile: {
+              person: {
+                _fullname: 'STEVENS, ANDREW',
+              },
+            },
+          },
+          {
+            id: 'id_4',
+            profile: {
+              person: {
+                _fullname: 'DOE, JANE',
+              },
+            },
+          },
+        ]
+
+        beforeEach(function () {
+          output = movesByVehicle({ moves: mockMoves })
+        })
+
+        it('should order moves by name', function () {
+          const items = output.map(group => group.items.map(move => move.id))
+          expect(items).to.deep.equal([['id_4', 'id_2', 'id_1', 'id_3']])
+        })
+      })
+
+      describe('expected time', function () {
+        const mockMoves = [
+          {
+            id: 'id_1',
+            _expectedCollectionTime: '2020-10-10T14:00:00',
+          },
+          {
+            id: 'id_2',
+            _expectedCollectionTime: '2020-10-10T15:00:00',
+          },
+          {
+            id: 'id_3',
+            _expectedCollectionTime: '2020-10-10T10:00:00',
+          },
+        ]
+
+        beforeEach(function () {
+          output = movesByVehicle({ moves: mockMoves })
+        })
+
+        it('should set expected time to earliest', function () {
+          expect(output[0].expectedTime).to.equal('2020-10-10T10:00:00')
+        })
+
+        it('should set expected time in label', function () {
+          const items = output.map(group => group.header[1].value)
+          expect(items).to.deep.equal(['appTime'])
+        })
+
+        it('should call correct set of components', function () {
+          expect(componentService.getComponent).to.be.calledOnceWithExactly(
+            'appTime',
+            {
+              datetime: '2020-10-10T10:00:00',
+              text: '2020-10-10T10:00:00',
+            }
+          )
+        })
+      })
+
+      describe('relative time', function () {
+        context('when today', function () {
+          let clock
+
+          beforeEach(function () {
+            const now = new Date('2020-10-10T15:09:00Z')
+            clock = sinon.useFakeTimers(now.getTime())
+          })
+
+          afterEach(function () {
+            clock.restore()
+          })
+
+          context('when moves are not complete', function () {
+            const mockMoves = [
+              {
+                id: 'id_1',
+                _expectedCollectionTime: '2020-10-10T14:00:00',
+                _hasLeftCustody: false,
+              },
+            ]
+
+            beforeEach(function () {
+              output = movesByVehicle({ moves: mockMoves })
+            })
+
+            it('should set expected time in label', function () {
+              const items = output.map(group => group.header[1].value)
+              expect(items).to.deep.equal(['appTimeappTime'])
+            })
+
+            it('should call correct set of components', function () {
+              expect(componentService.getComponent).to.be.calledTwice
+              expect(
+                componentService.getComponent.getCall(0)
+              ).to.be.calledWithExactly('appTime', {
+                datetime: '2020-10-10T14:00:00',
+                text: '2020-10-10T14:00:00',
+              })
+              expect(
+                componentService.getComponent.getCall(1)
+              ).to.be.calledWithExactly('appTime', {
+                datetime: '2020-10-10T14:00:00',
+                text: '2020-10-10T14:00:00',
+                relative: true,
+                displayAsTag: true,
+                imminentOffset: 60,
+              })
+            })
+          })
+
+          context('when moves are complete', function () {
+            const mockMoves = [
+              {
+                id: 'id_1',
+                _expectedCollectionTime: '2020-10-10T14:00:00',
+                _hasLeftCustody: true,
+              },
+            ]
+
+            beforeEach(function () {
+              output = movesByVehicle({ moves: mockMoves })
+            })
+
+            it('should set expected time in label', function () {
+              const items = output.map(group => group.header[1].value)
+              expect(items).to.deep.equal(['appTimegovukTag'])
+            })
+
+            it('should call correct set of components', function () {
+              expect(componentService.getComponent).to.be.calledTwice
+              expect(
+                componentService.getComponent.getCall(0)
+              ).to.be.calledWithExactly('appTime', {
+                datetime: '2020-10-10T14:00:00',
+                text: '2020-10-10T14:00:00',
+              })
+              expect(
+                componentService.getComponent.getCall(1)
+              ).to.be.calledWithExactly('govukTag', {
+                html: 'collections::labels.complete',
+                classes: 'govuk-tag--green',
+              })
+            })
+          })
+        })
+
+        context('when not today', function () {
+          let clock
+
+          beforeEach(function () {
+            const now = new Date('2020-10-05T15:09:00Z')
+            clock = sinon.useFakeTimers(now.getTime())
+          })
+
+          afterEach(function () {
+            clock.restore()
+          })
+
+          context('when moves are not complete', function () {
+            const mockMoves = [
+              {
+                id: 'id_1',
+                _expectedCollectionTime: '2020-10-10T14:00:00',
+                _hasLeftCustody: false,
+              },
+            ]
+
+            beforeEach(function () {
+              output = movesByVehicle({ moves: mockMoves })
+            })
+
+            it('should set expected time in label', function () {
+              const items = output.map(group => group.header[1].value)
+              expect(items).to.deep.equal(['appTime'])
+            })
+
+            it('should call correct set of components', function () {
+              expect(componentService.getComponent).to.be.calledOnceWithExactly(
+                'appTime',
+                {
+                  datetime: '2020-10-10T14:00:00',
+                  text: '2020-10-10T14:00:00',
+                }
+              )
+            })
+          })
+
+          context('when moves are complete', function () {
+            const mockMoves = [
+              {
+                id: 'id_1',
+                _expectedCollectionTime: '2020-10-10T14:00:00',
+                _hasLeftCustody: true,
+              },
+            ]
+
+            beforeEach(function () {
+              output = movesByVehicle({ moves: mockMoves })
+            })
+
+            it('should set expected time in label', function () {
+              const items = output.map(group => group.header[1].value)
+              expect(items).to.deep.equal(['appTimegovukTag'])
+            })
+
+            it('should call correct set of components', function () {
+              expect(componentService.getComponent).to.be.calledTwice
+              expect(
+                componentService.getComponent.getCall(0)
+              ).to.be.calledWithExactly('appTime', {
+                datetime: '2020-10-10T14:00:00',
+                text: '2020-10-10T14:00:00',
+              })
+              expect(
+                componentService.getComponent.getCall(1)
+              ).to.be.calledWithExactly('govukTag', {
+                html: 'collections::labels.complete',
+                classes: 'govuk-tag--green',
+              })
+            })
+          })
+        })
+      })
+
+      describe('complete moves', function () {
+        context('with outgoing context', function () {
+          context('with all complete moves', function () {
+            const mockMoves = [
+              {
+                id: 'id_1',
+                _hasLeftCustody: true,
+              },
+              {
+                id: 'id_2',
+                _hasLeftCustody: true,
+              },
+            ]
+
+            beforeEach(function () {
+              output = movesByVehicle({ moves: mockMoves })
+            })
+
+            it('should mark group as complete', function () {
+              expect(output[0].isComplete).to.be.true
+            })
+          })
+
+          context('with some incomplete', function () {
+            const mockMoves = [
+              {
+                id: 'id_1',
+                _hasLeftCustody: true,
+              },
+              {
+                id: 'id_2',
+                _hasLeftCustody: false,
+              },
+            ]
+
+            beforeEach(function () {
+              output = movesByVehicle({ moves: mockMoves })
+            })
+
+            it('should not mark group as complete', function () {
+              expect(output[0].isComplete).to.be.false
+            })
+          })
+        })
+
+        context('with incoming context', function () {
+          context('with all complete moves', function () {
+            const mockMoves = [
+              {
+                id: 'id_1',
+                _hasArrived: true,
+              },
+              {
+                id: 'id_2',
+                _hasArrived: true,
+              },
+            ]
+
+            beforeEach(function () {
+              output = movesByVehicle({ moves: mockMoves, context: 'incoming' })
+            })
+
+            it('should mark group as complete', function () {
+              expect(output[0].isComplete).to.be.true
+            })
+          })
+
+          context('with some incomplete', function () {
+            const mockMoves = [
+              {
+                id: 'id_1',
+                _hasArrived: true,
+              },
+              {
+                id: 'id_2',
+                _hasArrived: false,
+              },
+            ]
+
+            beforeEach(function () {
+              output = movesByVehicle({ moves: mockMoves, context: 'incoming' })
+            })
+
+            it('should not mark group as complete', function () {
+              expect(output[0].isComplete).to.be.false
+            })
+          })
+        })
+      })
+    })
+  })
+})

--- a/common/services/move.js
+++ b/common/services/move.js
@@ -40,6 +40,7 @@ const defaultInclude = [
 function getAll({
   apiClient,
   filter = {},
+  metaQuery = {},
   combinedData = [],
   page = 1,
   isAggregation = false,
@@ -48,6 +49,7 @@ function getAll({
   return apiClient
     .findAll('move', {
       ...filter,
+      ...metaQuery,
       include: isAggregation ? [] : include,
       page,
       per_page: isAggregation ? 1 : 100,
@@ -69,6 +71,7 @@ function getAll({
       return getAll({
         apiClient,
         filter,
+        metaQuery,
         combinedData: moves,
         page: page + 1,
         include,
@@ -190,6 +193,10 @@ class MoveService extends BaseService {
         'profile.person_escort_record.flags',
         'to_location',
       ],
+      metaQuery: {
+        meta:
+          'vehicle_registration,expected_time_of_arrival,expected_collection_time',
+      },
       filter: omitBy(
         {
           ...statusFilter,

--- a/common/services/move.test.js
+++ b/common/services/move.test.js
@@ -386,6 +386,31 @@ describe('Move Service', function () {
         })
       })
 
+      context('with filter', function () {
+        beforeEach(async function () {
+          moves = await moveService.getAll({
+            metaQuery: {
+              meta:
+                'vehicle_registration,expected_time_of_arrival,expected_collection_time',
+            },
+          })
+        })
+
+        it('should call the API client with filter', function () {
+          expect(apiClient.findAll.firstCall).to.be.calledWithExactly('move', {
+            meta:
+              'vehicle_registration,expected_time_of_arrival,expected_collection_time',
+            page: 1,
+            per_page: 100,
+            include: undefined,
+          })
+        })
+
+        it('should return moves', function () {
+          expect(moves).to.deep.equal(mockMoves)
+        })
+      })
+
       context('with from_location arguments as arrays', function () {
         beforeEach(async function () {
           moves = await moveService.getAll({
@@ -649,6 +674,10 @@ describe('Move Service', function () {
             'profile.person_escort_record.flags',
             'to_location',
           ],
+          metaQuery: {
+            meta:
+              'vehicle_registration,expected_time_of_arrival,expected_collection_time',
+          },
           filter: {},
         })
       })
@@ -692,6 +721,10 @@ describe('Move Service', function () {
             'filter[to_location_id]': mockToLocationId,
             'filter[supplier_id]': mockSupplierId,
           },
+          metaQuery: {
+            meta:
+              'vehicle_registration,expected_time_of_arrival,expected_collection_time',
+          },
         })
       })
 
@@ -722,6 +755,10 @@ describe('Move Service', function () {
             'profile.person_escort_record.flags',
             'to_location',
           ],
+          metaQuery: {
+            meta:
+              'vehicle_registration,expected_time_of_arrival,expected_collection_time',
+          },
           filter: {
             'filter[to_location_id]': mockToLocationId,
           },

--- a/common/templates/collection-as-cards.njk
+++ b/common/templates/collection-as-cards.njk
@@ -2,6 +2,36 @@
 
 {% block pageContent %}
   {% for group in resultsAsCards %}
+    {% set expectedTime %}
+      {% if group.expectedTime %}
+        {{ appTime({
+          datetime: group.expectedTime,
+          text: group.expectedTime | formatTime
+        }) }}
+
+        {% if group.showRelativeTime %}
+          {{ appTime({
+            datetime: group.expectedTime,
+            text: group.expectedTime | formatTime,
+            relative: true,
+            displayAsTag: true,
+            imminentOffset: 60
+          }) }}
+        {% endif %}
+      {% else %}
+        {{ t("collections::labels.no_expected_time") }}
+      {% endif %}
+
+      {% if group.isComplete %}
+        {{ govukTag({
+          html: t("collections::labels.complete", {
+            context: group.context
+          }),
+          classes: "govuk-tag--green"
+        }) }}
+      {% endif %}
+    {% endset %}
+
     <div class="
       govuk-!-margin-top-7
       app-border-top-2

--- a/locales/en/collections.json
+++ b/locales/en/collections.json
@@ -49,6 +49,13 @@
   "download_csv_incoming_moves": "Download moves (.csv)",
   "download_csv_single_requests": "Download moves (.csv)",
   "labels": {
+    "vehicle_registration": "Vehicle registration",
+    "awaiting_vehicle": "Awaiting vehicle",
+    "expected_time_incoming": "Expected arrival time",
+    "expected_time_outgoing": "Expected collection time",
+    "no_expected_time": "Not provided",
+    "complete_incoming": "Arrived",
+    "complete_outgoing": "Left custody",
     "from_location": "Move from",
     "to_location": "Move to",
     "earliest_move_date": "Earliest date of travel",

--- a/locales/en/default.json
+++ b/locales/en/default.json
@@ -14,6 +14,7 @@
   "person_noun": "person",
   "person_noun_police": "detainee",
   "person_noun_prison": "prisoner",
+  "people": "People",
   "person": "person",
   "person_plural": "people",
   "n_person": "{{count}} person",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

This adds the ability to view the incoming and outgoing dashboards to group moves by the van that the people will be getting on.

Previously groupings were done by destination or pickup location.

This change has been adapted so it still supports the existing view by default. This grouping can currently be seen by changing the query string parameter `group_by`. 

Once we are confident there is sufficient data within production we can either enable this by default or allow users to choose their preferred view.

### Why did it change

This change is possible by the supplier's sending the van for each move.

Grouping moves by van allows users within prison reception or police custody suites to better manage their workload. It allows them to know which vans are arriving in which order and who needs to get on them. They can time when they need to prepare people more efficiently.

It also allows them to see when people are coming into their establishment and allows them to start preparing any necessary check-in processes.

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

- [P4-2595](https://dsdmoj.atlassian.net/browse/P4-2595)

## Screenshots
<!--- (Optional) Include screenshots if changes update interfaces or components -->
<!--- Delete/copy as appropriate --->

[**OUTGOING**](https://booksecuremove-br-moves-group.herokuapp.com/moves/day/2021-01-12/b8dec44a-fd67-4969-a4ff-046e862609c7/outgoing?status=active&group_by=vehicle)
[**INCOMING**](https://booksecuremove-br-moves-group.herokuapp.com/moves/day/2021-01-12/b8dec44a-fd67-4969-a4ff-046e862609c7/incoming?status=active&group_by=vehicle)

| Before | After |
| ------ | ----- |
| <kbd>![image](https://user-images.githubusercontent.com/3327997/104044152-2ed0f300-51dd-11eb-8147-8d05b864f191.png)</kbd> | <kbd>![image](https://user-images.githubusercontent.com/3327997/104043881-c41fb780-51dc-11eb-9bfb-d4eef5957f6a.png)</kbd> |
| <kbd>![image](https://user-images.githubusercontent.com/3327997/104045344-b53a0480-51de-11eb-8f8d-30028ea3140f.png)</kbd> | <kbd>![image](https://user-images.githubusercontent.com/3327997/104045221-8328a280-51de-11eb-9163-4c5cee3087f0.png)</kbd> |

## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed

### Other considerations

Commit messages with a `fix` or `feat` type are automatically used to generate the [changelog](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/CHANGELOG.md) and
[GitHub release notes](https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/releases) during the release task. Please make sure they will read well on their own in a
summary of changes and that the commit body gives a more detailed description of those changes if necessary.

- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
- [x] Update [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md) with any new instructions or tasks
