### PR TITLE
Revert Sentry warnings for a missing location

### DIFF
--- a/common/middleware/set-location.js
+++ b/common/middleware/set-location.js
@@ -1,4 +1,3 @@
-const Sentry = require('@sentry/node')
 const { find, flatMapDeep } = require('lodash')
 
 // If we want to also use this as normal middleware, we can't have an extra property
@@ -41,11 +40,6 @@ async function setLocation(req, res, next) {
   if (!location) {
     const error = new Error('Location not found')
     error.statusCode = 404
-
-    Sentry.withScope(scope => {
-      scope.setLevel('warning')
-      Sentry.captureException(error)
-    })
 
     return next(error)
   }

--- a/common/middleware/set-location.test.js
+++ b/common/middleware/set-location.test.js
@@ -1,5 +1,3 @@
-const Sentry = require('@sentry/node')
-
 const setLocation = require('./set-location')
 
 describe('Set location middleware', function () {
@@ -19,9 +17,6 @@ describe('Set location middleware', function () {
         },
       }
       next = sinon.stub()
-
-      sinon.stub(Sentry, 'captureException')
-      sinon.stub(Sentry, 'withScope')
     })
 
     context('without a param or session location', function () {
@@ -113,28 +108,8 @@ describe('Set location middleware', function () {
       })
 
       context('not found', function () {
-        let mockScope
-
         beforeEach(async function () {
-          mockScope = {
-            setLevel: sinon.stub(),
-          }
-
           await setLocation(req, res, next)
-
-          // run callback with mock scope
-          Sentry.withScope.args[0][0](mockScope)
-        })
-
-        it('should send warning to sentry', function () {
-          expect(Sentry.withScope).to.be.calledOnce
-
-          expect(mockScope.setLevel).to.be.calledOnceWithExactly('warning')
-
-          expect(Sentry.captureException).to.have.been.calledOnceWith(
-            sinon.match.instanceOf(Error)
-          )
-          expect(Sentry.captureException.args[0][0].statusCode).to.equal(404)
         })
 
         it('should call next', function () {
@@ -229,28 +204,8 @@ describe('Set location middleware', function () {
       })
 
       context('not found', function () {
-        let mockScope
-
         beforeEach(async function () {
-          mockScope = {
-            setLevel: sinon.stub(),
-          }
-
           await setLocation(req, res, next)
-
-          // run callback with mock scope
-          Sentry.withScope.args[0][0](mockScope)
-        })
-
-        it('should send warning to sentry', function () {
-          expect(Sentry.withScope).to.be.calledOnce
-
-          expect(mockScope.setLevel).to.be.calledOnceWithExactly('warning')
-
-          expect(Sentry.captureException).to.have.been.calledOnceWith(
-            sinon.match.instanceOf(Error)
-          )
-          expect(Sentry.captureException.args[0][0].statusCode).to.equal(404)
         })
 
         it('should call next', function () {

--- a/server.js
+++ b/server.js
@@ -103,7 +103,7 @@ if (config.SENTRY.DSN) {
     Sentry.Handlers.requestHandler({
       // Ensure we don't include `data` to avoid sending any PPI
       request: ['cookies', 'headers', 'method', 'query_string', 'url'],
-      user: ['id', 'username', 'permissions', 'locations'],
+      user: ['id', 'username', 'permissions'],
     })
   )
   app.use(sentryRequestId)

--- a/server.js
+++ b/server.js
@@ -103,7 +103,7 @@ if (config.SENTRY.DSN) {
     Sentry.Handlers.requestHandler({
       // Ensure we don't include `data` to avoid sending any PPI
       request: ['cookies', 'headers', 'method', 'query_string', 'url'],
-      user: ['id', 'username', 'permissions'],
+      user: ['id', 'username', 'permissions', 'locations'],
     })
   )
   app.use(sentryRequestId)


### PR DESCRIPTION
This reverts commit a9f1f53.

We've solved the bug which caused us to introduce these warnings and now we're getting them appearing for legitimate cases, so we can stop sending them to Sentry.