### PR TITLE
[P4-2783] Bring organisation switcher inline with wider HMPPS estate

### DIFF
--- a/common/assets/scss/overrides/_moj-frontend.scss
+++ b/common/assets/scss/overrides/_moj-frontend.scss
@@ -1,3 +1,13 @@
 .moj-badge {
   background-color: govuk-colour("white");
 }
+
+/* Changes to display the action inline */
+.moj-organisation-nav__title {
+  width: auto;
+}
+
+.moj-organisation-nav__link {
+  float: left;
+  margin-left: govuk-spacing(3);
+}

--- a/locales/en/actions.json
+++ b/locales/en/actions.json
@@ -37,7 +37,7 @@
   "print_move": "Print move",
   "print_allocation": "Print allocation",
   "sign_out": "Sign out",
-  "switch_location": "Switch location",
+  "switch_location": "Change location",
   "confirm_and_save": "Confirm and save",
   "save_and_continue": "Save and continue",
   "save_and_return_to_overview": "Save and return to overview",


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

This change tweaks the styling of the organisation switcher component
to bring it more inline with the wider HMPPS services.

It moves the action from the right to inline, next to the current
location.

### Why did it change

We want users to have a seamless experience when navigating between services 
within the HMPPS estate. So making generic components like this visually appear the
same will help this experience.

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

- [P4-2783](https://dsdmoj.atlassian.net/browse/P4-2783)

## Screenshots
<!--- (Optional) Include screenshots if changes update interfaces or components -->
<!--- Delete/copy as appropriate --->

| Before | After |
| ------ | ----- |
| <kbd>![image](https://user-images.githubusercontent.com/3327997/118635666-c10c8780-b7cb-11eb-8c10-3dd37c3197f6.png)</kbd> | <kbd>![image](https://user-images.githubusercontent.com/3327997/118635593-a803d680-b7cb-11eb-9037-41d99ba3cd11.png)</kbd> |

## Checklists

### Testing

#### Automated testing

- [ ] ~Added unit tests to cover changes~
- [ ] ~Added end-to-end tests to cover any journey changes~

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [x] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed
