### PR TITLE
[P4-2719] Hide print PER button for court role

### DIFF
--- a/common/lib/permissions.js
+++ b/common/lib/permissions.js
@@ -23,6 +23,7 @@ const policePermissions = [
   'person_escort_record:create',
   'person_escort_record:update',
   'person_escort_record:confirm',
+  'person_escort_record:print',
 ]
 
 const contractDeliveryManagerPermissions = [
@@ -34,7 +35,9 @@ const contractDeliveryManagerPermissions = [
   'moves:view:proposed',
   'move:view',
   'person_escort_record:view',
+  'person_escort_record:print',
   'youth_risk_assessment:view',
+  'youth_risk_assessment:print',
 ]
 
 const secureChildrensHomePermissions = [
@@ -59,10 +62,12 @@ const secureChildrensHomePermissions = [
   'person_escort_record:create',
   'person_escort_record:update',
   'person_escort_record:confirm',
+  'person_escort_record:print',
   'youth_risk_assessment:view',
   'youth_risk_assessment:create',
   'youth_risk_assessment:update',
   'youth_risk_assessment:confirm',
+  'youth_risk_assessment:print',
 ]
 const secureTrainingCentrePermissions = [
   'dashboard:view',
@@ -86,10 +91,12 @@ const secureTrainingCentrePermissions = [
   'person_escort_record:create',
   'person_escort_record:update',
   'person_escort_record:confirm',
+  'person_escort_record:print',
   'youth_risk_assessment:view',
   'youth_risk_assessment:create',
   'youth_risk_assessment:update',
   'youth_risk_assessment:confirm',
+  'youth_risk_assessment:print',
 ]
 
 const supplierPermissions = [
@@ -99,7 +106,9 @@ const supplierPermissions = [
   'moves:download',
   'move:view',
   'person_escort_record:view',
+  'person_escort_record:print',
   'youth_risk_assessment:view',
+  'youth_risk_assessment:print',
 ]
 const prisonPermissions = [
   'moves:view:outgoing',
@@ -114,10 +123,12 @@ const prisonPermissions = [
   'person_escort_record:create',
   'person_escort_record:update',
   'person_escort_record:confirm',
+  'person_escort_record:print',
   'youth_risk_assessment:view',
   'youth_risk_assessment:create',
   'youth_risk_assessment:update',
   'youth_risk_assessment:confirm',
+  'youth_risk_assessment:print',
 ]
 const ocaPermissions = [
   'dashboard:view',
@@ -135,6 +146,7 @@ const ocaPermissions = [
   'person_escort_record:create',
   'person_escort_record:update',
   'person_escort_record:confirm',
+  'person_escort_record:print',
 ]
 const pmuPermissions = [
   'allocations:view',
@@ -147,7 +159,9 @@ const pmuPermissions = [
   'move:review',
   'move:view',
   'person_escort_record:view',
+  'person_escort_record:print',
   'youth_risk_assessment:view',
+  'youth_risk_assessment:print',
 ]
 const courtPermissions = [
   'dashboard:view',
@@ -157,12 +171,14 @@ const courtPermissions = [
   'move:view',
   'person_escort_record:view',
   'youth_risk_assessment:view',
+  'youth_risk_assessment:print',
 ]
 const personEscortRecordAuthorPermissions = [
   'person_escort_record:view',
   'person_escort_record:create',
   'person_escort_record:update',
   'person_escort_record:confirm',
+  'person_escort_record:print',
   'dashboard:view',
   'moves:view:outgoing',
   'moves:view:incoming',

--- a/common/lib/user.test.js
+++ b/common/lib/user.test.js
@@ -149,6 +149,7 @@ describe('User class', function () {
           'person_escort_record:create',
           'person_escort_record:update',
           'person_escort_record:confirm',
+          'person_escort_record:print',
         ]
 
         expect(permissions).to.have.members(policePermissions)
@@ -174,10 +175,12 @@ describe('User class', function () {
           'person_escort_record:create',
           'person_escort_record:update',
           'person_escort_record:confirm',
+          'person_escort_record:print',
           'youth_risk_assessment:view',
           'youth_risk_assessment:create',
           'youth_risk_assessment:update',
           'youth_risk_assessment:confirm',
+          'youth_risk_assessment:print',
         ])
       })
     })
@@ -210,10 +213,12 @@ describe('User class', function () {
           'person_escort_record:create',
           'person_escort_record:update',
           'person_escort_record:confirm',
+          'person_escort_record:print',
           'youth_risk_assessment:view',
           'youth_risk_assessment:create',
           'youth_risk_assessment:update',
           'youth_risk_assessment:confirm',
+          'youth_risk_assessment:print',
         ]
 
         expect(permissions).to.have.members(stcPermissions)
@@ -248,10 +253,12 @@ describe('User class', function () {
           'person_escort_record:create',
           'person_escort_record:update',
           'person_escort_record:confirm',
+          'person_escort_record:print',
           'youth_risk_assessment:view',
           'youth_risk_assessment:create',
           'youth_risk_assessment:update',
           'youth_risk_assessment:confirm',
+          'youth_risk_assessment:print',
         ])
       })
     })
@@ -275,10 +282,12 @@ describe('User class', function () {
           'person_escort_record:create',
           'person_escort_record:update',
           'person_escort_record:confirm',
+          'person_escort_record:print',
           'youth_risk_assessment:view',
           'youth_risk_assessment:create',
           'youth_risk_assessment:update',
           'youth_risk_assessment:confirm',
+          'youth_risk_assessment:print',
         ])
       })
     })
