### PR TITLE
chore: Remove second query string library

### DIFF
--- a/app/filters/views/filters.njk
+++ b/app/filters/views/filters.njk
@@ -17,10 +17,8 @@
 
   <form method="POST">
     <input type="hidden" name="referrer" value="{{filters.referrer.url}}">
-    {% for name, values in filters.referrer.values %}
-      {% for value in values %}
-        <input type="hidden" name="{{name}}" value="{{value}}">
-      {% endfor %}
+    {% for name, value in filters.referrer.values %}
+      <input type="hidden" name="{{name}}" value="{{value}}">
     {% endfor %}
     {% for key, filterComponent in filters.components %}
       {% if filterComponent.component and not filterComponent.skip %}

--- a/common/controllers/filters.js
+++ b/common/controllers/filters.js
@@ -1,3 +1,5 @@
+const { omit } = require('lodash')
+
 const getDefaultValues = fields => {
   return Object.keys(fields).reduce((values, key) => {
     if (fields[key].defaultValue !== undefined) {
@@ -22,17 +24,9 @@ const removeDefaultFilterValues = (fields, values) => {
 }
 
 const getReferrerValues = (fields, values) => {
-  const referrerValues = { ...values }
-  Object.keys(fields).forEach(filter => {
-    delete referrerValues[filter]
-  })
-  Object.keys(referrerValues).forEach(key => {
-    if (!Array.isArray(referrerValues[key])) {
-      referrerValues[key] = [referrerValues[key]]
-    }
-  })
+  const omittedKeys = Object.keys(fields)
 
-  return referrerValues
+  return omit(values, omittedKeys)
 }
 
 module.exports = {

--- a/common/controllers/filters.test.js
+++ b/common/controllers/filters.test.js
@@ -34,9 +34,9 @@ describe('Filters controllers', function () {
   })
 
   describe('#getReferrerValues()', function () {
-    it('should return arrayified values for referrer', function () {
+    it('should return values for referrer', function () {
       const values = getReferrerValues(fields, { a: '1' })
-      expect(values).to.deep.equal({ a: ['1'] })
+      expect(values).to.deep.equal({ a: '1' })
     })
 
     it('should not remove filter args', function () {

--- a/common/helpers/url.test.js
+++ b/common/helpers/url.test.js
@@ -145,7 +145,7 @@ describe('URL Helpers', function () {
           })
 
           it('should return a url with query', function () {
-            expect(output).to.equal('/compiled/url?foo=bar&status=approved')
+            expect(output).to.equal('/compiled/url?status=approved&foo=bar')
           })
         })
 
@@ -167,7 +167,7 @@ describe('URL Helpers', function () {
           })
 
           it('should override the querystring', function () {
-            expect(output).to.equal('/compiled/url?foo=buzz&status=approved')
+            expect(output).to.equal('/compiled/url?status=approved&foo=buzz')
           })
         })
       })

--- a/common/lib/request.js
+++ b/common/lib/request.js
@@ -1,4 +1,4 @@
-const queryString = require('query-string')
+const queryString = require('qs')
 
 function getQueryString(target, source) {
   const output = queryString.stringify({ ...target, ...source })

--- a/common/lib/request.test.js
+++ b/common/lib/request.test.js
@@ -38,7 +38,7 @@ describe('Request library', function () {
 
           const querystring = getQueryString(requestQuery, newQuery)
 
-          expect(querystring).to.equal('?foo=bar&hello=world')
+          expect(querystring).to.equal('?hello=world&foo=bar')
         })
       })
 
@@ -54,7 +54,7 @@ describe('Request library', function () {
 
           const querystring = getQueryString(target, source)
 
-          expect(querystring).to.equal('?foo=world&hello=world')
+          expect(querystring).to.equal('?hello=world&foo=world')
         })
       })
     })

--- a/common/middleware/set-request-filters.test.js
+++ b/common/middleware/set-request-filters.test.js
@@ -94,7 +94,7 @@ describe('#setRequestFilters()', function () {
       expect(res.locals.requestFilters).to.deep.equal({
         categories: ['fake_categories'],
         links: {
-          editFilters: '/filters?filterA=x&foo=bar&referrer=%2Ffoo',
+          editFilters: '/filters?foo=bar&filterA=x&referrer=%2Ffoo',
           clearFilters: '/foo?foo=bar',
         },
       })

--- a/common/presenters/filters-to-categories-list-component.js
+++ b/common/presenters/filters-to-categories-list-component.js
@@ -1,5 +1,11 @@
+const queryString = require('qs')
+
 const i18n = require('../../config/i18n')
-const request = require('../lib/request')
+
+function getUrl(page, args) {
+  const stringified = queryString.stringify(args, { arrayFormat: 'comma' })
+  return `${page}${stringified ? `?${stringified}` : ''}`
+}
 
 const getCategoryItems = (fieldValues, values, pageUrl, key) => {
   const items = (Array.isArray(fieldValues) ? fieldValues : [fieldValues]).map(
@@ -12,7 +18,7 @@ const getCategoryItems = (fieldValues, values, pageUrl, key) => {
         delete removeValues[key]
       }
 
-      const href = request.getUrl(pageUrl, removeValues)
+      const href = getUrl(pageUrl, removeValues)
       return {
         href,
         text: i18n.t(`filters::${key}.${value}.label`),

--- a/common/presenters/filters-to-categories-list-component.test.js
+++ b/common/presenters/filters-to-categories-list-component.test.js
@@ -48,61 +48,69 @@ describe('Presenters', function () {
         ])
       })
     })
-  })
 
