### PR TITLE
[P4-2818] Prevent editing of completed moves

### DIFF
--- a/app/move/app/edit/controllers/base.js
+++ b/app/move/app/edit/controllers/base.js
@@ -4,6 +4,21 @@ const filters = require('../../../../../config/nunjucks/filters')
 const CreateBaseController = require('../../new/controllers/base')
 
 class UpdateBaseController extends CreateBaseController {
+  middlewareChecks() {
+    this.use(this.canEdit)
+    super.middlewareChecks()
+  }
+
+  canEdit(req, res, next) {
+    const { id, _hasLeftCustody } = req.move
+
+    if (_hasLeftCustody) {
+      return res.redirect(`/move/${id}`)
+    }
+
+    next()
+  }
+
   middlewareLocals() {
     super.middlewareLocals()
     this.use(this.setNextStep)

--- a/common/helpers/move/get-update-urls.js
+++ b/common/helpers/move/get-update-urls.js
@@ -3,6 +3,10 @@ const getMoveUrl = require('./get-move-url')
 const getUpdateUrls = (move, canAccess = () => false, updateSteps = []) => {
   const updateUrls = {}
 
+  if (move._hasLeftCustody) {
+    return updateUrls
+  }
+
   if (!canAccess(`move:update:${move.move_type}`)) {
     return updateUrls
   }

--- a/common/helpers/move/get-update-urls.test.js
+++ b/common/helpers/move/get-update-urls.test.js
@@ -36,18 +36,35 @@ describe('Move helpers', function () {
           .returns(true)
           .withArgs('move:allowed')
           .returns(true)
-        updateUrls = getUpdateUrls(move, canAccess, updateSteps)
-      })
-      it('should get expected value for key', function () {
-        expect(updateUrls.foo).to.equal('/move/moveId/edit/foo')
       })
 
-      it('should get expected value for key when multiple steps exist', function () {
-        expect(updateUrls.bar).to.equal('/move/moveId/edit/bar-details')
+      context('when move has not left custody', function () {
+        beforeEach(function () {
+          updateUrls = getUpdateUrls(move, canAccess, updateSteps)
+        })
+
+        it('should get expected value for key', function () {
+          expect(updateUrls.foo).to.equal('/move/moveId/edit/foo')
+        })
+
+        it('should get expected value for key when multiple steps exist', function () {
+          expect(updateUrls.bar).to.equal('/move/moveId/edit/bar-details')
+        })
+
+        it('should return undefined if the route is inaccessible', function () {
+          expect(updateUrls.baz).to.be.undefined
+        })
       })
 
-      it('should return undefined if the route is inaccessible', function () {
-        expect(updateUrls.baz).to.be.undefined
+      context('when move has left custody', function () {
+        beforeEach(function () {
+          move._hasLeftCustody = true
+          updateUrls = getUpdateUrls(move, canAccess, updateSteps)
+        })
+
+        it('should not expose any urls', function () {
+          expect(updateUrls).to.deep.equal({})
+        })
       })
     })
 

--- a/common/lib/api-client/models/accept.js
+++ b/common/lib/api-client/models/accept.js
@@ -1,0 +1,8 @@
+module.exports = {
+  fields: {
+    timestamp: '',
+  },
+  options: {
+    collectionPath: 'accept',
+  },
+}

--- a/common/lib/api-client/models/complete.js
+++ b/common/lib/api-client/models/complete.js
@@ -1,0 +1,9 @@
+module.exports = {
+  fields: {
+    notes: '',
+    timestamp: '',
+  },
+  options: {
+    collectionPath: 'complete',
+  },
+}

--- a/common/lib/api-client/models/index.js
+++ b/common/lib/api-client/models/index.js
@@ -1,9 +1,11 @@
+const accept = require('./accept')
 const allocation = require('./allocation')
 const allocationComplexCase = require('./allocation-complex-case')
 const approve = require('./approve')
 const assessmentQuestion = require('./assessment-question')
 const cancel = require('./cancel')
 const category = require('./category')
+const complete = require('./complete')
 const courtCase = require('./court-case')
 const courtHearing = require('./court-hearing')
 const document = require('./document')
@@ -28,17 +30,20 @@ const profile = require('./profile')
 const redirect = require('./redirect')
 const region = require('./region')
 const reject = require('./reject')
+const start = require('./start')
 const supplier = require('./supplier')
 const timetableEntry = require('./timetable-entry')
 const youthRiskAssessment = require('./youth-risk-assessment')
 
 module.exports = {
+  accept,
   allocation,
   allocation_complex_case: allocationComplexCase,
   approve,
   assessment_question: assessmentQuestion,
   cancel,
   category,
+  complete,
   court_case: courtCase,
   court_hearing: courtHearing,
   document,
@@ -63,6 +68,7 @@ module.exports = {
   redirect,
   region,
   reject,
+  start,
   supplier,
   timetable_entry: timetableEntry,
   youth_risk_assessment: youthRiskAssessment,

--- a/common/lib/api-client/models/start.js
+++ b/common/lib/api-client/models/start.js
@@ -1,0 +1,8 @@
+module.exports = {
+  fields: {
+    timestamp: '',
+  },
+  options: {
+    collectionPath: 'start',
+  },
+}

--- a/common/presenters/move-to-meta-list-component.js
+++ b/common/presenters/move-to-meta-list-component.js
@@ -7,6 +7,7 @@ const getUpdateLinks = require('../helpers/move/get-update-links')
 
 function moveToMetaListComponent(
   {
+    _hasLeftCustody,
     id,
     date,
     date_from: dateFrom,
@@ -52,7 +53,7 @@ function moveToMetaListComponent(
       : notAgreedLabel
 
   const actions = getUpdateLinks(
-    { id, move_type: moveType },
+    { _hasLeftCustody, id, move_type: moveType },
     canAccess,
     updateSteps
   )

--- a/common/presenters/move-to-meta-list-component.test.js
+++ b/common/presenters/move-to-meta-list-component.test.js
@@ -10,6 +10,7 @@ const moveToMetaListComponent = proxyquire('./move-to-meta-list-component', {
 })
 
 const mockMove = {
+  _hasLeftCustody: false,
   date: '2019-06-09',
   time_due: '2000-01-01T14:00:00Z',
   move_type: 'court_appearance',
@@ -51,7 +52,11 @@ describe('Presenters', function () {
       describe('response', function () {
         it('should get the actions', function () {
           expect(getUpdateLinks).to.be.calledOnceWithExactly(
-            { id: mockMove.id, move_type: mockMove.move_type },
+            {
+              _hasLeftCustody: false,
+              id: mockMove.id,
+              move_type: mockMove.move_type,
+            },
             canAccess,
             updateSteps
           )

--- a/common/services/move.js
+++ b/common/services/move.js
@@ -1,5 +1,5 @@
 const dateFunctions = require('date-fns')
-const { mapValues, omitBy, isUndefined, isEmpty } = require('lodash')
+const { mapValues, omitBy, pickBy, isUndefined, isEmpty } = require('lodash')
 
 const restClient = require('../lib/api-client/rest-client')
 
@@ -332,6 +332,45 @@ class MoveService extends BaseService {
         timestamp,
         ...data,
       })
+  }
+
+  accept(id) {
+    if (!id) {
+      return Promise.reject(new Error(noMoveIdMessage))
+    }
+
+    const timestamp = dateFunctions.formatISO(new Date())
+
+    return this.apiClient.one('move', id).all('accept').post({
+      timestamp,
+    })
+  }
+
+  complete(id, { notes } = {}) {
+    if (!id) {
+      return Promise.reject(new Error(noMoveIdMessage))
+    }
+
+    const timestamp = dateFunctions.formatISO(new Date())
+
+    return this.apiClient.one('move', id).all('complete').post(
+      pickBy({
+        timestamp,
+        notes,
+      })
+    )
+  }
+
+  start(id) {
+    if (!id) {
+      return Promise.reject(new Error(noMoveIdMessage))
+    }
+
+    const timestamp = dateFunctions.formatISO(new Date())
+
+    return this.apiClient.one('move', id).all('start').post({
+      timestamp,
+    })
   }
 
   unassign(id) {

--- a/common/services/move.test.js
+++ b/common/services/move.test.js
@@ -1332,4 +1332,169 @@ describe('Move Service', function () {
       })
     })
   })
+
+  describe('#accept()', function () {
+    const mockId = '#moveId'
+    const mockResponse = {
+      data: mockMove,
+    }
+
+    context('without move ID', function () {
+      it('should reject with error', function () {
+        return expect(moveService.accept()).to.be.rejectedWith(
+          'No move ID supplied'
+        )
+      })
+    })
+
+    context('with move ID', function () {
+      const currentDate = new Date(2020, 1, 1, 0, 0)
+      let clock
+      beforeEach(async function () {
+        clock = sinon.useFakeTimers({
+          now: currentDate,
+        })
+        formatISOStub.resetHistory()
+        sinon.stub(apiClient, 'post').resolves(mockResponse)
+        sinon.spy(apiClient, 'all')
+        sinon.spy(apiClient, 'one')
+
+        await moveService.accept(mockId)
+      })
+      afterEach(function () {
+        clock.restore()
+      })
+
+      it('should add the timestamp', function () {
+        expect(formatISOStub).to.be.calledOnceWithExactly(currentDate)
+      })
+
+      it('should call accept method with data', function () {
+        expect(apiClient.one).to.be.calledOnceWithExactly('move', '#moveId')
+        expect(apiClient.all).to.be.calledOnceWithExactly('accept')
+        expect(apiClient.post).to.be.calledOnceWithExactly({
+          timestamp: '#timestamp',
+        })
+      })
+    })
+  })
+
+  describe('#complete()', function () {
+    const mockId = '#moveId'
+    const mockResponse = {
+      data: mockMove,
+    }
+
+    context('without move ID', function () {
+      it('should reject with error', function () {
+        return expect(moveService.complete()).to.be.rejectedWith(
+          'No move ID supplied'
+        )
+      })
+    })
+
+    context('with move ID', function () {
+      const currentDate = new Date(2020, 1, 1, 0, 0)
+      let clock
+
+      beforeEach(function () {
+        clock = sinon.useFakeTimers({
+          now: currentDate,
+        })
+        formatISOStub.resetHistory()
+        sinon.stub(apiClient, 'post').resolves(mockResponse)
+        sinon.spy(apiClient, 'all')
+        sinon.spy(apiClient, 'one')
+      })
+
+      afterEach(function () {
+        clock.restore()
+      })
+
+      context('without data', function () {
+        beforeEach(async function () {
+          await moveService.complete(mockId)
+        })
+
+        it('should add the timestamp', function () {
+          expect(formatISOStub).to.be.calledOnceWithExactly(currentDate)
+        })
+
+        it('should call complete method with timestamp', function () {
+          expect(apiClient.one).to.be.calledOnceWithExactly('move', '#moveId')
+          expect(apiClient.all).to.be.calledOnceWithExactly('complete')
+          expect(apiClient.post).to.be.calledOnceWithExactly({
+            timestamp: '#timestamp',
+          })
+        })
+      })
+
+      context('with data', function () {
+        beforeEach(async function () {
+          await moveService.complete(mockId, {
+            notes: 'Lorem ipsum',
+          })
+        })
+
+        it('should add the timestamp', function () {
+          expect(formatISOStub).to.be.calledOnceWithExactly(currentDate)
+        })
+
+        it('should call complete method with data', function () {
+          expect(apiClient.one).to.be.calledOnceWithExactly('move', '#moveId')
+          expect(apiClient.all).to.be.calledOnceWithExactly('complete')
+          expect(apiClient.post).to.be.calledOnceWithExactly({
+            timestamp: '#timestamp',
+            notes: 'Lorem ipsum',
+          })
+        })
+      })
+    })
+  })
+
+  describe('#start()', function () {
+    const mockId = '#moveId'
+    const mockResponse = {
+      data: mockMove,
+    }
+
+    context('without move ID', function () {
+      it('should reject with error', function () {
+        return expect(moveService.start()).to.be.rejectedWith(
+          'No move ID supplied'
+        )
+      })
+    })
+
+    context('with move ID', function () {
+      const currentDate = new Date(2020, 1, 1, 0, 0)
+      let clock
+      beforeEach(async function () {
+        clock = sinon.useFakeTimers({
+          now: currentDate,
+        })
+        formatISOStub.resetHistory()
+        sinon.stub(apiClient, 'post').resolves(mockResponse)
+        sinon.spy(apiClient, 'all')
+        sinon.spy(apiClient, 'one')
+
+        await moveService.start(mockId)
+      })
+      afterEach(function () {
+        clock.restore()
+      })
+
+      it('should add the timestamp', function () {
+        expect(formatISOStub).to.be.calledOnceWithExactly(currentDate)
+      })
+
+      it('should call start method', function () {
+        expect(apiClient.one).to.be.calledOnceWithExactly('move', '#moveId')
+        expect(apiClient.all).to.be.calledOnceWithExactly('start')
+        expect(apiClient.post).to.be.calledOnceWithExactly({
+          timestamp: '#timestamp',
+        })
+      })
+    })
+  })
 })

--- a/test/e2e/_helpers.js
+++ b/test/e2e/_helpers.js
@@ -313,6 +313,18 @@ export async function createMoveFixture({
     .catch(errorHandler(data))
 }
 
+export function acceptMove(moveId) {
+  return moveService.accept(moveId)
+}
+
+export function startMove(moveId) {
+  return moveService.start(moveId)
+}
+
+export function completeMove(moveId) {
+  return moveService.complete(moveId)
+}
+
 export async function fillInPersonEscortRecord(moveId) {
   const move = await moveService.getById(moveId)
   const personEscortRecord = move.profile.person_escort_record

--- a/test/e2e/_move.js
+++ b/test/e2e/_move.js
@@ -262,6 +262,22 @@ export async function checkUpdatePagesForbidden() {
 }
 
 /**
+ * Check all update pages are redirect
+ *
+ * @returns {undefined}
+ */
+export async function checkUpdatePagesRedirected(moveId, pages = updatePages) {
+  for await (const updatePage of pages) {
+    const url = getUpdateMove(t.ctx.move.id, updatePage)
+
+    await t
+      .navigateTo(url)
+      .expect(page.getCurrentUrl())
+      .match(/\/move\/[\w]{8}(-[\w]{4}){3}-[\w]{12}$/)
+  }
+}
+
+/**
  * Click link to update page
  *
  * @param {string} page - page key

--- a/test/e2e/move.update.police.test.js
+++ b/test/e2e/move.update.police.test.js
@@ -1,9 +1,11 @@
 import { addDays, format } from 'date-fns'
 
+import { acceptMove, startMove } from './_helpers'
 import {
   createCourtMove,
   checkUpdateLinks,
   checkUpdatePagesAccessible,
+  checkUpdatePagesRedirected,
   checkPoliceNationalComputerReadOnly,
   checkUpdatePersonalDetails,
   checkUpdateRiskInformation,
@@ -80,4 +82,25 @@ fixture.beforeEach(async t => {
 
 test('User should be able to update move details', async t => {
   await checkUpdateMoveDetails()
+})
+
+fixture.beforeEach(async t => {
+  await t.useRole(policeUser).navigateTo(home)
+  t.ctx.move = await createCourtMove()
+  await acceptMove(t.ctx.move.id)
+  await startMove(t.ctx.move.id)
+  await t.navigateTo(getMove(t.ctx.move.id))
+})('Existing move that has left custody')
+
+test('User should not be able to update any information', async t => {
+  // No edit links should be visible
+  await checkUpdateLinks(undefined, true)
+  await checkUpdatePagesRedirected(t.ctx.move.id, [
+    'personal_details',
+    'risk',
+    'health',
+    'court',
+    'move',
+    'date',
+  ])
 })

--- a/test/e2e/move.update.sch.test.js
+++ b/test/e2e/move.update.sch.test.js
@@ -1,11 +1,13 @@
+import { acceptMove, startMove } from './_helpers'
 import {
   checkUpdateLinks,
   checkUpdatePagesAccessible,
+  checkUpdatePagesRedirected,
   checkUpdateDocuments,
   createMove,
 } from './_move'
 import { schUser } from './_roles'
-import { home } from './_routes'
+import { home, getMove } from './_routes'
 
 fixture('Existing move from Secure Children Home (SCH) to Court').beforeEach(
   async t => {
@@ -137,3 +139,22 @@ test.meta('hasDocument', 'true')(
     )
   }
 )
+
+fixture.beforeEach(async t => {
+  await t.useRole(schUser).navigateTo(home)
+  t.ctx.move = await createMove({
+    defaultMoveOptions: {
+      to_location_type: 'court',
+      move_type: 'court_appearance',
+    },
+  })
+  await acceptMove(t.ctx.move.id)
+  await startMove(t.ctx.move.id)
+  await t.navigateTo(getMove(t.ctx.move.id))
+})('Existing move that has left custody')
+
+test('User should not be able to update any information', async t => {
+  // No edit links should be visible
+  await checkUpdateLinks(undefined, true)
+  await checkUpdatePagesRedirected(t.ctx.move.id)
+})

--- a/test/e2e/move.update.stc.test.js
+++ b/test/e2e/move.update.stc.test.js
@@ -1,11 +1,13 @@
+import { acceptMove, startMove } from './_helpers'
 import {
   checkUpdateLinks,
   checkUpdatePagesAccessible,
+  checkUpdatePagesRedirected,
   checkUpdateDocuments,
   createMove,
 } from './_move'
 import { stcUser } from './_roles'
-import { home } from './_routes'
+import { home, getMove } from './_routes'
 
 fixture('Existing move from Secure Training Centre (STC) to Court').beforeEach(
   async t => {
@@ -137,3 +139,22 @@ test.meta('hasDocument', 'true')(
     )
   }
 )
+
+fixture.beforeEach(async t => {
+  await t.useRole(stcUser).navigateTo(home)
+  t.ctx.move = await createMove({
+    defaultMoveOptions: {
+      to_location_type: 'court',
+      move_type: 'court_appearance',
+    },
+  })
+  await acceptMove(t.ctx.move.id)
+  await startMove(t.ctx.move.id)
+  await t.navigateTo(getMove(t.ctx.move.id))
+})('Existing move that has left custody')
+
+test('User should not be able to update any information', async t => {
+  // No edit links should be visible
+  await checkUpdateLinks(undefined, true)
+  await checkUpdatePagesRedirected(t.ctx.move.id)
+})


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

This change prevents the edit links from being displayed and the pages being accessible once a move
has left custody.

This also adds methods to support changing the status of a move to the move service. This allows them
to be used by end-to-end tests so that we can fully test this behaviour.

### Why did it change

Currently all update links and pages are available and accessible
after a move has left custody. This includes moves in transit and
completed moves.

This information should not be updatable by our users because the
move has already begun in the accepted state. This could lead to a
mismatch in data in our system and what has actually taken place.

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

- [P4-2818](https://dsdmoj.atlassian.net/browse/P4-2818)

## Screenshots
<!--- (Optional) Include screenshots if changes update interfaces or components -->
<!--- Delete/copy as appropriate --->

| Before | After |
| ------ | ----- |
| <kbd>![image](https://user-images.githubusercontent.com/3327997/118141886-c2bc0100-b401-11eb-91b3-feff48319a28.png)</kbd> | <kbd>![image](https://user-images.githubusercontent.com/3327997/118141676-84bedd00-b401-11eb-9f0b-2dc013d5a9db.png)</kbd> |
| <kbd>![image](https://user-images.githubusercontent.com/3327997/118141911-c94a7880-b401-11eb-9a57-9eaee1330b41.png)</kbd> | <kbd>![image](https://user-images.githubusercontent.com/3327997/118141756-a0c27e80-b401-11eb-92a9-13f3b67885b4.png)</kbd> |
| <kbd>![image](https://user-images.githubusercontent.com/3327997/118141941-d0718680-b401-11eb-85d6-4ddb5483bfe1.png)</kbd> | <kbd>![image](https://user-images.githubusercontent.com/3327997/118141786-a9b35000-b401-11eb-998c-c2ecc8561639.png)</kbd> |
## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [x] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [x] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed
