### PR TITLE
Allow multiple moves and allocation to be created at the same time

### DIFF
--- a/app/allocation/config/create.config.js
+++ b/app/allocation/config/create.config.js
@@ -1,7 +1,9 @@
-module.exports = {
-  name: 'create-an-allocation',
-  templatePath: 'allocation/views/create/',
-  template: '../../../form-wizard',
-  journeyName: 'create-an-allocation',
-  journeyPageTitle: 'actions::create_allocation',
+module.exports = function config(id) {
+  return {
+    name: `create-an-allocation-${id}`,
+    templatePath: 'allocation/views/create/',
+    template: '../../../form-wizard',
+    journeyName: `create-an-allocation-${id}`,
+    journeyPageTitle: 'actions::create_allocation',
+  }
 }

--- a/app/allocation/index.js
+++ b/app/allocation/index.js
@@ -1,5 +1,7 @@
 const router = require('express').Router()
+const { v4: uuidv4 } = require('uuid')
 
+const { uuidRegex } = require('../../common/helpers/url')
 const { protectRoute } = require('../../common/middleware/permissions')
 const wizard = require('../../common/middleware/unique-form-wizard')
 const { setMove } = require('../move/middleware')
@@ -17,10 +19,11 @@ const { cancelSteps, removeMoveSteps, createSteps } = require('./steps')
 router.param('allocationId', setAllocation)
 router.param('moveId', setMove)
 
+router.get('/new', (req, res) => res.redirect(`${req.baseUrl}/new/${uuidv4()}`))
 router.use(
-  '/new',
+  `/new/:id(${uuidRegex})`,
   protectRoute('allocation:create'),
-  wizard(createSteps, createFields, createConfig)
+  wizard(createSteps, createFields, createConfig, 'params.id')
 )
 
 router.get(

--- a/app/move/app/new/config.js
+++ b/app/move/app/new/config.js
@@ -1,10 +1,12 @@
 const CreateBaseController = require('./controllers/base')
 
-module.exports = {
-  controller: CreateBaseController,
-  journeyName: 'create-a-move',
-  journeyPageTitle: 'actions::create_move',
-  name: 'create-a-move',
-  template: '../../../form-wizard',
-  templatePath: 'move/views/create/',
+module.exports = function config(id) {
+  return {
+    controller: CreateBaseController,
+    journeyName: `create-a-move-${id}`,
+    journeyPageTitle: 'actions::create_move',
+    name: `create-a-move-${id}`,
+    template: '../../../form-wizard',
+    templatePath: 'move/views/create/',
+  }
 }

--- a/app/move/app/new/controllers/save.js
+++ b/app/move/app/new/controllers/save.js
@@ -1,6 +1,7 @@
 const Sentry = require('@sentry/node')
 const { get, omit, capitalize, flatten, values, some } = require('lodash')
 
+const { uuidRegex } = require('../../../../../common/helpers/url')
 const analytics = require('../../../../../common/lib/analytics')
 const filters = require('../../../../../config/nunjucks/filters')
 
@@ -116,16 +117,21 @@ class SaveController extends CreateBaseController {
 
   async successHandler(req, res, next) {
     const move = req.sessionModel.get('move')
-    const fromLocationType = req.sessionModel.get('from_location_type')
+    const timingCategory = capitalize(
+      req.sessionModel.get('from_location_type')
+    )
     const journeyDuration = Math.round(
       new Date().getTime() - req.sessionModel.get('journeyTimestamp')
+    )
+    const timingVariable = capitalize(
+      req.form.options.name.replace(new RegExp(`-${uuidRegex}`, 'g'), '')
     )
 
     try {
       await analytics.sendJourneyTime({
-        utv: capitalize(req.form.options.name),
+        utv: timingVariable,
         utt: journeyDuration,
-        utc: capitalize(fromLocationType),
+        utc: timingCategory,
       })
 
       req.journeyModel.reset()

--- a/app/move/app/new/controllers/save.test.js
+++ b/app/move/app/new/controllers/save.test.js
@@ -887,6 +887,36 @@ describe('Move controllers', function () {
         })
       })
 
+      context('when journey contains UUID', function () {
+        const mockJourneyTimestamp = 12345
+        const mockCurrentTimestamp = new Date('2017-08-10').getTime()
+        const mockFromLocationType = 'police'
+
+        beforeEach(async function () {
+          this.clock = sinon.useFakeTimers(mockCurrentTimestamp)
+          analytics.sendJourneyTime.resolves({})
+          req.sessionModel.get.withArgs('move').returns(mockMove)
+          req.sessionModel.get
+            .withArgs('journeyTimestamp')
+            .returns(mockJourneyTimestamp)
+            .withArgs('from_location_type')
+            .returns(mockFromLocationType)
+          req.form.options.name =
+            'create-a-move-507b0fc0-6972-428c-bfc6-d26028de61ae'
+          await controller.successHandler(req, res, nextSpy)
+        })
+
+        afterEach(function () {
+          this.clock.restore()
+        })
+
+        it('should remove the UUID from timing variable', function () {
+          const args = analytics.sendJourneyTime.args[0][0]
+          expect(args).to.have.property('utv')
+          expect(args.utv).to.equal('Create-a-move')
+        })
+      })
+
       context('when send journey time fails', function () {
         const mockError = new Error('Error')
 

--- a/app/move/app/new/index.js
+++ b/app/move/app/new/index.js
@@ -1,6 +1,8 @@
 // NPM dependencies
 const router = require('express').Router()
+const { v4: uuidv4 } = require('uuid')
 
+const { uuidRegex } = require('../../../../common/helpers/url')
 const { protectRoute } = require('../../../../common/middleware/permissions')
 const wizard = require('../../../../common/middleware/unique-form-wizard')
 const fields = require('../../fields')
@@ -12,7 +14,11 @@ const steps = require('./steps')
 router.use(protectRoute('move:create'))
 
 // Define routes
-router.use(wizard(steps, fields.createFields, config))
+router.get('/', (req, res) => res.redirect(`${req.baseUrl}/${uuidv4()}`))
+router.use(
+  `/:id(${uuidRegex})`,
+  wizard(steps, fields.createFields, config, 'params.id')
+)
 
 // Export
 module.exports = {

--- a/server.js
+++ b/server.js
@@ -193,6 +193,12 @@ app.use(
           'www.googletagmanager.com',
           'www.google-analytics.com',
         ],
+        connectSrc: [
+          "'self'",
+          "'unsafe-inline'",
+          'www.googletagmanager.com',
+          'www.google-analytics.com',
+        ],
         imgSrc: ["'self'", 'www.google-analytics.com'],
         fontSrc: ["'self'", 'fonts.googleapis.com'],
       },

--- a/test/e2e/move.new.police.test.js
+++ b/test/e2e/move.new.police.test.js
@@ -144,7 +144,7 @@ test('With a new person', async t => {
   // PNC lookup
   await t
     .expect(page.getCurrentUrl())
-    .contains('/move/new/person-lookup-pnc')
+    .contains('/person-lookup-pnc')
     .click(createMovePage.steps.personLookup.nodes.noIdentifierLink)
     .click(createMovePage.steps.personLookup.nodes.moveSomeoneNew)
 

--- a/test/e2e/move.new.prison.test.js
+++ b/test/e2e/move.new.prison.test.js
@@ -29,9 +29,7 @@ test('With unfound person', async t => {
 
   await t.click(createMovePage.steps.personLookupResults.nodes.searchAgainLink)
 
-  await t
-    .expect(page.getCurrentUrl())
-    .contains('/move/new/person-lookup-prison-number')
+  await t.expect(page.getCurrentUrl()).contains('/person-lookup-prison-number')
 })
 
 test('With existing person', async t => {

--- a/test/e2e/move.new.stc.test.js
+++ b/test/e2e/move.new.stc.test.js
@@ -14,7 +14,7 @@ test('With a new person', async t => {
   // PNC lookup
   await t
     .expect(page.getCurrentUrl())
-    .contains('/move/new/person-lookup-pnc')
+    .contains('/person-lookup-pnc')
     .click(createMovePage.steps.personLookup.nodes.noIdentifierLink)
     .click(createMovePage.steps.personLookup.nodes.moveSomeoneNew)
 
@@ -69,7 +69,7 @@ test('With a new person', async t => {
   // PNC lookup
   await t
     .expect(page.getCurrentUrl())
-    .contains('/move/new/person-lookup-pnc')
+    .contains('/person-lookup-pnc')
     .click(createMovePage.steps.personLookup.nodes.noIdentifierLink)
     .click(createMovePage.steps.personLookup.nodes.moveSomeoneNew)
 
@@ -124,7 +124,7 @@ test('With a new person', async t => {
   // PNC lookup
   await t
     .expect(page.getCurrentUrl())
-    .contains('/move/new/person-lookup-pnc')
+    .contains('/person-lookup-pnc')
     .click(createMovePage.steps.personLookup.nodes.noIdentifierLink)
     .click(createMovePage.steps.personLookup.nodes.moveSomeoneNew)
 
@@ -176,7 +176,7 @@ test('With a new person', async t => {
   // PNC lookup
   await t
     .expect(page.getCurrentUrl())
-    .contains('/move/new/person-lookup-pnc')
+    .contains('/person-lookup-pnc')
     .click(createMovePage.steps.personLookup.nodes.noIdentifierLink)
     .click(createMovePage.steps.personLookup.nodes.moveSomeoneNew)
 

--- a/test/e2e/pages/allocation-criteria.js
+++ b/test/e2e/pages/allocation-criteria.js
@@ -38,7 +38,11 @@ class AllocationCriteriaPage extends Page {
   }
 
   async fill() {
-    await t.expect(this.getCurrentUrl()).contains(this.url)
+    await t
+      .expect(this.getCurrentUrl())
+      .match(
+        /\/allocation\/new\/[\w]{8}(-[\w]{4}){3}-[\w]{12}\/allocation-criteria$/
+      )
 
     const fieldsToFill = {
       estate: {

--- a/test/e2e/pages/allocation-details.js
+++ b/test/e2e/pages/allocation-details.js
@@ -27,7 +27,11 @@ class AllocationDetailsPage extends Page {
   }
 
   async fill() {
-    await t.expect(this.getCurrentUrl()).contains(this.url)
+    await t
+      .expect(this.getCurrentUrl())
+      .match(
+        /\/allocation\/new\/[\w]{8}(-[\w]{4}){3}-[\w]{12}\/allocation-details$/
+      )
 
     const locationValue = await this.nodes.locationValue.innerText
 

--- a/test/e2e/pages/create-move.js
+++ b/test/e2e/pages/create-move.js
@@ -115,9 +115,7 @@ class CreateMovePage extends Page {
    * @returns {Promise<FormDetails>}
    */
   async fillInPncSearch(searchTerm) {
-    await t
-      .expect(this.getCurrentUrl())
-      .contains(`${this.url}/person-lookup-pnc`)
+    await t.expect(this.getCurrentUrl()).contains('/person-lookup-pnc')
 
     return fillInForm({
       pncNumberSearch: {
@@ -136,7 +134,7 @@ class CreateMovePage extends Page {
   async fillInPrisonNumberSearch(searchTerm) {
     await t
       .expect(this.getCurrentUrl())
-      .contains(`${this.url}/person-lookup-prison-number`)
+      .contains('/person-lookup-prison-number')
 
     return fillInForm({
       prisonNumberSearch: {
@@ -172,9 +170,7 @@ class CreateMovePage extends Page {
    * @returns {Promise<FormDetails>} - filled in personal details
    */
   async fillInPersonalDetails(personalDetails, { include, exclude } = {}) {
-    await t
-      .expect(this.getCurrentUrl())
-      .contains(`${this.url}/personal-details`)
+    await t.expect(this.getCurrentUrl()).contains('/personal-details')
 
     const person = await generatePerson(personalDetails)
     let data = {
@@ -226,7 +222,7 @@ class CreateMovePage extends Page {
    * @returns {Promise<FormDetails>} - filled in move details
    */
   async fillInMoveDetails(moveType) {
-    await t.expect(this.getCurrentUrl()).contains(`${this.url}/move-details`)
+    await t.expect(this.getCurrentUrl()).contains('/move-details')
 
     const fields = {
       moveType: {
@@ -290,7 +286,7 @@ class CreateMovePage extends Page {
    * @returns {Promise<FormDetails>} - filled in move details
    */
   async fillInDate(dateValue = 'Today') {
-    await t.expect(this.getCurrentUrl()).contains(`${this.url}/move-date`)
+    await t.expect(this.getCurrentUrl()).contains('/move-date')
     let dateCustom
 
     let dateType = dateValue
@@ -322,7 +318,7 @@ class CreateMovePage extends Page {
    * Fill in date range
    */
   async fillInDateRange() {
-    await t.expect(this.getCurrentUrl()).contains(`${this.url}/move-date-range`)
+    await t.expect(this.getCurrentUrl()).contains('/move-date-range')
 
     return fillInForm({
       dateFrom: {
@@ -346,9 +342,7 @@ class CreateMovePage extends Page {
     selectAll = true,
     fillInOptional = false,
   } = {}) {
-    await t
-      .expect(this.getCurrentUrl())
-      .contains(`${this.url}/court-information`)
+    await t.expect(this.getCurrentUrl()).contains('/court-information')
 
     const fields = {
       selectedItems: {
@@ -385,7 +379,7 @@ class CreateMovePage extends Page {
    * @returns {Promise}
    */
   async fillInHospitalDetails() {
-    await t.expect(this.getCurrentUrl()).contains('/move/new/hospital')
+    await t.expect(this.getCurrentUrl()).contains('/hospital')
 
     return fillInForm({
       timeDue: {
@@ -407,7 +401,7 @@ class CreateMovePage extends Page {
    * @returns {Promise}
    */
   async fillInCourtHearings() {
-    await t.expect(this.getCurrentUrl()).contains('/move/new/court-hearings')
+    await t.expect(this.getCurrentUrl()).contains('/court-hearings')
 
     return fillInForm({
       hasCourtCase: {
@@ -427,9 +421,7 @@ class CreateMovePage extends Page {
     selectAll = true,
     fillInOptional = false,
   } = {}) {
-    await t
-      .expect(this.getCurrentUrl())
-      .contains(`${this.url}/risk-information`)
+    await t.expect(this.getCurrentUrl()).contains('/risk-information')
 
     const fields = {
       selectedItems: {
@@ -478,7 +470,7 @@ class CreateMovePage extends Page {
    * @returns {Promise}
    */
   async fillInReleaseStatus() {
-    await t.expect(this.getCurrentUrl()).contains(`${this.url}/release-status`)
+    await t.expect(this.getCurrentUrl()).contains('/release-status')
 
     return fillInForm({
       notToBeReleasedRadio: {
@@ -495,9 +487,7 @@ class CreateMovePage extends Page {
    * @returns {Promise}
    */
   async fillInAgreementStatus() {
-    await t
-      .expect(this.getCurrentUrl())
-      .contains(`${this.url}/agreement-status`)
+    await t.expect(this.getCurrentUrl()).contains('/agreement-status')
 
     return fillInForm({
       moveAgreed: {
@@ -518,7 +508,7 @@ class CreateMovePage extends Page {
    * @returns {Promise}
    */
   async fillInPrisonTransferReasons() {
-    await t.expect(this.getCurrentUrl()).contains(`${this.url}/transfer-reason`)
+    await t.expect(this.getCurrentUrl()).contains('/transfer-reason')
 
     return fillInForm({
       prisonTransferReason: {
@@ -537,9 +527,7 @@ class CreateMovePage extends Page {
     selectAll = true,
     fillInOptional = false,
   } = {}) {
-    await t
-      .expect(this.getCurrentUrl())
-      .contains(`${this.url}/health-information`)
+    await t.expect(this.getCurrentUrl()).contains('/health-information')
 
     if (!selectAll) {
       return fillInForm({
@@ -604,7 +592,7 @@ class CreateMovePage extends Page {
    * @returns {Promise}
    */
   async fillInSpecialVehicle() {
-    await t.expect(this.getCurrentUrl()).contains(`${this.url}/special-vehicle`)
+    await t.expect(this.getCurrentUrl()).contains('/special-vehicle')
 
     return fillInForm({
       specialVehicleRadio: {
@@ -622,7 +610,7 @@ class CreateMovePage extends Page {
    * @returns {Promise}
    */
   async fillInDocumentUploads(files) {
-    await t.expect(this.getCurrentUrl()).contains(`${this.url}/document`)
+    await t.expect(this.getCurrentUrl()).contains('/document')
     await t.setFilesToUpload(
       '#documents',
       files.map(fileName => `../fixtures/files/${fileName}`)
@@ -655,7 +643,7 @@ class CreateMovePage extends Page {
   checkPersonLookupResults(count, searchTerm) {
     return t
       .expect(this.getCurrentUrl())
-      .contains(`${this.url}/person-lookup-results`)
+      .contains('/person-lookup-results')
       .expect(this.steps.personLookupResults.nodes.searchSummary.innerText)
       .contains(
         `${count} ${pluralize('person', count)} found for “${searchTerm}”`


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

This set of changes adds support to create moves and allocations within the same session using multiple tabs.

It uses the existing unique form wizard to create a new wizard for each journey. This prevents journeys being reset when a new one is opened in a new tab.

### Why did it change

The Form Wizard that is used to power a lot of the form journeys was original designed to only support one journey and session at a time.

However, as our system is a repeat use system we have started to see errors where the journey is missing pre-requisite steps.

The assumption based on the data from Sentry is that users are using multiple tabs to try and complete multiple moves at the same time. This behaviour makes sense when you think of how people want to use this system.

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

- https://sentry.io/organizations/ministryofjustice/issues/2080838686

## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [x] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed
