### PR TITLE
[P4-2908] Add identity bar to new move page design

### DIFF
--- a/app/move/app/view/index.js
+++ b/app/move/app/view/index.js
@@ -17,6 +17,7 @@ const {
 } = require('./controllers')
 const {
   localsActions,
+  localsIdentityBar,
   localsMoveDetails,
   localsTabs,
   localsWarnings,
@@ -37,6 +38,7 @@ router.use(setPersonEscortRecord)
 router.use(setYouthRiskAssessment)
 router.use(setBreadcrumb)
 router.use(localsActions)
+router.use(localsIdentityBar)
 router.use(localsMoveDetails)
 router.use(localsTabs)
 

--- a/app/move/app/view/middleware/index.js
+++ b/app/move/app/view/middleware/index.js
@@ -1,4 +1,5 @@
 const localsActions = require('./locals.actions')
+const localsIdentityBar = require('./locals.identity-bar')
 const localsMoveDetails = require('./locals.move-details')
 const localsTabs = require('./locals.tabs')
 const localsWarnings = require('./locals.warnings')
@@ -6,6 +7,7 @@ const setBreadcrumb = require('./set-breadcrumb')
 
 module.exports = {
   localsActions,
+  localsIdentityBar,
   localsMoveDetails,
   localsTabs,
   localsWarnings,

--- a/app/move/app/view/middleware/locals.identity-bar.js
+++ b/app/move/app/view/middleware/locals.identity-bar.js
@@ -1,0 +1,34 @@
+const filters = require('../../../../../config/nunjucks/filters')
+
+function localsIdentityCard(req, res, next) {
+  const { move } = req
+
+  if (!move) {
+    return next()
+  }
+
+  const identityBar = {
+    caption: {
+      text: req.t('moves::detail.page_caption'),
+    },
+    heading: {
+      html: req.t('moves::detail.page_heading', {
+        name: move.profile?.person?._fullname || req.t('awaiting_person'),
+        reference: move.reference,
+      }),
+    },
+    summary: {
+      html: req.t('moves::detail.page_heading_summary', {
+        fromLocation: move.from_location?.title,
+        toLocation: move.to_location?.title,
+        date: filters.formatDate(move.date),
+      }),
+    },
+  }
+
+  res.locals.identityBar = identityBar
+
+  next()
+}
+
+module.exports = localsIdentityCard

--- a/app/move/app/view/middleware/locals.identity-bar.js
+++ b/app/move/app/view/middleware/locals.identity-bar.js
@@ -8,6 +8,7 @@ function localsIdentityCard(req, res, next) {
   }
 
   const identityBar = {
+    classes: 'sticky',
     caption: {
       text: req.t('moves::detail.page_caption'),
     },

--- a/app/move/app/view/middleware/locals.identity-bar.test.js
+++ b/app/move/app/view/middleware/locals.identity-bar.test.js
@@ -76,6 +76,7 @@ describe('Move view app', function () {
 
         it('should set identity bar on locals', function () {
           expect(res.locals.identityBar).to.be.deep.equal({
+            classes: 'sticky',
             caption: {
               text: 'moves::detail.page_caption',
             },

--- a/app/move/app/view/middleware/locals.identity-bar.test.js
+++ b/app/move/app/view/middleware/locals.identity-bar.test.js
@@ -1,0 +1,165 @@
+const filters = require('../../../../../config/nunjucks/filters')
+
+const middleware = require('./locals.identity-bar')
+
+describe('Move view app', function () {
+  describe('Middleware', function () {
+    describe('#localsIdentityBar()', function () {
+      let req, res, nextSpy
+
+      beforeEach(function () {
+        req = {
+          t: sinon.stub().returnsArg(0),
+        }
+        res = {
+          locals: {},
+        }
+        nextSpy = sinon.spy()
+
+        sinon.stub(filters, 'formatDate').returnsArg(0)
+      })
+
+      context('by default', function () {
+        beforeEach(function () {
+          req.move = {
+            id: '12345',
+            reference: 'AB1234XY',
+            date: '2020-10-07',
+            profile: {
+              person: {
+                _fullname: 'DOE, JOHN',
+              },
+            },
+            from_location: {
+              title: 'Guildford Custody Suite',
+            },
+            to_location: {
+              title: 'HMP Brixton',
+            },
+            foo: 'bar',
+          }
+
+          middleware(req, res, nextSpy)
+        })
+
+        describe('translations', function () {
+          it('should translate caption', function () {
+            expect(req.t).to.be.calledWithExactly('moves::detail.page_caption')
+          })
+
+          it('should translate heading', function () {
+            expect(req.t).to.be.calledWithExactly(
+              'moves::detail.page_heading',
+              {
+                name: 'DOE, JOHN',
+                reference: 'AB1234XY',
+              }
+            )
+            expect(req.t).not.to.be.calledWithExactly('awaiting_person')
+          })
+
+          it('should translate summary', function () {
+            expect(req.t).to.be.calledWithExactly(
+              'moves::detail.page_heading_summary',
+              {
+                fromLocation: 'Guildford Custody Suite',
+                toLocation: 'HMP Brixton',
+                date: '2020-10-07',
+              }
+            )
+          })
+        })
+
+        it('should format date', function () {
+          expect(filters.formatDate).to.be.calledWithExactly('2020-10-07')
+        })
+
+        it('should set identity bar on locals', function () {
+          expect(res.locals.identityBar).to.be.deep.equal({
+            caption: {
+              text: 'moves::detail.page_caption',
+            },
+            heading: {
+              html: 'moves::detail.page_heading',
+            },
+            summary: {
+              html: 'moves::detail.page_heading_summary',
+            },
+          })
+        })
+
+        it('should call next', function () {
+          expect(nextSpy).to.be.calledOnceWithExactly()
+        })
+      })
+
+      context('without profile', function () {
+        beforeEach(function () {
+          req.move = {
+            id: '12345',
+            reference: 'AB1234XY',
+            date: '2020-10-07',
+            profile: null,
+            from_location: {
+              title: 'Guildford Custody Suite',
+            },
+            to_location: {
+              title: 'HMP Brixton',
+            },
+            foo: 'bar',
+          }
+
+          middleware(req, res, nextSpy)
+        })
+
+        describe('translations', function () {
+          it('should translate caption', function () {
+            expect(req.t).to.be.calledWithExactly('moves::detail.page_caption')
+          })
+
+          it('should translate heading', function () {
+            expect(req.t).to.be.calledWithExactly(
+              'moves::detail.page_heading',
+              {
+                name: 'awaiting_person',
+                reference: 'AB1234XY',
+              }
+            )
+            expect(req.t).to.be.calledWithExactly('awaiting_person')
+          })
+
+          it('should translate summary', function () {
+            expect(req.t).to.be.calledWithExactly(
+              'moves::detail.page_heading_summary',
+              {
+                fromLocation: 'Guildford Custody Suite',
+                toLocation: 'HMP Brixton',
+                date: '2020-10-07',
+              }
+            )
+          })
+        })
+
+        it('should call next', function () {
+          expect(nextSpy).to.be.calledOnceWithExactly()
+        })
+      })
+
+      context('with move', function () {
+        beforeEach(function () {
+          req.move = undefined
+
+          middleware(req, res, nextSpy)
+        })
+
+        it('should not set identity bar on locals', function () {
+          expect(res.locals).not.to.have.property('identityBar')
+        })
+
+        it('should call next', function () {
+          expect(nextSpy).to.be.calledOnceWithExactly()
+        })
+      })
+    })
+  })
+})

--- a/app/move/app/view/views/_layout.njk
+++ b/app/move/app/view/views/_layout.njk
@@ -9,7 +9,9 @@
 {% endblock %}
 
 {% block content %}
-  {% block contentHeader %}{% endblock %}
+  {% block contentHeader %}
+    {{ appIdentityBar(identityBar) }}
+  {% endblock %}
 
   {% block contentContainer %}
   <div class="govuk-grid-row">

--- a/app/move/app/view/views/_layout.njk
+++ b/app/move/app/view/views/_layout.njk
@@ -16,32 +16,6 @@
   {% block contentContainer %}
   <div class="govuk-grid-row">
 
-    <aside class="govuk-grid-column-one-third">
-
-      {% block contentSidebar %}
-
-        <h3 class="govuk-heading-m app-border-top-2 app-border--blue govuk-!-padding-top-3 govuk-!-margin-bottom-3">
-          {{ t("moves::move_details") }}
-        </h3>
-
-        {{ appMetaList(moveDetails) }}
-
-        {% if actions | length %}
-          <ul class="govuk-list govuk-!-margin-top-4 govuk-!-margin-bottom-0">
-            {% for action in actions %}
-              <li>
-                <a href="{{ action.url }}" class="{{ action.classes }}">
-                  {{ t(action.text) }}
-                </a>
-              </li>
-            {% endfor %}
-          </ul>
-        {% endif %}
-
-      {% endblock %}
-
-    </aside>
-
     <div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-6">
 
       {% block contentMain %}
@@ -68,6 +42,32 @@
       {% endblock %}
 
     </div>
+
+    <aside class="govuk-grid-column-one-third app-!-tabs-offset">
+
+      {% block contentSidebar %}
+
+        <h3 class="govuk-heading-m app-border-top-2 app-border--blue govuk-!-padding-top-3 govuk-!-margin-bottom-3">
+          {{ t("moves::move_details") }}
+        </h3>
+
+        {{ appMetaList(moveDetails) }}
+
+        {% if actions | length %}
+          <ul class="govuk-list govuk-!-margin-top-4 govuk-!-margin-bottom-0">
+            {% for action in actions %}
+              <li>
+                <a href="{{ action.url }}" class="{{ action.classes }}">
+                  {{ t(action.text) }}
+                </a>
+              </li>
+            {% endfor %}
+          </ul>
+        {% endif %}
+
+      {% endblock %}
+
+    </aside>
 
   </div>
   {% endblock %}

--- a/common/assets/javascripts/application.js
+++ b/common/assets/javascripts/application.js
@@ -20,6 +20,7 @@ import MultiFileUpload from '../../components/multi-file-upload/multi-file-uploa
 
 const accessibleAutocomplete = require('accessible-autocomplete')
 const { initAll } = require('govuk-frontend')
+const HcSticky = require('hc-sticky')
 const StickySidebar = require('sticky-sidebar/dist/sticky-sidebar')
 
 const AddAnother = require('../../components/add-another/add-another')
@@ -70,6 +71,24 @@ if ($stickySidebars.length) {
     bottomSpacing: 20,
     containerSelector: '.sticky-sidebar-container',
     innerWrapperSelector: '.sticky-sidebar__inner',
+  })
+}
+
+const elements = document.querySelectorAll('.sticky')
+
+for (let i = 0; i < elements.length; i++) {
+  const element = elements[i]
+  // eslint-disable-next-line no-undef
+  const computedStyle = getComputedStyle(element)
+  const verticalPadding =
+    parseFloat(computedStyle.paddingTop) +
+    parseFloat(computedStyle.paddingBottom)
+  const elementHeight = element.offsetHeight - verticalPadding
+
+  // eslint-disable-next-line no-new
+  new HcSticky(elements[i], {
+    stickyClass: 'is-sticky',
+    innerTop: elementHeight,
   })
 }
 

--- a/common/assets/scss/overrides/_positioning.scss
+++ b/common/assets/scss/overrides/_positioning.scss
@@ -11,6 +11,12 @@
 }
 
 @include govuk-media-query($from: tablet) {
+  // vertical offset used to align a side column to the keyline
+  // of the GOV.UK tabs component
+  .app-\!-tabs-offset {
+    padding-top: 55px;
+  }
+
   .app-\!-position-top-right {
     position: absolute;
     top: 0;

--- a/common/components/card/_card.scss
+++ b/common/components/card/_card.scss
@@ -1,4 +1,5 @@
 $_image-width: 80px;
+$_image-height: 100px;
 
 .app-card {
   @include govuk-clearfix;
@@ -40,6 +41,7 @@ $_image-width: 80px;
 .app-card__image {
   display: block;
   width: $_image-width;
+  height: $_image-height;
 }
 
 .app-card__badge {
@@ -91,8 +93,9 @@ $_image-width: 80px;
 
   @include mq($from: desktop) {
     display: grid;
-    grid-template-columns: repeat(4, 1fr);
-    grid-gap: govuk-spacing(3);
+    grid-auto-columns: max-content;
+    grid-auto-flow: column;
+    grid-gap: govuk-spacing(5);
   }
 }
 

--- a/locales/en/default.json
+++ b/locales/en/default.json
@@ -21,7 +21,7 @@
   "person_plural": "people",
   "n_person": "{{count}} person",
   "n_person_plural": "{{count}} people",
-  "age_with_date_of_birth": "{{date_of_birth}}<br>(Age {{age}})",
+  "age_with_date_of_birth": "{{date_of_birth}} (Age {{age}})",
   "supplier_fallback": "the supplier",
   "opens_new_window": "Opens in a new window",
   "last_updated_at": "Last updated {{date}} at {{time}}",

--- a/locales/en/moves.json
+++ b/locales/en/moves.json
@@ -109,6 +109,9 @@
     }
   },
   "detail": {
+    "page_caption": "Move for",
+    "page_heading": "{{-name}} ({{-reference}})",
+    "page_heading_summary": "From <strong>{{ fromLocation }}</strong> to <strong>{{ toLocation }}</strong> on <strong>{{ date }}</strong>",
     "page_title": "Move for {{-name}}",
     "court_hearings": {
       "heading": "Court hearing",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17115,6 +17115,11 @@
         }
       }
     },
+    "hc-sticky": {
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/hc-sticky/-/hc-sticky-2.2.7.tgz",
+      "integrity": "sha512-xGEvtKqwztK3xC5a26U0ZNLu8bNMP378ZPuEfHRxHtQCsT/Y0Kg7BG3w02oWuD46ecOWUioUZoJAXT2tJs3Q7Q=="
+    },
     "he": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -136,6 +136,7 @@
     "got": "11.8.2",
     "govuk-frontend": "3.9.0",
     "grant-express": "5.4.8",
+    "hc-sticky": "2.2.7",
     "helmet": "4.6.0",
     "hmpo-form-wizard": "11.11.0",
     "i18next": "20.3.4",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

This adds the new identity bar component to the move page redesign.

[**DEMO**](https://booksecuremove-pr-1833.herokuapp.com/move/cc721283-e508-4635-ad9b-7f8fc80187b0/beta/warnings)

### Why did it change

This component will be re-used by both the new move page and the person page.

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

- [P4-2908](https://dsdmoj.atlassian.net/browse/P4-2908)

## Screenshots
<!--- (Optional) Include screenshots if changes update interfaces or components -->
<!--- Delete/copy as appropriate --->

| Before | After |
| ------ | ----- |
| <kbd>![image](https://user-images.githubusercontent.com/3327997/126404036-198e8bc4-375b-4983-8b16-6643fabcca4f.png)</kbd> | <kbd>![image](https://user-images.githubusercontent.com/3327997/126403824-3346fe08-7e81-40f7-a32c-42c9bd3fc40b.png)</kbd> |
| <kbd>![image](https://user-images.githubusercontent.com/3327997/126403798-5a9bc163-3e34-48d1-bf01-2116a8599f90.png)</kbd> | <kbd>![image](https://user-images.githubusercontent.com/3327997/126403769-5ebd81ce-9ef2-44a2-a56b-07d4f68b0dc4.png)</kbd> |

## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [x] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed
