### PR TITLE
chore: Add youth risk assessment permissions to prison role

### DIFF
--- a/common/lib/permissions.js
+++ b/common/lib/permissions.js
@@ -102,6 +102,10 @@ const prisonPermissions = [
   'person_escort_record:create',
   'person_escort_record:update',
   'person_escort_record:confirm',
+  'youth_risk_assessment:view',
+  'youth_risk_assessment:create',
+  'youth_risk_assessment:update',
+  'youth_risk_assessment:confirm',
 ]
 const ocaPermissions = [
   'dashboard:view',
@@ -131,6 +135,7 @@ const pmuPermissions = [
   'move:review',
   'move:view',
   'person_escort_record:view',
+  'youth_risk_assessment:view',
 ]
 const courtPermissions = [
   'dashboard:view',
@@ -139,6 +144,7 @@ const courtPermissions = [
   'moves:download',
   'move:view',
   'person_escort_record:view',
+  'youth_risk_assessment:view',
 ]
 const personEscortRecordAuthorPermissions = [
   'person_escort_record:view',

--- a/common/lib/user.test.js
+++ b/common/lib/user.test.js
@@ -174,6 +174,10 @@ describe('User class', function () {
           'person_escort_record:create',
           'person_escort_record:update',
           'person_escort_record:confirm',
+          'youth_risk_assessment:view',
+          'youth_risk_assessment:create',
+          'youth_risk_assessment:update',
+          'youth_risk_assessment:confirm',
         ])
       })
     })
@@ -271,6 +275,10 @@ describe('User class', function () {
           'person_escort_record:create',
           'person_escort_record:update',
           'person_escort_record:confirm',
+          'youth_risk_assessment:view',
+          'youth_risk_assessment:create',
+          'youth_risk_assessment:update',
+          'youth_risk_assessment:confirm',
         ])
       })
     })
@@ -318,6 +326,7 @@ describe('User class', function () {
           'move:review',
           'move:view',
           'person_escort_record:view',
+          'youth_risk_assessment:view',
         ])
       })
     })
@@ -353,6 +362,7 @@ describe('User class', function () {
           'moves:download',
           'move:view',
           'person_escort_record:view',
+          'youth_risk_assessment:view',
         ])
       })
     })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

This adds the ability to create/edit/confirm youth risk assessments
for users with the prison or YOI role.