@@ -305,6 +314,7 @@ describe('User class', function () {
           'person_escort_record:create',
           'person_escort_record:update',
           'person_escort_record:confirm',
+          'person_escort_record:print',
         ])
       })
     })
@@ -326,7 +336,9 @@ describe('User class', function () {
           'move:review',
           'move:view',
           'person_escort_record:view',
+          'person_escort_record:print',
           'youth_risk_assessment:view',
+          'youth_risk_assessment:print',
         ])
       })
     })
@@ -344,7 +356,9 @@ describe('User class', function () {
           'moves:download',
           'move:view',
           'person_escort_record:view',
+          'person_escort_record:print',
           'youth_risk_assessment:view',
+          'youth_risk_assessment:print',
         ])
       })
     })
@@ -363,6 +377,7 @@ describe('User class', function () {
           'move:view',
           'person_escort_record:view',
           'youth_risk_assessment:view',
+          'youth_risk_assessment:print',
         ])
       })
     })
@@ -378,6 +393,7 @@ describe('User class', function () {
           'person_escort_record:create',
           'person_escort_record:update',
           'person_escort_record:confirm',
+          'person_escort_record:print',
           'dashboard:view',
           'moves:view:outgoing',
           'moves:view:incoming',
@@ -441,10 +457,12 @@ describe('User class', function () {
           'person_escort_record:create',
           'person_escort_record:update',
           'person_escort_record:confirm',
+          'person_escort_record:print',
           'youth_risk_assessment:view',
           'youth_risk_assessment:create',
           'youth_risk_assessment:update',
           'youth_risk_assessment:confirm',
+          'youth_risk_assessment:print',
         ]
 
         expect(permissions).to.have.members(allPermissions)

--- a/common/presenters/assessment-print-button.js
+++ b/common/presenters/assessment-print-button.js
@@ -1,0 +1,21 @@
+const i18n = require('../../config/i18n')
+
+module.exports = function assessmentPrintbutton({
+  baseUrl,
+  canAccess,
+  context,
+} = {}) {
+  if (canAccess && canAccess(`${context}:print`)) {
+    return `
+      <p>
+        <a href="${baseUrl}/print" class="app-icon app-icon--print">
+          ${i18n.t('actions::print_assessment', {
+            context,
+          })}
+        </a>
+      </p>
+    `
+  }
+
+  return ''
+}

--- a/common/presenters/assessment-print-button.test.js
+++ b/common/presenters/assessment-print-button.test.js
@@ -1,0 +1,42 @@
+const i18n = require('../../config/i18n')
+
+const presenter = require('./assessment-print-button')
+
+describe('Presenters', function () {
+  describe('#assessmentPrintButton', function () {
+    let output
+    let mockArgs
+
+    beforeEach(function () {
+      sinon.stub(i18n, 't').returnsArg(0)
+      mockArgs = {
+        baseUrl: '/base-url',
+        canAccess: sinon.stub().returns(true),
+        context: 'person_escort_record',
+      }
+    })
+
+    context('without print permission', function () {
+      beforeEach(function () {
+        mockArgs.canAccess.withArgs('person_escort_record:print').returns(false)
+        output = presenter(mockArgs)
+      })
+
+      it('should return blank', function () {
+        expect(output).to.deep.equal('')
+      })
+    })
+
+    context('with print permission', function () {
+      beforeEach(function () {
+        output = presenter(mockArgs)
+      })
+
+      it('should return the print button html', function () {
+        expect(output).to.deep.equal(
+          '\n      <p>\n        <a href="/base-url/print" class="app-icon app-icon--print">\n          actions::print_assessment\n        </a>\n      </p>\n    '
+        )
+      })
+    })
+  })
+})

--- a/common/presenters/message-banner/assessment-to-confirmed-banner.js
+++ b/common/presenters/message-banner/assessment-to-confirmed-banner.js
@@ -1,5 +1,6 @@
 const i18n = require('../../../config/i18n')
 const filters = require('../../../config/nunjucks/filters')
+const assessmentPrintButton = require('../assessment-print-button')
 
 module.exports = function assessmentToConfirmedBanner({
   assessment,
@@ -20,17 +21,7 @@ module.exports = function assessmentToConfirmedBanner({
     </p>
   `
 
-  if (canAccess && canAccess(`${context}:print`)) {
-    content += `
-      <p>
-        <a href="${baseUrl}/print" class="app-icon app-icon--print">
-          ${i18n.t('actions::print_assessment', {
-            context,
-          })}
-        </a>
-      </p>
-    `
-  }
+  content += assessmentPrintButton({ baseUrl, canAccess, context })
 
   return {
     allowDismiss: false,

--- a/common/presenters/message-banner/assessment-to-confirmed-banner.js
+++ b/common/presenters/message-banner/assessment-to-confirmed-banner.js
@@ -4,28 +4,33 @@ const filters = require('../../../config/nunjucks/filters')
 module.exports = function assessmentToConfirmedBanner({
   assessment,
   baseUrl,
+  canAccess,
   context,
 } = {}) {
   if (!assessment) {
     return {}
   }
 
-  const content = `
+  let content = `
     <p>
       ${i18n.t(`messages::assessment.${assessment.status}.content`, {
         context,
         date: filters.formatDateWithTimeAndDay(assessment.confirmed_at),
       })}
     </p>
-
-    <p>
-      <a href="${baseUrl}/print" class="app-icon app-icon--print">
-        ${i18n.t('actions::print_assessment', {
-          context,
-        })}
-      </a>
-    </p>
   `
+
+  if (canAccess && canAccess(`${context}:print`)) {
+    content += `
+      <p>
+        <a href="${baseUrl}/print" class="app-icon app-icon--print">
+          ${i18n.t('actions::print_assessment', {
+            context,
+          })}
+        </a>
+      </p>
+    `
+  }
 
   return {
     allowDismiss: false,

--- a/common/presenters/message-banner/assessment-to-confirmed-banner.test.js
+++ b/common/presenters/message-banner/assessment-to-confirmed-banner.test.js
@@ -27,6 +27,7 @@ describe('Presenters', function () {
             confirmed_at: '2020-10-10',
           },
           baseUrl: '/base-url',
+          canAccess: sinon.stub().returns(true),
           context: 'person_escort_record',
         }
 
@@ -43,7 +44,7 @@ describe('Presenters', function () {
             },
             content: {
               html:
-                '\n    <p>\n      messages::assessment.completed.content\n    </p>\n\n    <p>\n      <a href="/base-url/print" class="app-icon app-icon--print">\n        actions::print_assessment\n      </a>\n    </p>\n  ',
+                '\n    <p>\n      messages::assessment.completed.content\n    </p>\n  \n      <p>\n        <a href="/base-url/print" class="app-icon app-icon--print">\n          actions::print_assessment\n        </a>\n      </p>\n    ',
             },
           })
         })
@@ -71,6 +72,40 @@ describe('Presenters', function () {
           expect(filters.formatDateWithTimeAndDay).to.be.calledWithExactly(
             mockArgs.assessment.confirmed_at
           )
+        })
+      })
+
+      context('without print permission', function () {
+        const mockArgs = {
+          assessment: {
+            status: 'completed',
+            confirmed_at: '2020-10-10',
+          },
+          baseUrl: '/base-url',
+          canAccess: sinon
+            .stub()
+            .returns(true)
+            .withArgs('person_escort_record:print')
+            .returns(false),
+          context: 'person_escort_record',
+        }
+
+        beforeEach(function () {
+          output = presenter(mockArgs)
+        })
+
+        it('should return message component without print button', function () {
+          expect(output).to.deep.equal({
+            allowDismiss: false,
+            classes: 'app-message--instruction govuk-!-padding-right-0',
+            title: {
+              text: 'messages::assessment.completed.heading',
+            },
+            content: {
+              html:
+                '\n    <p>\n      messages::assessment.completed.content\n    </p>\n  ',
+            },
+          })
         })
       })
     })

--- a/common/presenters/message-banner/assessment-to-handed-over-banner.js
+++ b/common/presenters/message-banner/assessment-to-handed-over-banner.js
@@ -5,13 +5,14 @@ const componentService = require('../../services/component')
 module.exports = function assessmentToHandedOverBanner({
   assessment,
   baseUrl,
+  canAccess,
   context,
 } = {}) {
   if (!assessment) {
     return {}
   }
 
-  const content = `
+  let content = `
     <p>
       ${i18n.t('messages::assessment.handed_over.content', {
         context,
@@ -26,15 +27,21 @@ module.exports = function assessmentToHandedOverBanner({
       }),
       iconFallbackText: 'Warning',
     })}
+    `
 
-    <p>
-      <a href="${baseUrl}/print" class="app-icon app-icon--print">
-        ${i18n.t('actions::print_assessment', {
-          context,
-        })}
-      </a>
-    </p>
+  if (canAccess && canAccess(`${context}:print`)) {
+    content += `
+      <p>
+        <a href="${baseUrl}/print" class="app-icon app-icon--print">
+          ${i18n.t('actions::print_assessment', {
+            context,
+          })}
+        </a>
+      </p>
+    `
+  }
 
+  content += `
     <p class="govuk-!-font-size-16 govuk-!-margin-top-1">
       ${i18n.t('handed_over_at', {
         date: filters.formatDateWithTimeAndDay(

--- a/common/presenters/message-banner/assessment-to-handed-over-banner.js
+++ b/common/presenters/message-banner/assessment-to-handed-over-banner.js
@@ -1,6 +1,7 @@
 const i18n = require('../../../config/i18n')
 const filters = require('../../../config/nunjucks/filters')
 const componentService = require('../../services/component')
+const assessmentPrintButton = require('../assessment-print-button')
 
 module.exports = function assessmentToHandedOverBanner({
   assessment,
@@ -29,17 +30,7 @@ module.exports = function assessmentToHandedOverBanner({
     })}
     `
 
-  if (canAccess && canAccess(`${context}:print`)) {
-    content += `
-      <p>
-        <a href="${baseUrl}/print" class="app-icon app-icon--print">
-          ${i18n.t('actions::print_assessment', {
-            context,
-          })}
-        </a>
-      </p>
-    `
-  }
+  content += assessmentPrintButton({ baseUrl, canAccess, context })
 
   content += `
     <p class="govuk-!-font-size-16 govuk-!-margin-top-1">

--- a/common/presenters/message-banner/assessment-to-handed-over-banner.test.js
+++ b/common/presenters/message-banner/assessment-to-handed-over-banner.test.js
@@ -32,6 +32,7 @@ describe('Presenters', function () {
             },
           },
           baseUrl: '/base-url',
+          canAccess: sinon.stub().returns(true),
           context: 'person_escort_record',
         }
 
@@ -48,7 +49,7 @@ describe('Presenters', function () {
             },
             content: {
               html:
-                '\n    <p>\n      messages::assessment.handed_over.content\n    </p>\n\n    govukWarningText\n\n    <p>\n      <a href="/base-url/print" class="app-icon app-icon--print">\n        actions::print_assessment\n      </a>\n    </p>\n\n    <p class="govuk-!-font-size-16 govuk-!-margin-top-1">\n      handed_over_at\n    </p>\n  ',
+                '\n    <p>\n      messages::assessment.handed_over.content\n    </p>\n\n    govukWarningText\n    \n      <p>\n        <a href="/base-url/print" class="app-icon app-icon--print">\n          actions::print_assessment\n        </a>\n      </p>\n    \n    <p class="govuk-!-font-size-16 govuk-!-margin-top-1">\n      handed_over_at\n    </p>\n  ',
             },
           })
         })
@@ -86,6 +87,43 @@ describe('Presenters', function () {
           expect(filters.formatDateWithTimeAndDay).to.be.calledWithExactly(
             mockArgs.assessment.handover_occurred_at
           )
+        })
+      })
+
+      context('without print permission', function () {
+        const mockArgs = {
+          assessment: {
+            status: 'completed',
+            confirmed_at: '2020-10-10',
+            handover_details: {
+              foo: 'bar',
+            },
+          },
+          baseUrl: '/base-url',
+          canAccess: sinon
+            .stub()
+            .returns(true)
+            .withArgs('person_escort_record:print')
+            .returns(false),
+          context: 'person_escort_record',
+        }
+
+        beforeEach(function () {
+          output = presenter(mockArgs)
+        })
+
+        it('should return message component without print button', function () {
+          expect(output).to.deep.equal({
+            allowDismiss: false,
+            classes: 'app-message--instruction govuk-!-padding-right-0',
+            title: {
+              text: 'messages::assessment.handed_over.heading',
+            },
+            content: {
+              html:
+                '\n    <p>\n      messages::assessment.handed_over.content\n    </p>\n\n    govukWarningText\n    \n    <p class="govuk-!-font-size-16 govuk-!-margin-top-1">\n      handed_over_at\n    </p>\n  ',
+            },
+          })
         })
       })
     })

--- a/common/presenters/message-banner/assessment-to-unconfirmed-banner.js
+++ b/common/presenters/message-banner/assessment-to-unconfirmed-banner.js
@@ -40,15 +40,17 @@ module.exports = function assessmentToUnconfirmedBanner({
       `
     }
 
-    content += `
-      <p>
-        <a href="${baseUrl}/print" class="app-icon app-icon--print">
-          ${i18n.t('actions::print_assessment', {
-            context,
-          })}
-        </a>
-      </p>
-    `
+    if (canAccess && canAccess(`${context}:print`)) {
+      content += `
+        <p>
+          <a href="${baseUrl}/print" class="app-icon app-icon--print">
+            ${i18n.t('actions::print_assessment', {
+              context,
+            })}
+          </a>
+        </p>
+      `
+    }
   }
 
   if (assessment.amended_at || assessment.completed_at) {

--- a/common/presenters/message-banner/assessment-to-unconfirmed-banner.js
+++ b/common/presenters/message-banner/assessment-to-unconfirmed-banner.js
@@ -1,6 +1,7 @@
 const i18n = require('../../../config/i18n')
 const filters = require('../../../config/nunjucks/filters')
 const componentService = require('../../services/component')
+const assessmentPrintButton = require('../assessment-print-button')
 const frameworkToTaskListComponent = require('../framework-to-task-list-component')
 
 module.exports = function assessmentToUnconfirmedBanner({
@@ -40,17 +41,7 @@ module.exports = function assessmentToUnconfirmedBanner({
       `
     }
 
-    if (canAccess && canAccess(`${context}:print`)) {
-      content += `
-        <p>
-          <a href="${baseUrl}/print" class="app-icon app-icon--print">
-            ${i18n.t('actions::print_assessment', {
-              context,
-            })}
-          </a>
-        </p>
-      `
-    }
+    content += assessmentPrintButton({ baseUrl, canAccess, context })
   }
 
   if (assessment.amended_at || assessment.completed_at) {

--- a/common/presenters/message-banner/assessment-to-unconfirmed-banner.test.js
+++ b/common/presenters/message-banner/assessment-to-unconfirmed-banner.test.js
@@ -45,6 +45,7 @@ describe('Presenters', function () {
               },
             },
             baseUrl: '/base-url',
+            canAccess: sinon.stub().returns(true),
             context: 'person_escort_record',
           }
         })
@@ -97,6 +98,10 @@ describe('Presenters', function () {
 
           context('without confirm access', function () {
             beforeEach(function () {
+              mockArgs.canAccess
+                .withArgs('person_escort_record:confirm')
+                .returns(false)
+
               output = presenter({
                 ...mockArgs,
               })
@@ -111,7 +116,7 @@ describe('Presenters', function () {
                 },
                 content: {
                   html:
-                    '\n    <div class="govuk-grid-row">\n      <div class="govuk-grid-column-two-thirds">\n        appTaskList\n      </div>\n    </div>\n  \n      <p>\n        <a href="/base-url/print" class="app-icon app-icon--print">\n          actions::print_assessment\n        </a>\n      </p>\n    ',
+                    '\n    <div class="govuk-grid-row">\n      <div class="govuk-grid-column-two-thirds">\n        appTaskList\n      </div>\n    </div>\n  \n        <p>\n          <a href="/base-url/print" class="app-icon app-icon--print">\n            actions::print_assessment\n          </a>\n        </p>\n      ',
                 },
               })
             })
@@ -129,6 +134,32 @@ describe('Presenters', function () {
               expect(componentService.getComponent).not.to.be.calledWith(
                 'govukButton'
               )
+            })
+          })
+
+          context('without print access', function () {
+            beforeEach(function () {
+              mockArgs.canAccess
+                .withArgs('person_escort_record:print')
+                .returns(false)
+
+              output = presenter({
+                ...mockArgs,
+              })
+            })
+
+            it('should return message component', function () {
+              expect(output).to.deep.equal({
+                allowDismiss: false,
+                classes: 'app-message--instruction govuk-!-padding-right-0',
+                title: {
+                  text: `messages::assessment.${mockArgs.assessment.status}.heading`,
+                },
+                content: {
+                  html:
+                    '\n    <div class="govuk-grid-row">\n      <div class="govuk-grid-column-two-thirds">\n        appTaskList\n      </div>\n    </div>\n  \n        govukButton\n      ',
+                },
+              })
             })
           })
 
@@ -177,7 +208,7 @@ describe('Presenters', function () {
                   },
                   content: {
                     html:
-                      '\n    <div class="govuk-grid-row">\n      <div class="govuk-grid-column-two-thirds">\n        appTaskList\n      </div>\n    </div>\n  \n        govukButton\n      \n      <p>\n        <a href="/base-url/print" class="app-icon app-icon--print">\n          actions::print_assessment\n        </a>\n      </p>\n    ',
+                      '\n    <div class="govuk-grid-row">\n      <div class="govuk-grid-column-two-thirds">\n        appTaskList\n      </div>\n    </div>\n  \n        govukButton\n      \n        <p>\n          <a href="/base-url/print" class="app-icon app-icon--print">\n            actions::print_assessment\n          </a>\n        </p>\n      ',
                   },
                 })
               })

--- a/common/presenters/message-banner/assessment-to-unconfirmed-banner.test.js
+++ b/common/presenters/message-banner/assessment-to-unconfirmed-banner.test.js
@@ -116,7 +116,7 @@ describe('Presenters', function () {
                 },
                 content: {
                   html:
-                    '\n    <div class="govuk-grid-row">\n      <div class="govuk-grid-column-two-thirds">\n        appTaskList\n      </div>\n    </div>\n  \n        <p>\n          <a href="/base-url/print" class="app-icon app-icon--print">\n            actions::print_assessment\n          </a>\n        </p>\n      ',
+                    '\n    <div class="govuk-grid-row">\n      <div class="govuk-grid-column-two-thirds">\n        appTaskList\n      </div>\n    </div>\n  \n      <p>\n        <a href="/base-url/print" class="app-icon app-icon--print">\n          actions::print_assessment\n        </a>\n      </p>\n    ',
                 },
               })
             })
@@ -208,7 +208,7 @@ describe('Presenters', function () {
                   },
                   content: {
                     html:
-                      '\n    <div class="govuk-grid-row">\n      <div class="govuk-grid-column-two-thirds">\n        appTaskList\n      </div>\n    </div>\n  \n        govukButton\n      \n        <p>\n          <a href="/base-url/print" class="app-icon app-icon--print">\n            actions::print_assessment\n          </a>\n        </p>\n      ',
+                      '\n    <div class="govuk-grid-row">\n      <div class="govuk-grid-column-two-thirds">\n        appTaskList\n      </div>\n    </div>\n  \n        govukButton\n      \n      <p>\n        <a href="/base-url/print" class="app-icon app-icon--print">\n          actions::print_assessment\n        </a>\n      </p>\n    ',
                   },
                 })
               })

--- a/common/presenters/message-banner/move-to-message-banner-component.js
+++ b/common/presenters/message-banner/move-to-message-banner-component.js
@@ -25,11 +25,21 @@ function moveToMessageBannerComponent({ move = {}, moveUrl, canAccess } = {}) {
   }
 
   if (assessment?.status === 'confirmed' && assessment.handover_occurred_at) {
-    return assessmentToHandedOverBanner({ assessment, baseUrl, context })
+    return assessmentToHandedOverBanner({
+      assessment,
+      baseUrl,
+      canAccess,
+      context,
+    })
   }
 
   if (assessment?.status === 'confirmed') {
-    return assessmentToConfirmedBanner({ assessment, baseUrl, context })
+    return assessmentToConfirmedBanner({
+      assessment,
+      baseUrl,
+      canAccess,
+      context,
+    })
   }
 
   if (assessment?.status !== 'confirmed') {

--- a/common/presenters/message-banner/move-to-message-banner-component.test.js
+++ b/common/presenters/message-banner/move-to-message-banner-component.test.js
@@ -112,6 +112,7 @@ describe('Presenters', function () {
                       handover_occurred_at: '2018-10-10T14:30:00Z',
                     },
                     baseUrl: '/move/12345/person-escort-record',
+                    canAccess: mockArgs.canAccess,
                     context: 'person_escort_record',
                   })
                 })
@@ -148,6 +149,7 @@ describe('Presenters', function () {
                       status: 'confirmed',
                     },
                     baseUrl: '/move/12345/person-escort-record',
+                    canAccess: mockArgs.canAccess,
                     context: 'person_escort_record',
                   })
                 })
@@ -260,8 +262,8 @@ describe('Presenters', function () {
                   status: 'in_progress',
                 },
                 baseUrl: '/move/12345/youth-risk-assessment',
-                context: 'youth_risk_assessment',
                 canAccess: mockArgs.canAccess,
+                context: 'youth_risk_assessment',
               })
             })
           })
@@ -289,8 +291,8 @@ describe('Presenters', function () {
                 assessmentToStartBannerStub
               ).to.have.been.calledOnceWithExactly({
                 baseUrl: '/move/12345/person-escort-record',
-                context: 'person_escort_record',
                 canAccess: mockArgs.canAccess,
+                context: 'person_escort_record',
               })
             })
           })
@@ -322,8 +324,8 @@ describe('Presenters', function () {
                   status: 'in_progress',
                 },
                 baseUrl: '/move/12345/person-escort-record',
-                context: 'person_escort_record',
                 canAccess: mockArgs.canAccess,
+                context: 'person_escort_record',
               })
             })
           })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Two new permissions have been added `person_escort_record:print` and `youth_risk_assessment:print`, this allows us to pick which roles can print the respective forms.

### Why did it change

It was requested that we remove the `print` button on PERs for court users due to security concerns.

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

- [P4-2719]()

## Screenshots
<!--- (Optional) Include screenshots if changes update interfaces or components -->
<!--- Delete/copy as appropriate --->

| Before | After |
| ------ | ----- |
| <kbd><img src=""></kbd> | <kbd><img src=""></kbd> |

## Checklists

### Testing

#### Automated testing

- [ ] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [ ] Chrome
- [x] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [ ] No environment variables were added or changed

<!--- Delete if changes DO NOT include new environment variables -->
- [ ] Documented in the [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/main/README.md)
- [ ] Added to [continous integration](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-book-secure-move-frontend)
- [ ] Added to staging environment (deployment repository)
- [ ] Added to preproduction environment (deployment repository)
- [ ] Added to production environment (deployment repository)

### Other considerations

Commit messages with a `fix` or `feat` type are automatically used to generate the [changelog](ministryofjustice/hmpps-book-secure-move-frontend/blob/main/CHANGELOG.md) and
[GitHub release notes](https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/releases) during the release task. Please make sure they will read well on their own in a
summary of changes and that the commit body gives a more detailed description of those changes if necessary.

- [ ] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
- [ ] Update [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/main/README.md) with any new instructions or tasks
