### PR TITLE
Ensure supplier user locations aren't cleared out

### DIFF
--- a/app/auth/middleware.js
+++ b/app/auth/middleware.js
@@ -6,6 +6,7 @@ const {
   getFullname,
   getLocations,
   getSupplierId,
+  populateSupplierLocations,
 } = require('../../common/services/user')
 
 function processAuthResponse() {
@@ -29,20 +30,24 @@ function processAuthResponse() {
 
       const previousSession = { ...req.session }
 
+      const user = new User({
+        fullname,
+        locations,
+        roles: decodedAccessToken.authorities,
+        username,
+        userId,
+        supplierId,
+      })
+
+      await populateSupplierLocations(user)
+
       req.session.regenerate(error => {
         if (error) {
           return next(error)
         }
 
         req.session.authExpiry = decodedAccessToken.exp
-        req.session.user = new User({
-          fullname,
-          locations,
-          roles: decodedAccessToken.authorities,
-          username,
-          userId,
-          supplierId,
-        })
+        req.session.user = user
 
         // copy any previous session properties ignoring grant or any that already exist
         Object.keys(previousSession).forEach(key => {

--- a/app/locations/controllers.js
+++ b/app/locations/controllers.js
@@ -4,6 +4,7 @@ const { populateSupplierLocations } = require('../../common/services/user')
 
 async function locations(req, res, next) {
   const userPermissions = get(req.session, 'user.permissions', [])
+  const userLocations = get(req.session, 'user.locations', [])
 
   let regions = []
 
@@ -14,8 +15,6 @@ async function locations(req, res, next) {
   } catch (error) {
     return next(error)
   }
-
-  const userLocations = req.userLocations
 
   try {
     await populateSupplierLocations(req.session.user)

--- a/app/locations/controllers.js
+++ b/app/locations/controllers.js
@@ -4,14 +4,19 @@ async function locations(req, res, next) {
   const userPermissions = get(req.session, 'user.permissions', [])
 
   let regions = []
-  let userLocations = req.userLocations
-  const supplierId = req.session.user.supplierId
 
   try {
     if (userPermissions.includes('allocation:create')) {
       regions = await req.services.referenceData.getRegions()
     }
+  } catch (error) {
+    return next(error)
+  }
 
+  const supplierId = req.session.user.supplierId
+  let userLocations = req.userLocations
+
+  try {
     if (supplierId) {
       userLocations = await req.services.referenceData.getLocationsBySupplierId(
         supplierId

--- a/app/locations/controllers.js
+++ b/app/locations/controllers.js
@@ -1,7 +1,5 @@
 const { get } = require('lodash')
 
-const { populateSupplierLocations } = require('../../common/services/user')
-
 async function locations(req, res, next) {
   const userPermissions = get(req.session, 'user.permissions', [])
   const userLocations = get(req.session, 'user.locations', [])
@@ -12,12 +10,6 @@ async function locations(req, res, next) {
     if (userPermissions.includes('allocation:create')) {
       regions = await req.services.referenceData.getRegions()
     }
-  } catch (error) {
-    return next(error)
-  }
-
-  try {
-    await populateSupplierLocations(req.session.user)
   } catch (error) {
     return next(error)
   }

--- a/app/locations/controllers.js
+++ b/app/locations/controllers.js
@@ -26,13 +26,9 @@ async function locations(req, res, next) {
     if (userPermissions.includes('locations:contract_delivery_manager')) {
       const suppliers = await req.services.referenceData.getSuppliers()
       const supplierLocations = await Promise.all(
-        suppliers.map(async supplier => {
-          const locations =
-            await req.services.referenceData.getLocationsBySupplierId(
-              supplier.id
-            )
-          return locations
-        })
+        suppliers.map(supplier =>
+          req.services.referenceData.getLocationsBySupplierId(supplier.id)
+        )
       )
 
       // The locations have been uniqued based on title to prevent

--- a/app/locations/controllers.test.js
+++ b/app/locations/controllers.test.js
@@ -63,9 +63,9 @@ describe('Locations controllers', function () {
         session: {
           user: {
             permissions: [],
+            locations: mockUserLocations,
           },
         },
-        userLocations: mockUserLocations,
         services: {
           referenceData: mockReferenceData,
         },

--- a/app/locations/controllers.test.js
+++ b/app/locations/controllers.test.js
@@ -1,6 +1,6 @@
 const { locations: locationsController } = require('./controllers')
 
-const mockUserLocations = [
+const mockLocations = [
   {
     id: '2c952ca0-f750-4ac3-ac76-fb631445f974',
     title: 'D location',
@@ -19,42 +19,11 @@ const mockUserLocations = [
     disabled_at: '123',
   },
 ]
-const mockSupplierLocations = [
-  ...mockUserLocations,
-  {
-    id: '70923762-bc17-4ea1-bae3-4ef429f9081e',
-    title: 'a location',
-  },
-]
-
-const mockSecondSupplierLocation = [
-  {
-    id: '0987654-bc17-4ea1-bae3-4ef429f9081e',
-    title: 'b location',
-  },
-  {
-    id: '70923762-bc17-4ea1-bae3-4ef429f9081e',
-    title: 'A location',
-  },
-]
-
-const mockSuppliers = [
-  {
-    id: 'b95bfb7c-18cd-419d-8119-2dee1506726f',
-    name: 'GEOAmey',
-  },
-  {
-    id: '35660b02-243f-4df2-9337-e3ec49b6d70d',
-    name: 'Serco',
-  },
-]
 
 describe('Locations controllers', function () {
   let req, res, nextSpy
   const mockReferenceData = {
     getRegions: sinon.fake.returns(Promise.resolve([])),
-    getLocationsBySupplierId: sinon.stub().resolves(mockSupplierLocations),
-    getSuppliers: sinon.stub().resolves(mockSuppliers),
   }
 
   describe('#locations', function () {
@@ -63,7 +32,7 @@ describe('Locations controllers', function () {
         session: {
           user: {
             permissions: [],
-            locations: mockUserLocations,
+            locations: mockLocations,
           },
         },
         services: {
@@ -110,83 +79,15 @@ describe('Locations controllers', function () {
           const params = res.render.args[0][1]
           expect(params).to.have.property('activeLocations')
           expect(params.activeLocations).to.deep.equal(
-            mockUserLocations.filter(l => l.disabled_at === null)
+            mockLocations.filter(l => l.disabled_at === null)
           )
           expect(params).to.have.property('inactiveLocations')
           expect(params.inactiveLocations).to.deep.equal(
-            mockUserLocations.filter(l => l.disabled_at !== null)
+            mockLocations.filter(l => l.disabled_at !== null)
           )
         })
       }
     )
-
-    context('when the user is a supplier', function () {
-      beforeEach(async function () {
-        mockReferenceData.getLocationsBySupplierId = sinon
-          .stub()
-          .resolves(mockSupplierLocations)
-        req.session.user.supplierId = 'aussiemanandvan'
-
-        await locationsController(req, res)
-      })
-
-      it('should fetch user locations', async function () {
-        expect(
-          mockReferenceData.getLocationsBySupplierId
-        ).to.be.calledOnceWithExactly('aussiemanandvan')
-      })
-
-      it('should render template', function () {
-        expect(res.render).to.be.calledOnce
-      })
-
-      it('should return locations', function () {
-        const params = res.render.args[0][1]
-        expect(params).to.have.property('activeLocations')
-        expect(params.activeLocations).to.deep.equal(
-          mockSupplierLocations.filter(l => l.disabled_at === null)
-        )
-        expect(params).to.have.property('inactiveLocations')
-        expect(params.inactiveLocations).to.deep.equal(
-          mockSupplierLocations.filter(l => l.disabled_at !== null)
-        )
-      })
-
-      it('should set the location on the user session', function () {
-        expect(req.session.user.locations).to.deep.equal(mockSupplierLocations)
-      })
-    })
-
-    context('when the user is a Contract Delivery Manager', function () {
-      beforeEach(async function () {
-        req.session.user.permissions = ['locations:contract_delivery_manager']
-        mockReferenceData.getSuppliers = sinon.stub().resolves(mockSuppliers)
-        mockReferenceData.getLocationsBySupplierId = sinon
-          .stub()
-          .onFirstCall()
-          .returns(mockSupplierLocations)
-          .onSecondCall()
-          .returns(mockSecondSupplierLocation)
-
-        await locationsController(req, res)
-      })
-
-      it('should fetch locations for each supplier', async function () {
-        expect(mockReferenceData.getLocationsBySupplierId).to.be.calledTwice
-      })
-
-      it('should render template', function () {
-        expect(res.render).to.be.calledOnce
-      })
-
-      it('should set the location on the user session', function () {
-        // The second location in the mockSecondSupplierLocation array
-        // is a duplicate, so should not be included
-        expect(req.session.user.locations).to.deep.equal(
-          mockSupplierLocations.concat(mockSecondSupplierLocation[0])
-        )
-      })
-    })
 
     context('when there is an API error', function () {
       it('should fail gracefully for regions API', async function () {
@@ -194,14 +95,6 @@ describe('Locations controllers', function () {
         req.services.referenceData.getRegions = sinon.fake.returns(
           Promise.reject(new Error())
         )
-        await locationsController(req, res, nextSpy)
-        expect(nextSpy).to.be.calledOnce
-      })
-
-      it('should fail gracefully for locations by supplier API', async function () {
-        req.session.user.permissions = ['locations:contract_delivery_manager']
-        req.services.referenceData.getLocationsBySupplierId =
-          sinon.fake.returns(Promise.reject(new Error()))
         await locationsController(req, res, nextSpy)
         expect(nextSpy).to.be.calledOnce
       })

--- a/app/locations/index.js
+++ b/app/locations/index.js
@@ -7,15 +7,12 @@ const { redirect } = require('../auth/controllers')
 
 const { locations } = require('./controllers')
 const {
-  setUserLocations,
   checkLocationsLength,
   setLocation,
   setRegion,
   setAllLocations,
   setHasSelectedLocation,
 } = require('./middleware')
-
-router.use(setUserLocations)
 
 // Define routes
 router.get('/', checkLocationsLength, locations)

--- a/app/locations/middleware.js
+++ b/app/locations/middleware.js
@@ -1,13 +1,10 @@
 const { find, get } = require('lodash')
 
-function setUserLocations(req, res, next) {
-  req.userLocations = get(req.session, 'user.locations', [])
-  next()
-}
-
 function checkLocationsLength(req, res, next) {
-  if (req.userLocations.length === 1) {
-    return res.redirect(`${req.baseUrl}/${req.userLocations[0].id}`)
+  const userLocations = get(req.session, 'user.locations', [])
+
+  if (userLocations.length === 1) {
+    return res.redirect(`${req.baseUrl}/${userLocations[0].id}`)
   }
 
   next()
@@ -34,7 +31,8 @@ function setSelectedLocation(req, locationKey, locationValue) {
 function setLocation(req, res, next) {
   const { locationId } = req.params
 
-  const location = find(req.userLocations, { id: locationId })
+  const userLocations = get(req.session, 'user.locations', [])
+  const location = find(userLocations, { id: locationId })
 
   if (!location) {
     return next(getError('Location'))
@@ -76,7 +74,6 @@ function setHasSelectedLocation(req, res, next) {
 }
 
 const external = {
-  setUserLocations,
   checkLocationsLength,
   setLocation,
   setRegion,

--- a/app/locations/middleware.test.js
+++ b/app/locations/middleware.test.js
@@ -24,58 +24,15 @@ const mockUserLocations = [
 describe('Locations middleware', function () {
   let req, res, nextSpy
 
-  describe('#setUserLocations', function () {
-    beforeEach(function () {
-      req = {
-        session: {},
-      }
-      res = {
-        redirect: sinon.spy(),
-      }
-      nextSpy = sinon.spy()
-    })
-
-    context('when no user exists on session', function () {
-      beforeEach(function () {
-        middleware.setUserLocations(req, res, nextSpy)
-      })
-
-      it('should set empty user locations on request', function () {
-        expect(req).to.have.property('userLocations')
-        expect(req.userLocations).to.be.an('array').that.is.empty
-      })
-
-      it('should call next', function () {
-        expect(nextSpy).to.be.calledOnceWithExactly()
-      })
-    })
-
-    context('when locations exists on user', function () {
-      beforeEach(function () {
-        req.session.user = {
-          locations: mockUserLocations,
-        }
-
-        middleware.setUserLocations(req, res, nextSpy)
-      })
-
-      it('should set locations on request', function () {
-        expect(req).to.have.property('userLocations')
-        expect(req.userLocations).to.deep.equal(mockUserLocations)
-      })
-
-      it('should call next', function () {
-        expect(nextSpy).to.be.calledOnceWithExactly()
-      })
-    })
-  })
-
   describe('#checkLocationsLength', function () {
     const baseUrl = '/locations'
 
     beforeEach(function () {
       req = {
         baseUrl,
+        session: {
+          user: {},
+        },
       }
       res = {
         redirect: sinon.spy(),
@@ -85,13 +42,13 @@ describe('Locations middleware', function () {
 
     context('when user only has one location', function () {
       beforeEach(function () {
-        req.userLocations = mockUserLocations.slice(0, 1)
+        req.session.user.locations = mockUserLocations.slice(0, 1)
         middleware.checkLocationsLength(req, res, nextSpy)
       })
 
       it('should redirect to location ID', function () {
         expect(res.redirect).to.be.calledOnceWithExactly(
-          `${baseUrl}/${req.userLocations[0].id}`
+          `${baseUrl}/${req.session.user.locations[0].id}`
         )
       })
 
@@ -102,7 +59,7 @@ describe('Locations middleware', function () {
 
     context('when user has multiple locations', function () {
       beforeEach(function () {
-        req.userLocations = mockUserLocations
+        req.session.user.locations = mockUserLocations
         middleware.checkLocationsLength(req, res, nextSpy)
       })
 
@@ -117,7 +74,7 @@ describe('Locations middleware', function () {
 
     context('when user has no locations', function () {
       beforeEach(function () {
-        req.userLocations = []
+        req.session.user.locations = []
         middleware.checkLocationsLength(req, res, nextSpy)
       })
 
@@ -134,7 +91,7 @@ describe('Locations middleware', function () {
   describe('#setLocation', function () {
     let nextSpy
 
-    const originalSession = {}
+    const originalSession = { user: {} }
     beforeEach(function () {
       sinon.stub(middleware, 'setSelectedLocation')
       req = {
@@ -148,7 +105,7 @@ describe('Locations middleware', function () {
     context('when locationId is not found in user locations', function () {
       beforeEach(function () {
         req.params.locationId = 'not_authorised'
-        req.userLocations = mockUserLocations
+        req.session.user.locations = mockUserLocations
 
         middleware.setLocation(req, {}, nextSpy)
       })
@@ -166,7 +123,7 @@ describe('Locations middleware', function () {
     context('when locationId is found in user locations', function () {
       beforeEach(function () {
         req.params.locationId = mockUserLocations[0].id
-        req.userLocations = mockUserLocations
+        req.session.user.locations = mockUserLocations
 
         middleware.setLocation(req, {}, nextSpy)
       })


### PR DESCRIPTION
## Proposed changes

### What changed

We now populate the locations for supply users when the session is generated, rather than when they visit the locations page.

### Why did it change

We think that supplier users are losing their locations when their authentication session needs regenerating because they don't visit the locations page.

### Issue tracking

- [P4-2975](https://dsdmoj.atlassian.net/browse/P4-2975)

## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

- [x] No environment variables were added or changed