### PR TITLE
Ensure locations are sorted correctly

### DIFF
--- a/app/locations/controllers.js
+++ b/app/locations/controllers.js
@@ -1,4 +1,4 @@
-const { get, sortBy, uniqBy } = require('lodash')
+const { get, uniqBy } = require('lodash')
 
 async function locations(req, res, next) {
   const userPermissions = get(req.session, 'user.permissions', [])
@@ -40,10 +40,6 @@ async function locations(req, res, next) {
   }
 
   req.session.user.locations = userLocations
-
-  userLocations = sortBy(userLocations, location => {
-    return location?.title?.toLowerCase()
-  })
 
   const activeLocations = userLocations.filter(
     location => location.disabled_at === null

--- a/common/presenters/moves-by-location.js
+++ b/common/presenters/moves-by-location.js
@@ -23,5 +23,5 @@ module.exports = function movesByLocation(data, locationKey = 'to_location') {
     })
   })
 
-  return sortBy(locations, 'sortKey')
+  return sortBy(locations, location => location?.sortKey?.toUpperCase())
 }

--- a/common/presenters/moves-by-location.test.js
+++ b/common/presenters/moves-by-location.test.js
@@ -88,11 +88,11 @@ describe('Presenters', function () {
           const keys = transformedResponse.map(group => group.sortKey)
           expect(keys).to.deep.equal([
             'HMIRC The Verne',
-            'HMP Brockhill',
+            'HMP BROCKHILL',
             'HMP Camp Hill',
             'HMP Coldingley',
             'HMP Dartmoor',
-            'HMP Kirkham',
+            'HMP KIRKHAM',
             'HMP Lindholme',
             'HMP Long Lartin',
             'HMP Reading',
@@ -153,11 +153,11 @@ describe('Presenters', function () {
           )
           expect(keys).to.deep.equal([
             ['HMIRC The Verne'],
-            ['HMP Brockhill'],
+            ['HMP BROCKHILL'],
             ['HMP Camp Hill'],
             ['HMP Coldingley'],
             ['HMP Dartmoor'],
-            ['HMP Kirkham'],
+            ['HMP KIRKHAM'],
             ['HMP Lindholme'],
             ['HMP Long Lartin'],
             ['HMP Reading'],

--- a/common/services/reference-data.js
+++ b/common/services/reference-data.js
@@ -7,6 +7,10 @@ const BaseService = require('./base')
 const locationInclude = ['suppliers']
 const regionInclude = ['locations']
 
+function sortLocations(locations) {
+  return sortBy(locations, ({ title = '' }) => title.toUpperCase())
+}
+
 class ReferenceDataService extends BaseService {
   getGenders() {
     return this.apiClient.findAll('gender').then(response => response.data)
@@ -41,7 +45,8 @@ class ReferenceDataService extends BaseService {
         const hasNext = links.next && data.length !== 0
 
         if (!hasNext) {
-          return sortBy(locations, 'title')
+          return sortLocations(locations)
+          // return sortBy(locations, location => location?.title?.toUpperCase())
         }
 
         return this.getLocations({
@@ -95,7 +100,8 @@ class ReferenceDataService extends BaseService {
         ...attributes,
       }
     })
-    return locations
+
+    return sortLocations(locations)
   }
 
   getRegionById(id) {
@@ -134,9 +140,9 @@ class ReferenceDataService extends BaseService {
     const locationPromises = ids.map(id => {
       return callback(id).catch(() => false)
     })
-    return Promise.all(locationPromises).then(locations =>
-      locations.filter(Boolean)
-    )
+    return Promise.all(locationPromises)
+      .then(locations => locations.filter(Boolean))
+      .then(locations => sortLocations(locations))
   }
 
   getSuppliers() {

--- a/common/services/reference-data.test.js
+++ b/common/services/reference-data.test.js
@@ -59,6 +59,22 @@ const mockLocations = [
     id: '2c952ca0-f750-4ac3-ac76-fb631445f974',
     title: 'Axminster Crown Court',
   },
+  {
+    id: '5e5da09d-a1b3-46c2-9f62-87c458893c21',
+    title: 'AYLESBURY (HMP)',
+  },
+  {
+    id: 'a4817921-1091-4a02-8757-c491e476e364',
+    title: 'BERWYN (HMP)',
+  },
+  {
+    id: '48e9427a-8c9d-4c45-a015-a35df05b119b',
+    title: 'ALTCOURSE (HMP)',
+  },
+  {
+    id: '4f867e1d-e2bd-48ad-ad54-57a94dc38ee5',
+    title: 'Blackpool Custody Suite',
+  },
 ]
 const mockRegions = [
   {
@@ -252,7 +268,9 @@ describe('Reference Data Service', function () {
         })
 
         it('should return locations sorted by title', function () {
-          expect(locations).to.deep.equal(sortBy(mockLocations, 'title'))
+          expect(locations).to.deep.equal(
+            sortBy(locations, location => location?.title?.toUpperCase())
+          )
         })
       })
 
@@ -319,7 +337,9 @@ describe('Reference Data Service', function () {
 
         it('should return locations sorted by title', function () {
           expect(locations).to.deep.equal(
-            sortBy([...mockLocations, ...mockLocations], 'title')
+            sortBy([...mockLocations, ...mockLocations], location =>
+              location?.title?.toUpperCase()
+            )
           )
         })
       })
@@ -451,7 +471,7 @@ describe('Reference Data Service', function () {
         )
       })
 
-      it('should call getLocations methods', function () {
+      it('should call et methods', function () {
         expect(referenceDataService.getLocations).to.be.calledOnce
       })
 
@@ -487,7 +507,12 @@ describe('Reference Data Service', function () {
         beforeEach(async function () {
           sinon
             .stub(referenceDataService, 'getLocationByNomisAgencyId')
-            .resolvesArg(0)
+            .onFirstCall()
+            .resolves({ key: 'GCS', title: 'Guildford Custody Suite' })
+            .onSecondCall()
+            .resolves({ key: 'PNT', title: 'GREATER MANCHESTER HMP' })
+            .onThirdCall()
+            .resolves({ key: 'AFR', title: 'Aylesbury Court' })
 
           locations = await referenceDataService.getLocationsByNomisAgencyId(
             mockAgencyIds
@@ -503,8 +528,12 @@ describe('Reference Data Service', function () {
           ).to.equal(mockAgencyIds.length)
         })
 
-        it('should return an list of locations', function () {
-          expect(locations).to.deep.equal(mockAgencyIds)
+        it('should return an list of locations sorted by title', function () {
+          expect(locations).to.deep.equal([
+            { key: 'AFR', title: 'Aylesbury Court' },
+            { key: 'PNT', title: 'GREATER MANCHESTER HMP' },
+            { key: 'GCS', title: 'Guildford Custody Suite' },
+          ])
         })
       })
 
@@ -635,8 +664,10 @@ describe('Reference Data Service', function () {
         )
       })
 
-      it('should return locations', function () {
-        expect(locations).to.deep.equal(mockResponse)
+      it('should return locations sorted by title', function () {
+        expect(locations).to.deep.equal(
+          sortBy(mockResponse, location => location?.title?.toUpperCase())
+        )
       })
     })
   })

--- a/test/fixtures/moves.json
+++ b/test/fixtures/moves.json
@@ -1333,7 +1333,7 @@
       "id": "ad78dbc3-6d08-475a-b5c5-39dcd463b624",
       "type": "locations",
       "key": "hmp_kirkham",
-      "title": "HMP Kirkham",
+      "title": "HMP KIRKHAM",
       "location_type": "prison",
       "nomis_agency_id": null
     },
@@ -1538,7 +1538,7 @@
       "id": "6ee51bfe-217a-421f-8874-9e2b9b03cc53",
       "type": "locations",
       "key": "hmp_brockhill",
-      "title": "HMP Brockhill",
+      "title": "HMP BROCKHILL",
       "location_type": "prison",
       "nomis_agency_id": null
     },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Previously locations were be sorted unix-style which is alphabetically
but case-sensitive. 

This change fixes that sorting in the service closer to the source
of the data rather than at controller level.

Closes #744

This had been addressed at controller level in #1421 

### Why did it change

We have a mix of casing for location titles and
ideally need to ensure the alphabetical sorting is not case-sensitive.

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

- #744

## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [x] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed
