### PR TITLE
chore: Pin convert-hrtime to version 3

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,7 +18,7 @@ updates:
       - dependency-name: 'webpack-merge'
         versions: ['>=5']
       - dependency-name: 'convert-hrtime'
-        versions: ['>= 5']
+        versions: ['>=4']
     commit-message:
       prefix: 'build'
       include: 'scope'


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

As of version 4 the module is pure ESM which conflicts with the way
we are importing it.

To prevent needing to rewrite large pieces of the codebase at this stage
it is easier to pin the current version.