### PR TITLE
[P4-2890] Use correct location property for journey events

### DIFF
--- a/locales/en/events.json
+++ b/locales/en/events.json
@@ -35,15 +35,15 @@
   },
   "JourneyAdmitToReception": {
     "heading": "Admitted to reception",
-    "description": "Vehicle {{journey.vehicle.registration}} admitted to reception of {{journey.to_location.title}}"
+    "description": "Vehicle {{journey.vehicle.registration}} admitted to reception of {{location.title}}"
   },
   "JourneyAdmitThroughOuterGate": {
     "heading": "Admitted through outer gate",
-    "description": "Vehicle {{journey.vehicle.registration}} admitted through outer gate of {{journey.to_location.title}}"
+    "description": "Vehicle {{journey.vehicle.registration}} admitted through outer gate of {{location.title}}"
   },
   "JourneyArriveAtOuterGate": {
     "heading": "Arrived at outer gate",
-    "description": "Vehicle {{journey.vehicle.registration}} arrived at outer gate of {{journey.to_location.title}}"
+    "description": "Vehicle {{journey.vehicle.registration}} arrived at outer gate of {{location.title}}"
   },
   "JourneyCancel": {
     "heading": "Journey cancelled",


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

This change updates the property used to display the location in
some of the journey events.


### Why did it change

Previously it was always using the to location but in some instances
the event will be recording the arrival at the from location.

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

- [P4-2890](https://dsdmoj.atlassian.net/browse/P4-2890)

## Screenshots
<!--- (Optional) Include screenshots if changes update interfaces or components -->
<!--- Delete/copy as appropriate --->

| Before | After |
| ------ | ----- |
| <kbd>![image](https://user-images.githubusercontent.com/3327997/118981105-e804be00-b971-11eb-934e-8110afc4174a.png)</kbd> | <kbd>![image](https://user-images.githubusercontent.com/3327997/118981010-cc99b300-b971-11eb-85f3-66896ea71509.png)</kbd> |

### Testing

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [x] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed
