### PR TITLE
Add warnings tab to new move page design

### DIFF
--- a/app/move/app/view/index.js
+++ b/app/move/app/view/index.js
@@ -14,7 +14,12 @@ const {
   renderTimeline,
   renderWarnings,
 } = require('./controllers')
-const { localsActions, localsMoveDetails, localsTabs } = require('./middleware')
+const {
+  localsActions,
+  localsMoveDetails,
+  localsTabs,
+  localsWarnings,
+} = require('./middleware')
 
 router.get('/', (req, res) => res.redirect(`${req.baseUrl}/warnings`))
 
@@ -32,7 +37,7 @@ router.use(localsMoveDetails)
 router.use(localsTabs)
 
 // Define routes
-router.get('/warnings', renderWarnings)
+router.get('/warnings', localsWarnings, renderWarnings)
 router.get('/assessments', renderAssessments)
 router.get('/timeline', renderTimeline)
 

--- a/app/move/app/view/middleware/index.js
+++ b/app/move/app/view/middleware/index.js
@@ -1,9 +1,11 @@
 const localsActions = require('./locals.actions')
 const localsMoveDetails = require('./locals.move-details')
 const localsTabs = require('./locals.tabs')
+const localsWarnings = require('./locals.warnings')
 
 module.exports = {
   localsActions,
   localsMoveDetails,
   localsTabs,
+  localsWarnings,
 }

--- a/app/move/app/view/middleware/locals.warnings.js
+++ b/app/move/app/view/middleware/locals.warnings.js
@@ -1,0 +1,59 @@
+const { isEmpty, map, sortBy } = require('lodash')
+
+const presenters = require('../../../../../common/presenters')
+
+function setWarnings(req, res, next) {
+  const { profile = {}, id: moveId } = req.move || {}
+  const assessmentAnswers = profile.assessment_answers || []
+  const personEscortRecord = profile.person_escort_record
+  const youthRiskAssessment = profile.youth_risk_assessment
+  const requiresYouthRiskAssessment = profile.requires_youth_risk_assessment
+
+  const assessment = presenters
+    .assessmentAnswersByCategory(assessmentAnswers)
+    .filter(category => category.key !== 'court')
+    .map(presenters.assessmentCategoryToPanelComponent)
+
+  const youthAssessmentSections = map(
+    youthRiskAssessment?._framework?.sections,
+    presenters.frameworkSectionToPanelList({
+      baseUrl: `/move/${moveId}/youth-risk-assessment`,
+    })
+  )
+  const perAssessmentSections = map(
+    personEscortRecord?._framework?.sections,
+    presenters.frameworkSectionToPanelList({
+      baseUrl: `/move/${moveId}/person-escort-record`,
+    })
+  )
+
+  const assessmentSections =
+    !isEmpty(personEscortRecord) || !requiresYouthRiskAssessment
+      ? sortBy(perAssessmentSections, 'order')
+      : sortBy(youthAssessmentSections, 'order')
+
+  let tagList
+  const personEscortRecordIsCompleted =
+    !isEmpty(personEscortRecord) &&
+    !['not_started', 'in_progress'].includes(personEscortRecord.status)
+
+  if (personEscortRecordIsCompleted) {
+    tagList = presenters.frameworkFlagsToTagList({
+      flags: personEscortRecord.flags,
+      hrefPrefix: req.originalUrl,
+      includeLink: true,
+    })
+  }
+
+  res.locals.warnings = {
+    sections:
+      !isEmpty(assessmentSections) || requiresYouthRiskAssessment
+        ? assessmentSections
+        : assessment,
+    tagList,
+  }
+
+  next()
+}
+
+module.exports = setWarnings

--- a/app/move/app/view/middleware/locals.warnings.test.js
+++ b/app/move/app/view/middleware/locals.warnings.test.js
@@ -1,0 +1,284 @@
+const presenters = require('../../../../../common/presenters')
+
+const middleware = require('./locals.warnings')
+
+describe('Move view app', function () {
+  describe('Middleware', function () {
+    describe('#localsWarnings()', function () {
+      let req, res, nextSpy, frameworkSectionStub
+
+      beforeEach(function () {
+        frameworkSectionStub = sinon.stub().returnsArg(0)
+        sinon
+          .stub(presenters, 'frameworkFlagsToTagList')
+          .returns('__frameworkFlagsToTagList__')
+        sinon
+          .stub(presenters, 'frameworkSectionToPanelList')
+          .returns(frameworkSectionStub)
+        sinon.stub(presenters, 'assessmentAnswersByCategory').returnsArg(0)
+        sinon
+          .stub(presenters, 'assessmentCategoryToPanelComponent')
+          .returnsArg(0)
+
+        req = {
+          move: {
+            id: 'moveId',
+            status: 'requested',
+            profile: {
+              assessment_answers: [],
+            },
+          },
+          baseUrl: '/base-url',
+          originalUrl: '/original-url',
+        }
+        res = {
+          locals: {},
+        }
+        nextSpy = sinon.spy()
+      })
+
+      describe('sections', function () {
+        context('with Person Escort Record', function () {
+          beforeEach(function () {
+            req.move.profile.person_escort_record = {
+              _framework: {
+                sections: [
+                  { name: 'foo', order: 2 },
+                  { name: 'bar', order: 1 },
+                ],
+              },
+              id: 'per_12345',
+            }
+            middleware(req, res, nextSpy)
+          })
+
+          it('should call frameworkSectionToPanelList presenter for each section', function () {
+            expect(frameworkSectionStub.callCount).to.equal(2)
+            expect(presenters.frameworkSectionToPanelList).to.be.calledTwice
+            expect(presenters.frameworkSectionToPanelList).to.be.calledWith({
+              baseUrl: `/move/${req.move.id}/person-escort-record`,
+            })
+          })
+
+          it('should set sections variable to PER sections correctly ordered', function () {
+            expect(res.locals.warnings).to.have.property('sections')
+            expect(res.locals.warnings.sections).to.deep.equal([
+              { name: 'bar', order: 1 },
+              { name: 'foo', order: 2 },
+            ])
+          })
+        })
+
+        context('with Youth Risk Assessment', function () {
+          beforeEach(function () {
+            req.move.profile.requires_youth_risk_assessment = true
+            req.move.profile.youth_risk_assessment = {
+              _framework: {
+                sections: [
+                  { name: 'fizz', order: 2 },
+                  { name: 'buzz', order: 1 },
+                ],
+              },
+              id: 'yra_12345',
+            }
+          })
+
+          context('with Person Escort Record', function () {
+            beforeEach(function () {
+              req.move.profile.person_escort_record = {
+                _framework: {
+                  sections: [
+                    { name: 'foo', order: 2 },
+                    { name: 'bar', order: 1 },
+                  ],
+                },
+                id: 'per_12345',
+              }
+              middleware(req, res, nextSpy)
+            })
+
+            it('should call frameworkSectionToPanelList presenter for each section', function () {
+              expect(frameworkSectionStub.callCount).to.equal(4)
+              expect(presenters.frameworkSectionToPanelList).to.be.calledTwice
+              expect(presenters.frameworkSectionToPanelList).to.be.calledWith({
+                baseUrl: `/move/${req.move.id}/person-escort-record`,
+              })
+            })
+
+            it('should set sections variable to PER sections correctly ordered', function () {
+              expect(res.locals.warnings).to.have.property('sections')
+              expect(res.locals.warnings.sections).to.deep.equal([
+                { name: 'bar', order: 1 },
+                { name: 'foo', order: 2 },
+              ])
+            })
+          })
+
+          context('without Person Escort Record', function () {
+            beforeEach(function () {
+              middleware(req, res, nextSpy)
+            })
+
+            it('should call frameworkSectionToPanelList presenter for each section', function () {
+              expect(frameworkSectionStub.callCount).to.equal(2)
+              expect(presenters.frameworkSectionToPanelList).to.be.calledTwice
+              expect(presenters.frameworkSectionToPanelList).to.be.calledWith({
+                baseUrl: `/move/${req.move.id}/person-escort-record`,
+              })
+              expect(presenters.frameworkSectionToPanelList).to.be.calledWith({
+                baseUrl: `/move/${req.move.id}/youth-risk-assessment`,
+              })
+            })
+
+            it('should set sections variable to YRA sections correctly ordered', function () {
+              expect(res.locals.warnings).to.have.property('sections')
+              expect(res.locals.warnings.sections).to.deep.equal([
+                { name: 'buzz', order: 1 },
+                { name: 'fizz', order: 2 },
+              ])
+            })
+          })
+        })
+
+        context('with assessment answers', function () {
+          beforeEach(function () {
+            req.move.profile.assessment_answers = [
+              { name: 'buzz', order: 3, key: 'risk' },
+              { name: 'fizz', order: 7, key: 'health' },
+              { name: 'foo', order: 2, key: 'risk' },
+              { name: 'bar', order: 1, key: 'court' },
+            ]
+          })
+
+          context('when move requires youth risk assessment', function () {
+            beforeEach(function () {
+              req.move.profile.requires_youth_risk_assessment = true
+              middleware(req, res, nextSpy)
+            })
+
+            it('should set sections variable to empty array', function () {
+              expect(res.locals.warnings).to.have.property('sections')
+              expect(res.locals.warnings.sections).to.deep.equal([])
+            })
+          })
+
+          context(
+            'when move does not require youth risk assessment',
+            function () {
+              beforeEach(function () {
+                req.move.profile.requires_youth_risk_assessment = false
+                middleware(req, res, nextSpy)
+              })
+
+              it('should set sections variable to assessment answers', function () {
+                expect(res.locals.warnings).to.have.property('sections')
+                expect(res.locals.warnings.sections).to.deep.equal([
+                  { name: 'buzz', order: 3, key: 'risk' },
+                  { name: 'fizz', order: 7, key: 'health' },
+                  { name: 'foo', order: 2, key: 'risk' },
+                ])
+              })
+            }
+          )
+        })
+
+        context('without profile', function () {
+          beforeEach(function () {
+            delete req.move.profile
+            middleware(req, res, nextSpy)
+          })
+
+          it('should set sections variable as empty array', function () {
+            expect(res.locals.warnings).to.have.property('sections')
+            expect(res.locals.warnings.sections).to.deep.equal([])
+          })
+        })
+      })
+
+      describe('tagList', function () {
+        context('when Person Escort Record is completed', function () {
+          beforeEach(function () {
+            req.move.profile.person_escort_record = {
+              status: 'completed',
+              flags: ['foo', 'bar'],
+            }
+            middleware(req, res, nextSpy)
+          })
+
+          it('should call correct presenter', function () {
+            expect(
+              presenters.frameworkFlagsToTagList
+            ).to.have.been.calledOnceWithExactly({
+              flags: req.move.profile.person_escort_record.flags,
+              hrefPrefix: '/original-url',
+              includeLink: true,
+            })
+          })
+
+          it('should set tagList variable', function () {
+            expect(res.locals.warnings).to.have.property('tagList')
+            expect(res.locals.warnings.tagList).to.equal(
+              '__frameworkFlagsToTagList__'
+            )
+          })
+        })
+
+        context('when Person Escort Record is not completed', function () {
+          beforeEach(function () {
+            req.move.profile.person_escort_record = {
+              status: 'in_progress',
+              flags: ['foo', 'bar'],
+            }
+            middleware(req, res, nextSpy)
+          })
+
+          it('should call correct presenter', function () {
+            expect(presenters.frameworkFlagsToTagList).not.to.have.been.called
+          })
+
+          it('should set tagList variable as undefined', function () {
+            expect(res.locals.warnings).to.have.property('tagList')
+            expect(res.locals.warnings.tagList).to.be.undefined
+          })
+        })
+
+        context('without Person Escort Record', function () {
+          beforeEach(function () {
+            req.move.profile = {}
+            middleware(req, res, nextSpy)
+          })
+
+          it('should call correct presenter', function () {
+            expect(presenters.frameworkFlagsToTagList).not.to.have.been.called
+          })
+
+          it('should set tagList variable as undefined', function () {
+            expect(res.locals.warnings).to.have.property('tagList')
+            expect(res.locals.warnings.tagList).to.be.undefined
+          })
+        })
+
+        context('without profile', function () {
+          beforeEach(function () {
+            req.move.profile = undefined
+            middleware(req, res, nextSpy)
+          })
+
+          it('should call correct presenter', function () {
+            expect(presenters.frameworkFlagsToTagList).not.to.have.been.called
+          })
+
+          it('should set tagList variable as undefined', function () {
+            expect(res.locals.warnings).to.have.property('tagList')
+            expect(res.locals.warnings.tagList).to.be.undefined
+          })
+        })
+      })
+
+      it('should call next', function () {
+        middleware(req, res, nextSpy)
+        expect(nextSpy).to.be.calledOnceWithExactly()
+      })
+    })
+  })
+})

--- a/app/move/app/view/views/warnings.njk
+++ b/app/move/app/view/views/warnings.njk
@@ -1,4 +1,65 @@
 {% extends "./_layout.njk" %}
 
-{% block contentMain %}
+{% macro renderAssessmentComponent(assessment) %}
+  {% if assessment.isCompleted == false %}
+    {{ govukInsetText({
+      classes: "govuk-inset-text--compact govuk-!-margin-0",
+      text: t("assessment::section_incomplete")
+    }) }}
+  {% elif assessment.count > 0 %}
+    {% if assessment.panels %}
+      {% for panel in assessment.panels %}
+        {{ appPanel(panel) }}
+      {% endfor %}
+    {% else %}
+      {{ govukSummaryList(assessment) }}
+    {% endif %}
+  {% else %}
+    {{ appMessage({
+      classes: "app-message--muted govuk-!-margin-top-2",
+      allowDismiss: false,
+      content: {
+        html: t('assessment::no_items.text', {
+          context: assessment.context or assessment.key,
+          name: assessment.name,
+          url: assessment.url
+        })
+      }
+    }) }}
+  {% endif %}
+{% endmacro %}
+
+{% block tabContent %}
+
+  <h2 class="govuk-heading-m govuk-!-margin-bottom-2">
+    {{ t("assessment::overview") }}
+  </h2>
+
+  <div data-tag-list-source="person-escort-record">
+    {% for tag in warnings.tagList %}
+      {{ appTag(tag) }}
+    {% else %}
+      {{ govukInsetText({
+        classes: "govuk-inset-text--compact govuk-!-margin-0",
+        text: t("assessment::incomplete")
+      }) }}
+    {% endfor %}
+  </div>
+
+  {% if warnings.sections | length %}
+
+    {% for section in warnings.sections %}
+      <section class="app-!-position-relative govuk-!-margin-top-7">
+        <h2 class="govuk-heading-m govuk-!-margin-bottom-2">
+          {{ section.name or t('assessment::heading.text', {
+            context: section.key
+          }) }}
+        </h2>
+
+        {{ renderAssessmentComponent(section) }}
+      </section>
+    {% endfor %}
+
+  {% endif %}
+
 {% endblock %}

