### PR TITLE
refactor: Fix slack channel name

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -533,6 +533,6 @@ workflows:
                 - main
     jobs:
       - hmpps/npm_security_audit:
-          slack_channel: pecs_dev
+          slack_channel: pecs-dev
           context:
             - hmpps-common-vars


### PR DESCRIPTION
Channel name was wrong and slack hook on fail didn't work.
