### PR TITLE
[P4-2820] Remove double label in datetime validation messages

### DIFF
--- a/locales/en/validation.json
+++ b/locales/en/validation.json
@@ -14,7 +14,7 @@
   "time": "must be a valid time, for example 12:00 or 12pm",
   "time_with_label": "{{label}} must be a valid time, for example 12:00 or 12pm",
   "datetime": "$t(validation::time)",
-  "datetime_with_label": "{{label}} $t(validation::time)",
+  "datetime_with_label": "$t(validation::time)",
   "after": "must be in the future",
   "after_with_label": "{{label}} must be in the future",
   "before": "must be in the past",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

This change removes the double label output.

### Why did it change

The `datetime` validation was inserted the label twice, both in the
contents and the contents of the key it references.

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

- [P4-2820](https://dsdmoj.atlassian.net/browse/P4-2820)

## Screenshots
<!--- (Optional) Include screenshots if changes update interfaces or components -->
<!--- Delete/copy as appropriate --->

| Before | After |
| ------ | ----- |
| <kbd>![image](https://user-images.githubusercontent.com/3327997/118263468-3ddaf100-b4ae-11eb-88e4-f130aaa1ad8a.png)</kbd> | <kbd>![image](https://user-images.githubusercontent.com/3327997/118263427-2bf94e00-b4ae-11eb-9cb7-1de23ed006ca.png)</kbd> |

## Checklists

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [x] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed
