### PR TITLE
Catch error when redirecting moves without a current location

### DIFF
--- a/app/moves/middleware/redirect-base-url.js
+++ b/app/moves/middleware/redirect-base-url.js
@@ -6,7 +6,7 @@ function redirectBaseUrl(req, res) {
 
   if (
     canAccess('moves:view:proposed') &&
-    currentLocation.location_type === 'prison'
+    currentLocation?.location_type === 'prison'
   ) {
     return res.redirect(`${baseUrl}/requested`)
   }

--- a/app/moves/middleware/redirect-base-url.test.js
+++ b/app/moves/middleware/redirect-base-url.test.js
@@ -114,7 +114,7 @@ describe('Moves middleware', function () {
         'when user has permission to see the proposed moves',
         function () {
           beforeEach(function () {
-            req.canAccess.withArgs('move:proposed:view').returns(true)
+            req.canAccess.withArgs('moves:view:proposed').returns(true)
             res.redirect.resetHistory()
             middleware(req, res)
           })

--- a/common/lib/api-client/auth.js
+++ b/common/lib/api-client/auth.js
@@ -84,11 +84,10 @@ Auth.prototype = {
         return response.data
       })
       .catch(error => {
-        debug(
-          `${error.response.status} ${error.response.statusText}`,
-          `(POST ${url})`,
-          error
-        )
+        const debugMessage = error.response
+          ? `${error.response.status} ${error.response.statusText}`
+          : error.message
+        debug(debugMessage, `(POST ${url})`, error)
         // record error
         const duration = authTimer()
         clientMetrics.recordError(reqLabels, error, duration)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

This uses optional chaining so if the parent object doesn't exist the value will return `undefined` rather
than throw a "Cannot find property" error.

### Why did it change

The test for this catch was using the wrong permission name which meant
that it didn't catch the scenario where the current location didn't
exist and the app would through a "Cannot read property" error.

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

https://sentry.io/organizations/ministryofjustice/issues/2149703392/?project=2014813&query=is%3Aunresolved

## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [x] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed