### PR TITLE
[P4-1892] Capture handover details

### DIFF
--- a/app/person-escort-record/app/confirm/controllers.js
+++ b/app/person-escort-record/app/confirm/controllers.js
@@ -1,0 +1,94 @@
+const { formatISO, parseISO, set } = require('date-fns')
+
+const ConfirmAssessmentController = require('../../../../common/controllers/framework/confirm-assessment')
+
+class HandoverController extends ConfirmAssessmentController {
+  middlewareSetup() {
+    super.middlewareSetup()
+    this.use(this.setSupplier)
+  }
+
+  middlewareLocals() {
+    super.middlewareLocals()
+    this.use(this.setBreadcrumb)
+  }
+
+  setBreadcrumb(req, res, next) {
+    res.breadcrumb({
+      text: req.t(req.form.options.pageTitle),
+      href: '',
+    })
+
+    next()
+  }
+
+  setSupplier(req, res, next) {
+    const supplierName = req.move?.supplier?.name
+
+    if (supplierName) {
+      const { fields } = req.form.options
+      const item = fields.handover_receiving_organisation.items[0]
+
+      item.text = supplierName
+      item.value = supplierName
+    }
+
+    next()
+  }
+
+  async saveValues(req, res, next) {
+    try {
+      const values = req.form.values
+
+      // process organisation
+      if (values.handover_receiving_organisation === 'other') {
+        values.handover_receiving_organisation =
+          values.handover_other_organisation
+      }
+
+      // process handover time
+      if (values.handover_occurred_at === 'now') {
+        values.handover_occurred_at = formatISO(new Date())
+      } else if (values.handover_occurred_at === 'other') {
+        const timeParts = values.handover_other_time.split(':')
+        const parsedDate = parseISO(values.handover_other_date)
+        const handoverDate = set(parsedDate, {
+          hours: timeParts[0],
+          minutes: timeParts[1],
+        })
+
+        values.handover_occurred_at = formatISO(handoverDate)
+      }
+
+      const {
+        handover_occurred_at: handoverOccurredAt,
+        handover_dispatching_officer: dispatchingOfficer,
+        handover_dispatching_officer_id: dispatchingOfficerId,
+        handover_dispatching_officer_contact: dispatchingOfficerContact,
+        handover_receiving_officer: receivingOfficer,
+        handover_receiving_officer_id: receivingOfficerId,
+        handover_receiving_officer_contact: receivingOfficerContact,
+        handover_receiving_organisation: receivingOrganisation,
+      } = values
+
+      await req.services.personEscortRecord.confirm(req.assessment.id, {
+        handoverOccurredAt,
+        dispatchingOfficer,
+        dispatchingOfficerId,
+        dispatchingOfficerContact,
+        receivingOfficer,
+        receivingOfficerId,
+        receivingOfficerContact,
+        receivingOrganisation,
+      })
+
+      next()
+    } catch (error) {
+      next(error)
+    }
+  }
+}
+
+module.exports = {
+  HandoverController,
+}

--- a/app/person-escort-record/app/confirm/controllers.test.js
+++ b/app/person-escort-record/app/confirm/controllers.test.js
@@ -1,0 +1,313 @@
+const timezoneMock = require('timezone-mock')
+
+const ConfirmAssessmentController = require('../../../../common/controllers/framework/confirm-assessment')
+
+const { HandoverController } = require('./controllers')
+
+const controller = new HandoverController({ route: '/' })
+
+describe('Person Escort Record controllers', function () {
+  describe('HandoverController', function () {
+    describe('#middlewareSetup', function () {
+      beforeEach(function () {
+        sinon.stub(ConfirmAssessmentController.prototype, 'middlewareSetup')
+        sinon.stub(controller, 'use')
+        sinon.stub(controller, 'setSupplier')
+
+        controller.middlewareSetup()
+      })
+
+      it('should call parent method', function () {
+        expect(ConfirmAssessmentController.prototype.middlewareSetup).to.have
+          .been.calledOnce
+      })
+
+      it('should call set supplier', function () {
+        expect(controller.use).to.have.been.calledWithExactly(
+          controller.setSupplier
+        )
+      })
+
+      it('should call correct number of middleware', function () {
+        expect(controller.use.callCount).to.equal(1)
+      })
+    })
+
+    describe('#middlewareLocals', function () {
+      beforeEach(function () {
+        sinon.stub(ConfirmAssessmentController.prototype, 'middlewareLocals')
+        sinon.stub(controller, 'use')
+        sinon.stub(controller, 'setBreadcrumb')
+
+        controller.middlewareLocals()
+      })
+
+      it('should call parent method', function () {
+        expect(ConfirmAssessmentController.prototype.middlewareLocals).to.have
+          .been.calledOnce
+      })
+
+      it('should call set breadcrumb', function () {
+        expect(controller.use).to.have.been.calledWithExactly(
+          controller.setBreadcrumb
+        )
+      })
+
+      it('should call correct number of middleware', function () {
+        expect(controller.use.callCount).to.equal(1)
+      })
+    })
+
+    describe('#setSupplier', function () {
+      let mockReq, nextSpy
+
+      beforeEach(function () {
+        nextSpy = sinon.spy()
+        mockReq = {
+          form: {
+            options: {
+              fields: {
+                handover_receiving_organisation: {
+                  items: [
+                    {
+                      text: 'foo',
+                      value: 'foo',
+                    },
+                    {
+                      text: 'bar',
+                      value: 'bar',
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        }
+      })
+
+      context('without supplier name', function () {
+        beforeEach(function () {
+          controller.setSupplier(mockReq, {}, nextSpy)
+        })
+
+        it('should not update with supplier name', function () {
+          expect(
+            mockReq.form.options.fields.handover_receiving_organisation.items
+          ).to.deep.equal([
+            {
+              text: 'foo',
+              value: 'foo',
+            },
+            {
+              text: 'bar',
+              value: 'bar',
+            },
+          ])
+        })
+      })
+
+      context('with supplier name', function () {
+        beforeEach(function () {
+          mockReq.move = {
+            supplier: {
+              name: 'Serco',
+            },
+          }
+          controller.setSupplier(mockReq, {}, nextSpy)
+        })
+
+        it('should update with supplier name', function () {
+          expect(
+            mockReq.form.options.fields.handover_receiving_organisation.items
+          ).to.deep.equal([
+            {
+              text: 'Serco',
+              value: 'Serco',
+            },
+            {
+              text: 'bar',
+              value: 'bar',
+            },
+          ])
+        })
+      })
+    })
+
+    describe('#setBreadcrumb', function () {
+      let mockReq, mockRes, nextSpy
+
+      beforeEach(function () {
+        nextSpy = sinon.spy()
+        mockReq = {
+          form: {
+            options: {
+              pageTitle: 'Step title',
+            },
+          },
+          t: sinon.stub().returnsArg(0),
+        }
+        mockRes = {
+          breadcrumb: sinon.stub().returnsThis(),
+        }
+        controller.setBreadcrumb(mockReq, mockRes, nextSpy)
+      })
+
+      it('should set breadcrumb item', function () {
+        expect(mockRes.breadcrumb).to.have.been.calledOnceWithExactly({
+          text: 'Step title',
+          href: '',
+        })
+      })
+
+      it('should call next without error', function () {
+        expect(nextSpy).to.be.calledOnceWithExactly()
+      })
+    })
+
+    describe('#saveValues', function () {
+      let clock
+      let mockReq
+      let nextSpy
+
+      beforeEach(function () {
+        timezoneMock.register('UTC')
+        const now = new Date('2014-11-05T15:09:00Z')
+        clock = sinon.useFakeTimers(now.getTime())
+        nextSpy = sinon.spy()
+
+        mockReq = {
+          form: {
+            values: {
+              handover_occurred_at: '2020-10-10T14:20:00Z',
+              handover_dispatching_officer: 'John Smith',
+              handover_dispatching_officer_id: '123',
+              handover_dispatching_officer_contact: '077777',
+              handover_receiving_officer: 'Jane Doe',
+              handover_receiving_officer_id: '456',
+              handover_receiving_officer_contact: '088888',
+              handover_receiving_organisation: 'Serco',
+            },
+          },
+          assessment: {
+            id: '12345',
+          },
+          services: {
+            personEscortRecord: {
+              confirm: sinon.stub().resolves({}),
+            },
+          },
+        }
+      })
+
+      afterEach(function () {
+        clock.restore()
+        timezoneMock.unregister()
+      })
+
+      context('when promises resolve', function () {
+        beforeEach(async function () {
+          await controller.saveValues(mockReq, {}, nextSpy)
+        })
+
+        it('should call service method', function () {
+          expect(
+            mockReq.services.personEscortRecord.confirm
+          ).to.be.calledOnceWithExactly(mockReq.assessment.id, {
+            handoverOccurredAt: '2020-10-10T14:20:00Z',
+            dispatchingOfficer: 'John Smith',
+            dispatchingOfficerId: '123',
+            dispatchingOfficerContact: '077777',
+            receivingOfficer: 'Jane Doe',
+            receivingOfficerId: '456',
+            receivingOfficerContact: '088888',
+            receivingOrganisation: 'Serco',
+          })
+        })
+
+        it('should call next', function () {
+          expect(nextSpy).to.be.calledOnceWithExactly()
+        })
+      })
+
+      context('when service rejects with error', function () {
+        const error = new Error()
+
+        beforeEach(async function () {
+          mockReq.services.personEscortRecord.confirm = sinon
+            .stub()
+            .rejects(error)
+
+          await controller.saveValues(mockReq, {}, nextSpy)
+        })
+
+        it('should call next with the error', function () {
+          expect(nextSpy).to.be.calledOnceWithExactly(error)
+        })
+      })
+
+      describe('handover time', function () {
+        context('with current timestamp', function () {
+          beforeEach(async function () {
+            mockReq.form.values.handover_occurred_at = 'now'
+            await controller.saveValues(mockReq, {}, nextSpy)
+          })
+
+          it('should use current timestamp for handover time', function () {
+            expect(
+              mockReq.services.personEscortRecord.confirm.args[0][1]
+                .handoverOccurredAt
+            ).to.equal('2014-11-05T15:09:00Z')
+          })
+        })
+
+        context('with custom timestamp', function () {
+          beforeEach(async function () {
+            mockReq.form.values.handover_occurred_at = 'other'
+            mockReq.form.values.handover_other_time = '14:37'
+            mockReq.form.values.handover_other_date = '2017-04-19'
+            await controller.saveValues(mockReq, {}, nextSpy)
+          })
+
+          it('should use custom timestamp for handover time', function () {
+            expect(
+              mockReq.services.personEscortRecord.confirm.args[0][1]
+                .handoverOccurredAt
+            ).to.equal('2017-04-19T14:37:00+01:00')
+          })
+        })
+      })
+
+      describe('receiving organisation', function () {
+        context('with standard option selected', function () {
+          beforeEach(async function () {
+            mockReq.form.values.handover_receiving_organisation = 'Serco'
+            await controller.saveValues(mockReq, {}, nextSpy)
+          })
+
+          it('should use submitted value', function () {
+            expect(
+              mockReq.services.personEscortRecord.confirm.args[0][1]
+                .receivingOrganisation
+            ).to.equal('Serco')
+          })
+        })
+
+        context('with custom organisation', function () {
+          beforeEach(async function () {
+            mockReq.form.values.handover_receiving_organisation = 'other'
+            mockReq.form.values.handover_other_organisation =
+              'Harry Blogs Haulage'
+            await controller.saveValues(mockReq, {}, nextSpy)
+          })
+
+          it('should use custom value', function () {
+            expect(
+              mockReq.services.personEscortRecord.confirm.args[0][1]
+                .receivingOrganisation
+            ).to.equal('Harry Blogs Haulage')
+          })
+        })
+      })
+    })
+  })
+})

--- a/app/person-escort-record/app/confirm/fields.js
+++ b/app/person-escort-record/app/confirm/fields.js
@@ -1,16 +1,182 @@
-const confirmPersonEscortRecord = {
-  id: 'confirm_person_escort_record',
-  name: 'confirm_person_escort_record',
+const { cloneDeep } = require('lodash')
+
+const { time: timeFormatter } = require('../../../../common/formatters')
+const commonDateField = require('../../../move/fields/common.date')
+const { time: timeValidator } = require('../../../move/validators')
+
+const confirmHandover = {
+  id: 'confirm_handover',
+  name: 'confirm_handover',
   component: 'govukCheckboxes',
   items: [
     {
-      text: 'fields::confirm_person_escort_record.label',
+      text: 'fields::confirm_handover.label',
       value: 'yes',
     },
   ],
   validate: 'required',
 }
+const handoverDispatchingOfficer = {
+  id: 'handover_dispatching_officer',
+  name: 'handover_dispatching_officer',
+  component: 'govukInput',
+  classes: 'govuk-input--width-20',
+  label: {
+    text: 'fields::handover_dispatching_officer.label',
+    classes: 'govuk-label--s',
+  },
+  validate: 'required',
+}
+const handoverDispatchingOfficerId = {
+  id: 'handover_dispatching_officer_id',
+  name: 'handover_dispatching_officer_id',
+  component: 'govukInput',
+  classes: 'govuk-input--width-20',
+  label: {
+    text: 'fields::handover_dispatching_officer_id.label',
+    classes: 'govuk-label--s',
+  },
+  validate: 'required',
+}
+const handoverDispatchingOfficerContact = {
+  id: 'handover_dispatching_officer_contact',
+  name: 'handover_dispatching_officer_contact',
+  component: 'govukInput',
+  classes: 'govuk-input--width-20',
+  label: {
+    text: 'fields::handover_dispatching_officer_contact.label',
+    classes: 'govuk-label--s',
+  },
+  validate: 'required',
+}
+const handoverReceivingOfficer = {
+  id: 'handover_receiving_officer',
+  name: 'handover_receiving_officer',
+  component: 'govukInput',
+  classes: 'govuk-input--width-20',
+  label: {
+    text: 'fields::handover_receiving_officer.label',
+    classes: 'govuk-label--s',
+  },
+  validate: 'required',
+}
+const handoverReceivingOfficerId = {
+  id: 'handover_receiving_officer_id',
+  name: 'handover_receiving_officer_id',
+  component: 'govukInput',
+  classes: 'govuk-input--width-20',
+  label: {
+    text: 'fields::handover_receiving_officer_id.label',
+    classes: 'govuk-label--s',
+  },
+  validate: 'required',
+}
+const handoverReceivingOfficerContact = {
+  id: 'handover_receiving_officer_contact',
+  name: 'handover_receiving_officer_contact',
+  component: 'govukInput',
+  classes: 'govuk-input--width-20',
+  label: {
+    text: 'fields::handover_receiving_officer_contact.label',
+    classes: 'govuk-label--s',
+  },
+  validate: 'required',
+}
+const handoverReceivingOrganisation = {
+  name: 'handover_receiving_organisation',
+  component: 'govukRadios',
+  fieldset: {
+    legend: {
+      text: 'fields::handover_receiving_organisation.label',
+      classes: 'govuk-fieldset__legend--s',
+    },
+  },
+  items: [
+    {
+      id: 'handover_receiving_organisation',
+      value: 'fields::handover_receiving_organisation.items.supplier.label',
+      text: 'fields::handover_receiving_organisation.items.supplier.label',
+    },
+    {
+      value: 'other',
+      text: 'fields::handover_receiving_organisation.items.other.label',
+      conditional: 'handover_other_organisation',
+    },
+  ],
+  validate: 'required',
+}
+const handoverOtherOganisation = {
+  id: 'handover_other_organisation',
+  name: 'handover_other_organisation',
+  component: 'govukInput',
+  classes: 'govuk-input--width-20',
+  label: {
+    text: 'fields::handover_other_organisation.label',
+    classes: 'govuk-label--s',
+  },
+  validate: 'required',
+}
+const handoverTime = {
+  validate: 'required',
+  name: 'handover_occurred_at',
+  component: 'govukRadios',
+  fieldset: {
+    legend: {
+      text: 'fields::handover_occurred_at.label',
+      classes: 'govuk-fieldset__legend--m',
+    },
+  },
+  items: [
+    {
+      id: 'handover_occurred_at',
+      value: 'now',
+      text: 'fields::handover_occurred_at.items.now.label',
+    },
+    {
+      value: 'other',
+      text: 'fields::handover_occurred_at.items.historic.label',
+      conditional: ['handover_other_date', 'handover_other_time'],
+    },
+  ],
+}
+const handoverOtherDate = {
+  ...cloneDeep(commonDateField),
+  validate: [...commonDateField.validate, 'required', 'before'],
+  id: 'handover_other_date',
+  name: 'handover_other_date',
+  label: {
+    text: 'fields::handover_other_date.label',
+    classes: 'govuk-label--s',
+  },
+}
+const handoverOtherTime = {
+  id: 'handover_other_time',
+  name: 'handover_other_time',
+  validate: ['required', timeValidator],
+  formatter: [timeFormatter],
+  component: 'govukInput',
+  classes: 'govuk-input--width-5',
+  autocomplete: 'off',
+  label: {
+    html: 'fields::handover_other_time.label',
+    classes: 'govuk-label--s',
+  },
+  hint: {
+    html: 'fields::handover_other_time.hint',
+  },
+}
 
 module.exports = {
-  confirm_person_escort_record: confirmPersonEscortRecord,
+  confirm_handover: confirmHandover,
+  handover_dispatching_officer: handoverDispatchingOfficer,
+  handover_dispatching_officer_id: handoverDispatchingOfficerId,
+  handover_dispatching_officer_contact: handoverDispatchingOfficerContact,
+  handover_receiving_officer: handoverReceivingOfficer,
+  handover_receiving_officer_id: handoverReceivingOfficerId,
+  handover_receiving_officer_contact: handoverReceivingOfficerContact,
+  handover_receiving_organisation: handoverReceivingOrganisation,
+  handover_other_organisation: handoverOtherOganisation,
+  handover_occurred_at: handoverTime,
+  handover_other_date: handoverOtherDate,
+  handover_other_time: handoverOtherTime,
 }

--- a/app/person-escort-record/app/confirm/handover-details.njk
+++ b/app/person-escort-record/app/confirm/handover-details.njk
@@ -1,0 +1,55 @@
+{% extends "form-wizard.njk" %}
+
+{% macro renderField(name) %}
+  {{ callAsMacro(options.fields[name].component)(options.fields[name]) }}
+{% endmacro %}
+
+{% block fields %}
+  <h2 class="govuk-heading-m">
+    {{ t("assessment::handover.before_handover.heading") }}
+  </h2>
+
+  <div class="markdown govuk-!-margin-bottom-6">
+    {% markdown %}{{ t("assessment::handover.before_handover.content", { per_href: "/move/" + move.id + "/person-escort-record" }) | safe }}{% endmarkdown %}
+  </div>
+
+  {{ callAsMacro(options.fields.confirm_handover.component)(options.fields.confirm_handover) }}
+
+  {{ govukInsetText({
+    html: t("assessment::handover.not_fit_to_travel", {
+      cancel_href: "/move/" + move.id + "/cancel"
+    })
+  }) }}
+
+  <fieldset class="govuk-fieldset">
+    <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+      {{ t("assessment::handover.dispatching_officer") }}
+    </legend>
+
+    {{ renderField("handover_dispatching_officer") }}
+    {{ renderField("handover_dispatching_officer_id") }}
+    {{ renderField("handover_dispatching_officer_contact") }}
+  </fieldset>
+
+  <fieldset class="govuk-fieldset">
+    <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+      {{ t("assessment::handover.receiving_officer") }}
+    </legend>
+
+    {{ renderField("handover_receiving_officer") }}
+    {{ renderField("handover_receiving_officer_id") }}
+    {{ renderField("handover_receiving_officer_contact") }}
+    {{ renderField("handover_receiving_organisation") }}
+  </fieldset>
+
+  {{ renderField("handover_occurred_at") }}
+
+  {{ govukWarningText({
+    text: t("assessment::handover.warning_text"),
+    iconFallbackText: "Warning"
+  }) }}
+{% endblock %}
+
+{% block contentSidebar %}
+  {% include "includes/move-summary.njk" %}
+{% endblock %}

--- a/app/person-escort-record/app/confirm/steps.js
+++ b/app/person-escort-record/app/confirm/steps.js
@@ -1,20 +1,35 @@
-const ConfirmAssessmentController = require('../../../../common/controllers/framework/confirm-assessment')
+const { HandoverController } = require('./controllers')
 
-module.exports = {
+const single = {
   '/': {
     entryPoint: true,
     reset: true,
     resetJourney: true,
     skip: true,
-    next: 'provide-confirmation',
+    next: 'handover',
   },
-  '/provide-confirmation': {
+  '/handover': {
     checkJourney: false,
-    controller: ConfirmAssessmentController,
-    fields: ['confirm_person_escort_record'],
-    buttonText: 'actions::confirm_and_complete_record',
-    pageTitle: 'person-escort-record::journeys.confirm.heading',
-    beforeFieldsContent: 'person-escort-record::journeys.confirm.content',
-    template: 'form-wizard',
+    controller: HandoverController,
+    fields: [
+      'confirm_handover',
+      'handover_dispatching_officer',
+      'handover_dispatching_officer_id',
+      'handover_dispatching_officer_contact',
+      'handover_receiving_officer',
+      'handover_receiving_officer_id',
+      'handover_receiving_officer_contact',
+      'handover_receiving_organisation',
+      'handover_other_organisation',
+      'handover_occurred_at',
+      'handover_other_date',
+      'handover_other_time',
+    ],
+    buttonText: 'actions::confirm_handover',
+    pageTitle: 'assessment::handover.heading',
+    templatePath: 'person-escort-record/app/confirm',
+    template: 'handover-details',
   },
 }
+
+module.exports = single

--- a/app/person-escort-record/views/print-record.njk
+++ b/app/person-escort-record/views/print-record.njk
@@ -274,7 +274,7 @@
 
         {% for handover in [1, 2, 3, 4, 5] %}
           <div class="app-border-bottom-1 govuk-!-padding-bottom-4{{ ' govuk-!-margin-bottom-4' if not loop.last }} ">
-            <h3 class="govuk-heading-s govuk-!-margin-top-2 govuk-!-margin-bottom-2">
+            <h3 class="govuk-heading-s govuk-!-margin-top-0 govuk-!-margin-bottom-2">
               {{ t("person-escort-record::sections.handover.subheading") }} {{ loop.index }}
             </h3>
 
@@ -282,12 +282,13 @@
               "to": ".................................................",
               "time": "..........",
               "date": "................",
-              "phone": "...................",
               "dispatching_name": "........................................",
               "dispatching_id": "........",
+              "dispatching_contact": "..............",
               "receiving_name": "........................................",
               "receiving_id": "........",
-              "singature": ".................................................."
+              "receiving_contact": "..............",
+              "signature": "..........................."
             } %}
 
             {% if loop.first %}
@@ -295,19 +296,20 @@
                 "to": handoverDetails.receiving_organisation or defaultValues.to,
                 "time": (handoverDetails.occurred_at or defaultValues.time) | formatTime,
                 "date": (handoverDetails.occurred_at or defaultValues.date) | formatDate,
-                "phone": handoverDetails.receiving_officer_contact or defaultValues.phone,
                 "dispatching_name": handoverDetails.dispatching_officer or defaultValues.dispatching_name,
                 "dispatching_id": handoverDetails.dispatching_officer_id or defaultValues.dispatching_id,
+                "dispatching_contact": handoverDetails.dispatching_officer_contact or defaultValues.dispatching_contact,
                 "receiving_name": handoverDetails.receiving_officer or defaultValues.receiving_name,
                 "receiving_id": handoverDetails.receiving_officer_id or defaultValues.receiving_id,
-                "singature": defaultValues.singature
+                "receiving_contact": handoverDetails.receiving_officer_contact or defaultValues.receiving_contact,
+                "signature": defaultValues.signature
               } %}
             {% else %}
               {% set values = defaultValues %}
             {% endif %}
 
             <p class="govuk-!-font-size-16 govuk-!-margin-bottom-3">
-              {{ t("person-escort-record::sections.handover.fields.to") }}: {{ values.to }}&nbsp;&nbsp;&nbsp;{{ t("person-escort-record::sections.handover.fields.time") }}: {{ values.time }}&nbsp;&nbsp;&nbsp;{{ t("person-escort-record::sections.handover.fields.date") }}: {{ values.date }}&nbsp;&nbsp;&nbsp;{{ t("person-escort-record::sections.handover.fields.phone") }}: {{ values.phone }}
+              {{ t("person-escort-record::sections.handover.fields.to") }}: {{ values.to }}&nbsp;&nbsp;&nbsp;{{ t("person-escort-record::sections.handover.fields.time") }}: {{ values.time }}&nbsp;&nbsp;&nbsp;{{ t("person-escort-record::sections.handover.fields.date") }}: {{ values.date }}&nbsp;&nbsp;&nbsp;
             </p>
 
             <div class="govuk-grid-row">
@@ -316,11 +318,11 @@
                   {{ t("person-escort-record::sections.handover.fields.dispatching_officer") }}
                 </h4>
 
-                <p class="govuk-!-font-size-16 govuk-!-margin-bottom-3">
+                <p class="govuk-!-font-size-16 govuk-!-margin-bottom-2">
                   {{ t("person-escort-record::sections.handover.fields.name") }}: {{ values.dispatching_name }}&nbsp;&nbsp;{{ t("person-escort-record::sections.handover.fields.id") }}: {{ values.dispatching_id }}
                 </p>
                 <p class="govuk-!-font-size-16 govuk-!-margin-bottom-0">
-                  {{ t("person-escort-record::sections.handover.fields.signature") }}: {{ values.singature }}
+                  {{ t("person-escort-record::sections.handover.fields.phone") }}: {{ values.dispatching_contact }}&nbsp;&nbsp;{{ t("person-escort-record::sections.handover.fields.signature") }}: {{ values.signature }}
                 </p>
               </div>
 
@@ -329,11 +331,11 @@
                   {{ t("person-escort-record::sections.handover.fields.receiving_officer") }}
                 </h4>
 
-                <p class="govuk-!-font-size-16 govuk-!-margin-bottom-3">
+                <p class="govuk-!-font-size-16 govuk-!-margin-bottom-2">
                   {{ t("person-escort-record::sections.handover.fields.name") }}: {{ values.receiving_name }}&nbsp;&nbsp;{{ t("person-escort-record::sections.handover.fields.id") }}: {{ values.receiving_id }}
                 </p>
                 <p class="govuk-!-font-size-16 govuk-!-margin-bottom-0">
-                  {{ t("person-escort-record::sections.handover.fields.signature") }}: {{ values.singature }}
+                  {{ t("person-escort-record::sections.handover.fields.phone") }}: {{ values.receiving_contact }}&nbsp;&nbsp;{{ t("person-escort-record::sections.handover.fields.signature") }}: {{ values.signature }}
                 </p>
               </div>
             </div>

--- a/common/controllers/framework/confirm-assessment.js
+++ b/common/controllers/framework/confirm-assessment.js
@@ -1,8 +1,14 @@
 const { get } = require('lodash')
 
+const setMoveWithSummary = require('../../middleware/set-move-with-summary')
 const FormWizardController = require('../form-wizard')
 
 class ConfirmAssessmentController extends FormWizardController {
+  middlewareLocals() {
+    this.use(setMoveWithSummary)
+    super.middlewareLocals()
+  }
+
   middlewareChecks() {
     this.use(this.checkStatus)
     super.middlewareChecks()

--- a/common/controllers/framework/confirm-assessment.test.js
+++ b/common/controllers/framework/confirm-assessment.test.js
@@ -1,11 +1,42 @@
+const proxyquire = require('proxyquire')
+
 const FormWizardController = require('../form-wizard')
 
-const ConfirmAssessmentController = require('./confirm-assessment')
+const setMoveWithSummary = sinon.stub()
+
+const ConfirmAssessmentController = proxyquire('./confirm-assessment', {
+  '../../middleware/set-move-with-summary': setMoveWithSummary,
+})
 
 const controller = new ConfirmAssessmentController({ route: '/' })
 
 describe('Framework controllers', function () {
   describe('ConfirmAssessmentController', function () {
+    describe('#middlewareLocals', function () {
+      beforeEach(function () {
+        sinon.stub(FormWizardController.prototype, 'middlewareLocals')
+        sinon.stub(controller, 'use')
+        sinon.stub(controller, 'checkStatus')
+
+        controller.middlewareLocals()
+      })
+
+      it('should call parent method', function () {
+        expect(FormWizardController.prototype.middlewareLocals).to.have.been
+          .calledOnce
+      })
+
+      it('should call set move with summary', function () {
+        expect(controller.use).to.have.been.calledWithExactly(
+          setMoveWithSummary
+        )
+      })
+
+      it('should call correct number of middleware', function () {
+        expect(controller.use.callCount).to.equal(1)
+      })
+    })
+
     describe('#middlewareChecks', function () {
       beforeEach(function () {
         sinon.stub(FormWizardController.prototype, 'middlewareChecks')

--- a/common/presenters/message-banner/assessment-to-handed-over-banner.js
+++ b/common/presenters/message-banner/assessment-to-handed-over-banner.js
@@ -34,6 +34,15 @@ module.exports = function assessmentToHandedOverBanner({
         })}
       </a>
     </p>
+
+    <p class="govuk-!-font-size-16 govuk-!-margin-top-1">
+      ${i18n.t('handed_over_at', {
+        date: filters.formatDateWithTimeAndDay(
+          assessment.handover_occurred_at,
+          true
+        ),
+      })}
+    </p>
   `
 
   return {

--- a/common/presenters/message-banner/assessment-to-handed-over-banner.test.js
+++ b/common/presenters/message-banner/assessment-to-handed-over-banner.test.js
@@ -48,7 +48,7 @@ describe('Presenters', function () {
             },
             content: {
               html:
-                '\n    <p>\n      messages::assessment.handed_over.content\n    </p>\n\n    govukWarningText\n\n    <p>\n      <a href="/base-url/print" class="app-icon app-icon--print">\n        actions::print_assessment\n      </a>\n    </p>\n  ',
+                '\n    <p>\n      messages::assessment.handed_over.content\n    </p>\n\n    govukWarningText\n\n    <p>\n      <a href="/base-url/print" class="app-icon app-icon--print">\n        actions::print_assessment\n      </a>\n    </p>\n\n    <p class="govuk-!-font-size-16 govuk-!-margin-top-1">\n      handed_over_at\n    </p>\n  ',
             },
           })
         })
@@ -76,6 +76,9 @@ describe('Presenters', function () {
           )
           expect(i18n.t).to.be.calledWithExactly('actions::print_assessment', {
             context: 'person_escort_record',
+          })
+          expect(i18n.t).to.be.calledWithExactly('handed_over_at', {
+            date: mockArgs.assessment.handover_occurred_at,
           })
         })
 

--- a/common/services/person-escort-record.js
+++ b/common/services/person-escort-record.js
@@ -1,3 +1,5 @@
+const { isEmpty, pickBy } = require('lodash')
+
 const { FRAMEWORKS } = require('../../config')
 
 const BaseService = require('./base')
@@ -16,16 +18,45 @@ class PersonEscortRecordService extends BaseService {
       .then(response => response.data)
   }
 
-  confirm(id) {
+  confirm(
+    id,
+    {
+      handoverOccurredAt,
+      dispatchingOfficer,
+      dispatchingOfficerId,
+      dispatchingOfficerContact,
+      receivingOfficer,
+      receivingOfficerId,
+      receivingOfficerContact,
+      receivingOrganisation,
+    } = {}
+  ) {
     if (!id) {
       return Promise.reject(new Error(noIdMessage))
     }
 
+    const handoverDetails = pickBy({
+      dispatching_officer: dispatchingOfficer,
+      dispatching_officer_id: dispatchingOfficerId,
+      dispatching_officer_contact: dispatchingOfficerContact,
+      receiving_officer: receivingOfficer,
+      receiving_officer_id: receivingOfficerId,
+      receiving_officer_contact: receivingOfficerContact,
+      receiving_organisation: receivingOrganisation,
+    })
+
     return this.apiClient
-      .update('person_escort_record', {
-        id,
-        status: 'confirmed',
-      })
+      .update(
+        'person_escort_record',
+        pickBy({
+          id,
+          status: 'confirmed',
+          handover_occurred_at: handoverOccurredAt,
+          handover_details: !isEmpty(handoverDetails)
+            ? handoverDetails
+            : undefined,
+        })
+      )
       .then(response => response.data)
   }
 

--- a/common/services/person-escort-record.test.js
+++ b/common/services/person-escort-record.test.js
@@ -78,22 +78,63 @@ describe('Services', function () {
       })
 
       context('with ID', function () {
-        beforeEach(async function () {
-          output = await personEscortRecordService.confirm(mockId)
+        context('without handover details', function () {
+          beforeEach(async function () {
+            output = await personEscortRecordService.confirm(mockId)
+          })
+
+          it('calls the api service', function () {
+            expect(apiClient.update).to.have.been.calledOnceWithExactly(
+              'person_escort_record',
+              {
+                id: mockId,
+                status: 'confirmed',
+              }
+            )
+          })
+
+          it('returns the data', function () {
+            expect(output).to.deep.equal(mockRecord)
+          })
         })
 
-        it('calls the api service', function () {
-          expect(apiClient.update).to.have.been.calledOnceWithExactly(
-            'person_escort_record',
-            {
-              id: mockId,
-              status: 'confirmed',
-            }
-          )
-        })
+        context('with handover details', function () {
+          beforeEach(async function () {
+            output = await personEscortRecordService.confirm(mockId, {
+              handoverOccurredAt: '2020-10-10T14:00:00Z',
+              dispatchingOfficer: 'John Smith',
+              dispatchingOfficerId: '123',
+              dispatchingOfficerContact: '07777',
+              receivingOfficer: 'Steve Jones',
+              receivingOfficerId: '456',
+              receivingOfficerContact: '08888',
+              receivingOrganisation: 'Serco',
+            })
+          })
 
-        it('returns the data', function () {
-          expect(output).to.deep.equal(mockRecord)
+          it('calls the api service', function () {
+            expect(apiClient.update).to.have.been.calledOnceWithExactly(
+              'person_escort_record',
+              {
+                id: mockId,
+                status: 'confirmed',
+                handover_occurred_at: '2020-10-10T14:00:00Z',
+                handover_details: {
+                  dispatching_officer: 'John Smith',
+                  dispatching_officer_id: '123',
+                  dispatching_officer_contact: '07777',
+                  receiving_officer: 'Steve Jones',
+                  receiving_officer_id: '456',
+                  receiving_officer_contact: '08888',
+                  receiving_organisation: 'Serco',
+                },
+              }
+            )
+          })
+
+          it('returns the data', function () {
+            expect(output).to.deep.equal(mockRecord)
+          })
         })
       })
     })

--- a/common/templates/framework-section.njk
+++ b/common/templates/framework-section.njk
@@ -57,6 +57,13 @@
     </div>
 
   </div>
+
+  {% if moveId %}
+    {{ govukBackLink({
+      text: t("actions::back_to_move"),
+      href: "/move/" + moveId
+    }) }}
+  {% endif %}
 {% endblock %}
 
 {% block footer %}

--- a/locales/en/actions.json
+++ b/locales/en/actions.json
@@ -47,6 +47,7 @@
   "print_assessment": "Print $t({{context}})",
   "view_assessment": "View $t({{context}})",
   "provide_confirmation": "Provide confirmation",
+  "confirm_handover": "Confirm handover",
   "confirm_and_complete_record": "Confirm and complete record",
   "confirm_youth_risk_assessment": "Confirm assessment",
   "add_item": "Add {{name}}",

--- a/locales/en/assessment.json
+++ b/locales/en/assessment.json
@@ -58,5 +58,16 @@
     "title": "Some answers on this page need to be reviewed. They are from the last $t({{context}}) confirmed on {{date}}."
   },
   "prefilled_message": "This answer needs to be reviewed",
-  "feedback_prompt": "This is a new feature — <a href=\"{{url}}\">give us your feedback</a> to help us improve it"
+  "feedback_prompt": "This is a new feature — <a href=\"{{url}}\">give us your feedback</a> to help us improve it",
+  "handover": {
+    "heading": "Handover",
+    "before_handover": {
+      "heading": "Before you handover",
+      "content": "Check that you have:\n\n- <a href=\"{{ per_href }}\">reviewed the Person Escort Record</a> and the information is up to date\n- confirmed the correct person is being moved\n- completed the correct level of search\n- communicated risk and health information with receiving officer"
+    },
+    "not_fit_to_travel": "If this person is not fit to travel you must <a href=\"{{cancel_href}}\" class=\"app-link--destructive\">cancel this move</a>",
+    "dispatching_officer": "Dispatching officer",
+    "receiving_officer": "Receiving officer",
+    "warning_text": "Once you handover this person, you will no longer be able to update their Person Escort Record"
+  }
 }

--- a/locales/en/assessment.json
+++ b/locales/en/assessment.json
@@ -1,6 +1,6 @@
 {
   "page_title": "$t({{context}})",
-  "page_title_with_name": "$t({{context}}) for {{name}}",
+  "page_title_with_name": "$t({{context}}) for {{-name}}",
   "section_overview": "{{section}} overview",
   "locked": "A $t({{context}}) cannot be updated once it has been confirmed or once the move has started.",
   "statuses": {

--- a/locales/en/default.json
+++ b/locales/en/default.json
@@ -25,6 +25,7 @@
   "last_updated_at": "Last updated {{date}} at {{time}}",
   "amended_at": "Updated at {{date}}",
   "completed_at": "Completed at {{date}}",
+  "handed_over_at": "Handed over at {{date}}",
   "created_on": "Created on",
   "created_on_alert": "Alert created on",
   "created_on_personal_care_need": "Personal care need created on",

--- a/locales/en/fields.json
+++ b/locales/en/fields.json
@@ -458,12 +458,12 @@
       "details": "Give details"
     }
   },
-  "confirm_person_escort_record": {
-    "label": "Check this box to confirm that, to the best your knowledge, all information provided in this Person Escort Record is correct",
+  "confirm_handover": {
+    "label": "Check this box to confirm that all the above tasks have been completed",
     "error_message": "You must provide confirmation"
   },
   "confirm_youth_risk_assessment": {
-    "label": "Check this box to confirm that, to the best your knowledge, all information provided in this assessment is correct",
+    "label": "Check this box to confirm that, to the best your knowledge, all information provided in the assessment is correct",
     "error_message": "You must provide confirmation"
   },
   "unlock": {
@@ -487,7 +487,55 @@
   "operational_capacity": {
     "label": "Operational capacity"
   },
-  "usable_capacity": {
-    "label": "Usable capacity"
+  "handover_dispatching_officer": {
+    "label": "Full name of dispatching officer"
+  },
+  "handover_dispatching_officer_id": {
+    "label": "ID of dispatching officer"
+  },
+  "handover_dispatching_officer_contact": {
+    "label": "Contact number of dispatching officer"
+  },
+  "handover_receiving_officer": {
+    "label": "Full name of receiving officer"
+  },
+  "handover_receiving_officer_id": {
+    "label": "ID of receiving officer"
+  },
+  "handover_receiving_officer_contact": {
+    "label": "Contact number of receiving officer"
+  },
+  "handover_receiving_organisation": {
+    "label": "Organisation of receiving officer",
+    "items": {
+      "supplier": {
+        "label": "Supplier"
+      },
+      "other": {
+        "label": "Another organisation"
+      }
+    }
+  },
+  "handover_other_organisation": {
+    "label": "Name of organisation"
+  },
+  "handover_occurred_at": {
+    "label": "Handover time",
+    "items": {
+      "now": {
+        "label": "Now"
+      },
+      "historic": {
+        "label": "Enter manually"
+      }
+    }
+  },
+  "handover_other_date": {
+    "label": "Date of handover"
+  },
+  "handover_other_time": {
+    "label": "Time of handover",
+    "hint": "For example 11:00 or 11am",
+    "error_message": "You must provide a valid handover time"
   }
 }

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -47,7 +47,7 @@
       "content": "All information in this $t({{context}}) was confirmed at <strong>{{date}}</strong>."
     },
     "handed_over": {
-      "heading": "Person handed over",
+      "heading": "Person has been handed over",
       "content": "This person was handed over to <strong>{{details.receiving_officer}} ({{details.receiving_officer_id}}), {{details.receiving_organisation}}</strong> by <strong>{{details.dispatching_officer}} ({{details.dispatching_officer_id}})</strong> at <strong>{{date}}</strong>.",
       "warning": "Contact relevant parties if you have any additional risk or health information to share about this person:<br><br>{{details.dispatching_officer}} — {{details.dispatching_officer_contact}}<br>{{details.receiving_officer}}, {{details.receiving_organisation}} — {{details.receiving_officer_contact}}"
     }

--- a/locales/en/moves.json
+++ b/locales/en/moves.json
@@ -39,7 +39,7 @@
     },
     "timetable": {
       "heading": "This court date may already exist in NOMIS",
-      "subheading": "{{name}}’s timetable for {{date}}"
+      "subheading": "{{-name}}’s timetable for {{date}}"
     },
     "court_information": {
       "heading": "Is there information for the court?"
@@ -148,7 +148,7 @@
       }
     },
     "page_title": "Cancel move for ‘{{-name}}’",
-    "warning": "You must also contact the supplier to cancel the move request for {{name}}"
+    "warning": "You must also contact the supplier to cancel the move request for {{-name}}"
   },
   "review": {
     "page_title": "Review request for ‘{{-name}}’",
@@ -159,9 +159,9 @@
     }
   },
   "confirmation": {
-    "page_title": "Move requested for {{name}}",
-    "page_title_assign": "{{name}} added to allocation",
-    "page_title_proposed": "Move sent for {{name}}",
+    "page_title": "Move requested for {{-name}}",
+    "page_title_assign": "{{-name}} added to allocation",
+    "page_title_proposed": "Move sent for {{-name}}",
     "detail": "The move for <strong><a href=\"{{href}}\">{{name}}</a></strong> to <strong>{{location}}</strong> on <strong>{{date}}</strong> has been requested with {{supplier}}.",
     "detail_proposed": "The move for <strong><a href=\"{{href}}\">{{name}}</a></strong> to <strong>{{location}}</strong> has been sent to the Population Management Unit (PMU) for review.",
     "detail_assign": "<strong><a href=\"{{href}}\">{{name}}</a></strong> has been added to an allocation for <strong><a href=\"{{allocationHref}}\">$t(n_person) to {{location}}</a></strong> on <strong>{{date}}</strong>.",

--- a/locales/en/person-escort-record.json
+++ b/locales/en/person-escort-record.json
@@ -25,7 +25,7 @@
         "phone": "Phone",
         "name": "Name",
         "id": "ID",
-        "signature": "Signature"
+        "signature": "Sign"
       }
     },
     "property_handover": {

--- a/locales/en/person-escort-record.json
+++ b/locales/en/person-escort-record.json
@@ -3,7 +3,8 @@
   "journeys": {
     "confirm": {
       "heading":"Confirm and complete this Person Escort Record",
-      "content":"Once you are confident the information below is correct and won’t change, provide your confirmation that this record is correct in order to complete it.\n\n!!! warning\nOnce you confirm and complete the Person Escort Record you will no longer be able to update the information.\n!!!"
+      "content":"!!! warning\nOnce handover is recorded for this person their Person Escort Record will no longer be able to be updated.\n!!!",
+      "before":"Check that:\n- the correct person is being moved\n- the property information is accurate\n- any risks are understood by receiving party\n!!! warning\nOnce handover is recorded for this person their Person Escort Record can no longer be updated.\n!!!"
     }
   },
   "nomis_mappings": {

--- a/locales/en/validation.json
+++ b/locales/en/validation.json
@@ -33,7 +33,7 @@
     "instructions_review": "If you still need to move this person try <a href=\"{{date_href}}\">changing the date</a>."
   },
   "move_not_supported": {
-    "heading": "{{name}} cannot be moved using this service",
+    "heading": "{{-name}} cannot be moved using this service",
     "message": "As this person is a Category {{category}} prisoner, they cannot be moved using this service."
   },
   "assign_conflict": {

--- a/test/e2e/pages/confirm-person-escort-record.js
+++ b/test/e2e/pages/confirm-person-escort-record.js
@@ -1,0 +1,85 @@
+import faker from 'faker'
+import { Selector, t } from 'testcafe'
+
+import { fillInForm } from '../_helpers'
+
+import Page from './page'
+
+class ConfirmPersonEscortRecordPage extends Page {
+  constructor() {
+    super()
+
+    this.fields = {
+      handoverDispatchingOfficer: Selector('#handover_dispatching_officer'),
+      handoverDispatchingOfficerId: Selector(
+        '#handover_dispatching_officer_id'
+      ),
+      handoverDispatchingOfficerContact: Selector(
+        '#handover_dispatching_officer_contact'
+      ),
+      handoverReceivingOfficer: Selector('#handover_receiving_officer'),
+      handoverReceivingOfficerId: Selector('#handover_receiving_officer_id'),
+      handoverReceivingOfficerContact: Selector(
+        '#handover_receiving_officer_contact'
+      ),
+      handoverReceivingOrganisation: Selector(
+        '[name="handover_receiving_organisation"]'
+      ),
+      handoverOtherOrganisation: Selector('#handover_other_organisation'),
+      handoverOccurredAt: Selector('[name="handover_occurred_at"]'),
+      confirmationCheckbox: Selector('[name="confirm_handover"]'),
+    }
+  }
+
+  /**
+   * Fill in Handover details
+   *
+   * @returns {Promise<FormDetails>}
+   */
+  async fillIn() {
+    await t.click(this.fields.confirmationCheckbox)
+
+    return fillInForm({
+      handoverDispatchingOfficer: {
+        selector: this.fields.handoverDispatchingOfficer,
+        value: `${faker.name.firstName()} ${faker.name.lastName()}`,
+      },
+      handoverDispatchingOfficerId: {
+        selector: this.fields.handoverDispatchingOfficerId,
+        value: faker.random.alphaNumeric(6),
+      },
+      handoverDispatchingOfficerContact: {
+        selector: this.fields.handoverDispatchingOfficerContact,
+        value: faker.phone.phoneNumberFormat(),
+      },
+      handoverReceivingOfficer: {
+        selector: this.fields.handoverReceivingOfficer,
+        value: `${faker.name.firstName()} ${faker.name.lastName()}`,
+      },
+      handoverReceivingOfficerId: {
+        selector: this.fields.handoverReceivingOfficerId,
+        value: faker.random.alphaNumeric(6),
+      },
+      handoverReceivingOfficerContact: {
+        selector: this.fields.handoverReceivingOfficerContact,
+        value: faker.phone.phoneNumberFormat(),
+      },
+      handoverReceivingOrganisation: {
+        selector: this.fields.handoverReceivingOrganisation,
+        value: 'Another organisation',
+        type: 'radio',
+      },
+      handoverOtherOrganisation: {
+        selector: this.fields.handoverOtherOrganisation,
+        value: faker.company.companyName(0),
+      },
+      handoverOccurredAt: {
+        selector: this.fields.handoverOccurredAt,
+        value: 'Now',
+        type: 'radio',
+      },
+    })
+  }
+}
+
+export default ConfirmPersonEscortRecordPage

--- a/test/e2e/pages/index.js
+++ b/test/e2e/pages/index.js
@@ -1,5 +1,6 @@
 import AllocationJourney from './allocation-journey'
 import CancelMovePage from './cancel-move'
+import ConfirmPersonEscortRecordPage from './confirm-person-escort-record'
 import CreateMovePage from './create-move'
 import DashboardPage from './dashboard'
 import MoveDetailPage from './move-detail'
@@ -22,6 +23,7 @@ const dashboardPage = new DashboardPage()
 const populationDashboardPage = new PopulationDashboardPage()
 const populationEditPage = new PopulationEditPage()
 const populationWeeklyPage = new PopulationWeeklyPage()
+const confirmPersonEscortRecordPage = new ConfirmPersonEscortRecordPage()
 
 export {
   page,
@@ -36,4 +38,5 @@ export {
   populationDashboardPage,
   populationEditPage,
   populationWeeklyPage,
+  confirmPersonEscortRecordPage,
 }

--- a/test/e2e/pages/move-detail.js
+++ b/test/e2e/pages/move-detail.js
@@ -71,9 +71,6 @@ class MoveDetailPage extends Page {
       personEscortRecordConfirmationButton: this.nodes.instructionBanner
         .find('.govuk-button')
         .withText('Provide confirmation'),
-      personEscortRecordConfirmationCheckbox: Selector(
-        '[name="confirm_person_escort_record"]'
-      ),
       getCancelLink: Selector('.app-link--destructive'),
       getUpdateLink: category => {
         return Selector(`[data-update-link="${category}"]`)

--- a/test/e2e/person-escort-record.new.test.js
+++ b/test/e2e/person-escort-record.new.test.js
@@ -6,7 +6,7 @@ import { fillInPersonEscortRecord } from './_helpers'
 import { createCourtMove } from './_move'
 import { personEscortRecordUser } from './_roles'
 import { home, getMove } from './_routes'
-import { moveDetailPage } from './pages'
+import { moveDetailPage, confirmPersonEscortRecordPage } from './pages'
 
 const latestFramework = frameworksService.getPersonEscortRecord()
 const numberOfSections = Object.keys(latestFramework.sections).length
@@ -96,8 +96,9 @@ test('Start new Record', async t => {
   await t
     .click(moveDetailPage.nodes.personEscortRecordConfirmationButton)
     .expect(moveDetailPage.getCurrentUrl())
-    .contains('/person-escort-record/confirm/provide-confirmation')
-    .click(moveDetailPage.nodes.personEscortRecordConfirmationCheckbox)
+    .contains('/person-escort-record/confirm/handover')
+
+  const handoverDetails = await confirmPersonEscortRecordPage.fillIn()
 
   await moveDetailPage.submitForm()
 
@@ -105,8 +106,23 @@ test('Start new Record', async t => {
   await t
     .expect(moveDetailPage.nodes.instructionBanner.innerText)
     .contains(
-      'Person Escort Record has been confirmed',
-      'Should contain confirmed PER banner'
+      'Person has been handed over',
+      'Should contain handed over PER banner'
+    )
+    .expect(moveDetailPage.nodes.instructionBanner.innerText)
+    .contains(
+      `${handoverDetails.handoverDispatchingOfficer} (${handoverDetails.handoverDispatchingOfficerId})`,
+      'Should contain dispatching officer'
+    )
+    .expect(moveDetailPage.nodes.instructionBanner.innerText)
+    .contains(
+      `${handoverDetails.handoverReceivingOfficer} (${handoverDetails.handoverReceivingOfficerId})`,
+      'Should contain receiving officer'
+    )
+    .expect(moveDetailPage.nodes.instructionBanner.innerText)
+    .contains(
+      handoverDetails.handoverOtherOrganisation,
+      'Should contain receiving organisation'
     )
     .expect(moveDetailPage.nodes.personEscortRecordSectionStatuses.count)
     .eql(0, 'Should not show PER sections')


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

This change amends the confirmation banner and confirmation step to capture handover details.

### Why did it change

The handover details are required for us to know who has handed a person over from an establishment. This process can happen after the actual handover has taken place so we have added support for a historic time to be recorded.

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

- [P4-1892](https://dsdmoj.atlassian.net/browse/P4-1892)

## Screenshots
<!--- (Optional) Include screenshots if changes update interfaces or components -->
<!--- Delete/copy as appropriate --->

| Before | After |
| ------ | ----- |
| <kbd>![image](https://user-images.githubusercontent.com/3327997/107514501-a9f14480-6ba1-11eb-86a5-eaca7a025f3f.png)</kbd> | <kbd>![image](https://user-images.githubusercontent.com/3327997/107514318-6ac2f380-6ba1-11eb-85e1-5431ae01d02a.png)</kbd> |
| <kbd>![image](https://user-images.githubusercontent.com/3327997/107514468-9e058280-6ba1-11eb-9e49-454880ceb184.png)</kbd> | <kbd>![image](https://user-images.githubusercontent.com/3327997/107514384-7f9f8700-6ba1-11eb-9330-d4958e9da104.png)</kbd> |

## Checklists

### Testing

#### Automated testing

- [ ] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [x] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed
