### PR TITLE
[P4-2629] Show 0 values in numeric fields

### DIFF
--- a/app/population/controllers/edit/details.js
+++ b/app/population/controllers/edit/details.js
@@ -1,4 +1,4 @@
-const { omit } = require('lodash')
+const { omit, mapValues } = require('lodash')
 
 const FormWizardController = require('../../../../common/controllers/form-wizard')
 
@@ -86,6 +86,30 @@ class DetailsController extends FormWizardController {
     }
 
     next()
+  }
+
+  stringifyValues({ fields, values }) {
+    return mapValues(values, (item, key) => {
+      if (fields[key] && fields[key].inputmode === 'numeric') {
+        return item.toString()
+      }
+
+      return item
+    })
+  }
+
+  getValues(req, res, cb) {
+    super.getValues(req, res, (err, values) => {
+      if (err) {
+        return cb(err, values)
+      }
+      const stringedValues = this.stringifyValues({
+        fields: req.form.options.fields,
+        values,
+      })
+
+      return cb(err, stringedValues)
+    })
   }
 }
 module.exports = DetailsController


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

Using the [form-wizard lifecycle](https://github.com/UKHomeOffice/passports-form-wizard/wiki/HMPO%20Forms%20Flow.pdf), on the `getValues` method, if the form input is a numeric one, convert it to a string. This reduces the chances of introducing bugs due to type conversions.

### What changed

<!--- Describe the changes in detail - the "what"-->

### Why did it change

In JavaScript the number 0 is falsey, but the string "0" is truthy.

The govuk input uses the value directly when deciding if to display it or not - https://github.com/alphagov/govuk-frontend/blob/master/src/govuk/components/input/template.njk#L51

Unfortunately this means that 0 number values are not displayed. The solution is to turn it into a string before the template is rendered.

<!--- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

- [P4-2629](https://dsdmoj.atlassian.net/browse/P4-2629)

## Screenshots
<!--- (Optional) Include screenshots if changes update interfaces or components -->
<!--- Delete/copy as appropriate --->

| Before | After |
| ------ | ----- |
| ![Screenshot_2021-01-27 Change numbers - create_population(1)](https://user-images.githubusercontent.com/196695/106032116-fa5ba300-60c7-11eb-91f1-942e4eed66fb.png) | ![Screenshot_2021-01-27 Change numbers - create_population](https://user-images.githubusercontent.com/196695/106032130-ffb8ed80-60c7-11eb-828e-8616f7e1b25a.png) |


## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [ ] Chrome
- [x] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed

### Other considerations

Commit messages with a `fix` or `feat` type are automatically used to generate the [changelog](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/CHANGELOG.md) and
[GitHub release notes](https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/releases) during the release task. Please make sure they will read well on their own in a
summary of changes and that the commit body gives a more detailed description of those changes if necessary.

- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
- [ ] Update [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md) with any new instructions or tasks
