### PR TITLE
Load image assets correctly

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -99,10 +99,6 @@ const commonConfig = {
         ],
       },
       {
-        test: /\.(jpe?g|png|gif|svg)$/i,
-        type: 'asset',
-      },
-      {
         test: /\.(png|svg|jpe?g|gif|ico)$/,
         use: [
           {
@@ -110,6 +106,29 @@ const commonConfig = {
             options: {
               name: `[name]${IS_PRODUCTION ? '.[contenthash:8]' : ''}.[ext]`,
               outputPath: 'images/',
+            },
+          },
+          {
+            loader: ImageMinimizerPlugin.loader,
+            options: {
+              minimizerOptions: {
+                plugins: [
+                  ['gifsicle', { interlaced: true }],
+                  ['jpegtran', { progressive: true }],
+                  ['optipng', { optimizationLevel: 5 }],
+                  [
+                    'svgo',
+                    {
+                      plugins: [
+                        {
+                          name: 'removeViewBox',
+                          active: false,
+                        },
+                      ],
+                    },
+                  ],
+                ],
+              },
             },
           },
         ],
@@ -163,27 +182,6 @@ const commonConfig = {
           transform: transformManifestFile(frameworksService.transformManifest),
         },
       ],
-    }),
-    new ImageMinimizerPlugin({
-      minimizerOptions: {
-        // Lossless optimization with custom option
-        plugins: [
-          ['gifsicle', { interlaced: true }],
-          ['jpegtran', { progressive: true }],
-          ['optipng', { optimizationLevel: 5 }],
-          [
-            'svgo',
-            {
-              plugins: [
-                {
-                  name: 'removeViewBox',
-                  active: false,
-                },
-              ],
-            },
-          ],
-        ],
-      },
     }),
   ],
 }


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

This change corrects the way assets are loaded and moves the optimiser
inline to ensure assets are optimised correctly.

### Why did it change

During a recent change the assets started to become inlined which
prevented them from displaying correctly.

## Screenshots
<!--- (Optional) Include screenshots if changes update interfaces or components -->
<!--- Delete/copy as appropriate --->

| Before | After |
| ------ | ----- |
| <kbd>![image](https://user-images.githubusercontent.com/3327997/119114211-daa50d80-ba1d-11eb-9ac2-032fa4c93275.png)</kbd> | <kbd>![image](https://user-images.githubusercontent.com/3327997/119113455-070c5a00-ba1d-11eb-9e7e-e31a527c599e.png)</kbd> |

## Checklists

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed
