### PR TITLE
fix: Use correct action content for digital handover in banner

### DIFF
--- a/common/presenters/message-banner/assessment-to-unconfirmed-banner.js
+++ b/common/presenters/message-banner/assessment-to-unconfirmed-banner.js
@@ -34,7 +34,7 @@ module.exports = function assessmentToUnconfirmedBanner({
       content += `
         ${componentService.getComponent('govukButton', {
           href: assessment.editable ? `${baseUrl}/confirm` : '',
-          text: i18n.t('actions::provide_confirmation'),
+          text: i18n.t('actions::provide_confirmation', { context }),
           disabled: !assessment.editable,
         })}
       `

--- a/common/presenters/message-banner/assessment-to-unconfirmed-banner.test.js
+++ b/common/presenters/message-banner/assessment-to-unconfirmed-banner.test.js
@@ -190,7 +190,10 @@ describe('Presenters', function () {
                   }
                 )
                 expect(i18n.t).to.be.calledWithExactly(
-                  'actions::provide_confirmation'
+                  'actions::provide_confirmation',
+                  {
+                    context: 'person_escort_record',
+                  }
                 )
               })
 

--- a/locales/en/actions.json
+++ b/locales/en/actions.json
@@ -47,6 +47,7 @@
   "print_assessment": "Print $t({{context}})",
   "view_assessment": "View $t({{context}})",
   "provide_confirmation": "Provide confirmation",
+  "provide_confirmation_person_escort_record": "Record handover",
   "confirm_handover": "Confirm handover",
   "confirm_and_complete_record": "Confirm and complete record",
   "confirm_youth_risk_assessment": "Confirm assessment",

--- a/test/e2e/pages/move-detail.js
+++ b/test/e2e/pages/move-detail.js
@@ -70,7 +70,7 @@ class MoveDetailPage extends Page {
         .withText('Start Person Escort Record'),
       personEscortRecordConfirmationButton: this.nodes.instructionBanner
         .find('.govuk-button')
-        .withText('Provide confirmation'),
+        .withText('Record handover'),
       getCancelLink: Selector('.app-link--destructive'),
       getUpdateLink: category => {
         return Selector(`[data-update-link="${category}"]`)


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

The completed banner still contained the old wording for confirming a
PER.

This fix updates the copy to be more accurate to the action taking
place.

## Screenshots
<!--- (Optional) Include screenshots if changes update interfaces or components -->
<!--- Delete/copy as appropriate --->

| Before | After |
| ------ | ----- |
| <kbd>![image](https://user-images.githubusercontent.com/3327997/107955892-42b70400-6f96-11eb-8949-4d1f9ae6222b.png)</kbd> | <kbd>![image](https://user-images.githubusercontent.com/3327997/107955818-26b36280-6f96-11eb-8ef8-95cc3978732d.png)</kbd> |

## Checklists

### Testing

#### Automated testing

- [ ] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed
