### PR TITLE
Add keep alive agent to Got

### DIFF
--- a/common/lib/api-client/middleware/got-request.js
+++ b/common/lib/api-client/middleware/got-request.js
@@ -1,10 +1,13 @@
 const Sentry = require('@sentry/node')
+const HttpAgent = require('agentkeepalive')
 const debug = require('debug')('app:api-client:request')
 const cacheDebug = require('debug')('app:api-client:cache')
 const got = require('got')
 
 const cache = require('../cache')
 const clientMetrics = require('../client-metrics')
+
+const { HttpsAgent } = HttpAgent
 
 function requestMiddleware({
   cacheExpiry = 60,
@@ -30,7 +33,14 @@ function requestMiddleware({
 
       debug(`Got:${req.method}`, url)
 
-      const response = await got({ ...req, timeout })
+      const response = await got({
+        ...req,
+        agent: {
+          http: new HttpAgent(),
+          https: new HttpsAgent(),
+        },
+        timeout,
+      })
         .then(async res => {
           debug(
             `[${res.statusCode}] ${res.statusMessage}`,

--- a/package-lock.json
+++ b/package-lock.json
@@ -3869,7 +3869,6 @@
       "version": "4.1.4",
       "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.1.4.tgz",
       "integrity": "sha512-+V/rGa3EuU74H6wR04plBb7Ks10FbtUQgRj/FQOG7uUIEuaINI+AiqJR1k6t3SVNs7o7ZjIdus6706qqzVq8jQ==",
-      "dev": true,
       "requires": {
         "debug": "^4.1.0",
         "depd": "^1.1.2",
@@ -17425,7 +17424,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
       "integrity": "sha1-xG4xWaKT9riW2ikxbYtv6Lt5u+0=",
-      "dev": true,
       "requires": {
         "ms": "^2.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "@sentry/node": "6.3.6",
     "@sentry/tracing": "6.3.6",
     "accessible-autocomplete": "2.0.3",
+    "agentkeepalive": "4.1.4",
     "audit-ci": "4.0.0",
     "axios": "0.21.1",
     "axios-debug-log": "0.8.2",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

This changes the [default HTTPS agent](https://www.npmjs.com/package/got#agent) for the Got request library by adding the [keepaliveagent](https://www.npmjs.com/package/agentkeepalive) package.

### Why did it change

Quoting [imperva](https://www.imperva.com/learn/performance/http-keep-alive/):

>The HTTP keep-alive header maintains a connection between a client and your server, reducing the time needed to serve files. A persistent connection also reduces the number of TCP and SSL/TLS connection requests, leading to a drop in round trip time (RTT).

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

- [P4-2709](https://dsdmoj.atlassian.net/browse/P4-2709)

## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [x] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed
