### PR TITLE
Enable journeys to be viewed from a move

### DIFF
--- a/app/move/views/view.njk
+++ b/app/move/views/view.njk
@@ -243,6 +243,14 @@
     }) }}
   {% endif %}
 
+  {% if canAccess("move:view:journeys") %}
+    <p class="govuk-!-margin-bottom-2">
+      <a href="{{ move.id }}/journeys">
+        {{ t("actions::view_journeys") }}
+      </a>
+    </p>
+  {% endif %}
+
   {% if canAccess("youth_risk_assessment:view") and youthRiskAssessment %}
     <p class="govuk-!-margin-bottom-2">
       <a href="{{ move.id }}/youth-risk-assessment">

--- a/locales/en/actions.json
+++ b/locales/en/actions.json
@@ -42,6 +42,7 @@
   "save_and_continue": "Save and continue",
   "save_and_return_to_overview": "Save and return to overview",
   "view_more_information": "View more information",
+  "view_journeys": "View journeys",
   "review": "Review",
   "start_assessment": "Start $t({{context}})",
   "print_assessment": "Print $t({{context}})",


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

This adds a link to the move detail page to allow a user to see the
journeys if they have access to that feature.