### PR TITLE
fix(pmu): Render missing values as empty string

### DIFF
--- a/app/population/controllers/edit/details.js
+++ b/app/population/controllers/edit/details.js
@@ -1,4 +1,4 @@
-const { omit, mapValues } = require('lodash')
+const { isNil, omit, mapValues } = require('lodash')
 
 const FormWizardController = require('../../../../common/controllers/form-wizard')
 
@@ -91,7 +91,11 @@ class DetailsController extends FormWizardController {
   stringifyValues({ fields, values }) {
     return mapValues(values, (item, key) => {
       if (fields[key] && fields[key].inputmode === 'numeric') {
-        return item.toString()
+        if (isNil(item)) {
+          return ''
+        } else {
+          return item.toString()
+        }
       }
 
       return item

--- a/app/population/controllers/edit/details.test.js
+++ b/app/population/controllers/edit/details.test.js
@@ -357,6 +357,19 @@ describe('Population controllers', function () {
         ).to.deep.equal({ numberField1: '0' })
       })
 
+      it('should stringify missing numeric input values', function () {
+        expect(
+          controllerInstance.stringifyValues({
+            fields: {
+              numberField1: {
+                inputmode: 'numeric',
+              },
+            },
+            values: { numberField1: null },
+          })
+        ).to.deep.equal({ numberField1: '' })
+      })
+
       it('should not stringify non-numeric input values', function () {
         expect(
           controllerInstance.stringifyValues({


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

For some reason in pre-prod there are some population free spaces missing values, which causes the display population details screen to error. I'm not sure what's caused that - perhaps its faulty previous data, (as an error with pre-population would be caught) - but it shouldn't show as an uncaught error on the details page.

This fix will set any missing values to an empty string, which would then require the user to supply a value to pass the validation logic and save the free spaces data.

### What changed

<!--- Describe the changes in detail - the "what"-->

### Why did it change

<!--- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

## Screenshots
<!--- (Optional) Include screenshots if changes update interfaces or components -->
<!--- Delete/copy as appropriate --->

### Error
![tostring-error](https://user-images.githubusercontent.com/196695/106468614-12e80680-6496-11eb-8f8b-87e55f5c6bac.png)

| Before | After |
| ------ | ----- |
| <kbd><img src=""></kbd> | <kbd><img src=""></kbd> |

## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [ ] Chrome
- [x] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [ ] No environment variables were added or changed

<!--- Delete if changes DO NOT include new environment variables -->
- [ ] Documented in the [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md)
- [ ] Added to [continous integration](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-book-secure-move-frontend)
- [ ] Added to staging environment (deployment repository)
- [ ] Added to preproduction environment (deployment repository)
- [ ] Added to production environment (deployment repository)

### Other considerations

Commit messages with a `fix` or `feat` type are automatically used to generate the [changelog](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/CHANGELOG.md) and
[GitHub release notes](https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/releases) during the release task. Please make sure they will read well on their own in a
summary of changes and that the commit body gives a more detailed description of those changes if necessary.

- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
- [ ] Update [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md) with any new instructions or tasks
