### PR TITLE
fix: Call timetable filter using string format instead of object

### DIFF
--- a/common/services/person.js
+++ b/common/services/person.js
@@ -105,10 +105,8 @@ class PersonService extends BaseService {
       .one('person', personId)
       .all('timetable_entry')
       .get({
-        filter: {
-          date_from: date,
-          date_to: date,
-        },
+        'filter[date_from]': date,
+        'filter[date_to]': date,
         include: ['location'],
       })
       .then(response => response.data)

--- a/common/services/person.test.js
+++ b/common/services/person.test.js
@@ -456,10 +456,8 @@ describe('Person Service', function () {
           expect(apiClient.one).to.be.calledOnceWithExactly('person', mockId)
           expect(apiClient.all).to.be.calledOnceWithExactly('timetable_entry')
           expect(apiClient.get).to.be.calledOnceWithExactly({
-            filter: {
-              date_from: mockDate,
-              date_to: mockDate,
-            },
+            'filter[date_from]': mockDate,
+            'filter[date_to]': mockDate,
             include: ['location'],
           })
         })
@@ -478,10 +476,8 @@ describe('Person Service', function () {
           expect(apiClient.one).to.be.calledOnceWithExactly('person', mockId)
           expect(apiClient.all).to.be.calledOnceWithExactly('timetable_entry')
           expect(apiClient.get).to.be.calledOnceWithExactly({
-            filter: {
-              date_from: undefined,
-              date_to: undefined,
-            },
+            'filter[date_from]': undefined,
+            'filter[date_to]': undefined,
             include: ['location'],
           })
         })


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

The Got request library requires search params to be called using
string format instead of an object.

This fix changes the format to one that is already used elsewhere.

### Why did it change

<!--- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

- [BOOK-A-SECURE-MOVE-FRONTEND-4E](https://sentry.io/organizations/ministryofjustice/issues/2393276985/?project=2014813&query=is%3Aunresolved)

## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed
