### PR TITLE
chore: Expand error logging detail in Sentry

### DIFF
--- a/common/controllers/form-wizard/index.js
+++ b/common/controllers/form-wizard/index.js
@@ -179,7 +179,20 @@ class BaseController extends Controller {
 
     if (err.statusCode === 422) {
       Sentry.withScope(scope => {
-        scope.setExtra('errors', err.errors)
+        if (err.errors && err.errors.length > 0) {
+          err.errors.forEach(({ title, ...rest }, idx) => {
+            scope.setContext(`Error ${idx + 1}`, {
+              ...rest,
+              // `title` is a reserved property when using `setContext` and
+              // will override the title passed as the first argument so it is
+              // being set manually instead so that we don't lose the value
+              error_title: title,
+            })
+          })
+
+          scope.setExtra('Errors JSON', JSON.stringify(err.errors))
+        }
+
         Sentry.captureException(err)
       })
     }

--- a/test/e2e/_helpers.js
+++ b/test/e2e/_helpers.js
@@ -44,9 +44,17 @@ function errorHandler(body) {
   return err => {
     Sentry.withScope(scope => {
       if (err.errors && err.errors.length > 0) {
-        err.errors.forEach((apiErr, idx) => {
-          scope.setContext(`error_${idx}`, apiErr)
+        err.errors.forEach(({ title, ...rest }, idx) => {
+          scope.setContext(`Error ${idx + 1}`, {
+            ...rest,
+            // `title` is a reserved property when using `setContext` and
+            // will override the title passed as the first argument so it is
+            // being set manually instead so that we don't lose the value
+            error_title: title,
+          })
         })
+
+        scope.setExtra('Errors JSON', JSON.stringify(err.errors))
       }
 
       scope.setContext('body', body)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

This change improves the way 422 errors are passed to Sentry.

This change improves the way that the error is sent with the exception
so that more detail, like the source of meta of an error can be seen.

### Why did it change

Previously errors were sent as additional data, however, this meant that
only the first two levels of properties could be seen.

## Screenshots
<!--- (Optional) Include screenshots if changes update interfaces or components -->
<!--- Delete/copy as appropriate --->

| Before | After |
| ------ | ----- |
| <kbd>![image](https://user-images.githubusercontent.com/3327997/104430066-89c06c80-5586-11eb-8f21-32a7945af945.png)</kbd> | <kbd>![image](https://user-images.githubusercontent.com/3327997/104429917-6990ad80-5586-11eb-986f-c98dc1b8040c.png)</kbd> |
|  | <kbd>![image](https://user-images.githubusercontent.com/3327997/104429831-54b41a00-5586-11eb-93d0-4fcbcd8812e4.png)</kbd> |


## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed
