### PR TITLE
fix: Single requests filter should not return allocations

### DIFF
--- a/common/services/single-request.js
+++ b/common/services/single-request.js
@@ -73,7 +73,7 @@ class SingleRequestService extends BaseService {
       ],
       filter: {
         ...statusFilter,
-        has_relationship_to_allocation: false,
+        has_relationship_to_allocation: 'false',
         from_location_id: fromLocationId.join(','),
         to_location_id: toLocationId.join(','),
         date_from: moveDateFrom,

--- a/common/services/single-request.test.js
+++ b/common/services/single-request.test.js
@@ -59,7 +59,7 @@ describe('Single request service', function () {
           ],
           filter: {
             status: undefined,
-            has_relationship_to_allocation: false,
+            has_relationship_to_allocation: 'false',
             from_location_id: '',
             to_location_id: '',
             date_from: undefined,
@@ -114,7 +114,7 @@ describe('Single request service', function () {
           expect(moveService.get.args[0][0]).to.deep.include({
             filter: {
               status: 'proposed',
-              has_relationship_to_allocation: false,
+              has_relationship_to_allocation: 'false',
               date_from: mockMoveDateRange[0],
               date_to: mockMoveDateRange[1],
               date_of_birth_from: mockDOBFrom,


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Use string value for the single requests allocation filter.

### Why did it change

The single requests filter should remove moves that are part of
an allocation.

When moving to the `POST` endpoint in the API the frontend needs to
ensure this value is sent as a string instead of a boolean, otherwise
the API won't filter by that value correctly.

## Screenshots
<!--- (Optional) Include screenshots if changes update interfaces or components -->
<!--- Delete/copy as appropriate --->

| Before | After |
| ------ | ----- |
| <kbd>![image (1)](https://user-images.githubusercontent.com/3327997/105704111-2cbda280-5f06-11eb-9ecd-f064a8db909b.png)</kbd> | <kbd>![image](https://user-images.githubusercontent.com/3327997/105704117-2e876600-5f06-11eb-92e3-fe17952450c1.png)</kbd> |

## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [x] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed
