### PR TITLE
fix: Don't assume property exists when logging profile error

### DIFF
--- a/app/move/app/new/controllers/save.js
+++ b/app/move/app/new/controllers/save.js
@@ -57,7 +57,8 @@ class SaveController extends CreateBaseController {
       } else {
         Sentry.withScope(scope => {
           scope.setExtra('Move ID', move.id)
-          scope.setExtra('Profile ID', data.profile.id)
+          scope.setExtra('Profile ID', data.profile?.id)
+          scope.setExtra('Person ID', data.person?.id)
           Sentry.captureException(new Error('No Person ID supplied'))
         })
       }

--- a/app/move/app/new/controllers/save.test.js
+++ b/app/move/app/new/controllers/save.test.js
@@ -354,6 +354,10 @@ describe('Move controllers', function () {
               'Profile ID',
               '12345'
             )
+            expect(mockScope.setExtra).to.be.calledWithExactly(
+              'Person ID',
+              mockValues.person.id
+            )
           })
         })
       })


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

This logging was introduced to try and debug when a move was trying to
be created without a person ID.

However, it seems the whole profile is missing so this change
adjusts the logging to not output the value if it doesn't exist.

Fixes BOOK-A-SECURE-MOVE-FRONTEND-3J

### Why did it change

<!--- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

- https://sentry.io/organizations/ministryofjustice/issues/2251754356/

## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [x] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed
