### PR TITLE
chore: Remove population dashboard feature flag

### DIFF
--- a/common/middleware/set-primary-navigation.js
+++ b/common/middleware/set-primary-navigation.js
@@ -1,6 +1,4 @@
-const { omit, get } = require('lodash')
-
-const { FEATURE_FLAGS } = require('../../config')
+const { omit } = require('lodash')
 
 function setPrimaryNavigation(req, res, next) {
   const items = [
@@ -9,13 +7,6 @@ function setPrimaryNavigation(req, res, next) {
       text: req.t('primary_navigation.home'),
       href: '/',
       active: req.path === '/',
-    },
-    {
-      permission: 'dashboard:view:population',
-      text: req.t('primary_navigation.population'),
-      href: '/population',
-      active: req.path.startsWith('/population'),
-      featureFlag: FEATURE_FLAGS.POPULATION_DASHBOARD,
     },
     {
       permission: 'moves:view:outgoing',
@@ -42,13 +33,17 @@ function setPrimaryNavigation(req, res, next) {
       active:
         req.path.startsWith('/allocations') && req.path.endsWith('/outgoing'),
     },
+    {
+      permission: 'dashboard:view:population',
+      text: req.t('primary_navigation.population'),
+      href: '/population',
+      active: req.path.startsWith('/population'),
+    },
   ]
 
   res.locals.primaryNavigation = items
     .filter(item => req.canAccess(item.permission))
-    .filter(item => get(item, 'featureFlag', true))
     .map(item => omit(item, 'permission'))
-    .map(item => omit(item, 'featureFlag'))
 
   next()
 }

--- a/config/index.js
+++ b/config/index.js
@@ -275,9 +275,6 @@ module.exports = {
     },
   },
   FEATURE_FLAGS: {
-    POPULATION_DASHBOARD: /true/i.test(
-      process.env.FEATURE_FLAG_POPULATION_DASHBOARD
-    ),
     GOT: /true/i.test(process.env.FEATURE_FLAG_GOT),
   },
   FRAMEWORKS: {


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

This reverts commit 1397d9992d5fb4c7bf2acec3f7aaadfd7e769cd1.

Which removes the feature flag created for releasing the population dashboard.

### What changed

This feature has been live in all environments so we can now remove the feature flag.

### Why did it change

<!--- Describe the reason these changes were made - the "why" -->

## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [x] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO NOT include new environment variables -->
- [x] Documented in the [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/main/README.md)
- [x] Added to [continous integration](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-book-secure-move-frontend)
- [ ] Added to staging environment (deployment repository)
- [ ] Added to preproduction environment (deployment repository)
- [ ] Added to production environment (deployment repository)
