### PR TITLE
fix: Fix reference to template path for assign journeys

### DIFF
--- a/app/move/app/assign/config.js
+++ b/app/move/app/assign/config.js
@@ -6,7 +6,7 @@ module.exports = function config(id) {
     journeyName: `assign-person-${id}`,
     journeyPageTitle: 'allocation::person:assign',
     name: `assign-person-${id}`,
-    template: '../../../form-wizard',
-    templatePath: 'move/views/create/',
+    template: '../../../../form-wizard',
+    templatePath: 'move/app/new/views/',
   }
 }


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

During the refactor to move these apps to their own folder the
path to the templates for the assign journey weren't updated correctly.

This fixes that reference.

Fixes BOOK-A-SECURE-MOVE-FRONTEND-3M

### Why did it change

<!--- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

- https://sentry.io/organizations/ministryofjustice/issues/2262712124