--- a/locales/en/assessment.json
+++ b/locales/en/assessment.json
@@ -1,6 +1,7 @@
 {
   "page_title": "$t({{context}})",
   "page_title_with_name": "$t({{context}}) for {{-name}}",
+  "overview": "Overview",
   "section_overview": "{{section}} overview",
   "locked": "A $t({{context}}) cannot be updated once it has been confirmed or once the move has started.",
   "locked_person_escort_record": "A $t({{context}}) cannot be updated once handover has been recorded or once the move has started.",


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

This creates a new middleware layer to set the locals required to
display warnings on the warnings tab.



### Why did it change

This new set of information is more streamlined than before as it
doesn't try to do any combining of previous warnings.

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

- [P4-2912](https://dsdmoj.atlassian.net/browse/P4-2912)

## Screenshots
<!--- (Optional) Include screenshots if changes update interfaces or components -->
<!--- Delete/copy as appropriate --->

| Before | After |
| ------ | ----- |
| Adult booking request |  |
| <kbd>![image](https://user-images.githubusercontent.com/3327997/123621814-856dd000-d803-11eb-9907-bcc51f398e28.png)</kbd> | <kbd>![image](https://user-images.githubusercontent.com/3327997/123621664-5eaf9980-d803-11eb-9023-bd1c4abb7073.png)</kbd> |
| With started PER |  |
| <kbd>![image](https://user-images.githubusercontent.com/3327997/123621767-78e97780-d803-11eb-84c2-69ab620b3ffd.png)</kbd> | <kbd>![image](https://user-images.githubusercontent.com/3327997/123621706-68d19800-d803-11eb-9b4b-123ff41eb30c.png)</kbd> |
| Youth booking request |  |
| <kbd>![image](https://user-images.githubusercontent.com/3327997/123621876-90286500-d803-11eb-9d5e-ede0e8799d9f.png)</kbd> | <kbd>![image](https://user-images.githubusercontent.com/3327997/123621953-9c142700-d803-11eb-839c-a36bf34d15c8.png)</kbd> |
| With incomplete PER |  |
| <kbd>![image](https://user-images.githubusercontent.com/3327997/123622211-e1d0ef80-d803-11eb-94eb-e07c1a87bcc5.png)</kbd> | <kbd>![image](https://user-images.githubusercontent.com/3327997/123622171-d7165a80-d803-11eb-93a5-2bc005b2f056.png)</kbd> |
| Youth request with completed PER |  |
| <kbd>![image](https://user-images.githubusercontent.com/3327997/123622296-fa410a00-d803-11eb-89f4-bb63c99bb331.png)</kbd> | <kbd>![image](https://user-images.githubusercontent.com/3327997/123622259-f0b7a200-d803-11eb-83e7-7908ae871e22.png)</kbd> |
| Adult request with completed PER |  |
| <kbd>![image](https://user-images.githubusercontent.com/3327997/123622365-0c22ad00-d804-11eb-92d8-dbd6aa893e8a.png)</kbd> | <kbd>![image](https://user-images.githubusercontent.com/3327997/123622427-1ba1f600-d804-11eb-9b66-beb18b388d99.png)</kbd> |

## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed
