### PR TITLE
fix: Use location from params on all specified routes

### DIFF
--- a/app/allocations/index.js
+++ b/app/allocations/index.js
@@ -11,6 +11,7 @@ const {
   setPagination,
 } = require('../../common/middleware/collection')
 const { protectRoute } = require('../../common/middleware/permissions')
+const setLocation = require('../../common/middleware/set-location')
 
 const {
   ACTIONS,
@@ -27,6 +28,7 @@ const {
 
 router.param('date', setDateRange)
 router.param('view', redirectDefaultQuery(DEFAULTS.QUERY))
+router.param('locationId', setLocation)
 
 router.use(protectRoute('allocations:view'))
 

--- a/app/allocations/middleware/set-body.allocations.js
+++ b/app/allocations/middleware/set-body.allocations.js
@@ -9,13 +9,16 @@ function setBodyAllocations(req, res, next) {
   const locationType = hasAssignerPermission ? 'fromLocations' : 'locations'
   const locations = req.locations
 
+  const { location } = req
+  const bodyLocations = location?.id ? [location.id] : locations
+
   set(req, 'body.allocations', {
     page,
     status,
     sortBy,
     sortDirection,
     moveDate: dateRange || dateHelpers.getCurrentWeekAsRange(),
-    [locationType]: locations,
+    [locationType]: bodyLocations,
   })
 
   next()

--- a/app/moves/index.js
+++ b/app/moves/index.js
@@ -15,6 +15,7 @@ const {
   setPagination,
 } = require('../../common/middleware/collection')
 const { protectRoute } = require('../../common/middleware/permissions')
+const setLocation = require('../../common/middleware/set-location')
 const setRequestFilters = require('../../common/middleware/set-request-filters')
 const requestFilterFields = require('../filters/fields')
 
@@ -43,11 +44,10 @@ const {
 } = require('./middleware')
 
 // Define param middleware
-router.param('locationId', setFromLocation)
+router.param('locationId', setLocation)
 router.param('date', setDateRange)
 router.param('view', redirectDefaultQuery(DEFAULTS.QUERY))
 
-// Define shared middleware
 router.use('^([^.]+)$', saveUrl)
 
 // Define routes
@@ -55,6 +55,7 @@ viewRouter.get(
   '/:view(requested)',
   protectRoute('moves:view:proposed'),
   setContext('single_requests'),
+  setFromLocation,
   COLLECTION_MIDDLEWARE,
   [
     setBodySingleRequests,
@@ -70,6 +71,7 @@ viewRouter.get(
   '/:view(requested)/download.:extension(csv|json)',
   protectRoute('moves:download'),
   protectRoute('moves:view:proposed'),
+  setFromLocation,
   [
     setBodySingleRequests,
     setBodyRequestFilters,
@@ -81,6 +83,7 @@ viewRouter.get(
   '/:view(outgoing)',
   protectRoute('moves:view:outgoing'),
   setContext('outgoing_moves'),
+  setFromLocation,
   COLLECTION_MIDDLEWARE,
   [
     setBodyMoves('outgoing', 'fromLocationId'),
@@ -93,6 +96,7 @@ viewRouter.get(
   '/:view(outgoing)/download.:extension(csv|json)',
   protectRoute('moves:download'),
   protectRoute('moves:view:outgoing'),
+  setFromLocation,
   [
     setBodyMoves('outgoing', 'fromLocationId'),
     setDownloadResultsMoves('outgoing'),
@@ -103,6 +107,7 @@ viewRouter.get(
   '/:view(incoming)',
   protectRoute('moves:view:incoming'),
   setContext('incoming_moves'),
+  setFromLocation,
   COLLECTION_MIDDLEWARE,
   [
     setBodyMoves('incoming', 'toLocationId'),
@@ -115,6 +120,7 @@ viewRouter.get(
   '/:view(incoming)/download.:extension(csv|json)',
   protectRoute('moves:download'),
   protectRoute('moves:view:incoming'),
+  setFromLocation,
   [
     setBodyMoves('incoming', 'toLocationId'),
     setDownloadResultsMoves('incoming'),

--- a/app/moves/middleware/set-body.moves.js
+++ b/app/moves/middleware/set-body.moves.js
@@ -7,11 +7,14 @@ function setBodyMoves(property, locationProperty) {
     const { status } = req.query
     const { dateRange } = req.params
     const locations = req.locations
+    const { location } = req
+
+    const bodyLocations = location?.id ? [location.id] : locations
 
     set(req, `body.${property}`, {
       status,
       dateRange: dateRange || dateHelpers.getCurrentDayAsRange(),
-      [locationProperty]: locations,
+      [locationProperty]: bodyLocations,
       supplierId: req.session?.user?.supplierId,
     })
 

--- a/app/moves/middleware/set-body.moves.test.js
+++ b/app/moves/middleware/set-body.moves.test.js
@@ -46,6 +46,32 @@ describe('Moves middleware', function () {
       })
     })
 
+    context('with location', function () {
+      beforeEach(function () {
+        mockReq.location = {
+          id: '1',
+        }
+        middleware(mockBodyProperty, mockLocationProperty)(
+          mockReq,
+          mockRes,
+          nextSpy
+        )
+      })
+
+      it('should assign req.body correctly', function () {
+        expect(mockReq.body[mockBodyProperty]).to.deep.equal({
+          dateRange: '#currentDayAsRange',
+          [mockLocationProperty]: ['1'],
+          supplierId: undefined,
+          status: undefined,
+        })
+      })
+
+      it('should call next', function () {
+        expect(nextSpy).to.be.calledOnceWithExactly()
+      })
+    })
+
     context('with dateRange param', function () {
       beforeEach(function () {
         mockReq.params.dateRange = ['2020-10-10', '2020-10-10']

--- a/app/moves/middleware/set-from-location.js
+++ b/app/moves/middleware/set-from-location.js
@@ -1,17 +1,9 @@
-const { find, get } = require('lodash')
-
-function setFromLocation(req, res, next, locationId) {
-  const userLocations = get(req.session, 'user.locations')
-  const location = find(userLocations, { id: locationId })
-
-  if (!location) {
-    const error = new Error('Location not found')
-    error.statusCode = 404
-
-    return next(error)
+function setFromLocation(req, res, next) {
+  if (!req.location) {
+    return next()
   }
 
-  res.locals.fromLocationId = locationId
+  res.locals.fromLocationId = req.location?.id
   next()
 }
 

--- a/app/moves/middleware/set-from-location.test.js
+++ b/app/moves/middleware/set-from-location.test.js
@@ -7,21 +7,14 @@ describe('Moves middleware', function () {
 
     beforeEach(function () {
       res = { locals: {} }
-      req = {
-        query: {},
-        session: {},
-      }
+      req = {}
       nextSpy = sinon.spy()
     })
 
-    context('when location exists in users locations', function () {
+    context('when location exists in req', function () {
       beforeEach(function () {
-        req.session.user = {
-          locations: [
-            {
-              id: locationId,
-            },
-          ],
+        req.location = {
+          id: locationId,
         }
 
         middleware(req, res, nextSpy, locationId)
@@ -29,7 +22,7 @@ describe('Moves middleware', function () {
 
       it('should set from location to locals', function () {
         expect(res.locals).to.have.property('fromLocationId')
-        expect(res.locals.fromLocationId).to.equal(locationId)
+        expect(res.locals.fromLocationId).to.equal(req.location.id)
       })
 
       it('should call next', function () {
@@ -37,9 +30,9 @@ describe('Moves middleware', function () {
       })
     })
 
-    context('when location does not exist in users locations', function () {
+    context('when location does not exist in req', function () {
       beforeEach(function () {
-        middleware(req, res, nextSpy, locationId)
+        middleware(req, res, nextSpy)
       })
 
       it('should not set from location to locals', function () {
@@ -47,13 +40,7 @@ describe('Moves middleware', function () {
       })
 
       it('should call next with 404 error', function () {
-        const error = nextSpy.args[0][0]
-
-        expect(nextSpy).to.be.calledOnce
-
-        expect(error).to.be.an('error')
-        expect(error.message).to.equal('Location not found')
-        expect(error.statusCode).to.equal(404)
+        expect(nextSpy).to.be.calledOnceWithExactly()
       })
     })
   })

--- a/app/moves/middleware/set-results.moves.js
+++ b/app/moves/middleware/set-results.moves.js
@@ -7,7 +7,7 @@ function setResultsMoves(bodyKey, locationKey) {
     const { group_by: groupBy } = req.query
 
     try {
-      if (!req.session?.currentLocation) {
+      if (!req.location) {
         return next()
       }
 
@@ -18,7 +18,7 @@ function setResultsMoves(bodyKey, locationKey) {
         req.resultsAsCards = presenters.movesByVehicle({
           moves: activeMoves,
           context: locationKey === 'from_location' ? 'incoming' : 'outgoing',
-          showLocations: !req.session?.currentLocation,
+          showLocations: !req.location,
         })
       } else {
         req.resultsAsCards = presenters.movesByLocation(

--- a/app/moves/middleware/set-results.moves.test.js
+++ b/app/moves/middleware/set-results.moves.test.js
@@ -37,9 +37,7 @@ describe('Moves middleware', function () {
             locationId: '5555',
           },
         },
-        session: {
-          currentLocation: '#location',
-        },
+        location: '#location',
         services: {
           move: moveService,
         },
@@ -53,7 +51,7 @@ describe('Moves middleware', function () {
 
       context('without current location', function () {
         beforeEach(async function () {
-          req.session.currentLocation = undefined
+          req.location = undefined
           await middleware(mockBodyKey, mockLocationKey)(req, res, nextSpy)
         })
 

--- a/app/population/index.js
+++ b/app/population/index.js
@@ -6,6 +6,7 @@ const {
   setDateRange,
   setDatePagination,
 } = require('../../common/middleware/collection')
+const setLocation = require('../../common/middleware/set-location')
 const wizard = require('../../common/middleware/unique-form-wizard')
 
 const { BASE_PATH, MOUNTPATH, DAILY_PATH, WEEKLY_PATH } = require('./constants')
@@ -22,6 +23,7 @@ const {
 const { editSteps } = require('./steps')
 
 router.param('date', setDateRange)
+router.param('locationId', setLocation)
 
 router.get('/', redirectBaseUrl)
 
@@ -50,7 +52,6 @@ router.get(
   setContext('population'),
   setDatePagination(MOUNTPATH + BASE_PATH),
   setLocationFreeSpaces,
-  setPopulation,
   setResultsAsFreeSpacesTables,
   dashboard
 )

--- a/app/population/middleware/set-breadcrumb.js
+++ b/app/population/middleware/set-breadcrumb.js
@@ -8,8 +8,7 @@ const {
 function setBreadcrumb(req, res, next) {
   const {
     date,
-    locationName,
-    locationId,
+    location,
     params: { period },
   } = req
 
@@ -42,14 +41,14 @@ function setBreadcrumb(req, res, next) {
       href: weeklyBasePath,
     })
     .breadcrumb({
-      text: locationName,
-      href: `${weeklyBasePath}/${locationId}`,
+      text: location?.title,
+      href: `${weeklyBasePath}/${location?.id}`,
     })
 
   if (period === 'day') {
     res.breadcrumb({
       text: format(parseISO(req.date), 'EEEE d MMMM'),
-      href: `${dailyBasePath}/${locationId}`,
+      href: `${dailyBasePath}/${location?.id}`,
     })
   }
 

--- a/app/population/middleware/set-breadcrumb.test.js
+++ b/app/population/middleware/set-breadcrumb.test.js
@@ -18,8 +18,10 @@ describe('Population middleware', function () {
       req = {
         baseUrl: '/url-path',
         date: '2020-07-29',
-        locationName: 'Lorem Ipsum',
-        locationId: 'ABADCAFE',
+        location: {
+          title: 'Lorem Ipsum',
+          id: 'ABADCAFE',
+        },
         params: {
           period: 'week',
         },
@@ -61,7 +63,7 @@ describe('Population middleware', function () {
       middleware(req, res, next)
       expect(breadcrumbSpy.secondCall).to.have.been.calledWithExactly({
         href: '/population/week/2020-07-27/ABADCAFE',
-        text: req.locationName,
+        text: req.location.title,
       })
     })
 

--- a/app/population/middleware/set-location-free-spaces.js
+++ b/app/population/middleware/set-location-free-spaces.js
@@ -1,13 +1,12 @@
 async function setLocationFreeSpaces(req, res, next) {
   try {
-    const { dateRange, locations } = req
-    const { locationId } = req.params
+    const { dateRange, locations, location } = req
 
     const dailyFreeSpaceByCategory = await req.services.locationsFreeSpaces.getPrisonFreeSpaces(
       {
         dateFrom: dateRange[0],
         dateTo: dateRange[1],
-        locationIds: locationId || locations?.join(),
+        locationIds: location?.id || locations?.join(),
       }
     )
 

--- a/app/population/middleware/set-location-free-spaces.test.js
+++ b/app/population/middleware/set-location-free-spaces.test.js
@@ -63,7 +63,9 @@ describe('Population middleware', function () {
       })
 
       it('should call locationFreeSpaces service with date and locationId', async function () {
-        req.params.locationId = 'BAADF00D'
+        req.location = {
+          id: 'BAADF00D',
+        }
 
         await middleware(req, res, next)
 

--- a/app/population/middleware/set-population.js
+++ b/app/population/middleware/set-population.js
@@ -1,7 +1,6 @@
 async function setPopulation(req, res, next) {
   try {
     const { dateRange, resultsAsPopulation } = req
-    const { locationId } = req.params
 
     const dailyFreeSpace =
       resultsAsPopulation?.[Object.keys(resultsAsPopulation)]
@@ -27,9 +26,8 @@ async function setPopulation(req, res, next) {
       )
     }
 
-    req.locationId = locationId
     req.date = dateRange[0]
-    req.wizardKey = `${req.locationId}-${req.date}`
+    req.wizardKey = `${req.location.id}-${req.date}`
 
     next()
   } catch (error) {

--- a/app/population/middleware/set-population.test.js
+++ b/app/population/middleware/set-population.test.js
@@ -42,8 +42,10 @@ describe('Population middleware', function () {
         body: {},
         dateRange: ['2020-08-01', '2020-08-01'],
         resultsAsPopulation: mockFreeSpaces,
+        location: {
+          id: 'BAADF00D',
+        },
         params: {
-          locationId: 'BAADF00D',
           date: '2020-08-01',
         },
         services: {

--- a/common/controllers/collection/render-as-cards.test.js
+++ b/common/controllers/collection/render-as-cards.test.js
@@ -48,70 +48,108 @@ describe('Collection controllers', function () {
     })
 
     describe('template params', function () {
-      beforeEach(function () {
-        controller(req, res)
-      })
+      context('by default', function () {
+        beforeEach(function () {
+          controller(req, res)
+        })
 
-      it('should contain actions property', function () {
-        const params = res.render.args[0][1]
-        expect(params).to.have.property('actions')
-        expect(params.actions).to.deep.equal(['1', '2'])
-      })
+        it('should contain actions property', function () {
+          const params = res.render.args[0][1]
+          expect(params).to.have.property('actions')
+          expect(params.actions).to.deep.equal(['1', '2'])
+        })
 
-      it('should contain context property', function () {
-        const params = res.render.args[0][1]
-        expect(params).to.have.property('context')
-        expect(params.context).to.equal('listContext')
-      })
+        it('should contain context property', function () {
+          const params = res.render.args[0][1]
+          expect(params).to.have.property('context')
+          expect(params.context).to.equal('listContext')
+        })
 
-      it('should contain resultsAsCards property', function () {
-        const params = res.render.args[0][1]
-        expect(params).to.have.property('resultsAsCards')
-        expect(params.resultsAsCards).to.deep.equal({
-          active: mockActiveMovesByDate,
-          cancelled: mockCancelledMovesByDate,
+        it('should contain resultsAsCards property', function () {
+          const params = res.render.args[0][1]
+          expect(params).to.have.property('resultsAsCards')
+          expect(params.resultsAsCards).to.deep.equal({
+            active: mockActiveMovesByDate,
+            cancelled: mockCancelledMovesByDate,
+          })
+        })
+
+        it('should contain dateRange property', function () {
+          const params = res.render.args[0][1]
+          expect(params).to.have.property('dateRange')
+          expect(params.dateRange).to.deep.equal(req.params.dateRange)
+        })
+
+        it('should contain datePagination property', function () {
+          const params = res.render.args[0][1]
+          expect(params).to.have.property('datePagination')
+          expect(params.datePagination).to.deep.equal(req.datePagination)
+        })
+
+        it('should contain period property', function () {
+          const params = res.render.args[0][1]
+          expect(params).to.have.property('period')
+          expect(params.period).to.deep.equal(req.params.period)
+        })
+
+        it('should contain filter property', function () {
+          const params = res.render.args[0][1]
+          expect(params).to.have.property('filter')
+          expect(params.filter).to.deep.equal(req.filter)
+        })
+
+        it('should contain activeStatus property', function () {
+          const params = res.render.args[0][1]
+          expect(params).to.have.property('activeStatus')
+          expect(params.activeStatus).to.deep.equal(req.query.status)
+        })
+
+        it('should contain total results property', function () {
+          const params = res.render.args[0][1]
+          expect(params).to.have.property('totalResults')
+          expect(params.totalResults).to.deep.equal(18)
+        })
+
+        it('should contain correct number of properties', function () {
+          const params = res.render.args[0][1]
+          expect(Object.keys(params)).to.have.length(9)
         })
       })
 
-      it('should contain dateRange property', function () {
-        const params = res.render.args[0][1]
-        expect(params).to.have.property('dateRange')
-        expect(params.dateRange).to.deep.equal(req.params.dateRange)
-      })
+      context('with different display location', function () {
+        beforeEach(function () {
+          res.locals.CURRENT_LOCATION = {
+            id: 'FACEFEED',
+          }
 
-      it('should contain datePagination property', function () {
-        const params = res.render.args[0][1]
-        expect(params).to.have.property('datePagination')
-        expect(params.datePagination).to.deep.equal(req.datePagination)
-      })
+          req.location = {
+            id: 'ABADCAFE',
+          }
 
-      it('should contain period property', function () {
-        const params = res.render.args[0][1]
-        expect(params).to.have.property('period')
-        expect(params.period).to.deep.equal(req.params.period)
-      })
+          req.actions = [
+            { permission: 'move:create' },
+            { permission: 'move:view' },
+          ]
 
-      it('should contain filter property', function () {
-        const params = res.render.args[0][1]
-        expect(params).to.have.property('filter')
-        expect(params.filter).to.deep.equal(req.filter)
-      })
+          controller(req, res)
+        })
 
-      it('should contain activeStatus property', function () {
-        const params = res.render.args[0][1]
-        expect(params).to.have.property('activeStatus')
-        expect(params.activeStatus).to.deep.equal(req.query.status)
-      })
+        it('should contain location property', function () {
+          const params = res.render.args[0][1]
+          expect(params).to.have.property('location')
+          expect(params.location).to.deep.equal({ id: 'ABADCAFE' })
+        })
 
-      it('should contain total results property', function () {
-        const params = res.render.args[0][1]
-        expect(params).to.have.property('totalResults')
-        expect(params.totalResults).to.deep.equal(18)
-      })
+        it('should filter actions', function () {
+          const params = res.render.args[0][1]
+          expect(params).to.have.property('actions')
+          expect(params.actions).to.deep.equal([{ permission: 'move:view' }])
+        })
 
-      it('should contain correct number of properties', function () {
-        const params = res.render.args[0][1]
-        expect(Object.keys(params)).to.have.length(9)
+        it('should contain correct number of properties', function () {
+          const params = res.render.args[0][1]
+          expect(Object.keys(params)).to.have.length(10)
+        })
       })
     })
 
@@ -120,8 +158,10 @@ describe('Collection controllers', function () {
         'if user can view move and individual location requested',
         function () {
           beforeEach(function () {
+            req.location = {
+              id: '83a4208b-21a5-4b1d-a576-5d9513e0b910',
+            }
             req.params = {
-              locationId: '83a4208b-21a5-4b1d-a576-5d9513e0b910',
               dateRange: ['2020-10-01', '2020-10-10'],
             }
             req.canAccess.withArgs('move:view').returns(true)

--- a/common/middleware/errors.js
+++ b/common/middleware/errors.js
@@ -1,5 +1,3 @@
-const { get } = require('lodash')
-
 const logger = require('../../config/logger')
 
 function _getMessage(error) {
@@ -41,7 +39,9 @@ function catchAll(showStackTrace = false) {
       return res.status(statusCode).send(error.message)
     }
 
-    const locationType = get(res.locals, 'CURRENT_LOCATION.location_type')
+    const locationType =
+      req?.location?.location_type ||
+      res.locals?.CURRENT_LOCATION?.location_type
     const showNomisMessage = locationType === 'prison' && statusCode === 500
 
     res.status(statusCode).render('error', {

--- a/common/middleware/errors.test.js
+++ b/common/middleware/errors.test.js
@@ -34,13 +34,15 @@ describe('Error middleware', function () {
 
   describe('#catchAll', function () {
     let nextSpy
-    const req = {}
+    let mockReq
+    // const req = {}
     let mockError
     let mockRes
 
     beforeEach(function () {
       nextSpy = sinon.spy()
       mockError = new Error('A mock error')
+      mockReq = {}
       mockRes = {
         status: sinon.stub().returnsThis(),
         render: sinon.spy(),
@@ -51,7 +53,7 @@ describe('Error middleware', function () {
     context('when headers have already been sent', function () {
       beforeEach(function () {
         mockRes.headersSent = true
-        errors.catchAll()(mockError, req, mockRes, nextSpy)
+        errors.catchAll()(mockError, mockReq, mockRes, nextSpy)
       })
 
       it('should call next middleware with error', function () {
@@ -67,7 +69,7 @@ describe('Error middleware', function () {
 
     context('when stack trace should be visible', function () {
       beforeEach(function () {
-        errors.catchAll(true)(mockError, req, mockRes, nextSpy)
+        errors.catchAll(true)(mockError, mockReq, mockRes, nextSpy)
       })
 
       it('should send showStackTrace property to template', function () {
@@ -81,7 +83,7 @@ describe('Error middleware', function () {
 
     context('when stack trace should not be visible', function () {
       beforeEach(function () {
-        errors.catchAll(false)(mockError, req, mockRes, nextSpy)
+        errors.catchAll(false)(mockError, mockReq, mockRes, nextSpy)
       })
 
       it('should send showStackTrace property to template', function () {
@@ -95,7 +97,7 @@ describe('Error middleware', function () {
 
     context('when show stack trace is not set', function () {
       beforeEach(function () {
-        errors.catchAll()(mockError, req, mockRes, nextSpy)
+        errors.catchAll()(mockError, mockReq, mockRes, nextSpy)
       })
 
       it('should send showStackTrace property to template', function () {
@@ -110,7 +112,7 @@ describe('Error middleware', function () {
     context('with a 404 error status code', function () {
       beforeEach(function () {
         mockError.statusCode = errorCode404
-        errors.catchAll()(mockError, req, mockRes, nextSpy)
+        errors.catchAll()(mockError, mockReq, mockRes, nextSpy)
       })
 
       it('should set correct status code on response', function () {
@@ -153,7 +155,7 @@ describe('Error middleware', function () {
     context('with a standard 403 error status code', function () {
       beforeEach(function () {
         mockError.statusCode = errorCode403
-        errors.catchAll()(mockError, req, mockRes, nextSpy)
+        errors.catchAll()(mockError, mockReq, mockRes, nextSpy)
       })
 
       it('should set correct status code on response', function () {
@@ -197,7 +199,7 @@ describe('Error middleware', function () {
       beforeEach(function () {
         mockError.statusCode = errorCode403
         mockError.code = 'EBADCSRFTOKEN'
-        errors.catchAll()(mockError, req, mockRes, nextSpy)
+        errors.catchAll()(mockError, mockReq, mockRes, nextSpy)
       })
 
       it('should set correct status code on response', function () {
@@ -244,7 +246,7 @@ describe('Error middleware', function () {
 
       context('without location', function () {
         beforeEach(function () {
-          errors.catchAll()(mockError, req, mockRes, nextSpy)
+          errors.catchAll()(mockError, mockReq, mockRes, nextSpy)
         })
 
         it('should set correct status code on response', function () {
@@ -284,12 +286,37 @@ describe('Error middleware', function () {
         })
       })
 
-      context('with prison location', function () {
+      context('with req location', function () {
+        beforeEach(function () {
+          mockReq.location = {
+            location_type: 'prison',
+          }
+          mockRes.locals.CURRENT_LOCATION = {
+            location_type: 'hospital',
+          }
+          errors.catchAll()(mockError, mockReq, mockRes, nextSpy)
+        })
+
+        it('should pass correct values to template', function () {
+          expect(mockRes.render.args[0][1]).to.deep.equal({
+            error: mockError,
+            statusCode: errorCode500,
+            showStackTrace: false,
+            showNomisMessage: true,
+            message: {
+              heading: 'errors::default.heading',
+              content: 'errors::default.content',
+            },
+          })
+        })
+      })
+
+      context('with locals location', function () {
         beforeEach(function () {
           mockRes.locals.CURRENT_LOCATION = {
             location_type: 'prison',
           }
-          errors.catchAll()(mockError, req, mockRes, nextSpy)
+          errors.catchAll()(mockError, mockReq, mockRes, nextSpy)
         })
 
         it('should pass correct values to template', function () {
@@ -310,7 +337,7 @@ describe('Error middleware', function () {
     context('with no error status code', function () {
       context('without location', function () {
         beforeEach(function () {
-          errors.catchAll()(mockError, req, mockRes, nextSpy)
+          errors.catchAll()(mockError, mockReq, mockRes, nextSpy)
         })
 
         it('should set correct status code on response', function () {
@@ -350,12 +377,37 @@ describe('Error middleware', function () {
         })
       })
 
-      context('with prison location', function () {
+      context('with req location', function () {
+        beforeEach(function () {
+          mockReq.location = {
+            location_type: 'prison',
+          }
+          mockRes.locals.CURRENT_LOCATION = {
+            location_type: 'hospital',
+          }
+          errors.catchAll()(mockError, mockReq, mockRes, nextSpy)
+        })
+
+        it('should pass correct values to template', function () {
+          expect(mockRes.render.args[0][1]).to.deep.equal({
+            error: mockError,
+            statusCode: errorCode500,
+            showStackTrace: false,
+            showNomisMessage: true,
+            message: {
+              heading: 'errors::default.heading',
+              content: 'errors::default.content',
+            },
+          })
+        })
+      })
+
+      context('with locals location', function () {
         beforeEach(function () {
           mockRes.locals.CURRENT_LOCATION = {
             location_type: 'prison',
           }
-          errors.catchAll()(mockError, req, mockRes, nextSpy)
+          errors.catchAll()(mockError, mockReq, mockRes, nextSpy)
         })
 
         it('should pass correct values to template', function () {

--- a/common/middleware/sentry-enrich-scope.js
+++ b/common/middleware/sentry-enrich-scope.js
@@ -1,7 +1,7 @@
 const Sentry = require('@sentry/node')
 
 module.exports = function sentryEnrichScope(req, res, next) {
-  const { currentLocation } = req.session
+  const currentLocation = req.location || req.session.currentLocation
 
   if (currentLocation) {
     const {

--- a/common/middleware/set-location.js
+++ b/common/middleware/set-location.js
@@ -1,0 +1,48 @@
+const { find, flatMapDeep } = require('lodash')
+
+// If we want to also use this as normal middleware, we can't have an extra property
+// param, as normal middleware uses the 4th param for error handling
+async function setLocation(req, res, next) {
+  const locationId = req.params?.locationId || req.session?.currentLocation?.id
+
+  if (!locationId) {
+    return next()
+  }
+
+  // Find this location in the available locations of the current user
+  const userLocations = req.session?.user?.locations
+  let location = find(userLocations, { id: locationId })
+
+  if (location) {
+    req.location = location
+    return next()
+  }
+
+  // Find this location in the currentRegion of the current user
+  const userRegionLocations = req.session?.currentRegion?.locations
+  location = find(userRegionLocations, { id: locationId })
+
+  if (location) {
+    req.location = location
+    return next()
+  }
+
+  // Find this location in the all regions
+  const allRegions = await req.services.referenceData.getRegions()
+  const flattenedRegions = flatMapDeep(allRegions, region => region.locations)
+  location = find(flattenedRegions, { id: locationId })
+
+  if (location) {
+    req.location = location
+    return next()
+  }
+
+  if (!location) {
+    const error = new Error('Location not found')
+    error.statusCode = 404
+
+    return next(error)
+  }
+}
+
+module.exports = setLocation

--- a/common/middleware/set-location.test.js
+++ b/common/middleware/set-location.test.js
@@ -1,0 +1,225 @@
+const setLocation = require('./set-location')
+
+describe('Set location middleware', function () {
+  describe('#setLocation', function () {
+    let next
+    const res = {}
+    let req
+
+    beforeEach(function () {
+      req = {
+        params: {},
+        session: {},
+        services: {
+          referenceData: {
+            getRegions: sinon.stub(),
+          },
+        },
+      }
+      next = sinon.stub()
+    })
+
+    context('without a param or session location', function () {
+      beforeEach(function () {
+        setLocation(req, res, next)
+      })
+
+      it('should call next', function () {
+        expect(next).to.have.been.calledWithExactly()
+      })
+
+      it('should not set req.location', function () {
+        expect(req.location).to.be.undefined
+      })
+    })
+
+    context('with param location', function () {
+      beforeEach(function () {
+        req.params.locationId = 'ABADCAFE'
+      })
+
+      context('found in userLocations', function () {
+        beforeEach(async function () {
+          req.session.user = {
+            locations: [{ id: 'ABADCAFE' }],
+          }
+
+          await setLocation(req, res, next)
+        })
+
+        it('should set req.location', function () {
+          expect(req.location).to.deep.equal({ id: 'ABADCAFE' })
+        })
+
+        it('should call next', function () {
+          expect(next).to.have.been.calledWithExactly()
+        })
+      })
+
+      context('found in session currentRegion locations', function () {
+        beforeEach(async function () {
+          req.session.user = {
+            locations: [{ id: 'FACEFEED' }],
+          }
+          req.session.currentRegion = {
+            locations: [{ id: 'ABADCAFE' }],
+          }
+
+          await setLocation(req, res, next)
+        })
+
+        it('should set req.location', function () {
+          expect(req.location).to.deep.equal({ id: 'ABADCAFE' })
+        })
+
+        it('should call next', function () {
+          expect(next).to.have.been.calledWithExactly()
+        })
+      })
+
+      context('found in all regions', function () {
+        beforeEach(async function () {
+          req.session.user = {
+            locations: [{ id: 'FACEFEED' }],
+          }
+          req.session.currentRegion = {
+            locations: [{ id: 'FACEFEED' }],
+          }
+
+          const allRegions = [
+            { id: 'region1', locations: [{ id: 'DEADBEEF' }] },
+            {
+              id: 'region2',
+              locations: [{ id: 'FACEFEED' }, { id: 'ABADCAFE' }],
+            },
+          ]
+          req.services.referenceData.getRegions.resolves(allRegions)
+
+          await setLocation(req, res, next)
+        })
+
+        it('should set req.location', function () {
+          expect(req.location).to.deep.equal({ id: 'ABADCAFE' })
+        })
+
+        it('should call next', function () {
+          expect(next).to.have.been.calledWithExactly()
+        })
+      })
+
+      context('not found', function () {
+        beforeEach(async function () {
+          await setLocation(req, res, next)
+        })
+
+        it('should call next', function () {
+          expect(next).to.have.been.calledWith(sinon.match.instanceOf(Error))
+          expect(next).to.have.been.calledWithMatch({
+            message: 'Location not found',
+            statusCode: 404,
+          })
+        })
+
+        it('should not set req.location', function () {
+          expect(req.location).to.be.undefined
+        })
+      })
+    })
+
+    context('with session location', function () {
+      beforeEach(function () {
+        delete req.params.locationId
+        req.session.currentLocation = {
+          id: 'ABADCAFE',
+        }
+      })
+
+      context('found in userLocations', function () {
+        beforeEach(async function () {
+          req.session.user = {
+            locations: [{ id: 'ABADCAFE' }],
+          }
+
+          await setLocation(req, res, next)
+        })
+
+        it('should set req.location', function () {
+          expect(req.location).to.deep.equal({ id: 'ABADCAFE' })
+        })
+
+        it('should call next', function () {
+          expect(next).to.have.been.calledWithExactly()
+        })
+      })
+
+      context('found in session currentRegion locations', function () {
+        beforeEach(async function () {
+          req.session.user = {
+            locations: [{ id: 'FACEFEED' }],
+          }
+          req.session.currentRegion = {
+            locations: [{ id: 'ABADCAFE' }],
+          }
+
+          await setLocation(req, res, next)
+        })
+
+        it('should set req.location', function () {
+          expect(req.location).to.deep.equal({ id: 'ABADCAFE' })
+        })
+
+        it('should call next', function () {
+          expect(next).to.have.been.calledWithExactly()
+        })
+      })
+
+      context('found in all regions', function () {
+        beforeEach(async function () {
+          req.session.user = {
+            locations: [{ id: 'FACEFEED' }],
+          }
+          req.session.currentRegion = {
+            locations: [{ id: 'FACEFEED' }],
+          }
+
+          const allRegions = [
+            { id: 'region1', locations: [{ id: 'DEADBEEF' }] },
+            {
+              id: 'region2',
+              locations: [{ id: 'FACEFEED' }, { id: 'ABADCAFE' }],
+            },
+          ]
+          req.services.referenceData.getRegions.resolves(allRegions)
+
+          await setLocation(req, res, next)
+        })
+
+        it('should set req.location', function () {
+          expect(req.location).to.deep.equal({ id: 'ABADCAFE' })
+        })
+
+        it('should call next', function () {
+          expect(next).to.have.been.calledWithExactly()
+        })
+      })
+
+      context('not found', function () {
+        beforeEach(async function () {
+          await setLocation(req, res, next)
+        })
+
+        it('should call next', function () {
+          expect(next).to.have.been.calledWith(sinon.match.instanceOf(Error))
+          expect(next).to.have.been.calledWithMatch({
+            message: 'Location not found',
+            statusCode: 404,
+          })
+        })
+
+        it('should not set req.location', function () {
+          expect(req.location).to.be.undefined
+        })
+      })
+    })
+  })
+})

--- a/common/templates/layouts/collection.njk
+++ b/common/templates/layouts/collection.njk
@@ -29,7 +29,7 @@
           <span class="govuk-caption-xl">
           {{ t("collections::subheading", {
             context: context
-          }) }}
+          }) }}{{ " " + location.title if location}}
           </span>
 
           <span class="govuk-!-display-block">{{ displayDate }}</span>

--- a/server.js
+++ b/server.js
@@ -31,6 +31,7 @@ const processOriginalRequestBody = require('./common/middleware/process-original
 const sentryEnrichScope = require('./common/middleware/sentry-enrich-scope')
 const sentryRequestId = require('./common/middleware/sentry-request-id')
 const setApiClient = require('./common/middleware/set-api-client')
+const setLocation = require('./common/middleware/set-location')
 const setLocations = require('./common/middleware/set-locations')
 const setPrimaryNavigation = require('./common/middleware/set-primary-navigation')
 const setServices = require('./common/middleware/set-services')
@@ -176,6 +177,8 @@ app.use(
   })
 )
 app.use(setLocations)
+// app.use(setLocation)
+app.use('.*(?<!image)$', setLocation)
 
 // unsafe-inline is required as govuk-template injects `js-enabled` class via inline script
 app.use(

--- a/test/e2e/moves.outgoing.multiple.test.js
+++ b/test/e2e/moves.outgoing.multiple.test.js
@@ -1,0 +1,40 @@
+import { Selector } from 'testcafe'
+
+import { E2E } from '../../config'
+
+import { outgoingMoves, home } from './_routes'
+import { page } from './pages'
+
+fixture('Multiple Windows').page(home)
+
+test.before(async t => {
+  await page.signIn(E2E.USERS.POLICE)
+})('Load multiple outgoing pages', async t => {
+  // First page
+  await page.chooseLocation({ position: 0 })
+  await t.navigateTo(outgoingMoves)
+  const initialOutgoingUrl = await t.eval(() => document.documentURI)
+  const initialLocationTitle = await Selector('.moj-organisation-nav__title')
+    .innerText
+
+  // Second page
+  await t.navigateTo(`${home}/locations`)
+  await page.chooseLocation({ position: 1 })
+  const secondLocationTitle = await Selector('.moj-organisation-nav__title')
+    .innerText
+  await t
+    .expect(initialLocationTitle)
+    .notEql(secondLocationTitle, 'first and second locations are not different')
+
+  await t.navigateTo(initialOutgoingUrl)
+  const reloadedLocationTitle = await Selector('.moj-organisation-nav__title')
+    .innerText
+  await t
+    .expect(secondLocationTitle)
+    .eql(reloadedLocationTitle, 'first and second locations are different')
+
+  const initialLocationContent = await Selector('span').withText(
+    initialLocationTitle
+  ).exists
+  await t.expect(initialLocationContent).ok('first location not found on page')
+})

--- a/test/e2e/pages/page.js
+++ b/test/e2e/pages/page.js
@@ -1,3 +1,4 @@
+import { isUndefined } from 'lodash'
 import { ClientFunction, Selector, t } from 'testcafe'
 
 import { E2E } from '../../../config'
@@ -44,21 +45,24 @@ export default class Page {
   }
 
   /**
-   * Randomly select a location
+   * Select a location, choosing randomly if no position is provided
    *
+   * @param {Number} position Unbounded index of location to choose
    * @returns {Promise}
    */
-  async chooseLocation() {
+  async chooseLocation({ position } = {}) {
     await t
       .expect(this.getCurrentUrl())
       .contains('/locations')
       .expect(this.nodes.locationsList.count)
       .notEql(0, { timeout: 15000 })
 
-    const count = await this.nodes.locationsList.count
-    const randomItem = Math.floor(Math.random() * count)
+    if (isUndefined(position)) {
+      const count = await this.nodes.locationsList.count
+      position = Math.floor(Math.random() * count)
+    }
 
-    await t.click(this.nodes.locationsList.nth(randomItem))
+    await t.click(this.nodes.locationsList.nth(position))
 
     await t.expect(this.getCurrentUrl()).notContains('/locations')
   }


### PR DESCRIPTION
Param middleware can only be applied to routes that specify the param.

This sets `req.location` based off the session, and overrides it if specified by the location from `params`. This `req.location` is then used for the majority of the app, baring a few specific instances where the session location is used.

This then allows moves, allocations and singles requests to be viewed that are not the currently selected location. In order to protect the user from mistakenly creating a move from the wrong location, if the currently selected location and the currently viewed location are different, the `create a move` button is hidden.

<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

<!--- Describe the changes in detail - the "what"-->

### Why did it change

<!--- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

- [P4-XXXX]()

## Screenshots
<!--- (Optional) Include screenshots if changes update interfaces or components -->
<!--- Delete/copy as appropriate --->

| Before | After |
| ------ | ----- |
|  ![Screenshot_2021-02-10 Outgoing moves for Wednesday 10 Feb 2021 (Today)(1)](https://user-images.githubusercontent.com/196695/107495636-40187100-6b88-11eb-8b28-51d84de594eb.png) | ![Screenshot_2021-02-10 Outgoing moves for Wednesday 10 Feb 2021 (Today)(2)](https://user-images.githubusercontent.com/196695/107495870-8968c080-6b88-11eb-806d-ea6c4c0907a7.png)|
| ![Screenshot_2021-02-10 Outgoing moves for Tuesday 9 Feb 2021 (Yesterday)(1)](https://user-images.githubusercontent.com/196695/107495657-46a6e880-6b88-11eb-8fd7-4e9f1383b6b0.png) |![Screenshot_2021-02-10 Outgoing moves for Tuesday 9 Feb 2021 (Yesterday)(2)](https://user-images.githubusercontent.com/196695/107495889-91286500-6b88-11eb-900f-ddf3b09dc4c0.png) |
| ![Screenshot_2021-02-10 Outgoing moves for Tuesday 9 Feb 2021 (Yesterday)(3)](https://user-images.githubusercontent.com/196695/107496224-f0867500-6b88-11eb-9c70-cc8a4ced114f.png) | |
| ![Screenshot_2021-02-10 Results for Friday 12 Feb 2021(1)](https://user-images.githubusercontent.com/196695/107495685-4dcdf680-6b88-11eb-815a-e762527e7bdd.png) | ![Screenshot_2021-02-10 Results for Friday 12 Feb 2021(2)](https://user-images.githubusercontent.com/196695/107495934-9d142700-6b88-11eb-98e5-54b130258628.png)|
| ![Screenshot_2021-02-10 Results for Friday 12 Feb 2021(3)](https://user-images.githubusercontent.com/196695/107496268-fda36400-6b88-11eb-93eb-07fdc37af3de.png) | | 

## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [x] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [ ] Chrome
- [x] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed

### Other considerations

Commit messages with a `fix` or `feat` type are automatically used to generate the [changelog](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/CHANGELOG.md) and
[GitHub release notes](https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/releases) during the release task. Please make sure they will read well on their own in a
summary of changes and that the commit body gives a more detailed description of those changes if necessary.

- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
- [ ] Update [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md) with any new instructions or tasks
