### PR TITLE
Remove additional breadcrumb from API client error handling

### DIFF
--- a/common/lib/api-client/middleware/got-request.js
+++ b/common/lib/api-client/middleware/got-request.js
@@ -1,4 +1,3 @@
-const Sentry = require('@sentry/node')
 const HttpAgent = require('agentkeepalive')
 const debug = require('debug')('app:api-client:request')
 const cacheDebug = require('debug')('app:api-client:cache')
@@ -61,7 +60,7 @@ function requestMiddleware({
           return res
         })
         .catch(error => {
-          const { requestUrl, statusCode, statusMessage, timings } =
+          const { statusCode, statusMessage, timings } =
             error.response || error.request || {}
 
           const text = statusMessage || error.message
@@ -75,17 +74,6 @@ function requestMiddleware({
               ((timings.error || timings.end) - timings.start) / 1000
             clientMetrics.recordError(req, error, duration)
           }
-
-          Sentry.addBreadcrumb({
-            type: 'http',
-            category: 'http',
-            data: {
-              method: req.method,
-              url: requestUrl ? decodeURIComponent(requestUrl) : undefined,
-              status_code: status,
-            },
-            level: Sentry.Severity.Info,
-          })
 
           throw error
         })

--- a/common/lib/api-client/middleware/got-request.test.js
+++ b/common/lib/api-client/middleware/got-request.test.js
@@ -1,4 +1,3 @@
-const Sentry = require('@sentry/node')
 const HttpAgent = require('agentkeepalive')
 const proxyquire = require('proxyquire').noPreserveCache()
 
@@ -63,8 +62,6 @@ describe('API Client', function () {
           params: {},
         },
       }
-
-      sinon.stub(Sentry, 'addBreadcrumb')
 
       requestDebugStub.resetHistory()
       cacheDebugStub.resetHistory()
@@ -252,19 +249,6 @@ describe('API Client', function () {
           expect(clientMetrics.recordError).not.to.be.called
         })
 
-        it('should add a Sentry breadcrumb', function () {
-          expect(Sentry.addBreadcrumb).to.be.calledOnceWithExactly({
-            type: 'http',
-            category: 'http',
-            data: {
-              method: 'GET',
-              url: undefined,
-              status_code: 500,
-            },
-            level: Sentry.Severity.Info,
-          })
-        })
-
         it('should rethrow error', function () {
           expect(thrownError).to.equal(error)
         })
@@ -311,19 +295,6 @@ describe('API Client', function () {
             )
           })
 
-          it('should add a Sentry breadcrumb', function () {
-            expect(Sentry.addBreadcrumb).to.be.calledOnceWithExactly({
-              type: 'http',
-              category: 'http',
-              data: {
-                method: 'GET',
-                url: 'http://host.com/path?foo&bar,fizz,buzz',
-                status_code: 408,
-              },
-              level: Sentry.Severity.Info,
-            })
-          })
-
           it('should rethrow error', function () {
             expect(thrownError).to.equal(error)
           })
@@ -357,19 +328,6 @@ describe('API Client', function () {
               error,
               (error.response.timings.end - error.response.timings.start) / 1000
             )
-          })
-
-          it('should add a Sentry breadcrumb', function () {
-            expect(Sentry.addBreadcrumb).to.be.calledOnceWithExactly({
-              type: 'http',
-              category: 'http',
-              data: {
-                method: 'GET',
-                url: 'http://host.com/path?foo&bar,fizz,buzz',
-                status_code: 400,
-              },
-              level: Sentry.Severity.Info,
-            })
           })
 
           it('should rethrow error', function () {
@@ -418,19 +376,6 @@ describe('API Client', function () {
               error,
               (error.request.timings.error - error.request.timings.start) / 1000
             )
-          })
-
-          it('should add a Sentry breadcrumb', function () {
-            expect(Sentry.addBreadcrumb).to.be.calledOnceWithExactly({
-              type: 'http',
-              category: 'http',
-              data: {
-                method: 'GET',
-                url: 'http://host.com/path?foo&bar,fizz,buzz',
-                status_code: 408,
-              },
-              level: Sentry.Severity.Info,
-            })
           })
 
           it('should rethrow error', function () {
@@ -487,19 +432,6 @@ describe('API Client', function () {
             error,
             (error.response.timings.end - error.response.timings.start) / 1000
           )
-        })
-
-        it('should add a Sentry breadcrumb', function () {
-          expect(Sentry.addBreadcrumb).to.be.calledOnceWithExactly({
-            type: 'http',
-            category: 'http',
-            data: {
-              method: 'GET',
-              url: 'http://host.com/response-path?foo&bar,fizz,buzz',
-              status_code: 400,
-            },
-            level: Sentry.Severity.Info,
-          })
         })
 
         it('should rethrow error', function () {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

A manual breadcrumb was previously added for errors occuring in the
API client to help debugging. This was required for Axios but GOT
will add the last call.

### Why did it change

This is causing duplicates so we can now remove this extra change.

## Screenshots
<!--- (Optional) Include screenshots if changes update interfaces or components -->
<!--- Delete/copy as appropriate --->

| Before | After |
| ------ | ----- |
| <kbd>![image](https://user-images.githubusercontent.com/3327997/124456184-52d35280-dd82-11eb-8875-41529505ac6a.png)</kbd> | <kbd>![image](https://user-images.githubusercontent.com/3327997/124456431-95952a80-dd82-11eb-84d8-8d6717707408.png)</kbd> |

## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Internet Explorer
