### PR TITLE
Increase logging around Form Wizard errors

### DIFF
--- a/app/move/app/new/controllers/document.test.js
+++ b/app/move/app/new/controllers/document.test.js
@@ -1,4 +1,3 @@
-const FormController = require('hmpo-form-wizard').Controller
 const FormError = require('hmpo-form-wizard/lib/error')
 const multer = require('multer')
 const proxyquire = require('proxyquire').noCallThru()
@@ -26,7 +25,7 @@ describe('Move controllers', function () {
       let req, nextSpy
 
       beforeEach(async function () {
-        sinon.spy(FormController.prototype, 'configure')
+        sinon.spy(BaseController.prototype, 'configure')
         nextSpy = sinon.spy()
         req = {
           originalUrl: '/xhr-url',
@@ -47,7 +46,7 @@ describe('Move controllers', function () {
       })
 
       it('should call parent configure method', function () {
-        expect(FormController.prototype.configure).to.be.calledOnceWithExactly(
+        expect(BaseController.prototype.configure).to.be.calledOnceWithExactly(
           req,
           {},
           nextSpy
@@ -256,7 +255,7 @@ describe('Move controllers', function () {
           send: sinon.stub(),
         }
         nextSpy = sinon.spy()
-        sinon.stub(FormController.prototype, 'errorHandler')
+        sinon.stub(BaseController.prototype, 'errorHandler')
       })
 
       context('with standard error', function () {
@@ -272,7 +271,7 @@ describe('Move controllers', function () {
 
         it('should call parent error handler', function () {
           expect(
-            FormController.prototype.errorHandler
+            BaseController.prototype.errorHandler
           ).to.be.calledOnceWithExactly(err, req, res, nextSpy)
         })
       })
@@ -295,7 +294,7 @@ describe('Move controllers', function () {
 
           it('should call parent error handler', function () {
             expect(
-              FormController.prototype.errorHandler
+              BaseController.prototype.errorHandler
             ).to.be.calledOnceWithExactly(uploadErr, req, res, nextSpy)
           })
         })
@@ -318,7 +317,7 @@ describe('Move controllers', function () {
 
           it('should not call parent error handler', function () {
             expect(
-              FormController.prototype.errorHandler
+              BaseController.prototype.errorHandler
             ).not.to.have.been.called
           })
         })
@@ -340,7 +339,7 @@ describe('Move controllers', function () {
           json: sinon.stub(),
         }
         nextSpy = sinon.spy()
-        sinon.stub(FormController.prototype, 'successHandler')
+        sinon.stub(BaseController.prototype, 'successHandler')
       })
 
       context('when request is not XHR', function () {
@@ -354,7 +353,7 @@ describe('Move controllers', function () {
 
         it('should call parent success handler', function () {
           expect(
-            FormController.prototype.successHandler
+            BaseController.prototype.successHandler
           ).to.be.calledOnceWithExactly(req, res, nextSpy)
         })
       })
@@ -379,7 +378,7 @@ describe('Move controllers', function () {
 
           it('should not call parent success handler', function () {
             expect(
-              FormController.prototype.successHandler
+              BaseController.prototype.successHandler
             ).not.to.have.been.called
           })
         })
@@ -401,7 +400,7 @@ describe('Move controllers', function () {
 
             it('should not call parent success handler', function () {
               expect(
-                FormController.prototype.successHandler
+                BaseController.prototype.successHandler
               ).not.to.have.been.called
             })
           })
@@ -422,7 +421,7 @@ describe('Move controllers', function () {
 
             it('should not call parent success handler', function () {
               expect(
-                FormController.prototype.successHandler
+                BaseController.prototype.successHandler
               ).not.to.have.been.called
             })
           })


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

This changes adds the journey details to the Sentry error when it
is triggered from within the Form Wizard.

### Why did it change

In some instances its hard to debug what steps as user has taken
to get to that error.

This change will allow us to see the exact steps a user has accessed
during that journey. This should aid in debugging some of these errors.

## Screenshots
<!--- (Optional) Include screenshots if changes update interfaces or components -->
<!--- Delete/copy as appropriate --->

<kbd>![image](https://user-images.githubusercontent.com/3327997/111470889-37cfca80-8720-11eb-8680-1720a3db57d1.png)</kbd>

## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed
