### PR TITLE
Avoid fetching unnecessary locations for supplier locations

### DIFF
--- a/app/auth/middleware.js
+++ b/app/auth/middleware.js
@@ -6,7 +6,7 @@ const {
   getFullname,
   getLocations,
   getSupplierId,
-  populateSupplierLocations,
+  getSupplierLocations,
 } = require('../../common/services/user')
 
 function processAuthResponse() {
@@ -39,7 +39,11 @@ function processAuthResponse() {
         supplierId,
       })
 
-      await populateSupplierLocations(user)
+      const supplierLocations = await getSupplierLocations(user)
+
+      if (supplierLocations) {
+        user.locations = supplierLocations
+      }
 
       req.session.regenerate(error => {
         if (error) {

--- a/app/auth/middleware.test.js
+++ b/app/auth/middleware.test.js
@@ -5,25 +5,16 @@ const userSuccessStub = {
   getLocations: () => Promise.resolve(['TEST']),
   getFullname: () => Promise.resolve('Mr Benn'),
   getSupplierId: () => Promise.resolve('undefined'),
-  getSupplierLocations: () => Promise.resolve(['SUPPLIER_TEST']),
 }
 const userLocationsFailureStub = {
   getLocations: () => Promise.reject(userFailureError),
   getFullname: () => Promise.resolve('Mr Benn'),
   getSupplierId: () => Promise.resolve('undefined'),
-  getSupplierLocations: () => Promise.resolve(null),
 }
 const userFullNameFailureStub = {
   getLocations: () => Promise.resolve(['TEST']),
   getFullname: () => Promise.reject(userFailureError),
   getSupplierId: () => Promise.resolve('undefined'),
-  getSupplierLocations: () => Promise.resolve(null),
-}
-const userSupplierLocationsFailureStub = {
-  getLocations: () => Promise.resolve(['TEST']),
-  getFullname: () => Promise.reject(userFailureError),
-  getSupplierId: () => Promise.resolve('undefined'),
-  getSupplierLocations: () => Promise.reject(userFailureError),
 }
 
 const expiryTime = 1000
@@ -139,24 +130,6 @@ describe('Authentication middleware', function () {
         })
       })
 
-      context('when the user supplier locations lookup fails', function () {
-        beforeEach(async function () {
-          const authentication = proxyquire('./middleware', {
-            '../../common/services/user': userSupplierLocationsFailureStub,
-          })
-
-          await authentication.processAuthResponse()(req, {}, nextSpy)
-        })
-
-        it('calls with with error', function () {
-          expect(nextSpy).to.be.calledOnceWithExactly(userFailureError)
-        })
-
-        it('doesn’t regenerate the session', function () {
-          expect(req.session.regenerate).not.to.be.called
-        })
-      })
-
       context('when the user locations lookup succeeds', function () {
         let authentication
 
@@ -202,7 +175,7 @@ describe('Authentication middleware', function () {
 
           it('sets the user info on the session', function () {
             expect(Array.isArray(req.session.user.permissions)).to.be.true
-            expect(req.session.user.locations).to.deep.equal(['SUPPLIER_TEST'])
+            expect(req.session.user.locations).to.deep.equal(['TEST'])
             expect(req.session.user.fullname).to.equal('Mr Benn')
           })
 

--- a/app/auth/middleware.test.js
+++ b/app/auth/middleware.test.js
@@ -1,30 +1,16 @@
 const proxyquire = require('proxyquire')
 
+const userSuccessStub = { loadUser: () => Promise.resolve('user') }
 const userFailureError = new Error('test')
-const userSuccessStub = {
-  getLocations: () => Promise.resolve(['TEST']),
-  getFullname: () => Promise.resolve('Mr Benn'),
-  getSupplierId: () => Promise.resolve('undefined'),
-}
-const userLocationsFailureStub = {
-  getLocations: () => Promise.reject(userFailureError),
-  getFullname: () => Promise.resolve('Mr Benn'),
-  getSupplierId: () => Promise.resolve('undefined'),
-}
-const userFullNameFailureStub = {
-  getLocations: () => Promise.resolve(['TEST']),
-  getFullname: () => Promise.reject(userFailureError),
-  getSupplierId: () => Promise.resolve('undefined'),
-}
+const userFailureStub = { loadUser: () => Promise.reject(userFailureError) }
 
 const expiryTime = 1000
-const payload = {
-  user_name: 'test',
-  test: 'test',
-  authorities: ['test'],
-  exp: expiryTime,
-}
-const encodedPayload = Buffer.from(JSON.stringify(payload)).toString('base64')
+
+const encodedAccessTokenPayload = Buffer.from(
+  JSON.stringify({ exp: expiryTime })
+).toString('base64')
+
+const accessToken = `test.${encodedAccessTokenPayload}.test`
 
 describe('Authentication middleware', function () {
   describe('#processAuthResponse', function () {
@@ -47,7 +33,7 @@ describe('Authentication middleware', function () {
     context('when there is no grant in session', function () {
       beforeEach(async function () {
         const authentication = proxyquire('./middleware', {
-          '../../common/services/user': userSuccessStub,
+          '../../common/lib/user': userSuccessStub,
         })
 
         await authentication.processAuthResponse()(req, {}, nextSpy)
@@ -70,7 +56,7 @@ describe('Authentication middleware', function () {
       beforeEach(async function () {
         req.session.grant = {}
         const authentication = proxyquire('./middleware', {
-          '../../common/services/user': userSuccessStub,
+          '../../common/lib/user': userSuccessStub,
         })
 
         await authentication.processAuthResponse()(req, {}, nextSpy)
@@ -91,37 +77,19 @@ describe('Authentication middleware', function () {
 
     context('when there is a grant response', function () {
       beforeEach(function () {
-        req.session.grant = {
-          response: {
-            access_token: `test.${encodedPayload}.test`,
-          },
-        }
+        req.session.grant = { response: { access_token: accessToken } }
       })
 
-      context('when the user locations lookup fails', function () {
+      context('when the user lookup fails', function () {
         beforeEach(async function () {
           const authentication = proxyquire('./middleware', {
-            '../../common/services/user': userLocationsFailureStub,
+            '../../common/lib/user': userFailureStub,
           })
 
           await authentication.processAuthResponse()(req, {}, nextSpy)
         })
 
-        it('returns next', function () {
-          expect(nextSpy).to.be.calledOnceWithExactly(userFailureError)
-        })
-      })
-
-      context('when the user fullname lookup fails', function () {
-        beforeEach(async function () {
-          const authentication = proxyquire('./middleware', {
-            '../../common/services/user': userFullNameFailureStub,
-          })
-
-          await authentication.processAuthResponse()(req, {}, nextSpy)
-        })
-
-        it('calls with with error', function () {
+        it('calls next with error', function () {
           expect(nextSpy).to.be.calledOnceWithExactly(userFailureError)
         })
 
@@ -130,12 +98,12 @@ describe('Authentication middleware', function () {
         })
       })
 
-      context('when the user locations lookup succeeds', function () {
+      context('when the user lookup succeeds', function () {
         let authentication
 
         beforeEach(function () {
           authentication = proxyquire('./middleware', {
-            '../../common/services/user': userSuccessStub,
+            '../../common/lib/user': userSuccessStub,
           })
         })
 
@@ -174,9 +142,7 @@ describe('Authentication middleware', function () {
           })
 
           it('sets the user info on the session', function () {
-            expect(Array.isArray(req.session.user.permissions)).to.be.true
-            expect(req.session.user.locations).to.deep.equal(['TEST'])
-            expect(req.session.user.fullname).to.equal('Mr Benn')
+            expect(req.session.user).to.equal('user')
           })
 
           it('sets the redirect URL in the session', function () {

--- a/app/auth/middleware.test.js
+++ b/app/auth/middleware.test.js
@@ -26,20 +26,6 @@ const userSupplierLocationsFailureStub = {
   getSupplierLocations: () => Promise.reject(userFailureError),
 }
 
-function UserStub({
-  fullname,
-  roles = [],
-  locations = [],
-  username,
-  userId,
-} = {}) {
-  this.fullname = fullname
-  this.permissions = []
-  this.locations = locations
-  this.username = username
-  this.userId = userId
-}
-
 const expiryTime = 1000
 const payload = {
   user_name: 'test',
@@ -70,7 +56,6 @@ describe('Authentication middleware', function () {
     context('when there is no grant in session', function () {
       beforeEach(async function () {
         const authentication = proxyquire('./middleware', {
-          '../../common/lib/user': UserStub,
           '../../common/services/user': userSuccessStub,
         })
 
@@ -94,7 +79,6 @@ describe('Authentication middleware', function () {
       beforeEach(async function () {
         req.session.grant = {}
         const authentication = proxyquire('./middleware', {
-          '../../common/lib/user': UserStub,
           '../../common/services/user': userSuccessStub,
         })
 
@@ -140,7 +124,6 @@ describe('Authentication middleware', function () {
       context('when the user fullname lookup fails', function () {
         beforeEach(async function () {
           const authentication = proxyquire('./middleware', {
-            '../../common/lib/user': UserStub,
             '../../common/services/user': userFullNameFailureStub,
           })
 
@@ -159,7 +142,6 @@ describe('Authentication middleware', function () {
       context('when the user supplier locations lookup fails', function () {
         beforeEach(async function () {
           const authentication = proxyquire('./middleware', {
-            '../../common/lib/user': UserStub,
             '../../common/services/user': userSupplierLocationsFailureStub,
           })
 
@@ -180,7 +162,6 @@ describe('Authentication middleware', function () {
 
         beforeEach(function () {
           authentication = proxyquire('./middleware', {
-            '../../common/lib/user': UserStub,
             '../../common/services/user': userSuccessStub,
           })
         })

--- a/app/auth/middleware.test.js
+++ b/app/auth/middleware.test.js
@@ -5,25 +5,25 @@ const userSuccessStub = {
   getLocations: () => Promise.resolve(['TEST']),
   getFullname: () => Promise.resolve('Mr Benn'),
   getSupplierId: () => Promise.resolve('undefined'),
-  populateSupplierLocations: async user => user.locations.push('SUPPLIER_TEST'),
+  getSupplierLocations: () => Promise.resolve(['SUPPLIER_TEST']),
 }
 const userLocationsFailureStub = {
   getLocations: () => Promise.reject(userFailureError),
   getFullname: () => Promise.resolve('Mr Benn'),
   getSupplierId: () => Promise.resolve('undefined'),
-  populateSupplierLocations: () => Promise.resolve(),
+  getSupplierLocations: () => Promise.resolve(null),
 }
 const userFullNameFailureStub = {
   getLocations: () => Promise.resolve(['TEST']),
   getFullname: () => Promise.reject(userFailureError),
   getSupplierId: () => Promise.resolve('undefined'),
-  populateSupplierLocations: () => Promise.resolve(),
+  getSupplierLocations: () => Promise.resolve(null),
 }
 const userSupplierLocationsFailureStub = {
   getLocations: () => Promise.resolve(['TEST']),
   getFullname: () => Promise.reject(userFailureError),
   getSupplierId: () => Promise.resolve('undefined'),
-  populateSupplierLocations: () => Promise.reject(userFailureError),
+  getSupplierLocations: () => Promise.reject(userFailureError),
 }
 
 function UserStub({
@@ -221,10 +221,7 @@ describe('Authentication middleware', function () {
 
           it('sets the user info on the session', function () {
             expect(Array.isArray(req.session.user.permissions)).to.be.true
-            expect(req.session.user.locations).to.deep.equal([
-              'TEST',
-              'SUPPLIER_TEST',
-            ])
+            expect(req.session.user.locations).to.deep.equal(['SUPPLIER_TEST'])
             expect(req.session.user.fullname).to.equal('Mr Benn')
           })
 

--- a/app/tools/controllers.js
+++ b/app/tools/controllers.js
@@ -1,7 +1,10 @@
 const faker = require('faker')
-const { camelCase, uniq } = require('lodash')
+const { camelCase } = require('lodash')
 
-const { permissionsByRole } = require('../../common/lib/permissions')
+const {
+  permissionsByRole,
+  rolesToPermissions,
+} = require('../../common/lib/permissions')
 const { generateAssessmentRespones } = require('../../mocks/assessment')
 
 const permittedActions = {
@@ -30,7 +33,7 @@ function renderPermissions(req, res) {
 
 function updatePermissions(req, res) {
   const roles = req.body.roles || []
-  const permissions = uniq(roles.map(role => permissionsByRole[role]).flat())
+  const permissions = rolesToPermissions(roles)
 
   req.session.activeRoles = roles
 

--- a/app/tools/controllers.test.js
+++ b/app/tools/controllers.test.js
@@ -1,5 +1,7 @@
 const proxyquire = require('proxyquire')
 
+const { rolesToPermissions } = require('../../common/lib/permissions')
+
 const permissionsStub = {
   permissionsByRole: {
     foo: ['one', 'two'],
@@ -7,6 +9,8 @@ const permissionsStub = {
     fizz: ['two'],
     buzz: ['two', 'three', 'one', 'four'],
   },
+  rolesToPermissions: roles =>
+    rolesToPermissions(roles, permissionsStub.permissionsByRole),
 }
 const mockDataStub = {
   generateAssessmentRespones: sinon.stub().returns(['fizz', 'buzz']),

--- a/common/lib/permissions.js
+++ b/common/lib/permissions.js
@@ -1,3 +1,5 @@
+const { uniq } = require('lodash')
+
 const policePermissions = [
   'dashboard:view',
   'moves:view:outgoing',
@@ -219,6 +221,10 @@ const permissionsByRole = {
   ROLE_PECS_READ_ONLY: readOnlyPermissions,
 }
 
+const rolesToPermissions = (roles, mapping = permissionsByRole) =>
+  uniq(roles.map(role => mapping[role] || []).flat())
+
 module.exports = {
   permissionsByRole,
+  rolesToPermissions,
 }

--- a/common/lib/permissions.test.js
+++ b/common/lib/permissions.test.js
@@ -1,0 +1,422 @@
+const { rolesToPermissions } = require('./permissions')
+
+describe('Permissions', function () {
+  describe('#rolesToPermissions', function () {
+    let permissions
+
+    context('when there are no roles', function () {
+      beforeEach(function () {
+        permissions = rolesToPermissions([])
+      })
+
+      it('should contain empty permissions', function () {
+        expect(permissions).to.have.members([])
+      })
+    })
+
+    context('when user has ROLE_PECS_POLICE', function () {
+      beforeEach(function () {
+        permissions = rolesToPermissions(['ROLE_PECS_POLICE'])
+      })
+
+      it('should contain correct permission', function () {
+        const policePermissions = [
+          'dashboard:view',
+          'moves:view:outgoing',
+          'moves:view:incoming',
+          'moves:download',
+          'move:view',
+          'move:create',
+          'move:create:court_appearance',
+          'move:create:hospital',
+          'move:create:prison_recall',
+          'move:create:police_transfer',
+          'move:create:video_remand',
+          'move:cancel',
+          'move:update',
+          'move:update:court_appearance',
+          'move:update:hospital',
+          'move:update:prison_transfer',
+          'move:update:secure_childrens_home',
+          'move:update:secure_training_centre',
+          'move:update:prison_recall',
+          'move:update:police_transfer',
+          'move:update:video_remand',
+          'person_escort_record:view',
+          'person_escort_record:create',
+          'person_escort_record:update',
+          'person_escort_record:confirm',
+          'person_escort_record:print',
+        ]
+
+        expect(permissions).to.have.members(policePermissions)
+      })
+    })
+
+    context('when user has ROLE_PECS_HMYOI', function () {
+      beforeEach(function () {
+        permissions = rolesToPermissions(['ROLE_PECS_HMYOI'])
+      })
+
+      it('should contain correct permission', function () {
+        expect(permissions).to.have.members([
+          'dashboard:view',
+          'moves:view:outgoing',
+          'moves:view:incoming',
+          'moves:download',
+          'move:view',
+          'move:create',
+          'move:create:court_appearance',
+          'move:create:hospital',
+          'move:cancel',
+          'person_escort_record:view',
+          'person_escort_record:create',
+          'person_escort_record:update',
+          'person_escort_record:confirm',
+          'person_escort_record:print',
+          'youth_risk_assessment:view',
+          'youth_risk_assessment:create',
+          'youth_risk_assessment:update',
+          'youth_risk_assessment:confirm',
+          'youth_risk_assessment:print',
+        ])
+      })
+    })
+
+    context('when user has ROLE_PECS_STC', function () {
+      beforeEach(function () {
+        permissions = rolesToPermissions(['ROLE_PECS_STC'])
+      })
+
+      it('should contain correct permission', function () {
+        const stcPermissions = [
+          'dashboard:view',
+          'moves:view:outgoing',
+          'moves:view:incoming',
+          'moves:view:proposed',
+          'moves:download',
+          'move:view',
+          'move:create',
+          'move:create:court_appearance',
+          'move:create:hospital',
+          'move:create:prison_transfer',
+          'move:create:secure_childrens_home',
+          'move:create:secure_training_centre',
+          'move:update',
+          'move:update:court_appearance',
+          'move:update:hospital',
+          'move:cancel',
+          'move:cancel:proposed',
+          'person_escort_record:view',
+          'person_escort_record:create',
+          'person_escort_record:update',
+          'person_escort_record:confirm',
+          'person_escort_record:print',
+          'youth_risk_assessment:view',
+          'youth_risk_assessment:create',
+          'youth_risk_assessment:update',
+          'youth_risk_assessment:confirm',
+          'youth_risk_assessment:print',
+        ]
+
+        expect(permissions).to.have.members(stcPermissions)
+      })
+    })
+
+    context('when user has ROLE_PECS_SCH', function () {
+      beforeEach(function () {
+        permissions = rolesToPermissions(['ROLE_PECS_SCH'])
+      })
+
+      it('should contain correct permission', function () {
+        expect(permissions).to.have.members([
+          'dashboard:view',
+          'moves:view:outgoing',
+          'moves:view:incoming',
+          'moves:view:proposed',
+          'moves:download',
+          'move:view',
+          'move:create',
+          'move:create:court_appearance',
+          'move:create:hospital',
+          'move:create:prison_transfer',
+          'move:create:secure_childrens_home',
+          'move:create:secure_training_centre',
+          'move:update',
+          'move:update:court_appearance',
+          'move:update:hospital',
+          'move:cancel',
+          'move:cancel:proposed',
+          'person_escort_record:view',
+          'person_escort_record:create',
+          'person_escort_record:update',
+          'person_escort_record:confirm',
+          'person_escort_record:print',
+          'youth_risk_assessment:view',
+          'youth_risk_assessment:create',
+          'youth_risk_assessment:update',
+          'youth_risk_assessment:confirm',
+          'youth_risk_assessment:print',
+        ])
+      })
+    })
+
+    context('when user has ROLE_PECS_PRISON', function () {
+      beforeEach(function () {
+        permissions = rolesToPermissions(['ROLE_PECS_PRISON'])
+      })
+
+      it('should contain correct permission', function () {
+        expect(permissions).to.have.members([
+          'dashboard:view',
+          'moves:view:outgoing',
+          'moves:view:incoming',
+          'moves:download',
+          'move:view',
+          'move:create',
+          'move:create:court_appearance',
+          'move:create:hospital',
+          'move:cancel',
+          'person_escort_record:view',
+          'person_escort_record:create',
+          'person_escort_record:update',
+          'person_escort_record:confirm',
+          'person_escort_record:print',
+          'youth_risk_assessment:view',
+          'youth_risk_assessment:create',
+          'youth_risk_assessment:update',
+          'youth_risk_assessment:confirm',
+          'youth_risk_assessment:print',
+        ])
+      })
+    })
+
+    context('when user has ROLE_PECS_OCA', function () {
+      beforeEach(function () {
+        permissions = rolesToPermissions(['ROLE_PECS_OCA'])
+      })
+
+      it('should contain correct permission', function () {
+        expect(permissions).to.have.members([
+          'dashboard:view',
+          'allocations:view',
+          'allocation:person:assign',
+          'moves:view:proposed',
+          'moves:download',
+          'move:cancel:proposed',
+          'move:view',
+          'move:create',
+          'move:create:prison_transfer',
+          'move:create:secure_childrens_home',
+          'move:create:secure_training_centre',
+          'person_escort_record:view',
+          'person_escort_record:create',
+          'person_escort_record:update',
+          'person_escort_record:confirm',
+          'person_escort_record:print',
+        ])
+      })
+    })
+
+    context('when user has ROLE_PECS_PMU', function () {
+      beforeEach(function () {
+        permissions = rolesToPermissions(['ROLE_PECS_PMU'])
+      })
+
+      it('should contain correct permission', function () {
+        expect(permissions).to.have.members([
+          'allocations:view',
+          'allocation:create',
+          'allocation:cancel',
+          'dashboard:view',
+          'dashboard:view:population',
+          'locations:all',
+          'moves:view:proposed',
+          'move:review',
+          'move:view',
+          'person_escort_record:view',
+          'person_escort_record:print',
+          'youth_risk_assessment:view',
+          'youth_risk_assessment:print',
+        ])
+      })
+    })
+
+    context('when user has ROLE_PECS_SUPPLIER role', function () {
+      beforeEach(function () {
+        permissions = rolesToPermissions(['ROLE_PECS_SUPPLIER'])
+      })
+
+      it('should contain correct permission', function () {
+        expect(permissions).to.have.members([
+          'locations:all',
+          'moves:view:outgoing',
+          'moves:view:incoming',
+          'moves:download',
+          'move:view',
+          'person_escort_record:view',
+          'person_escort_record:print',
+          'youth_risk_assessment:view',
+          'youth_risk_assessment:print',
+        ])
+      })
+    })
+
+    context('when user has ROLE_PECS_COURT role', function () {
+      beforeEach(function () {
+        permissions = rolesToPermissions(['ROLE_PECS_COURT'])
+      })
+
+      it('should contain correct permission', function () {
+        expect(permissions).to.have.members([
+          'dashboard:view',
+          'moves:view:outgoing',
+          'moves:view:incoming',
+          'moves:download',
+          'move:view',
+          'person_escort_record:view',
+          'youth_risk_assessment:view',
+          'youth_risk_assessment:print',
+        ])
+      })
+    })
+
+    context('when user has ROLE_PECS_PER_AUTHOR role', function () {
+      beforeEach(function () {
+        permissions = rolesToPermissions(['ROLE_PECS_PER_AUTHOR'])
+      })
+
+      it('should contain correct permission', function () {
+        expect(permissions).to.have.members([
+          'person_escort_record:view',
+          'person_escort_record:create',
+          'person_escort_record:update',
+          'person_escort_record:confirm',
+          'person_escort_record:print',
+          'dashboard:view',
+          'moves:view:outgoing',
+          'moves:view:incoming',
+          'move:view',
+        ])
+      })
+    })
+
+    context('when user has ROLE_PECS_CDM role', function () {
+      beforeEach(function () {
+        permissions = rolesToPermissions(['ROLE_PECS_CDM'])
+      })
+
+      it('should contain correct permission', function () {
+        expect(permissions).to.have.members([
+          'dashboard:view',
+          'allocations:view',
+          'locations:contract_delivery_manager',
+          'locations:all',
+          'moves:view:outgoing',
+          'moves:view:incoming',
+          'moves:view:proposed',
+          'move:view',
+          'move:view:journeys',
+          'person_escort_record:view',
+          'person_escort_record:print',
+          'youth_risk_assessment:view',
+          'youth_risk_assessment:print',
+        ])
+      })
+    })
+
+    context('when user has ROLE_PECS_READ_ONLY role', function () {
+      beforeEach(function () {
+        permissions = rolesToPermissions(['ROLE_PECS_READ_ONLY'])
+      })
+
+      it('should contain correct permission', function () {
+        expect(permissions).to.have.members([
+          'dashboard:view',
+          'allocations:view',
+          'locations:contract_delivery_manager',
+          'locations:all',
+          'moves:view:outgoing',
+          'moves:view:incoming',
+          'moves:view:proposed',
+          'move:view',
+          'person_escort_record:view',
+          'person_escort_record:print',
+          'youth_risk_assessment:view',
+          'youth_risk_assessment:print',
+        ])
+      })
+    })
+
+    context('when user has all roles', function () {
+      beforeEach(function () {
+        permissions = rolesToPermissions([
+          'ROLE_PECS_POLICE',
+          'ROLE_PECS_PRISON',
+          'ROLE_PECS_SUPPLIER',
+          'ROLE_PECS_STC',
+          'ROLE_PECS_SCH',
+          'ROLE_PECS_OCA',
+          'ROLE_PECS_PMU',
+          'ROLE_PECS_HMYOI',
+          'ROLE_PECS_COURT',
+          'ROLE_PECS_PER_AUTHOR',
+          'ROLE_PECS_CDM',
+          'ROLE_PECS_READ_ONLY',
+        ])
+      })
+
+      it('should contain correct permission', function () {
+        const allPermissions = [
+          'allocations:view',
+          'allocation:create',
+          'allocation:person:assign',
+          'allocation:cancel',
+          'moves:view:outgoing',
+          'moves:view:incoming',
+          'moves:download',
+          'move:review',
+          'move:view',
+          'move:create',
+          'move:create:court_appearance',
+          'move:create:prison_recall',
+          'move:create:police_transfer',
+          'move:create:hospital',
+          'move:create:secure_childrens_home',
+          'move:create:secure_training_centre',
+          'move:create:video_remand',
+          'move:cancel',
+          'move:update',
+          'move:update:court_appearance',
+          'move:update:hospital',
+          'move:update:prison_transfer',
+          'move:update:secure_childrens_home',
+          'move:update:secure_training_centre',
+          'move:update:prison_recall',
+          'move:update:police_transfer',
+          'move:update:video_remand',
+          'move:view:journeys',
+          'locations:all',
+          'locations:contract_delivery_manager',
+          'dashboard:view',
+          'dashboard:view:population',
+          'move:cancel:proposed',
+          'moves:view:proposed',
+          'move:create:prison_transfer',
+          'person_escort_record:view',
+          'person_escort_record:create',
+          'person_escort_record:update',
+          'person_escort_record:confirm',
+          'person_escort_record:print',
+          'youth_risk_assessment:view',
+          'youth_risk_assessment:create',
+          'youth_risk_assessment:update',
+          'youth_risk_assessment:confirm',
+          'youth_risk_assessment:print',
+        ]
+
+        expect(permissions).to.have.members(allPermissions)
+      })
+    })
+  })
+})

--- a/common/lib/user.js
+++ b/common/lib/user.js
@@ -1,6 +1,4 @@
-const { uniq } = require('lodash')
-
-const { permissionsByRole } = require('./permissions')
+const { rolesToPermissions } = require('./permissions')
 
 const forenameToInitial = name => {
   if (!name) {
@@ -20,21 +18,11 @@ function User({
 } = {}) {
   this.fullname = fullname
   this.displayName = forenameToInitial(fullname)
-  this.permissions = this.getPermissions(roles)
+  this.permissions = rolesToPermissions(roles)
   this.locations = locations
   this.username = username
   this.id = userId
   this.supplierId = supplierId
-}
-
-User.prototype = {
-  getPermissions(roles = []) {
-    const permissions = roles.reduce((accumulator, role) => {
-      const additionalPermissions = permissionsByRole[role] || []
-      return [...accumulator, ...additionalPermissions]
-    }, [])
-    return uniq(permissions)
-  },
 }
 
 module.exports = User

--- a/common/lib/user.js
+++ b/common/lib/user.js
@@ -8,21 +8,15 @@ const forenameToInitial = name => {
   return `${name.charAt()}. ${name.split(' ').pop()}`
 }
 
-function User({
-  fullname,
-  roles = [],
-  locations = [],
-  username,
-  userId,
-  supplierId,
-} = {}) {
+function User({ fullname, roles = [], username, userId, supplierId } = {}) {
   this.fullname = fullname
   this.displayName = forenameToInitial(fullname)
   this.permissions = rolesToPermissions(roles)
-  this.locations = locations
   this.username = username
   this.id = userId
   this.supplierId = supplierId
+
+  this.locations = []
 }
 
 module.exports = User

--- a/common/lib/user.test.js
+++ b/common/lib/user.test.js
@@ -3,7 +3,6 @@ const User = require('./user')
 describe('User class', function () {
   describe('when instantiated', function () {
     let user
-    let locations
     let fullname
 
     context('with fullname', function () {
@@ -57,23 +56,8 @@ describe('User class', function () {
       })
     })
 
-    context('with locations', function () {
-      beforeEach(function () {
-        locations = ['PECS_TEST']
-      })
-
-      it('should set locations', function () {
-        user = new User({ name: 'USERNAME', roles: [], locations })
-        expect(user.locations).to.deep.equal(locations)
-      })
-    })
-
-    context('without locations', function () {
-      it('should set locations to empty array', function () {
-        user = new User()
-
-        expect(user.locations).to.deep.equal([])
-      })
+    it('should set locations to empty array', function () {
+      expect(new User().locations).to.be.an('array').that.is.empty
     })
 
     context('with username', function () {

--- a/common/lib/user.test.js
+++ b/common/lib/user.test.js
@@ -3,7 +3,6 @@ const User = require('./user')
 describe('User class', function () {
   describe('when instantiated', function () {
     let user
-    let roles
     let locations
     let fullname
 
@@ -26,31 +25,35 @@ describe('User class', function () {
 
     context('with roles', function () {
       beforeEach(function () {
-        sinon.stub(User.prototype, 'getPermissions').returnsArg(0)
-        roles = ['ROLE_PECS_SUPPLIER']
+        user = new User({
+          roles: ['ROLE_PECS_SUPPLIER'],
+        })
       })
 
       it('should set permissions', function () {
-        user = new User({ name: 'USERNAME', roles })
-        expect(Array.isArray(user.permissions)).to.be.true
+        expect(user.permissions).to.not.be.empty
       })
     })
 
     context('without roles', function () {
-      it('should set permissions to empty array', function () {
-        user = new User()
+      beforeEach(function () {
+        user = new User({ roles: [] })
+      })
 
-        expect(user.permissions).to.deep.equal([])
+      it('should set permissions to empty array', function () {
+        expect(user.permissions).to.be.an('array').that.is.empty
       })
     })
 
     context("with a role that isn't expected", function () {
-      it('should set permissions to an empty array for unknown roles', function () {
+      beforeEach(function () {
         user = new User({
           roles: ['ROLE_PECS_UNKNOWN'],
         })
+      })
 
-        expect(user.permissions).to.deep.equal([])
+      it('should set permissions to an empty array for unknown roles', function () {
+        expect(user.permissions).to.be.an('array').that.is.empty
       })
     })
 
@@ -97,429 +100,6 @@ describe('User class', function () {
       it('should set supplierId', function () {
         user = new User({ name: 'USERNAME', supplierId })
         expect(user.supplierId).to.deep.equal(supplierId)
-      })
-    })
-  })
-
-  describe('#getPermissions()', function () {
-    let user, permissions
-
-    beforeEach(function () {
-      user = new User()
-    })
-
-    context('when user has no roles', function () {
-      beforeEach(function () {
-        permissions = user.getPermissions()
-      })
-
-      it('should contain empty permissions', function () {
-        expect(permissions).to.have.members([])
-      })
-    })
-
-    context('when user has ROLE_PECS_POLICE', function () {
-      beforeEach(function () {
-        permissions = user.getPermissions(['ROLE_PECS_POLICE'])
-      })
-
-      it('should contain correct permission', function () {
-        const policePermissions = [
-          'dashboard:view',
-          'moves:view:outgoing',
-          'moves:view:incoming',
-          'moves:download',
-          'move:view',
-          'move:create',
-          'move:create:court_appearance',
-          'move:create:hospital',
-          'move:create:prison_recall',
-          'move:create:police_transfer',
-          'move:create:video_remand',
-          'move:cancel',
-          'move:update',
-          'move:update:court_appearance',
-          'move:update:hospital',
-          'move:update:prison_transfer',
-          'move:update:secure_childrens_home',
-          'move:update:secure_training_centre',
-          'move:update:prison_recall',
-          'move:update:police_transfer',
-          'move:update:video_remand',
-          'person_escort_record:view',
-          'person_escort_record:create',
-          'person_escort_record:update',
-          'person_escort_record:confirm',
-          'person_escort_record:print',
-        ]
-
-        expect(permissions).to.have.members(policePermissions)
-      })
-    })
-
-    context('when user has ROLE_PECS_HMYOI', function () {
-      beforeEach(function () {
-        permissions = user.getPermissions(['ROLE_PECS_HMYOI'])
-      })
-
-      it('should contain correct permission', function () {
-        expect(permissions).to.have.members([
-          'dashboard:view',
-          'moves:view:outgoing',
-          'moves:view:incoming',
-          'moves:download',
-          'move:view',
-          'move:create',
-          'move:create:court_appearance',
-          'move:create:hospital',
-          'move:cancel',
-          'person_escort_record:view',
-          'person_escort_record:create',
-          'person_escort_record:update',
-          'person_escort_record:confirm',
-          'person_escort_record:print',
-          'youth_risk_assessment:view',
-          'youth_risk_assessment:create',
-          'youth_risk_assessment:update',
-          'youth_risk_assessment:confirm',
-          'youth_risk_assessment:print',
-        ])
-      })
-    })
-
-    context('when user has ROLE_PECS_STC', function () {
-      beforeEach(function () {
-        permissions = user.getPermissions(['ROLE_PECS_STC'])
-      })
-
-      it('should contain correct permission', function () {
-        const stcPermissions = [
-          'dashboard:view',
-          'moves:view:outgoing',
-          'moves:view:incoming',
-          'moves:view:proposed',
-          'moves:download',
-          'move:view',
-          'move:create',
-          'move:create:court_appearance',
-          'move:create:hospital',
-          'move:create:prison_transfer',
-          'move:create:secure_childrens_home',
-          'move:create:secure_training_centre',
-          'move:update',
-          'move:update:court_appearance',
-          'move:update:hospital',
-          'move:cancel',
-          'move:cancel:proposed',
-          'person_escort_record:view',
-          'person_escort_record:create',
-          'person_escort_record:update',
-          'person_escort_record:confirm',
-          'person_escort_record:print',
-          'youth_risk_assessment:view',
-          'youth_risk_assessment:create',
-          'youth_risk_assessment:update',
-          'youth_risk_assessment:confirm',
-          'youth_risk_assessment:print',
-        ]
-
-        expect(permissions).to.have.members(stcPermissions)
-      })
-    })
-
-    context('when user has ROLE_PECS_SCH', function () {
-      beforeEach(function () {
-        permissions = user.getPermissions(['ROLE_PECS_SCH'])
-      })
-
-      it('should contain correct permission', function () {
-        expect(permissions).to.have.members([
-          'dashboard:view',
-          'moves:view:outgoing',
-          'moves:view:incoming',
-          'moves:view:proposed',
-          'moves:download',
-          'move:view',
-          'move:create',
-          'move:create:court_appearance',
-          'move:create:hospital',
-          'move:create:prison_transfer',
-          'move:create:secure_childrens_home',
-          'move:create:secure_training_centre',
-          'move:update',
-          'move:update:court_appearance',
-          'move:update:hospital',
-          'move:cancel',
-          'move:cancel:proposed',
-          'person_escort_record:view',
-          'person_escort_record:create',
-          'person_escort_record:update',
-          'person_escort_record:confirm',
-          'person_escort_record:print',
-          'youth_risk_assessment:view',
-          'youth_risk_assessment:create',
-          'youth_risk_assessment:update',
-          'youth_risk_assessment:confirm',
-          'youth_risk_assessment:print',
-        ])
-      })
-    })
-
-    context('when user has ROLE_PECS_PRISON', function () {
-      beforeEach(function () {
-        permissions = user.getPermissions(['ROLE_PECS_PRISON'])
-      })
-
-      it('should contain correct permission', function () {
-        expect(permissions).to.have.members([
-          'dashboard:view',
-          'moves:view:outgoing',
-          'moves:view:incoming',
-          'moves:download',
-          'move:view',
-          'move:create',
-          'move:create:court_appearance',
-          'move:create:hospital',
-          'move:cancel',
-          'person_escort_record:view',
-          'person_escort_record:create',
-          'person_escort_record:update',
-          'person_escort_record:confirm',
-          'person_escort_record:print',
-          'youth_risk_assessment:view',
-          'youth_risk_assessment:create',
-          'youth_risk_assessment:update',
-          'youth_risk_assessment:confirm',
-          'youth_risk_assessment:print',
-        ])
-      })
-    })
-
-    context('when user has ROLE_PECS_OCA', function () {
-      beforeEach(function () {
-        permissions = user.getPermissions(['ROLE_PECS_OCA'])
-      })
-
-      it('should contain correct permission', function () {
-        expect(permissions).to.have.members([
-          'dashboard:view',
-          'allocations:view',
-          'allocation:person:assign',
-          'moves:view:proposed',
-          'moves:download',
-          'move:cancel:proposed',
-          'move:view',
-          'move:create',
-          'move:create:prison_transfer',
-          'move:create:secure_childrens_home',
-          'move:create:secure_training_centre',
-          'person_escort_record:view',
-          'person_escort_record:create',
-          'person_escort_record:update',
-          'person_escort_record:confirm',
-          'person_escort_record:print',
-        ])
-      })
-    })
-
-    context('when user has ROLE_PECS_PMU', function () {
-      beforeEach(function () {
-        permissions = user.getPermissions(['ROLE_PECS_PMU'])
-      })
-
-      it('should contain correct permission', function () {
-        expect(permissions).to.have.members([
-          'allocations:view',
-          'allocation:create',
-          'allocation:cancel',
-          'dashboard:view',
-          'dashboard:view:population',
-          'locations:all',
-          'moves:view:proposed',
-          'move:review',
-          'move:view',
-          'person_escort_record:view',
-          'person_escort_record:print',
-          'youth_risk_assessment:view',
-          'youth_risk_assessment:print',
-        ])
-      })
-    })
-
-    context('when user has ROLE_PECS_SUPPLIER role', function () {
-      beforeEach(function () {
-        permissions = user.getPermissions(['ROLE_PECS_SUPPLIER'])
-      })
-
-      it('should contain correct permission', function () {
-        expect(permissions).to.have.members([
-          'locations:all',
-          'moves:view:outgoing',
-          'moves:view:incoming',
-          'moves:download',
-          'move:view',
-          'person_escort_record:view',
-          'person_escort_record:print',
-          'youth_risk_assessment:view',
-          'youth_risk_assessment:print',
-        ])
-      })
-    })
-
-    context('when user has ROLE_PECS_COURT role', function () {
-      beforeEach(function () {
-        permissions = user.getPermissions(['ROLE_PECS_COURT'])
-      })
-
-      it('should contain correct permission', function () {
-        expect(permissions).to.have.members([
-          'dashboard:view',
-          'moves:view:outgoing',
-          'moves:view:incoming',
-          'moves:download',
-          'move:view',
-          'person_escort_record:view',
-          'youth_risk_assessment:view',
-          'youth_risk_assessment:print',
-        ])
-      })
-    })
-
-    context('when user has ROLE_PECS_PER_AUTHOR role', function () {
-      beforeEach(function () {
-        permissions = user.getPermissions(['ROLE_PECS_PER_AUTHOR'])
-      })
-
-      it('should contain correct permission', function () {
-        expect(permissions).to.have.members([
-          'person_escort_record:view',
-          'person_escort_record:create',
-          'person_escort_record:update',
-          'person_escort_record:confirm',
-          'person_escort_record:print',
-          'dashboard:view',
-          'moves:view:outgoing',
-          'moves:view:incoming',
-          'move:view',
-        ])
-      })
-    })
-
-    context('when user has ROLE_PECS_CDM role', function () {
-      beforeEach(function () {
-        permissions = user.getPermissions(['ROLE_PECS_CDM'])
-      })
-
-      it('should contain correct permission', function () {
-        expect(permissions).to.have.members([
-          'dashboard:view',
-          'allocations:view',
-          'locations:contract_delivery_manager',
-          'locations:all',
-          'moves:view:outgoing',
-          'moves:view:incoming',
-          'moves:view:proposed',
-          'move:view',
-          'move:view:journeys',
-          'person_escort_record:view',
-          'person_escort_record:print',
-          'youth_risk_assessment:view',
-          'youth_risk_assessment:print',
-        ])
-      })
-    })
-
-    context('when user has ROLE_PECS_READ_ONLY role', function () {
-      beforeEach(function () {
-        permissions = user.getPermissions(['ROLE_PECS_READ_ONLY'])
-      })
-
-      it('should contain correct permission', function () {
-        expect(permissions).to.have.members([
-          'dashboard:view',
-          'allocations:view',
-          'locations:contract_delivery_manager',
-          'locations:all',
-          'moves:view:outgoing',
-          'moves:view:incoming',
-          'moves:view:proposed',
-          'move:view',
-          'person_escort_record:view',
-          'person_escort_record:print',
-          'youth_risk_assessment:view',
-          'youth_risk_assessment:print',
-        ])
-      })
-    })
-
-    context('when user has all roles', function () {
-      beforeEach(function () {
-        permissions = user.getPermissions([
-          'ROLE_PECS_POLICE',
-          'ROLE_PECS_PRISON',
-          'ROLE_PECS_SUPPLIER',
-          'ROLE_PECS_STC',
-          'ROLE_PECS_SCH',
-          'ROLE_PECS_OCA',
-          'ROLE_PECS_PMU',
-          'ROLE_PECS_HMYOI',
-          'ROLE_PECS_COURT',
-          'ROLE_PECS_PER_AUTHOR',
-          'ROLE_PECS_CDM',
-          'ROLE_PECS_READ_ONLY',
-        ])
-      })
-
-      it('should contain correct permission', function () {
-        const allPermissions = [
-          'allocations:view',
-          'allocation:create',
-          'allocation:person:assign',
-          'allocation:cancel',
-          'moves:view:outgoing',
-          'moves:view:incoming',
-          'moves:download',
-          'move:review',
-          'move:view',
-          'move:create',
-          'move:create:court_appearance',
-          'move:create:prison_recall',
-          'move:create:police_transfer',
-          'move:create:hospital',
-          'move:create:secure_childrens_home',
-          'move:create:secure_training_centre',
-          'move:create:video_remand',
-          'move:cancel',
-          'move:update',
-          'move:update:court_appearance',
-          'move:update:hospital',
-          'move:update:prison_transfer',
-          'move:update:secure_childrens_home',
-          'move:update:secure_training_centre',
-          'move:update:prison_recall',
-          'move:update:police_transfer',
-          'move:update:video_remand',
-          'move:view:journeys',
-          'locations:all',
-          'locations:contract_delivery_manager',
-          'dashboard:view',
-          'dashboard:view:population',
-          'move:cancel:proposed',
-          'moves:view:proposed',
-          'move:create:prison_transfer',
-          'person_escort_record:view',
-          'person_escort_record:create',
-          'person_escort_record:update',
-          'person_escort_record:confirm',
-          'person_escort_record:print',
-          'youth_risk_assessment:view',
-          'youth_risk_assessment:create',
-          'youth_risk_assessment:update',
-          'youth_risk_assessment:confirm',
-          'youth_risk_assessment:print',
-        ]
-
-        expect(permissions).to.have.members(allPermissions)
       })
     })
   })

--- a/common/services/user.js
+++ b/common/services/user.js
@@ -28,10 +28,7 @@ function getFullname(token) {
 }
 
 async function getLocations(token, supplierId, permissions) {
-  const supplierLocations = await getSupplierLocations({
-    supplierId,
-    permissions,
-  })
+  const supplierLocations = await getSupplierLocations(supplierId, permissions)
 
   if (supplierLocations) {
     return supplierLocations
@@ -109,7 +106,7 @@ function getNomisLocations(token) {
     )
 }
 
-async function getSupplierLocations({ supplierId = null, permissions = [] }) {
+async function getSupplierLocations(supplierId, permissions) {
   if (supplierId) {
     return await referenceDataService.getLocationsBySupplierId(supplierId)
   }

--- a/common/services/user.js
+++ b/common/services/user.js
@@ -108,13 +108,9 @@ function getNomisLocations(token) {
     )
 }
 
-async function populateSupplierLocations(user) {
-  const { supplierId, permissions } = user
-
+async function getSupplierLocations({ supplierId = null, permissions = [] }) {
   if (supplierId) {
-    user.locations = await referenceDataService.getLocationsBySupplierId(
-      supplierId
-    )
+    return await referenceDataService.getLocationsBySupplierId(supplierId)
   }
 
   if (permissions.includes('locations:contract_delivery_manager')) {
@@ -127,7 +123,7 @@ async function populateSupplierLocations(user) {
 
     // The locations have been uniqued based on title to prevent
     // duplicates when multiple suppliers have the same location
-    user.locations = uniqBy(supplierLocations.flat(), 'id')
+    return uniqBy(supplierLocations.flat(), 'id')
   }
 }
 
@@ -135,5 +131,5 @@ module.exports = {
   getLocations,
   getFullname,
   getSupplierId,
-  populateSupplierLocations,
+  getSupplierLocations,
 }

--- a/common/services/user.js
+++ b/common/services/user.js
@@ -27,7 +27,16 @@ function getFullname(token) {
     .then(userDetails => userDetails.name)
 }
 
-function getLocations(token) {
+async function getLocations(token, supplierId, permissions) {
+  const supplierLocations = await getSupplierLocations({
+    supplierId,
+    permissions,
+  })
+
+  if (supplierLocations) {
+    return supplierLocations
+  }
+
   const { auth_source: authSource } = decodeAccessToken(token)
 
   switch (authSource) {
@@ -84,15 +93,7 @@ function getAuthGroups(token) {
 }
 
 async function getAuthLocations(token) {
-  const { authorities = [] } = decodeAccessToken(token)
-
-  // supplier locations are dynamic and set in app/locations/controllers.js
-  if (authorities.includes('ROLE_PECS_SUPPLIER')) {
-    return []
-  }
-
   const groups = await getAuthGroups(token)
-
   return referenceDataService.getLocationsByNomisAgencyId(groups)
 }
 
@@ -131,5 +132,4 @@ module.exports = {
   getLocations,
   getFullname,
   getSupplierId,
-  getSupplierLocations,
 }

--- a/common/services/user.test.js
+++ b/common/services/user.test.js
@@ -243,7 +243,7 @@ describe('User service', function () {
               .get('/')
               .reply(200, JSON.stringify(authGroups))
 
-            result = await getLocations(encodeToken(tokenData))
+            result = await getLocations(encodeToken(tokenData), null, [])
           })
 
           it('requests the user’s groups from HMPPS SSO', function () {
@@ -269,7 +269,7 @@ describe('User service', function () {
             .get('/')
             .reply(200, JSON.stringify(mockUserCaseloads))
 
-          result = await getLocations(token)
+          result = await getLocations(token, null, [])
         })
 
         it('requests the user’s caseloads from the NOMIS Elite 2 API', function () {
@@ -291,7 +291,7 @@ describe('User service', function () {
 
           token = encodeToken(tokenData)
 
-          result = await getLocations(token)
+          result = await getLocations(token, null, [])
         })
 
         it('defaults to an empty list of locations', function () {
@@ -309,7 +309,7 @@ describe('User service', function () {
 
     context('with a supplier ID', function () {
       beforeEach(async function () {
-        result = await getLocations(null, supplierStub.id)
+        result = await getLocations(null, supplierStub.id, [])
       })
 
       it('looks up locations for the supplier', async function () {


### PR DESCRIPTION
## Proposed changes

### What changed

This refactors how locations are fetched for users (following #1799) and various other parts of the authentication and user middleware. The refactor is relatively large, but the underlying behaviour should be pretty much unchanged, and we're able to remove around 150 lines of code :smile:. Worth reviewing commit by commit!

### Why did it change

This is to avoid unnecessarily fetching locations for supplier users which are then not used. It should also make the code related to user authentication and fetching easier to follow and understand.

### Issue tracking

Closes #1805