### PR TITLE
fix: Ensure the form wizard uses the default controller

### DIFF
--- a/app/allocation/config/cancel.config.js
+++ b/app/allocation/config/cancel.config.js
@@ -1,8 +1,5 @@
-const FormWizardController = require('../../../common/controllers/form-wizard')
-
 module.exports = function config(id) {
   return {
-    controller: FormWizardController,
     name: `cancel-allocation-${id}`,
     templatePath: 'allocation/views/',
     template: '../../../form-wizard',

--- a/app/allocation/config/create.config.js
+++ b/app/allocation/config/create.config.js
@@ -1,7 +1,4 @@
-const FormWizardController = require('../../../common/controllers/form-wizard')
-
 module.exports = {
-  controller: FormWizardController,
   name: 'create-an-allocation',
   templatePath: 'allocation/views/create/',
   template: '../../../form-wizard',

--- a/app/allocation/config/remove-move.config.js
+++ b/app/allocation/config/remove-move.config.js
@@ -1,8 +1,5 @@
-const FormWizardController = require('../../../common/controllers/form-wizard')
-
 module.exports = function config(id) {
   return {
-    controller: FormWizardController,
     name: `remove-move-from-allocation-${id}`,
     templatePath: 'allocation/views/cancel/',
     template: '../../../form-wizard',

--- a/app/move/app/cancel/config.js
+++ b/app/move/app/cancel/config.js
@@ -1,8 +1,5 @@
-const FormWizardController = require('../../../../common/controllers/form-wizard')
-
 module.exports = function config(id) {
   return {
-    controller: FormWizardController,
     journeyName: `cancel-move-${id}`,
     name: `cancel-move-${id}`,
     template: 'form-wizard',

--- a/app/move/app/review/config.js
+++ b/app/move/app/review/config.js
@@ -1,8 +1,5 @@
-const FormWizardController = require('../../../../common/controllers/form-wizard')
-
 module.exports = function config(id) {
   return {
-    controller: FormWizardController,
     template: 'form-wizard',
     name: `review-move-${id}`,
     journeyName: `review-move-${id}`,

--- a/app/move/app/unassign/config.js
+++ b/app/move/app/unassign/config.js
@@ -1,8 +1,5 @@
-const FormWizardController = require('../../../../common/controllers/form-wizard')
-
 module.exports = function config(id) {
   return {
-    controller: FormWizardController,
     journeyName: `unassign-person-${id}`,
     journeyPageTitle: 'actions::cancel_allocation',
     name: `unassign-person-${id}`,

--- a/app/population/index.js
+++ b/app/population/index.js
@@ -1,7 +1,6 @@
 const router = require('express').Router()
 const dailyRouter = require('express').Router({ mergeParams: true })
 
-const FormWizardController = require('../../common/controllers/form-wizard')
 const {
   setContext,
   setDateRange,
@@ -29,7 +28,6 @@ router.get('/', redirectBaseUrl)
 dailyRouter.get('/', setLocationFreeSpaces, setPopulation, setBreadcrumb, daily)
 
 const editConfig = {
-  controller: FormWizardController,
   name: 'edit-population',
   templatePath: 'population/views/edit/',
   template: '../../../form-wizard',

--- a/common/middleware/unique-form-wizard.js
+++ b/common/middleware/unique-form-wizard.js
@@ -1,15 +1,23 @@
 const wizard = require('hmpo-form-wizard')
 const { get } = require('lodash')
 
+const FormWizardController = require('../controllers/form-wizard')
+
 module.exports = function uniqueFormWizard(steps, fields, config, uniqueKey) {
   return (req, res, next) => {
     if (typeof config !== 'function') {
-      return wizard(steps, fields, config)(req, res, next)
+      return wizard(steps, fields, {
+        controller: FormWizardController,
+        ...config,
+      })(req, res, next)
     }
 
     const uniqueVal = get(req, uniqueKey)
     const uniqueConfig = uniqueVal ? config(uniqueVal) : config()
 
-    return wizard(steps, fields, uniqueConfig)(req, res, next)
+    return wizard(steps, fields, {
+      controller: FormWizardController,
+      ...uniqueConfig,
+    })(req, res, next)
   }
 }

--- a/common/middleware/unique-form-wizard.test.js
+++ b/common/middleware/unique-form-wizard.test.js
@@ -6,6 +6,8 @@ const wizard = proxyquire('./unique-form-wizard', {
   'hmpo-form-wizard': hmpoFormWizardStub,
 })
 
+const FormWizardController = require('../controllers/form-wizard')
+
 const mockSteps = {
   '/step-one': {},
   '/step-two': {},
@@ -39,7 +41,10 @@ describe('#uniqueFormWizard', function () {
       expect(hmpoFormWizardStub).to.be.calledOnceWithExactly(
         mockSteps,
         mockFields,
-        { foo: 'bar' }
+        {
+          controller: FormWizardController,
+          foo: 'bar',
+        }
       )
     })
 
@@ -63,85 +68,184 @@ describe('#uniqueFormWizard', function () {
     })
 
     context('with key that exists', function () {
-      beforeEach(function () {
-        wizard(
-          mockSteps,
-          mockFields,
-          mockConfig,
-          'params.id'
-        )(req, res, nextSpy)
+      context('without custom controller', function () {
+        beforeEach(function () {
+          wizard(
+            mockSteps,
+            mockFields,
+            mockConfig,
+            'params.id'
+          )(req, res, nextSpy)
+        })
+
+        it('should call wizard correctly', function () {
+          expect(hmpoFormWizardStub).to.be.calledOnceWithExactly(
+            mockSteps,
+            mockFields,
+            {
+              controller: FormWizardController,
+              foo: 'bar',
+              id: '12345',
+            }
+          )
+        })
+
+        it('should wizard with middleware args', function () {
+          expect(mwStub).to.be.calledOnceWithExactly(req, res, nextSpy)
+        })
+
+        it('should pass unique val to config', function () {
+          expect(mockConfig).to.be.calledOnceWithExactly('12345')
+        })
       })
 
-      it('should call wizard correctly', function () {
-        expect(hmpoFormWizardStub).to.be.calledOnceWithExactly(
-          mockSteps,
-          mockFields,
-          {
-            foo: 'bar',
-            id: '12345',
-          }
-        )
-      })
+      context('with custom controller', function () {
+        beforeEach(function () {
+          mockConfig = sinon.stub().callsFake((arg = '') => {
+            return { controller: { fizz: 'buzz' }, foo: 'bar', id: arg }
+          })
+          wizard(
+            mockSteps,
+            mockFields,
+            mockConfig,
+            'params.id'
+          )(req, res, nextSpy)
+        })
 
-      it('should wizard with middleware args', function () {
-        expect(mwStub).to.be.calledOnceWithExactly(req, res, nextSpy)
-      })
+        it('should call wizard correctly', function () {
+          expect(hmpoFormWizardStub).to.be.calledOnceWithExactly(
+            mockSteps,
+            mockFields,
+            {
+              controller: { fizz: 'buzz' },
+              foo: 'bar',
+              id: '12345',
+            }
+          )
+        })
 
-      it('should pass unique val to config', function () {
-        expect(mockConfig).to.be.calledOnceWithExactly('12345')
+        it('should wizard with middleware args', function () {
+          expect(mwStub).to.be.calledOnceWithExactly(req, res, nextSpy)
+        })
+
+        it('should pass unique val to config', function () {
+          expect(mockConfig).to.be.calledOnceWithExactly('12345')
+        })
       })
     })
 
     context('with key that does not exist', function () {
-      beforeEach(function () {
-        wizard(
-          mockSteps,
-          mockFields,
-          mockConfig,
-          'path.does.not.exist'
-        )(req, res, nextSpy)
+      context('without custom controller', function () {
+        beforeEach(function () {
+          wizard(
+            mockSteps,
+            mockFields,
+            mockConfig,
+            'path.does.not.exist'
+          )(req, res, nextSpy)
+        })
+
+        it('should call wizard correctly with default controller', function () {
+          expect(hmpoFormWizardStub).to.be.calledOnceWithExactly(
+            mockSteps,
+            mockFields,
+            {
+              controller: FormWizardController,
+              foo: 'bar',
+              id: '',
+            }
+          )
+        })
+
+        it('should wizard with middleware args', function () {
+          expect(mwStub).to.be.calledOnceWithExactly(req, res, nextSpy)
+        })
+
+        it('should not pass unique val to config', function () {
+          expect(mockConfig).to.be.calledOnceWithExactly()
+        })
       })
 
-      it('should call wizard correctly', function () {
-        expect(hmpoFormWizardStub).to.be.calledOnceWithExactly(
-          mockSteps,
-          mockFields,
-          {
-            foo: 'bar',
-            id: '',
-          }
-        )
-      })
+      context('with custom controller', function () {
+        beforeEach(function () {
+          mockConfig = sinon.stub().callsFake((arg = '') => {
+            return { controller: { fizz: 'buzz' }, foo: 'bar', id: arg }
+          })
+          wizard(
+            mockSteps,
+            mockFields,
+            mockConfig,
+            'path.does.not.exist'
+          )(req, res, nextSpy)
+        })
 
-      it('should wizard with middleware args', function () {
-        expect(mwStub).to.be.calledOnceWithExactly(req, res, nextSpy)
-      })
+        it('should call wizard correctly with custom controller', function () {
+          expect(hmpoFormWizardStub).to.be.calledOnceWithExactly(
+            mockSteps,
+            mockFields,
+            {
+              controller: { fizz: 'buzz' },
+              foo: 'bar',
+              id: '',
+            }
+          )
+        })
 
-      it('should not pass unique val to config', function () {
-        expect(mockConfig).to.be.calledOnceWithExactly()
+        it('should wizard with middleware args', function () {
+          expect(mwStub).to.be.calledOnceWithExactly(req, res, nextSpy)
+        })
+
+        it('should not pass unique val to config', function () {
+          expect(mockConfig).to.be.calledOnceWithExactly()
+        })
       })
     })
 
     context('when config is an object', function () {
-      beforeEach(function () {
-        wizard(
-          mockSteps,
-          mockFields,
-          { foo: 'bar' },
-          'params.id'
-        )(req, res, nextSpy)
+      context('without custom controller', function () {
+        beforeEach(function () {
+          wizard(
+            mockSteps,
+            mockFields,
+            { foo: 'bar' },
+            'params.id'
+          )(req, res, nextSpy)
+        })
+
+        it('should call wizard correctly with default controller', function () {
+          expect(hmpoFormWizardStub).to.be.calledOnceWithExactly(
+            mockSteps,
+            mockFields,
+            { controller: FormWizardController, foo: 'bar' }
+          )
+        })
+
+        it('should wizard with middleware args', function () {
+          expect(mwStub).to.be.calledOnceWithExactly(req, res, nextSpy)
+        })
       })
 
-      it('should call wizard correctly', function () {
-        expect(hmpoFormWizardStub).to.be.calledOnceWithExactly(
-          mockSteps,
-          mockFields,
-          { foo: 'bar' }
-        )
-      })
+      context('with custom controller', function () {
+        beforeEach(function () {
+          wizard(
+            mockSteps,
+            mockFields,
+            { controller: { fizz: 'bar' }, foo: 'bar' },
+            'params.id'
+          )(req, res, nextSpy)
+        })
 
-      it('should wizard with middleware args', function () {
-        expect(mwStub).to.be.calledOnceWithExactly(req, res, nextSpy)
+        it('should call wizard correctly with custom controller', function () {
+          expect(hmpoFormWizardStub).to.be.calledOnceWithExactly(
+            mockSteps,
+            mockFields,
+            { controller: { fizz: 'bar' }, foo: 'bar' }
+          )
+        })
+
+        it('should wizard with middleware args', function () {
+          expect(mwStub).to.be.calledOnceWithExactly(req, res, nextSpy)
+        })
       })
     })
   })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

This change uses the custom form wizard controller as the default
controller for all unique form wizards.

### Why did it change

There are some cases where we might not be defining it which can
cause rogue CSRF errors because the CSRF depends on the method
used internally.

## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed