### PR TITLE
[P4-2900] Update 422 error messages to include error title

### DIFF
--- a/common/lib/api-client/middleware/got-errors.js
+++ b/common/lib/api-client/middleware/got-errors.js
@@ -1,3 +1,5 @@
+const { get } = require('lodash')
+
 module.exports = {
   name: 'got-errors',
   error: function error(payload = {}) {
@@ -15,7 +17,13 @@ module.exports = {
       statusCode,
       statusMessage,
     } = payload.response
-    const error = new Error(body.error_description || statusMessage)
+    let message = body.error_description || statusMessage
+
+    if (statusCode === 422 && get(body, 'errors[0].title')) {
+      message += `: ${body.errors[0].title}`
+    }
+
+    const error = new Error(message)
     error.statusCode = statusCode || 500
     error.errors = body.errors
     error.requesturl = requestUrl

--- a/common/lib/api-client/middleware/got-errors.test.js
+++ b/common/lib/api-client/middleware/got-errors.test.js
@@ -87,32 +87,46 @@ describe('API Client', function () {
         })
 
         context('with data errors', function () {
-          it('should append errors to error class', function () {
-            const error = errorMiddleware.error({
+          let error
+
+          beforeEach(function () {
+            error = errorMiddleware.error({
               response: {
                 ...response,
+                statusCode: 422,
                 body: {
                   errors: [
                     {
                       name: 'Error 1',
+                      title: 'Error title 1',
                     },
                     {
                       name: 'Error 2',
+                      title: 'Error title 2',
                     },
                   ],
                 },
               },
             })
+          })
 
+          it('should append errors to error class', function () {
             expect(error).to.be.an.instanceOf(Error)
             expect(error.errors).to.deep.equal([
               {
                 name: 'Error 1',
+                title: 'Error title 1',
               },
               {
                 name: 'Error 2',
+                title: 'Error title 2',
               },
             ])
+          })
+
+          it('should update error message', function () {
+            expect(error).to.be.an.instanceOf(Error)
+            expect(error.message).to.deep.equal('API Error: Error title 1')
           })
         })
       })


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

This change updates the error message when the error is a 422 returned
by the API client.

This change updates the error message to include the title from the
first error.

Although an error response can contain multiple errors, in most cases
it is returning a single error.

### Why did it change

The main benefit is that it will allow errors within Sentry to be
separated and potentially handled differently in terms of assigning,
ignoring or actioning.

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

- [P4-2900](https://dsdmoj.atlassian.net/browse/P4-2900)

## Screenshots
<!--- (Optional) Include screenshots if changes update interfaces or components -->
<!--- Delete/copy as appropriate --->

| Before | After |
| ------ | ----- |
| <kbd>![image](https://user-images.githubusercontent.com/3327997/119377481-1574a300-bcb5-11eb-89ab-f18e29fd4401.png)</kbd> | <kbd>![image](https://user-images.githubusercontent.com/3327997/119377540-28877300-bcb5-11eb-80cf-5d4ac2705299.png)</kbd> |
## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed
