### PR TITLE
fix: Prevent right hand panel overlapping footer content

### DIFF
--- a/common/templates/form-wizard.njk
+++ b/common/templates/form-wizard.njk
@@ -118,9 +118,7 @@
           </h3>
 
           {% if person._image_url %}
-            <div class="govuk-!-width-one-half govuk-!-margin-bottom-3">
-              <img src="{{ person._image_url }}" alt="{{ person._fullname }}">
-            </div>
+            <img src="{{ person._image_url }}" alt="{{ person._fullname }}" height="190" class="govuk-!-margin-bottom-3">
           {% endif %}
 
           {{ appMetaList(moveSummary) }}

--- a/common/templates/includes/move-summary.njk
+++ b/common/templates/includes/move-summary.njk
@@ -6,9 +6,7 @@
       </h3>
 
       {% if move.profile.person._image_url %}
-        <div class="govuk-!-width-one-half govuk-!-margin-bottom-3">
-          <img src="{{ move.profile.person._image_url }}" alt="{{ move.profile.person._fullname }}">
-        </div>
+        <img src="{{ move.profile.person._image_url }}" alt="{{ move.profile.person._fullname }}" height="190" class="govuk-!-margin-bottom-3">
       {% endif %}
 
       {{ appMetaList(moveSummary) }}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Uses a fixed height for the right hand column image.

### Why did it change

In some instances the right hand panel will overlap the footer.

This is because the image element doesn't have a fixed height and
before the image has been fully loaded the JavaScript used to pin the
column when scrolling will set the height of the container.

When the image loads in the container is now too small so when scrolling
down or resizing the browser window, causing the column to stack,
will make the content overlap the following elements like the footer.

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

- [P4-XXXX]()

## Screenshots
<!--- (Optional) Include screenshots if changes update interfaces or components -->
<!--- Delete/copy as appropriate --->

| Before | After |
| ------ | ----- |
| <kbd>![image](https://user-images.githubusercontent.com/3327997/106732858-1c45b000-6609-11eb-80b7-71832b84d888.png)</kbd> | <kbd>![image](https://user-images.githubusercontent.com/3327997/106732015-14394080-6608-11eb-874a-2649ab77abb7.png)</kbd> |

## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [x] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed