### PR TITLE
Retry 502 and 504 errors on the API

### DIFF
--- a/common/lib/api-client/middleware/got-request.js
+++ b/common/lib/api-client/middleware/got-request.js
@@ -38,6 +38,11 @@ function requestMiddleware({
           http: new HttpAgent(),
           https: new HttpsAgent(),
         },
+        retry: {
+          limit: 1,
+          methods: ['GET'],
+          statusCodes: [502, 504],
+        },
         timeout,
       })
         .then(async res => {

--- a/common/lib/api-client/middleware/got-request.test.js
+++ b/common/lib/api-client/middleware/got-request.test.js
@@ -90,7 +90,16 @@ describe('API Client', function () {
           expect(gotStub.args[0][0]).to.have.all.keys({
             ...payload.req,
             agent: {},
+            retry: {},
             timeout: 5000,
+          })
+        })
+
+        it('should set retry options', function () {
+          expect(gotStub.args[0][0].retry).to.deep.equal({
+            limit: 1,
+            methods: ['GET'],
+            statusCodes: [502, 504],
           })
         })
 
@@ -126,6 +135,7 @@ describe('API Client', function () {
           expect(gotStub.args[0][0]).to.have.all.keys({
             ...payload.req,
             agent: {},
+            retry: 2,
             timeout: 5000,
           })
         })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

The API sometimes returns Bad Gateway or Gateway timeout errors.

In those instances, to prevent the request ending on the first attempt,
enabling a retry may avoid these errors for users.

### Why did it change

<!--- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

- [BOOK-A-SECURE-MOVE-FRONTEND-4T](https://sentry.io/organizations/ministryofjustice/issues/2422455305/?project=2014813&query=is%3Aunresolved&statsPeriod=14d)

## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [ ] ~Added end-to-end tests to cover any journey changes~

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed
