### PR TITLE
refactor: Stream person images to browser

### DIFF
--- a/app/person/controllers/image.js
+++ b/app/person/controllers/image.js
@@ -44,7 +44,7 @@ module.exports = fallbackImage => {
       }
     } catch (error) {
       const imagePath = nunjucksGlobals.getAssetPath(fallbackImage)
-      res.redirect(imagePath)
+      res.set('Cache-control', 'max-age=3600').redirect(imagePath)
     }
   }
 }

--- a/app/person/controllers/image.js
+++ b/app/person/controllers/image.js
@@ -5,17 +5,43 @@ const nunjucksGlobals = require('../../../config/nunjucks/globals')
 module.exports = fallbackImage => {
   return async (req, res) => {
     try {
+      const useOld = false
       const imageUrl = await req.services.person.getImageUrl(
         req.params.personId
       )
-      const response = await axios.get(imageUrl, {
-        responseType: 'arraybuffer',
-      })
 
-      res.writeHead(200, {
-        'Content-Type': response.headers['content-type'],
-      })
-      res.end(response.data, 'binary')
+      if (useOld) {
+        const response = await axios.get(imageUrl, {
+          responseType: 'arraybuffer',
+        })
+
+        res.writeHead(200, {
+          'Content-Type': response.headers['content-type'],
+        })
+        res.end(response.data, 'binary')
+      } else {
+        axios({
+          method: 'get',
+          url: imageUrl,
+          responseType: 'stream',
+        }).then(function (response) {
+          res.writeHead(200, {
+            'Content-Type': response.headers['content-type'],
+            'Content-Length': response.headers['content-length'],
+            ETag: response.headers.etag,
+            'Last-Modified': response.headers['last-modified'],
+          })
+
+          response.data.on('end', function () {})
+          response.data.on('error', function () {
+            // This won't work, because we've already started streaming
+            const imagePath = nunjucksGlobals.getAssetPath(fallbackImage)
+            res.redirect(imagePath)
+          })
+
+          response.data.pipe(res)
+        })
+      }
     } catch (error) {
       const imagePath = nunjucksGlobals.getAssetPath(fallbackImage)
       res.redirect(imagePath)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes
This PR has three different concept to discuss relating to the `/person/GUID/image` endpoint:

1. Streaming image contents
2. Adding `etag` and `last-modified` headers
3. Only loading required middleware

1. We store the person images on a remote server. Rather than load the full contents of the image file into memory, this can be streamed to the browser using node as an intermediary. This should reduce the memory overhead for these requests as only parts of the image are loaded at a time. This should also have an effect on overall throughput, as other requests are not blocked waiting for an image to complete loading.

2. Adding `etag` and `last-modified` headers allows the images to be cached. If however, we don't want them to be cached, we should explicitly state that in the headers we send back.

3. We currently apply all middleware configured on the `server` to the `/person` endpoint. This means that you need to be authenticated to view person images. This is probably a wise intentional decision. We also call other middleware such as `setLocations` and `setPrimaryNavigation` - these have no usefulness for this endpoint. This PR shows a way of not apply middleware for selective route patterns.

### Discussion points

- If we were running micro-services, I would say this is a prime candidate for separating out - as it is very small and doesn't require a lot of functionality from the rest of the app
- Alternatively, I'd suggest that perhaps this sort of translation from id to image file could be handled in the infrastructure layer, as long as there are not too many complications in getting to the image data
- This is a performance improvement PR, however we don't currently have enough in place to test which of these three changes improves performance - both on the `/person` endpoint, as well as overall performance. 

Note: This was tested using `curl -b cookies.txt -I http://localhost:3000/person/GUID/image`, with exported cookies from a currently logged in session.
 
### What changed

<!--- Describe the changes in detail - the "what"-->

### Why did it change

<!--- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

- [P4-XXXX]()

## Screenshots
<!--- (Optional) Include screenshots if changes update interfaces or components -->
<!--- Delete/copy as appropriate --->

| Before | After |
| ------ | ----- |
| <kbd><img src=""></kbd> | <kbd><img src=""></kbd> |

## Checklists

### Testing

#### Automated testing

- [ ] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [ ] No environment variables were added or changed

<!--- Delete if changes DO NOT include new environment variables -->
- [ ] Documented in the [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md)
- [ ] Added to [continous integration](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-book-secure-move-frontend)
- [ ] Added to staging environment (deployment repository)
- [ ] Added to preproduction environment (deployment repository)
- [ ] Added to production environment (deployment repository)

### Other considerations

Commit messages with a `fix` or `feat` type are automatically used to generate the [changelog](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/CHANGELOG.md) and
[GitHub release notes](https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/releases) during the release task. Please make sure they will read well on their own in a
summary of changes and that the commit body gives a more detailed description of those changes if necessary.

- [ ] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
- [ ] Update [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/master/README.md) with any new instructions or tasks
