### PR TITLE
Ensure move details handles null profiles correctly

### DIFF
--- a/common/presenters/move-to-meta-list-component.js
+++ b/common/presenters/move-to-meta-list-component.js
@@ -26,7 +26,7 @@ function moveToMetaListComponent(
     prison_transfer_reason: prisonTransferReason,
     move_agreed: moveAgreed,
     move_agreed_by: moveAgreedBy,
-    profile = {},
+    profile,
     reference,
     status,
   } = move || {}
@@ -96,7 +96,7 @@ function moveToMetaListComponent(
       },
       value: {
         text:
-          showPerson && profile.person ? profile.person._fullname : undefined,
+          showPerson && profile?.person ? profile.person._fullname : undefined,
       },
     },
     {

--- a/common/presenters/move-to-meta-list-component.test.js
+++ b/common/presenters/move-to-meta-list-component.test.js
@@ -10,38 +10,40 @@ const moveToMetaListComponent = proxyquire('./move-to-meta-list-component', {
   '../helpers/move/get-update-links': getUpdateLinks,
 })
 
-const mockMove = {
-  _hasLeftCustody: false,
-  _vehicleRegistration: 'GG01 AJY',
-  reference: 'ABC12345',
-  status: 'booked',
-  date: '2019-06-09',
-  time_due: '2000-01-01T14:00:00Z',
-  move_type: 'court_appearance',
-  profile: {
-    person: {
-      _fullname: 'BLOGGS, JOE',
-    },
-  },
-  from_location: {
-    title: 'HMP Leeds',
-  },
-  to_location: {
-    title: 'Barrow in Furness County Court',
-  },
-}
-
 const canAccess = sinon.stub()
 const updateSteps = ['a', 'b']
 
 describe('Presenters', function () {
   describe('#moveToMetaListComponent()', function () {
+    let mockMove
+
     beforeEach(function () {
       timezoneMock.register('UTC')
       sinon.stub(componentService, 'getComponent').returnsArg(0)
       sinon.stub(filters, 'formatDateWithRelativeDay').returnsArg(0)
       sinon.stub(i18n, 't').returnsArg(0)
       getUpdateLinks.resetHistory()
+
+      mockMove = {
+        _hasLeftCustody: false,
+        _vehicleRegistration: 'GG01 AJY',
+        reference: 'ABC12345',
+        status: 'booked',
+        date: '2019-06-09',
+        time_due: '2000-01-01T14:00:00Z',
+        move_type: 'court_appearance',
+        profile: {
+          person: {
+            _fullname: 'BLOGGS, JOE',
+          },
+        },
+        from_location: {
+          title: 'HMP Leeds',
+        },
+        to_location: {
+          title: 'Barrow in Furness County Court',
+        },
+      }
     })
 
     afterEach(function () {
@@ -621,6 +623,48 @@ describe('Presenters', function () {
               name: 'Jon Doe',
             }
           )
+        })
+      })
+
+      context('without profile', function () {
+        beforeEach(function () {
+          delete mockMove.profile
+          transformedResponse = moveToMetaListComponent(mockMove)
+        })
+
+        it('should not contain person key', function () {
+          const keys = transformedResponse.items.map(
+            item => item.key.text || item.key.html
+          )
+          expect(keys).not.to.include('person_noun')
+        })
+      })
+
+      context('without person', function () {
+        beforeEach(function () {
+          mockMove.profile = {}
+          transformedResponse = moveToMetaListComponent(mockMove)
+        })
+
+        it('should not contain person key', function () {
+          const keys = transformedResponse.items.map(
+            item => item.key.text || item.key.html
+          )
+          expect(keys).not.to.include('person_noun')
+        })
+      })
+
+      context('with null profile', function () {
+        beforeEach(function () {
+          mockMove.profile = null
+          transformedResponse = moveToMetaListComponent(mockMove)
+        })
+
+        it('should not contain person key', function () {
+          const keys = transformedResponse.items.map(
+            item => item.key.text || item.key.html
+          )
+          expect(keys).not.to.include('person_noun')
         })
       })
     })

--- a/test/e2e/_routes.js
+++ b/test/e2e/_routes.js
@@ -23,6 +23,7 @@ export const getTimeline = id => `${E2E.BASE_URL}/move/${id}/timeline`
 export const getUpdateMove = (id, page) =>
   `${E2E.BASE_URL}/move/${id}/edit/${getUpdatePageStub(page)}`
 export const newAllocation = `${E2E.BASE_URL}/allocation/new`
+export const allocation = id => `${E2E.BASE_URL}/allocation/${id}`
 export const allocations = `${E2E.BASE_URL}/allocations`
 export const allocationsWithDate = date =>
   `${E2E.BASE_URL}/allocations/week/${date}/outgoing`

--- a/test/e2e/allocation.assign.test.js
+++ b/test/e2e/allocation.assign.test.js
@@ -1,0 +1,66 @@
+import { Selector } from 'testcafe'
+
+import { createPersonFixture } from './_helpers'
+import { ocaUser, pmuUser } from './_roles'
+import { allocation, newAllocation } from './_routes'
+import { allocationJourney, createMovePage, page } from './pages/'
+
+fixture('Assign a person to an allocation').beforeEach(async t => {
+  await t.useRole(pmuUser).navigateTo(newAllocation)
+
+  t.ctx.personalDetails = await createPersonFixture()
+  t.ctx.allocation = await allocationJourney.createAllocation()
+
+  await t.useRole(ocaUser).navigateTo(allocation(t.ctx.allocation.id))
+})
+
+test('Assign person', async t => {
+  const { allocation, personalDetails } = t.ctx
+  // Add person
+  await t.click(allocationJourney.allocationViewPage.nodes.addPersonButton)
+
+  // PNC lookup
+  await createMovePage.fillInPrisonNumberSearch(personalDetails.prisonNumber)
+  await page.submitForm()
+
+  // PNC lookup results
+  await createMovePage.checkPersonLookupResults(1, personalDetails.prisonNumber)
+  await createMovePage.selectSearchResults(personalDetails.fullname)
+  await page.submitForm()
+
+  // Agreement status
+  await createMovePage.fillInAgreementStatus()
+  await page.submitForm()
+
+  // Risk information
+  await page.submitForm()
+
+  // Health information
+  await createMovePage.fillInSpecialVehicle()
+  await page.submitForm()
+
+  // Confirmation page
+  await createMovePage.checkConfirmationStep({
+    fullname: personalDetails.fullname,
+    location: allocation.toLocation,
+  })
+  await t.click(Selector('a').withText(allocation.toLocation))
+
+  await t
+    .expect(allocationJourney.allocationViewPage.nodes.allocatedMoves.count)
+    .eql(1, 'Should contain one allocated move')
+
+  // Click remove button
+  await t.click(
+    allocationJourney.allocationViewPage.nodes.removePersonButton(
+      personalDetails.fullname
+    )
+  )
+
+  // Remove person
+  await page.submitForm()
+
+  await t
+    .expect(allocationJourney.allocationViewPage.nodes.allocatedMoves.count)
+    .eql(0, 'Should not contain any allocated moves')
+})

--- a/test/e2e/pages/allocation-view.js
+++ b/test/e2e/pages/allocation-view.js
@@ -21,6 +21,13 @@ class AllocationViewPage extends Page {
       summaryPanel: Selector('#main-content h3')
         .withText('Allocation details')
         .sibling('dl'),
+      addPersonButton: Selector('a').withText('Add'),
+      removePersonButton: name =>
+        Selector('.app-card')
+          .withText(name)
+          .parent()
+          .find('a.govuk-button')
+          .withText('Remove'),
       allocatedMoves: Selector('.app-card'),
       allocatedMovesReferences: Selector('.app-card__caption'),
       allocatedMovesRemoveLinks: Selector('a').withText(

--- a/test/e2e/pages/create-move.js
+++ b/test/e2e/pages/create-move.js
@@ -71,7 +71,7 @@ class CreateMovePage extends Page {
       pregnant: Selector('#pregnant'),
       otherHealth: Selector('#other_health'),
       specialVehicle: Selector('#special_vehicle'),
-      specialVehicleRadio: Selector('[name="special_vehicle__explicit"]'),
+      specialVehicleRadio: Selector('[name^="special_vehicle"]'),
       notToBeReleased: Selector('#not_to_be_released'),
       notToBeReleasedRadio: Selector('[name="not_to_be_released__explicit"]'),
       hasCourtCase: Selector('[name="has_court_case"]'),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

This fixes the check for a person on a profile so that it doesn't error with `null` profiles.

Add end-to-end tests to test the assign/removal journeys for allocations.

### Why did it change

When there is no profile, the deserialized object contains a `null` value which prevents the fallback from being assigned. This caused the panel to error.

This bug wasn't picked up by any tests so some more tests for these journeys have been added.


## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [x] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed
