### PR TITLE
Ignore v15 of node

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,5 +28,5 @@ updates:
       day: 'sunday'
     ignore:
       - dependency-name: 'node'
-        versions: ['15.x']
+        versions: ['>=15']
     open-pull-requests-limit: 1


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Add condition to ignore v15 of Node.js.

### Why did it change

We're only interesting in even numbers of Node.js that will become LTS variants. 