### PR TITLE
chore: Fix advisory 1755

### DIFF
--- a/audit-ci.json
+++ b/audit-ci.json
@@ -1,5 +1,5 @@
 {
   "low": true,
   "registry": "https://registry.npmjs.org",
-  "allowlist": [1213, 1674, 1751, 1753, 1754]
+  "allowlist": [1213, 1674, 1751, 1753, 1754, 1755]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -22004,9 +22004,9 @@
       "dev": true
     },
     "normalize-url": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.0.tgz",
-      "integrity": "sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ=="
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.1.tgz",
+      "integrity": "sha512-9UZCFRHQdNrfTpGg8+1INIg93B6zE0aXMVFkw1WFwvO4SlZywU6aLg5Of0Ap/PgcbSw4LNxvMWXMeugwMCX0AA=="
     },
     "npm-bundled": {
       "version": "1.1.2",


### PR DESCRIPTION
Fixes 1755 where it affects runtime dependencies (got) and ignores for the dev dependencies for which there is not fix currently present.
