### PR TITLE
[P4-2679] Ensure uneditable PER message is correct for cancelled moves

### DIFF
--- a/common/presenters/message-banner/assessment-to-unconfirmed-banner.js
+++ b/common/presenters/message-banner/assessment-to-unconfirmed-banner.js
@@ -69,7 +69,7 @@ module.exports = function assessmentToUnconfirmedBanner({
   if (!assessment.editable) {
     content += `
       ${componentService.getComponent('govukWarningText', {
-        text: i18n.t(`messages::assessment.${assessment.status}.uneditable`, {
+        text: i18n.t('messages::assessment.completed.uneditable', {
           context,
         }),
         classes: 'govuk-!-padding-top-0 govuk-!-margin-top-5',

--- a/common/presenters/message-banner/assessment-to-unconfirmed-banner.test.js
+++ b/common/presenters/message-banner/assessment-to-unconfirmed-banner.test.js
@@ -247,7 +247,7 @@ describe('Presenters', function () {
               }
             )
             expect(i18n.t).to.be.calledWithExactly(
-              `messages::assessment.${mockArgs.assessment.status}.uneditable`,
+              'messages::assessment.completed.uneditable',
               {
                 context: 'person_escort_record',
               }

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -40,7 +40,7 @@
       "heading": "$t({{context}}) has been completed",
       "content": "Once you are confident the information provided is correct and won’t change, provide your confirmation that this record is correct.",
       "content_person_escort_record": "Once you are confident the information provided is correct and won’t change, provide your confirmation that this record is correct in order to print it",
-      "uneditable": "A $t({{context}}) cannot be confirmed once the move has started."
+      "uneditable": "A $t({{context}}) cannot be confirmed once the move has started or cancelled."
     },
     "confirmed": {
       "heading": "$t({{context}}) has been confirmed",


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

This updates the content key to ensure that the correct content is
displayed for cancelled moves with an incomplete PER.

The key was previously dynamic which mean if the PER was not complete
when cancelled it wouldn't find the content.

This fixes it by hard coding that key and updating the content to
explain this further scenario.

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

- [P4-2679](https://dsdmoj.atlassian.net/browse/P4-2679)

## Screenshots
<!--- (Optional) Include screenshots if changes update interfaces or components -->
<!--- Delete/copy as appropriate --->

| Before | After |
| ------ | ----- |
| <kbd>![image](https://user-images.githubusercontent.com/3327997/108707264-ab0e6400-7507-11eb-87e9-3719c71b7d91.png)</kbd> | <kbd>![image](https://user-images.githubusercontent.com/3327997/108707208-9b8f1b00-7507-11eb-9e4f-041524535669.png)</kbd> |

## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [x] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed
