### PR TITLE
Revert "Warn when the auth source cannot be determined"

### DIFF
--- a/common/services/user.js
+++ b/common/services/user.js
@@ -1,4 +1,3 @@
-const Sentry = require('@sentry/node')
 const axios = require('axios')
 const { uniqBy } = require('lodash')
 const rax = require('retry-axios')
@@ -42,11 +41,6 @@ async function getLocations(token, supplierId, permissions) {
     case 'nomis':
       return getNomisLocations(token)
     default:
-      Sentry.captureException(new Error('Unknown auth source'), {
-        level: Sentry.Severity.Warning,
-        tags: { authSource },
-      })
-
       return Promise.resolve([])
   }
 }

--- a/common/services/user.test.js
+++ b/common/services/user.test.js
@@ -1,4 +1,3 @@
-const Sentry = require('@sentry/node')
 const axios = require('axios')
 const proxyquire = require('proxyquire')
 
@@ -283,8 +282,6 @@ describe('User service', function () {
 
       context('User authentication source indeterminate', function () {
         beforeEach(async function () {
-          sinon.stub(Sentry, 'captureException')
-
           tokenData = {
             user_name: 'test',
           }
@@ -296,13 +293,6 @@ describe('User service', function () {
 
         it('defaults to an empty list of locations', function () {
           expect(result).to.be.an('array').that.is.empty
-        })
-
-        it('should send a warning to Sentry', function () {
-          expect(Sentry.captureException).to.have.been.calledOnceWith(
-            sinon.match.instanceOf(Error),
-            { tags: { authSource: undefined }, level: 'warning' }
-          )
         })
       })
     })


### PR DESCRIPTION
Reverts ministryofjustice/hmpps-book-secure-move-frontend#1796

We saw this occur for Delius authentication, which we currently don't support, so we can stop warning about this situation. The original bug that we introduced this warning for has been fixed.

> Delius is the Probation “equivalent” of NOMIS and has been added as an auth provider. We have no expectation at this time that Probation users need access to Book a Secure Move as far as I’m aware, so any attempt to use the service should be blocked as it was in this case.