### PR TITLE
Warn when the auth source cannot be determined

### DIFF
--- a/common/services/user.js
+++ b/common/services/user.js
@@ -1,3 +1,4 @@
+const Sentry = require('@sentry/node')
 const axios = require('axios')
 const rax = require('retry-axios')
 
@@ -34,6 +35,11 @@ function getLocations(token) {
     case 'nomis':
       return getNomisLocations(token)
     default:
+      Sentry.captureException(new Error('Unknown auth source'), {
+        level: Sentry.Severity.Warning,
+        tags: { authSource },
+      })
+
       return Promise.resolve([])
   }
 }

--- a/common/services/user.test.js
+++ b/common/services/user.test.js
@@ -1,3 +1,4 @@
+const Sentry = require('@sentry/node')
 const axios = require('axios')
 const proxyquire = require('proxyquire')
 
@@ -293,6 +294,8 @@ describe('User service', function () {
 
       context('User authentication source indeterminate', function () {
         beforeEach(async function () {
+          sinon.stub(Sentry, 'captureException')
+
           tokenData = {
             user_name: 'test',
           }
@@ -304,6 +307,13 @@ describe('User service', function () {
 
         it('defaults to an empty list of locations', function () {
           expect(result).to.be.an('array').that.is.empty
+        })
+
+        it('should send a warning to Sentry', function () {
+          expect(Sentry.captureException).to.have.been.calledOnceWith(
+            sinon.match.instanceOf(Error),
+            { tags: { authSource: undefined }, level: 'warning' }
+          )
         })
       })
     })


### PR DESCRIPTION
## Proposed changes

### What changed

This follows on from https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/pull/1790 to add more information around missing location errors. We hypothesis that perhaps the reason the user has no locations is because the auth source was unable to be determined.

### Why did it change

By warning in this situation we're hoping to be able to figure out in more detail what's going on.

### Issue tracking

- [P4-2975](https://dsdmoj.atlassian.net/browse/P4-2975)

## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

- [x] No environment variables were added or changed