### PR TITLE
fix: Reduce Sentry warnings for missing resources to correct instances

### DIFF
--- a/common/lib/populate-resources.js
+++ b/common/lib/populate-resources.js
@@ -18,13 +18,15 @@ const populateResources = (obj, req, options, processed = []) => {
     })
 
     // TODO: Find way to deserialize missing resources properly
-    Sentry.withScope(scope => {
-      scope.setLevel('warning')
-      scope.setExtra('Events', cleanedObj)
-      scope.setExtra('Events raw', JSON.stringify(cleanedObj))
-      scope.setExtra('Unpopulated resources', processed)
-      Sentry.captureException(unprocessedError)
-    })
+    if (processed.length > 1) {
+      Sentry.withScope(scope => {
+        scope.setLevel('warning')
+        scope.setExtra('Events', cleanedObj)
+        scope.setExtra('Events raw', JSON.stringify(cleanedObj))
+        scope.setExtra('Unpopulated resources', processed)
+        Sentry.captureException(unprocessedError)
+      })
+    }
 
     return
   }


### PR DESCRIPTION




<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

This changes wraps this warning with a check to ensure there are
missing resources before throwing the warning to Sentry.

### Why did it change

Currently we are throwing a sentry warning each time we try and
populate the resources for the events timeline.

In actual fact we only care about the instances when there are missing
resources.

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

- https://sentry.io/organizations/ministryofjustice/issues/2196140978