### PR TITLE
fix: Improve missing person ID error when creating a move

### DIFF
--- a/app/move/app/new/controllers/personal-details.js
+++ b/app/move/app/new/controllers/personal-details.js
@@ -41,24 +41,24 @@ class PersonalDetailsController extends CreateBaseController {
     }
   }
 
-  savePerson(req, id, data) {
-    const personService = req.services.person
-
-    if (id) {
-      return personService.update({
-        id,
-        ...data,
-      })
-    }
-
-    return personService.create(data)
-  }
-
   async saveValues(req, res, next) {
     try {
-      const id = req.getPersonId()
+      const personService = req.services.person
+      const person = req.sessionModel.get('person')
+      const newPersonId = req.sessionModel.get('newPersonId')
+      const data = { ...req.form.values }
 
-      req.form.values.person = await this.savePerson(req, id, req.form.values)
+      if (person && person.id === newPersonId) {
+        req.form.values.person = await personService.update({
+          ...data,
+          id: newPersonId,
+        })
+      } else {
+        const newPerson = await personService.create(data)
+        req.form.values.person = newPerson
+        req.form.values.newPersonId = newPerson.id
+      }
+
       super.saveValues(req, res, next)
     } catch (error) {
       next(error)

--- a/app/move/controllers/update/personal-details.test.js
+++ b/app/move/controllers/update/personal-details.test.js
@@ -24,10 +24,6 @@ describe('Move controllers', function () {
         expect(controller.configure).to.exist.and.equal(MixinProto.configure)
       })
 
-      it('should inherit savePerson from CreatePersonalDetails', function () {
-        expect(controller.savePerson).to.exist.and.equal(MixinProto.savePerson)
-      })
-
       it('should override saveValues', function () {
         expect(controller.saveValues).to.exist.and.equal(ownProto.saveValues)
       })

--- a/common/services/person.js
+++ b/common/services/person.js
@@ -39,9 +39,9 @@ class PersonService extends BaseService {
       .then(response => response.data)
   }
 
-  update(data) {
+  update(data = {}) {
     if (!data.id) {
-      return
+      return Promise.reject(new Error(noPersonIdMessage))
     }
 
     return this.apiClient

--- a/common/services/person.test.js
+++ b/common/services/person.test.js
@@ -302,16 +302,10 @@ describe('Person Service', function () {
     })
 
     context('without ID', function () {
-      beforeEach(async function () {
-        person = await personService.update({})
-      })
-
-      it('should not call API', function () {
-        expect(apiClient.update).not.to.be.called
-      })
-
-      it('should not format data', function () {
-        expect(personService.format).not.to.be.called
+      it('should reject with error', function () {
+        return expect(personService.update()).to.be.rejectedWith(
+          'No person ID supplied'
+        )
       })
     })
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

This change adds some extra logic around to cater for this scenario.

It also caters for a scenario where a person is selected using the
person lookup, but then the user decides to create a new person instead.

In the instance this does still occur we will now be capturing the move ID for the move
that was created and also the expected profile ID.

### Why did it change

We have seen a number of errors in Sentry where a profile can't
be updated because it is "missing a Person ID".

Some investigation allowed this error to be re-created when going back
to the personal details page and making a change during the move creation
journey.

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

- https://sentry.io/organizations/ministryofjustice/issues/2179979853

## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [x] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed
