### PR TITLE
[P4-2637] Fix inactive locations breaking e2e test

### DIFF
--- a/test/e2e/pages/page.js
+++ b/test/e2e/pages/page.js
@@ -31,6 +31,7 @@ export default class Page {
       ).withAttribute('href', /\/locations\/.+/),
       locationValue: Selector('.moj-organisation-nav__title'),
       dateSelectInput: '[name="date_select"]',
+      inactiveLocations: Selector('.govuk-details__summary-text'),
     }
     this.getCurrentUrl = ClientFunction(() => window.location.href)
   }
@@ -56,6 +57,10 @@ export default class Page {
       .contains('/locations')
       .expect(this.nodes.locationsList.count)
       .notEql(0, { timeout: 15000 })
+
+    if (await this.nodes.inactiveLocations.exists) {
+      await t.click(this.nodes.inactiveLocations)
+    }
 
     if (isUndefined(position)) {
       const count = await this.nodes.locationsList.count


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Location selection in e2e now clicks the inactive locations detail component prior to clicking a location.

### Why did it change

When I added the code for inactive locations, this e2e test didn't fail because it selects a random location, we were unlucky enough that no inactive locations were selected, so the e2e tests didn't fail and this went by undetected.

Clicking the inactive locations detail component first will make the inactive locations visible, which means the tests won't fail anymore.

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

- [P4-2637](https://dsdmoj.atlassian.net/browse/P4-2637)

## Screenshots
<!--- (Optional) Include screenshots if changes update interfaces or components -->
<!--- Delete/copy as appropriate --->

| Before | After |
| ------ | ----- |
| <kbd><img src=""></kbd> | <kbd><img src=""></kbd> |

## Checklists

### Testing

#### Automated testing

- [ ] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [ ] No environment variables were added or changed

<!--- Delete if changes DO NOT include new environment variables -->
- [ ] Documented in the [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/main/README.md)
- [ ] Added to [continous integration](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-book-secure-move-frontend)
- [ ] Added to staging environment (deployment repository)
- [ ] Added to preproduction environment (deployment repository)
- [ ] Added to production environment (deployment repository)

### Other considerations

Commit messages with a `fix` or `feat` type are automatically used to generate the [changelog](ministryofjustice/hmpps-book-secure-move-frontend/blob/main/CHANGELOG.md) and
[GitHub release notes](https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/releases) during the release task. Please make sure they will read well on their own in a
summary of changes and that the commit body gives a more detailed description of those changes if necessary.

- [ ] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
- [ ] Update [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/main/README.md) with any new instructions or tasks
