### PR TITLE
Create extra logging around timeouts

### DIFF
--- a/common/middleware/errors.js
+++ b/common/middleware/errors.js
@@ -32,6 +32,15 @@ function catchAll(showStackTrace = false) {
       return next(error)
     }
 
+    // Remove potentially sensitive data from error
+    if (error.config?.data) {
+      delete error.config.data
+    }
+
+    if (error.config?.headers) {
+      delete error.config.headers.Authorization
+    }
+
     const statusCode = error.statusCode || 500
     logger[statusCode < 500 ? 'info' : 'error'](error)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

<!--- Describe the changes in detail - the "what"-->

This creates some extra Sentry logging when the API returns with timeouts. It adds the URL that timed out to the Sentry breadcrumb so that we can determine what URL the frontend thinks failed.

It also includes a clean up to errors to remove certain properties before they are logged to stdout.

### Why did it change

<!--- Describe the reason these changes were made - the "why" -->

We see a large number of timeouts and it is sometimes hard to tie the frontend and API together in these instances. With this change it should help us see more specifically which URLs the errors are occurring on, and along with the transaction ID verify if the API did take longer than the timeout or not.

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

- [P4-XXXX]()

## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed
