### PR TITLE
fix: Remove duplicates from CDM locations list

### DIFF
--- a/app/locations/controllers.js
+++ b/app/locations/controllers.js
@@ -1,4 +1,4 @@
-const { get, sortBy } = require('lodash')
+const { get, sortBy, uniqBy } = require('lodash')
 
 async function locations(req, res, next) {
   const userPermissions = get(req.session, 'user.permissions', [])
@@ -34,7 +34,9 @@ async function locations(req, res, next) {
       })
     )
 
-    userLocations = [...new Set(supplierLocations.flat())]
+    // The locations have been uniqued based on title to prevent
+    // duplicates when multiple suppliers have the same location
+    userLocations = uniqBy(supplierLocations.flat(), 'id')
 
     req.session.user.locations = userLocations
   }

--- a/app/locations/controllers.test.js
+++ b/app/locations/controllers.test.js
@@ -178,8 +178,10 @@ describe('Locations controllers', function () {
       })
 
       it('should set the location on the user session', function () {
+        // The second location in the mockSecondSupplierLocation array
+        // is a duplicate, so should not be included
         expect(req.session.user.locations).to.deep.equal(
-          mockSupplierLocations.concat(mockSecondSupplierLocation)
+          mockSupplierLocations.concat(mockSecondSupplierLocation[0])
         )
       })
     })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Using the lodash uniqBy method to create a unique list of objects.
<!--- Describe the changes in detail - the "what"-->

### Why did it change
The previous method did not quite uniqe list.
<!--- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

- [P4-2639]()

## Screenshots
<!--- (Optional) Include screenshots if changes update interfaces or components -->
<!--- Delete/copy as appropriate --->

| Before | After |
| ------ | ----- |
| <kbd><img src=""></kbd> | <kbd><img src=""></kbd> |

## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [ ] Chrome
- [x] Firefox
- [ ] Edge
- [ ] Internet Explorer