### PR TITLE
[P4-2843] Update wording of secure youth estate triage question

### DIFF
--- a/locales/en/fields.json
+++ b/locales/en/fields.json
@@ -64,7 +64,7 @@
     "uncategorised": "Pending category"
   },
   "serving_youth_sentence": {
-    "label": "Is this person serving their sentence in the Secure Youth Estate?"
+    "label": "Is this person serving a sentence or on remand within the Secure Youth Estate?"
   },
   "from_location": {
     "label": "Move from",

--- a/locales/en/moves.json
+++ b/locales/en/moves.json
@@ -22,7 +22,7 @@
       "heading": "Personal details"
     },
     "serving_youth_sentence": {
-      "heading": "Is this person serving their sentence in the Secure Youth Estate?"
+      "heading": "Is this person serving a sentence or on remand within the Secure Youth Estate?"
     },
     "move_date": {
       "heading": "When is this person moving?"


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

This updates the wording used to determine if a person is serving
their sentence within the Secure Youth Estate or not.

### Why did it change

We use this question to decide whether they require a youth risk
assessment and we have seen some instances where this isn't being
answered "yes" if the person is on remand.

In some cases this leads to the incorrect level of assessment being
completed.

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

- [P4-2843](https://dsdmoj.atlassian.net/browse/P4-2843)

## Checklists

### Testing

#### Automated testing

- [ ] ~Added unit tests to cover changes~
- [ ] ~Added end-to-end tests to cover any journey changes~

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [x] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed
