### PR TITLE
fix: Don't cache failed authentication

### DIFF
--- a/common/lib/api-client/auth.js
+++ b/common/lib/api-client/auth.js
@@ -27,10 +27,20 @@ Auth.prototype = {
   getAccessToken() {
     if (this.isExpired()) {
       if (!this.fetchingTokenPromise) {
-        this.fetchingTokenPromise = this.refreshAccessToken().then(data => {
-          this.fetchingTokenPromise = null
-          return data
-        })
+        this.fetchingTokenPromise = this.refreshAccessToken()
+          .then(data => {
+            this.fetchingTokenPromise = null
+            return data
+          })
+          .catch(e => {
+            debug('getAccessToken: error refreshing token')
+
+            this.fetchingTokenPromise = null
+            this.accessToken = null
+            this.tokenExpiresAt = null
+
+            return e
+          })
       }
 
       return this.fetchingTokenPromise.then(data => {

--- a/common/lib/api-client/auth.test.js
+++ b/common/lib/api-client/auth.test.js
@@ -150,6 +150,45 @@ describe('API Client', function () {
           expect(accessToken).to.equal('mockToken')
         })
       })
+
+      context('on initial error', function () {
+        beforeEach(async function () {
+          authInstance.isExpired.returns(true)
+          authInstance.refreshAccessToken.rejects(new Error('Server on fire'))
+          try {
+            accessToken = await authInstance.getAccessToken()
+          } catch (e) {}
+        })
+
+        it('should attempt to refresh the token', function () {
+          expect(authInstance.refreshAccessToken).to.be.calledOnce
+        })
+
+        it('should clear the access token', function () {
+          expect(authInstance.accessToken).to.be.undefined
+        })
+
+        describe('on subsequent calls', function () {
+          beforeEach(async function () {
+            authInstance.refreshAccessToken.resolves(mockTokenResponse)
+            authInstance.isExpired.returns(true)
+
+            accessToken = await authInstance.getAccessToken()
+          })
+
+          it('should refresh the token', function () {
+            expect(authInstance.refreshAccessToken).to.be.calledTwice
+          })
+
+          it('should set the access token', function () {
+            expect(authInstance.accessToken).to.be.equal('newMockToken')
+          })
+
+          it('should return access token', function () {
+            expect(accessToken).to.equal('newMockToken')
+          })
+        })
+      })
     })
 
     describe('#refreshAccessToken()', function () {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

When the auth fails, the (internal) promise is rejected without being
cleared. This means the next time the code is executed, the Promise will
automatically reject.

By clearing the Promise (and other auth token values), the next request
will have a fresh Promise to resolve or reject as per the server
response

Unauthenticated requests are held while waiting for an auth token, if the auth fails, then all requests currently in flight will fail. To fix this issue would require per user auth tokens, see notes below.

### Other notes

When dealing with auth in `book-a-secure-move`, it is important to remember that user authentication happens via the auth service, and that the server is separately authenticated client for the backend api. This means that one api auth token is shared between all requests on the server, in a similar way to how oauth for the Ordnance Survey maps works. 

The initial attempt at fixing this bug applied a separate oauth for every request, which dramatically increased the number of oauth calls, as images are separate requests. Adding the auth key/objects to the session would be one way around this, but is not needed at the moment, and would need to be evaluated as to it's effect on data storage of the user session. When authorisation is moved completely into the API, this area will need to be revisted.


<!--- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

- [P4-XXXX]()

## Screenshots
<!--- (Optional) Include screenshots if changes update interfaces or components -->
<!--- Delete/copy as appropriate --->

| Before | After |
| ------ | ----- |
| <kbd><img src=""></kbd> | <kbd><img src=""></kbd> |

## Checklists

### Testing

#### Automated testing

- [ ] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [ ] No environment variables were added or changed

<!--- Delete if changes DO NOT include new environment variables -->
- [ ] Documented in the [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/main/README.md)
- [ ] Added to [continous integration](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-book-secure-move-frontend)
- [ ] Added to staging environment (deployment repository)
- [ ] Added to preproduction environment (deployment repository)
- [ ] Added to production environment (deployment repository)

### Other considerations

Commit messages with a `fix` or `feat` type are automatically used to generate the [changelog](ministryofjustice/hmpps-book-secure-move-frontend/blob/main/CHANGELOG.md) and
[GitHub release notes](https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/releases) during the release task. Please make sure they will read well on their own in a
summary of changes and that the commit body gives a more detailed description of those changes if necessary.

- [ ] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
- [ ] Update [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/main/README.md) with any new instructions or tasks
