### PR TITLE
[P4-2777] Allow handover to occur after a person has left custody

### DIFF
--- a/common/presenters/message-banner/assessment-to-unconfirmed-banner.js
+++ b/common/presenters/message-banner/assessment-to-unconfirmed-banner.js
@@ -34,9 +34,8 @@ module.exports = function assessmentToUnconfirmedBanner({
     if (canAccess && canAccess(`${context}:confirm`)) {
       content += `
         ${componentService.getComponent('govukButton', {
-          href: assessment.editable ? `${baseUrl}/confirm` : '',
+          href: `${baseUrl}/confirm`,
           text: i18n.t('actions::provide_confirmation', { context }),
-          disabled: !assessment.editable,
         })}
       `
     }
@@ -56,18 +55,6 @@ module.exports = function assessmentToUnconfirmedBanner({
           ),
         })}
       </p>
-    `
-  }
-
-  if (!assessment.editable) {
-    content += `
-      ${componentService.getComponent('govukWarningText', {
-        text: i18n.t('messages::assessment.completed.uneditable', {
-          context,
-        }),
-        classes: 'govuk-!-padding-top-0 govuk-!-margin-top-5',
-        iconFallbackText: 'Warning',
-      })}
     `
   }
 

--- a/common/presenters/message-banner/assessment-to-unconfirmed-banner.test.js
+++ b/common/presenters/message-banner/assessment-to-unconfirmed-banner.test.js
@@ -183,9 +183,8 @@ describe('Presenters', function () {
                 expect(componentService.getComponent).to.be.calledWithExactly(
                   'govukButton',
                   {
-                    href: '',
+                    href: '/base-url/confirm',
                     text: 'actions::provide_confirmation',
-                    disabled: true,
                   }
                 )
               })
@@ -234,7 +233,6 @@ describe('Presenters', function () {
                   {
                     href: '/base-url/confirm',
                     text: 'actions::provide_confirmation',
-                    disabled: false,
                   }
                 )
               })
@@ -265,7 +263,7 @@ describe('Presenters', function () {
               },
               content: {
                 html:
-                  '\n    <div class="govuk-grid-row">\n      <div class="govuk-grid-column-two-thirds">\n        appTaskList\n      </div>\n    </div>\n  \n      govukWarningText\n    ',
+                  '\n    <div class="govuk-grid-row">\n      <div class="govuk-grid-column-two-thirds">\n        appTaskList\n      </div>\n    </div>\n  ',
               },
             })
           })
@@ -273,12 +271,6 @@ describe('Presenters', function () {
           it('should translate with correct context', function () {
             expect(i18n.t).to.be.calledWithExactly(
               `messages::assessment.${mockArgs.assessment.status}.heading`,
-              {
-                context: 'person_escort_record',
-              }
-            )
-            expect(i18n.t).to.be.calledWithExactly(
-              'messages::assessment.completed.uneditable',
               {
                 context: 'person_escort_record',
               }

--- a/locales/en/assessment.json
+++ b/locales/en/assessment.json
@@ -3,6 +3,7 @@
   "page_title_with_name": "$t({{context}}) for {{-name}}",
   "section_overview": "{{section}} overview",
   "locked": "A $t({{context}}) cannot be updated once it has been confirmed or once the move has started.",
+  "locked_person_escort_record": "A $t({{context}}) cannot be updated once handover has been recorded or once the move has started.",
   "statuses": {
     "not_started": "Not started",
     "in_progress": "In progress",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

The current behaviour for handing a person over is prevented once
that move has left custody. This follows previous logic tied to marking
an assessment as "confirmed".

However, handover was built to support historic recording of that
information.

This change removes the logic to prevent handover occurring once a move
has left.

### Why did it change

This allows users to retrospectively record handover and for them to benefit from pre-filling of assessments.

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

- [P4-2777](https://dsdmoj.atlassian.net/browse/P4-2777)

## Screenshots
<!--- (Optional) Include screenshots if changes update interfaces or components -->
<!--- Delete/copy as appropriate --->

| Before | After |
| ------ | ----- |
| <kbd>![image](https://user-images.githubusercontent.com/3327997/115538166-829ab000-a293-11eb-9a1c-7a7ec0563fb3.png)</kbd> | <kbd>![image](https://user-images.githubusercontent.com/3327997/115537740-086a2b80-a293-11eb-9a1c-bb5058824f07.png)</kbd> |
| <kbd>![image](https://user-images.githubusercontent.com/3327997/115538136-7a427500-a293-11eb-9a71-a9130e1a9eb8.png)</kbd> | <kbd>![image](https://user-images.githubusercontent.com/3327997/115538066-6860d200-a293-11eb-84b9-7945707a3168.png)</kbd> |

## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed

### Other considerations

Commit messages with a `fix` or `feat` type are automatically used to generate the [changelog](ministryofjustice/hmpps-book-secure-move-frontend/blob/main/CHANGELOG.md) and
[GitHub release notes](https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/releases) during the release task. Please make sure they will read well on their own in a
summary of changes and that the commit body gives a more detailed description of those changes if necessary.

- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
- [x] Update [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/main/README.md) with any new instructions or tasks
