### PR TITLE
[P4-2908] Create new identity bar component

### DIFF
--- a/common/assets/scss/components/_all.scss
+++ b/common/assets/scss/components/_all.scss
@@ -13,6 +13,7 @@
 @import "data/data";
 @import "feedback-prompt/feedback-prompt";
 @import "filter/filter";
+@import "identity-bar/identity-bar";
 @import "internal-header/internal-header";
 @import "map/map";
 @import "message/message";

--- a/common/components/identity-bar/_identity-bar.scss
+++ b/common/components/identity-bar/_identity-bar.scss
@@ -1,0 +1,74 @@
+.app-identity-bar {
+  padding-bottom: govuk-spacing(9);
+
+  &.is-sticky {
+    top: 0 !important;
+    background: govuk-colour("white");
+    border-bottom: 1px solid $govuk-border-colour;
+    left: 0 !important;
+    padding: govuk-spacing(3) 0;
+    width: 100% !important;
+    z-index: 100;
+    box-shadow: 2px -1px 6px govuk-colour("mid-grey");
+  }
+}
+
+.app-identity-bar__inner {
+  .is-sticky & {
+    @include govuk-width-container();
+  }
+}
+
+.app-identity-bar__caption {
+  margin: 0;
+
+  .is-sticky & {
+    font-size: 19px;
+    display: inline;
+    color: govuk-colour("black");
+  }
+}
+
+.app-identity-bar__heading {
+  margin: 0;
+
+  .is-sticky & {
+    @include govuk-font($size: 19, $weight: bold);
+    display: inline;
+  }
+}
+
+.app-identity-bar__summary {
+  @include govuk-font($size: 19);
+  margin: govuk-spacing(1) 0 0;
+
+  .is-sticky & {
+    @include govuk-font($size: 16);
+  }
+}
+
+.app-identity-bar__actions {
+  margin: 0;
+  padding: govuk-spacing(6) 0 0;
+  list-style: none;
+
+  @include mq($from: desktop) {
+    float: right;
+  }
+
+  .govuk-button {
+    margin-bottom: 0;
+  }
+
+  .is-sticky & {
+    padding: 0;
+  }
+}
+
+.app-identity-bar__action-item {
+  display: block;
+
+  & + & {
+    margin-top: govuk-spacing(2);
+  }
+}

--- a/common/components/identity-bar/identity-bar.yaml
+++ b/common/components/identity-bar/identity-bar.yaml
@@ -1,0 +1,84 @@
+params:
+  - name: classes
+    type: string
+    required: false
+    description: Classes to add to the component.
+  - name: caption
+    type: object
+    required: true
+    description: Caption to show above the main title.
+    params:
+      - name: text
+        type: string
+        required: true
+        description: If `html` is set, this is not required. Text to use within the caption. If `html` is provided, the `text` argument will be ignored.
+      - name: html
+        type: string
+        required: true
+        description: If `text` is set, this is not required. HTML to use within the caption. If `html` is provided, the `text` argument will be ignored.
+  - name: heading
+    type: object
+    required: true
+    description: Caption to show above the main title.
+    params:
+      - name: text
+        type: string
+        required: true
+        description: If `html` is set, this is not required. Text to use within the title. If `html` is provided, the `text` argument will be ignored.
+      - name: html
+        type: string
+        required: true
+        description: If `text` is set, this is not required. HTML to use within the title. If `html` is provided, the `text` argument will be ignored.
+  - name: summary
+    type: object
+    required: true
+    description: Summary text to show above the underneath the title.
+    params:
+      - name: text
+        type: string
+        required: true
+        description: If `html` is set, this is not required. Text to use within the summary. If `html` is provided, the `text` argument will be ignored.
+      - name: html
+        type: string
+        required: true
+        description: If `text` is set, this is not required. HTML to use within the summary. If `html` is provided, the `text` argument will be ignored.
+  - name: actions
+    type: array
+    required: true
+    description: Array of actions to display on the right hand side.
+    params:
+      - name: text
+        type: string
+        required: true
+        description: If `html` is set, this is not required. Text to use within the item. If `html` is provided, the `text` argument will be ignored.
+      - name: html
+        type: string
+        required: true
+        description: If `text` is set, this is not required. HTML to use within the item. If `html` is provided, the `text` argument will be ignored.
+
+examples:
+  - name: default
+    data:
+      heading:
+        text: Identity bar heading
+  - name: with caption
+    data:
+      heading:
+        text: Identity bar with caption
+      caption:
+        text: Page caption
+  - name: with summary text
+    data:
+      heading:
+        text: Identity bar with summary
+      summary:
+        text: A short summary of this item
+  - name: with actions
+    data:
+      heading:
+        text: With actions
+      actions:
+        -
+          html: <a href="">Action one</a>
+        -
+          html: <a href="">Action two</a>

--- a/common/components/identity-bar/macro.njk
+++ b/common/components/identity-bar/macro.njk
@@ -1,0 +1,3 @@
+{% macro appIdentityBar(params) %}
+  {%- include "./template.njk" -%}
+{% endmacro %}

--- a/common/components/identity-bar/template.njk
+++ b/common/components/identity-bar/template.njk
@@ -1,0 +1,35 @@
+<div class="app-identity-bar{%- if params.classes %} {{ params.classes }}{% endif %}">
+  <div class="app-identity-bar__inner">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        {% if params.caption.html or params.caption.text %}
+          <span class="govuk-caption-l app-identity-bar__caption">
+            {{ params.caption.html | safe if params.caption.html else params.caption.text }}
+          </span>
+        {% endif %}
+
+        <h1 class="govuk-heading-xl app-identity-bar__heading">
+          {{ params.heading.html | safe if params.heading.html else params.heading.text }}
+        </h1>
+
+        {% if params.summary.html or params.summary.text %}
+          <p class="app-identity-bar__summary">
+            {{ params.summary.html | safe if params.summary.html else params.summary.text }}
+          </p>
+        {% endif %}
+      </div>
+
+      {% if params.actions | length %}
+        <div class="govuk-grid-column-one-third">
+          <ul class="app-identity-bar__actions">
+            {% for action in params.actions %}
+              <li class="app-identity-bar__action-item">
+                {{ action.html | safe if action.html else action.text }}
+              </li>
+            {% endfor %}
+          </ul>
+        </div>
+      {% endif %}
+    </div>
+  </div>
+</div>

--- a/common/components/identity-bar/template.test.js
+++ b/common/components/identity-bar/template.test.js
@@ -1,0 +1,195 @@
+const {
+  renderComponentHtmlToCheerio,
+  getExamples,
+} = require('../../../test/unit/component-helpers')
+
+const examples = getExamples('identity-bar')
+
+describe('Identity bar component', function () {
+  context('by default', function () {
+    let $, $component
+
+    beforeEach(function () {
+      $ = renderComponentHtmlToCheerio('identity-bar', examples.default)
+      $component = $('.app-identity-bar')
+    })
+
+    it('should render component', function () {
+      expect($component.get(0).tagName).to.equal('div')
+    })
+
+    it('should render heading', function () {
+      expect(
+        $component.find('.app-identity-bar__heading').text().trim()
+      ).to.equal('Identity bar heading')
+    })
+  })
+
+  context('with caption', function () {
+    let $, $component
+
+    beforeEach(function () {
+      $ = renderComponentHtmlToCheerio('identity-bar', examples['with caption'])
+      $component = $('.app-identity-bar')
+    })
+
+    it('should render component', function () {
+      expect($component.get(0).tagName).to.equal('div')
+    })
+
+    it('should render heading', function () {
+      expect(
+        $component.find('.app-identity-bar__heading').text().trim()
+      ).to.equal('Identity bar with caption')
+    })
+
+    it('should render caption', function () {
+      expect(
+        $component.find('.app-identity-bar__caption').text().trim()
+      ).to.equal('Page caption')
+    })
+  })
+
+  context('with summary', function () {
+    let $, $component
+
+    beforeEach(function () {
+      $ = renderComponentHtmlToCheerio(
+        'identity-bar',
+        examples['with summary text']
+      )
+      $component = $('.app-identity-bar')
+    })
+
+    it('should render component', function () {
+      expect($component.get(0).tagName).to.equal('div')
+    })
+
+    it('should render heading', function () {
+      expect(
+        $component.find('.app-identity-bar__heading').text().trim()
+      ).to.equal('Identity bar with summary')
+    })
+
+    it('should render caption', function () {
+      expect(
+        $component.find('.app-identity-bar__summary').text().trim()
+      ).to.equal('A short summary of this item')
+    })
+  })
+
+  context('with actions', function () {
+    let $, $component
+
+    beforeEach(function () {
+      $ = renderComponentHtmlToCheerio('identity-bar', examples['with actions'])
+      $component = $('.app-identity-bar')
+    })
+
+    it('should render component', function () {
+      expect($component.get(0).tagName).to.equal('div')
+    })
+
+    it('should render correct number of actions', function () {
+      const items = $component.find('.app-identity-bar__action-item')
+      expect(items.length).to.equal(2)
+    })
+
+    describe('items', function () {
+      let items
+
+      beforeEach(function () {
+        items = $component.find('.app-identity-bar__action-item')
+      })
+
+      it('should render items correctly', function () {
+        expect($(items[0]).text().trim()).to.equal('Action one')
+        expect($(items[1]).text().trim()).to.equal('Action two')
+      })
+    })
+  })
+
+  context('when html is passed to text', function () {
+    it('should render escaped html', function () {
+      const $ = renderComponentHtmlToCheerio('identity-bar', {
+        heading: {
+          text: 'A title with <strong>bold text</strong>',
+        },
+        caption: {
+          text: 'A caption with <strong>bold text</strong>',
+        },
+        summary: {
+          text: 'A summary with <strong>bold text</strong>',
+        },
+      })
+
+      const $component = $('.app-identity-bar')
+      expect($component.html()).to.contain(
+        'A title with &lt;strong&gt;bold text&lt;/strong&gt;'
+      )
+      expect($component.html()).to.contain(
+        'A caption with &lt;strong&gt;bold text&lt;/strong&gt;'
+      )
+      expect($component.html()).to.contain(
+        'A summary with &lt;strong&gt;bold text&lt;/strong&gt;'
+      )
+    })
+  })
+
+  context('when html is passed to html', function () {
+    it('should render unescaped html', function () {
+      const $ = renderComponentHtmlToCheerio('identity-bar', {
+        heading: {
+          html: 'A title with <strong>bold text</strong>',
+        },
+        caption: {
+          html: 'A caption with <strong>bold text</strong>',
+        },
+        summary: {
+          html: 'A summary with <strong>bold text</strong>',
+        },
+      })
+
+      const $component = $('.app-identity-bar')
+      expect($component.html()).to.contain(
+        'A title with <strong>bold text</strong>'
+      )
+      expect($component.html()).to.contain(
+        'A caption with <strong>bold text</strong>'
+      )
+      expect($component.html()).to.contain(
+        'A summary with <strong>bold text</strong>'
+      )
+    })
+  })
+
+  context('when both html and text params are used', function () {
+    it('should render unescaped html', function () {
+      const $ = renderComponentHtmlToCheerio('identity-bar', {
+        heading: {
+          html: 'A title with <strong>bold text</strong>',
+          text: 'A title with <strong>bold text</strong>',
+        },
+        caption: {
+          html: 'A caption with <strong>bold text</strong>',
+          text: 'A caption with <strong>bold text</strong>',
+        },
+        summary: {
+          html: 'A summary with <strong>bold text</strong>',
+          text: 'A summary with <strong>bold text</strong>',
+        },
+      })
+
+      const $component = $('.app-identity-bar')
+      expect($component.html()).to.contain(
+        'A title with <strong>bold text</strong>'
+      )
+      expect($component.html()).to.contain(
+        'A caption with <strong>bold text</strong>'
+      )
+      expect($component.html()).to.contain(
+        'A summary with <strong>bold text</strong>'
+      )
+    })
+  })
+})

--- a/common/templates/layouts/base.njk
+++ b/common/templates/layouts/base.njk
@@ -31,6 +31,7 @@
 {% from "feedback-prompt/macro.njk"   import appFeedbackPrompt %}
 {% from "filter/macro.njk"            import appFilter %}
 {% from "framework-response/macro.njk"import appFrameworkResponse %}
+{% from "identity-bar/macro.njk"      import appIdentityBar %}
 {% from "internal-header/macro.njk"   import appInternalHeader %}
 {% from "map/macro.njk"               import appMap %}
 {% from "message/macro.njk"           import appMessage %}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

This creates a new component to display the summary information for
a move or person page.

[**COMPONENT EXAMPLE**](https://booksecuremove-pr-1832.herokuapp.com/components/identity-bar)

### Why did it change

This component will be used by the new layouts for the move and person pages.

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

- [P4-2908](https://dsdmoj.atlassian.net/browse/P4-2908)

## Screenshots
<!--- (Optional) Include screenshots if changes update interfaces or components -->
<!--- Delete/copy as appropriate --->

<kbd>![image](https://user-images.githubusercontent.com/3327997/126401736-5b8cd1ff-b6ca-44ca-ac71-49f79c3aae23.png)</kbd>

<kbd>![image](https://user-images.githubusercontent.com/3327997/126401756-25ef227f-11a5-4bef-9b57-d98db76bc32a.png)</kbd>

## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [x] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed
