### PR TITLE
Avoid multiple API calls for location types

### DIFF
--- a/common/middleware/set-location-items.js
+++ b/common/middleware/set-location-items.js
@@ -3,29 +3,6 @@ const { set } = require('lodash')
 const fieldHelpers = require('../helpers/field')
 const referenceDataHelpers = require('../helpers/reference-data')
 
-const getLocations = async (locationTypes, req) => {
-  const locations = (
-    await Promise.all(
-      locationTypes.map(x => req.services.referenceData.getLocationsByType([x]))
-    )
-  )
-    .reduce((acc, val) => acc.concat(val))
-    .sort(sortByTitle)
-  return locations
-}
-
-const sortByTitle = (a, b) => {
-  if (a.title < b.title) {
-    return -1
-  }
-
-  if (a.title > b.title) {
-    return 1
-  }
-
-  return 0
-}
-
 const getLocationItems = (location, locations) => {
   return fieldHelpers.insertInitialOption(
     locations
@@ -48,7 +25,9 @@ function setLocationItems(locationTypes, fieldName) {
         locationTypes = [locationTypes]
       }
 
-      const locations = await getLocations(locationTypes, req)
+      const locations = await req.services.referenceData.getLocationsByType(
+        locationTypes
+      )
 
       const items = getLocationItems(locationTypes[0], locations)
 

--- a/common/middleware/set-location-items.js
+++ b/common/middleware/set-location-items.js
@@ -6,7 +6,7 @@ const referenceDataHelpers = require('../helpers/reference-data')
 const getLocations = async (locationTypes, req) => {
   const locations = (
     await Promise.all(
-      locationTypes.map(x => req.services.referenceData.getLocationsByType(x))
+      locationTypes.map(x => req.services.referenceData.getLocationsByType([x]))
     )
   )
     .reduce((acc, val) => acc.concat(val))

--- a/common/middleware/set-location-items.test.js
+++ b/common/middleware/set-location-items.test.js
@@ -69,7 +69,7 @@ describe('#setLocationItems()', function () {
       it('should call reference data service', function () {
         expect(
           referenceDataService.getLocationsByType
-        ).to.be.calledOnceWithExactly(mockLocationType)
+        ).to.be.calledOnceWithExactly([mockLocationType])
       })
 
       it('populates the move type items', function () {
@@ -154,10 +154,10 @@ describe('#setLocationItems()', function () {
           expect(referenceDataService.getLocationsByType).to.be.calledTwice
           expect(
             referenceDataService.getLocationsByType
-          ).to.be.calledWithExactly(mockLocationType[0])
+          ).to.be.calledWithExactly([mockLocationType[0]])
           expect(
             referenceDataService.getLocationsByType
-          ).to.be.calledWithExactly(mockLocationType[1])
+          ).to.be.calledWithExactly([mockLocationType[1]])
         })
 
         it('populates the move type items and sorts them', function () {

--- a/common/middleware/set-location-items.test.js
+++ b/common/middleware/set-location-items.test.js
@@ -137,11 +137,9 @@ describe('#setLocationItems()', function () {
 
       context('when service resolves', function () {
         beforeEach(async function () {
-          req.services.referenceData.getLocationsByType = sinon.stub()
-          req.services.referenceData.getLocationsByType.resolves(courtsMock)
-          req.services.referenceData.getLocationsByType
-            .onCall(1)
-            .resolves(courtsMock2)
+          req.services.referenceData.getLocationsByType = sinon
+            .stub()
+            .resolves(courtsMock.concat(courtsMock2))
 
           await setLocationItems(mockLocationType, mockFieldName)(
             req,
@@ -150,36 +148,32 @@ describe('#setLocationItems()', function () {
           )
         })
 
-        it('should call reference data service for each location type', function () {
-          expect(referenceDataService.getLocationsByType).to.be.calledTwice
+        it('should call reference data service for the location types', function () {
           expect(
             referenceDataService.getLocationsByType
-          ).to.be.calledWithExactly([mockLocationType[0]])
-          expect(
-            referenceDataService.getLocationsByType
-          ).to.be.calledWithExactly([mockLocationType[1]])
+          ).to.be.calledOnceWithExactly(mockLocationType)
         })
 
-        it('populates the move type items and sorts them', function () {
+        it('populates the move type items', function () {
           expect(req.form.options.fields[mockFieldName].items).to.deep.equal([
             {
               text: `--- Choose ${mockLocationType[0]} ---`,
-            },
-            {
-              text: 'Court 7777',
-              value: '7777',
             },
             {
               text: 'Court 8888',
               value: '8888',
             },
             {
+              text: 'Court 9999',
+              value: '9999',
+            },
+            {
               text: 'Court 8888',
               value: '8888-dupe',
             },
             {
-              text: 'Court 9999',
-              value: '9999',
+              text: 'Court 7777',
+              value: '7777',
             },
             {
               text: 'Court AAAA',
@@ -199,7 +193,6 @@ describe('#setLocationItems()', function () {
         beforeEach(async function () {
           req.services.referenceData.getLocationsByType = sinon
             .stub()
-            .onCall(1)
             .throws(errorMock)
 
           await setLocationItems(mockLocationType, mockFieldName)(

--- a/common/services/reference-data.js
+++ b/common/services/reference-data.js
@@ -81,10 +81,10 @@ class ReferenceDataService extends BaseService {
     )
   }
 
-  getLocationsByType(type) {
+  getLocationsByType(types = []) {
     return this.getLocations({
       filter: {
-        'filter[location_type]': type,
+        'filter[location_type]': types.length ? types.join(',') : undefined,
       },
     })
   }

--- a/common/services/reference-data.test.js
+++ b/common/services/reference-data.test.js
@@ -609,11 +609,11 @@ describe('Reference Data Service', function () {
       })
     })
 
-    context('with type', function () {
+    context('with a single type', function () {
       const mockType = 'court'
 
       beforeEach(async function () {
-        locations = await referenceDataService.getLocationsByType(mockType)
+        locations = await referenceDataService.getLocationsByType([mockType])
       })
 
       it('should call getMoves methods', function () {
@@ -634,6 +634,35 @@ describe('Reference Data Service', function () {
         it('should set location_type filter to agency ID', function () {
           expect(filters).to.contain.property('filter[location_type]')
           expect(filters['filter[location_type]']).to.equal(mockType)
+        })
+      })
+    })
+
+    context('with multiple types', function () {
+      const mockTypes = ['court', 'prison']
+
+      beforeEach(async function () {
+        locations = await referenceDataService.getLocationsByType(mockTypes)
+      })
+
+      it('should call getMoves methods', function () {
+        expect(referenceDataService.getLocations).to.be.calledOnce
+      })
+
+      it('should return first result', function () {
+        expect(locations).to.deep.equal(mockResponse)
+      })
+
+      describe('filters', function () {
+        let filters
+
+        beforeEach(function () {
+          filters = referenceDataService.getLocations.args[0][0].filter
+        })
+
+        it('should set location_type filter to agency IDs separated by a comma', function () {
+          expect(filters).to.contain.property('filter[location_type]')
+          expect(filters['filter[location_type]']).to.equal('court,prison')
         })
       })
     })

--- a/test/e2e/_helpers.js
+++ b/test/e2e/_helpers.js
@@ -225,7 +225,7 @@ export async function getRandomLocation(
   let locations
 
   if (locationType) {
-    locations = await referenceDataService.getLocationsByType(locationType)
+    locations = await referenceDataService.getLocationsByType([locationType])
   } else {
     locations = await referenceDataService.getLocations()
   }


### PR DESCRIPTION
## Proposed changes

### What changed

Rather than making an API call for each location type and combining the results, we can now make a single API with all of the location types.

### Why did it change

This avoids making multiple unnecessary calls to the API.

### Issue tracking

Closes #1028 

## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

- [x] No environment variables were added or changed