-  context('when passed an array value', function () {
-    it('should return the expected categories ', function () {
-      const values = {
-        foo: ['bar', 'baz'],
-      }
-      const categories = filtersToCategoriesListComponent(
-        fields,
-        values,
-        pageUrl
-      )
-      expect(categories).to.deep.equal([
-        {
-          heading: {
-            text: 'filters::foo.legend',
+    context('when passed an array value', function () {
+      it('should return the expected categories ', function () {
+        const values = {
+          foo: ['bar', 'baz', 'fizz', 'buzz'],
+        }
+        const categories = filtersToCategoriesListComponent(
+          fields,
+          values,
+          pageUrl
+        )
+        expect(categories).to.deep.equal([
+          {
+            heading: {
+              text: 'filters::foo.legend',
+            },
+            items: [
+              {
+                href: '/page?foo=baz%2Cfizz%2Cbuzz',
+                text: 'filters::foo.bar.label',
+              },
+              {
+                href: '/page?foo=bar%2Cfizz%2Cbuzz',
+                text: 'filters::foo.baz.label',
+              },
+              {
+                href: '/page?foo=bar%2Cbaz%2Cbuzz',
+                text: 'filters::foo.fizz.label',
+              },
+              {
+                href: '/page?foo=bar%2Cbaz%2Cfizz',
+                text: 'filters::foo.buzz.label',
+              },
+            ],
           },
-          items: [
-            {
-              href: '/page?foo=baz',
-              text: 'filters::foo.bar.label',
-            },
-            {
-              href: '/page?foo=bar',
-              text: 'filters::foo.baz.label',
-            },
-          ],
-        },
-      ])
+        ])
+      })
     })
-  })
 
-  context('when passed an undefined value', function () {
-    it('should return no categories ', function () {
-      const values = {}
-      const categories = filtersToCategoriesListComponent(
-        fields,
-        values,
-        pageUrl
-      )
-      expect(categories).to.deep.equal([])
+    context('when passed an undefined value', function () {
+      it('should return no categories ', function () {
+        const values = {}
+        const categories = filtersToCategoriesListComponent(
+          fields,
+          values,
+          pageUrl
+        )
+        expect(categories).to.deep.equal([])
+      })
     })
-  })
 
-  context('when passed an explicit default value', function () {
-    it('should return no categories ', function () {
-      const values = {
-        foo: 'default',
-      }
-      const categories = filtersToCategoriesListComponent(
-        fields,
-        values,
-        pageUrl
-      )
-      expect(categories).to.deep.equal([])
+    context('when passed an explicit default value', function () {
+      it('should return no categories ', function () {
+        const values = {
+          foo: 'default',
+        }
+        const categories = filtersToCategoriesListComponent(
+          fields,
+          values,
+          pageUrl
+        )
+        expect(categories).to.deep.equal([])
+      })
     })
   })
 })

--- a/common/presenters/table/object-to-table-head.js
+++ b/common/presenters/table/object-to-table-head.js
@@ -1,5 +1,5 @@
 const { omit, pickBy } = require('lodash')
-const queryString = require('query-string')
+const queryString = require('qs')
 
 const i18n = require('../../../config/i18n')
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10976,7 +10976,8 @@
     "decode-uri-component": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
+      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+      "dev": true
     },
     "decompress": {
       "version": "4.2.1",
@@ -13899,11 +13900,6 @@
           }
         }
       }
-    },
-    "filter-obj": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/filter-obj/-/filter-obj-1.1.0.tgz",
-      "integrity": "sha1-mzERErxsYSehbgFsbF1/GeCAXFs="
     },
     "finalhandler": {
       "version": "1.1.2",
@@ -24139,17 +24135,6 @@
         }
       }
     },
-    "query-string": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/query-string/-/query-string-7.0.0.tgz",
-      "integrity": "sha512-Iy7moLybliR5ZgrK/1R3vjrXq03S13Vz4Rbm5Jg3EFq1LUmQppto0qtXz4vqZ386MSRjZgnTSZ9QC+NZOSd/XA==",
-      "requires": {
-        "decode-uri-component": "^0.2.0",
-        "filter-obj": "^1.1.0",
-        "split-on-first": "^1.0.0",
-        "strict-uri-encode": "^2.0.0"
-      }
-    },
     "querystring": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
@@ -26115,11 +26100,6 @@
         "through": "2"
       }
     },
-    "split-on-first": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-1.1.0.tgz",
-      "integrity": "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw=="
-    },
     "split-string": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
@@ -26633,11 +26613,6 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-0.1.2.tgz",
       "integrity": "sha1-gIudDlb8Jz2Am6VzOOkpkZoanxo="
-    },
-    "strict-uri-encode": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
-      "integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY="
     },
     "string-argv": {
       "version": "0.3.1",

--- a/package.json
+++ b/package.json
@@ -141,7 +141,6 @@
     "pluralize": "8.0.0",
     "prom-client": "13.1.0",
     "qs": "6.10.1",
-    "query-string": "7.0.0",
     "redis": "3.1.2",
     "response-time": "2.3.2",
     "semver-sort": "0.0.4",


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

We currently use two libraries for working with querystrings:

- [qs](https://www.npmjs.com/package/qs)
- [query-string](https://www.npmjs.com/package/query-string)

This change removes the use of `query-string` which was used on fewer
occasions and doesn't currently support parsing of objects which we
use on some occasions.

### Why did it change

Having two dependencies doing very similar things seemed unnecessary. The benefit of moving to one will be easier maintenance moving forward too.

## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed

### Other considerations

Commit messages with a `fix` or `feat` type are automatically used to generate the [changelog](ministryofjustice/hmpps-book-secure-move-frontend/blob/main/CHANGELOG.md) and
[GitHub release notes](https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/releases) during the release task. Please make sure they will read well on their own in a
summary of changes and that the commit body gives a more detailed description of those changes if necessary.

- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
- [x] Update [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/main/README.md) with any new instructions or tasks
