### PR TITLE
Add require-await eslint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -59,6 +59,7 @@ module.exports = {
       { blankLine: 'always', prev: '*', next: 'block-like' },
       { blankLine: 'always', prev: 'block-like', next: '*' },
     ],
+    'require-await': 'error',
   },
   overrides: [
     {

--- a/app/allocation/controllers/create/save.js
+++ b/app/allocation/controllers/create/save.js
@@ -21,7 +21,7 @@ class SaveController extends CreateAllocationBaseController {
     }
   }
 
-  async successHandler(req, res, next) {
+  successHandler(req, res, next) {
     const { id } = req.sessionModel.get('allocation')
 
     try {

--- a/app/allocation/controllers/create/save.test.js
+++ b/app/allocation/controllers/create/save.test.js
@@ -98,7 +98,7 @@ describe('the save controller', function () {
     let journeyModel
     let redirect
     context('happy path', function () {
-      beforeEach(async function () {
+      beforeEach(function () {
         sessionModel = {
           toJSON: sinon.stub().returns(mockData),
           get: sinon.stub().returns(123),
@@ -108,7 +108,7 @@ describe('the save controller', function () {
           reset: sinon.stub(),
         }
         redirect = sinon.stub()
-        await controller.successHandler(
+        controller.successHandler(
           {
             sessionModel,
             journeyModel,
@@ -129,14 +129,14 @@ describe('the save controller', function () {
     })
     context('unhappy path', function () {
       const error = new Error('error')
-      beforeEach(async function () {
+      beforeEach(function () {
         next = sinon.stub()
         sessionModel = {
           get: sinon.stub().returns({
             id: 1,
           }),
         }
-        await controller.successHandler(
+        controller.successHandler(
           {
             sessionModel,
             journeyModel: {

--- a/app/allocations/middleware/set-filter.allocations.test.js
+++ b/app/allocations/middleware/set-filter.allocations.test.js
@@ -79,7 +79,7 @@ describe('Allocations middleware', function () {
           ])
         })
 
-        it('calls the servive with correct arguments', async function () {
+        it('calls the servive with correct arguments', function () {
           expect(
             allocationService.getByDateAndLocation
           ).to.have.been.calledWithExactly({
@@ -106,15 +106,15 @@ describe('Allocations middleware', function () {
           })
         })
 
-        it('calls the service on each item', async function () {
+        it('calls the service on each item', function () {
           expect(allocationService.getByDateAndLocation.callCount).to.equal(3)
         })
 
-        it('translate each item', async function () {
+        it('translate each item', function () {
           expect(i18n.t.callCount).to.equal(3)
         })
 
-        it('translates with count', async function () {
+        it('translates with count', function () {
           expect(i18n.t).to.be.calledWithExactly('statuses::pending', {
             count: 4,
           })

--- a/app/locations/middleware.test.js
+++ b/app/locations/middleware.test.js
@@ -184,7 +184,7 @@ describe('Locations middleware', function () {
       nextSpy = sinon.spy()
     })
 
-    context('when the region is found', async function () {
+    context('when the region is found', function () {
       beforeEach(async function () {
         await proxiedMiddleware.setRegion(req, {}, nextSpy)
       })
@@ -200,7 +200,7 @@ describe('Locations middleware', function () {
       })
     })
 
-    context('when the region is not found', async function () {
+    context('when the region is not found', function () {
       const error = new Error()
       beforeEach(async function () {
         req.services.referenceData.getRegionById = sinon.fake.returns(
@@ -218,7 +218,7 @@ describe('Locations middleware', function () {
       })
     })
 
-    context('when no region is returned', async function () {
+    context('when no region is returned', function () {
       beforeEach(async function () {
         mockReferenceData.getRegionById = sinon.fake.returns(Promise.resolve())
         await proxiedMiddleware.setRegion(req, {}, nextSpy)
@@ -246,17 +246,17 @@ describe('Locations middleware', function () {
       await middleware.setHasSelectedLocation(req, {}, nextSpy)
     })
 
-    it('should not set hasSelectedLocation property', async function () {
+    it('should not set hasSelectedLocation property', function () {
       expect(req.session.hasSelectedLocation).to.equal(true)
     })
 
-    it('should call next', async function () {
+    it('should call next', function () {
       expect(nextSpy).to.be.calledOnceWithExactly()
     })
   })
 
   describe('#setSelectedLocation', function () {
-    beforeEach(async function () {
+    beforeEach(function () {
       req = {
         session: {
           currentLocation: 'currentLocation',
@@ -266,43 +266,43 @@ describe('Locations middleware', function () {
     })
 
     context('when called with no location type', function () {
-      beforeEach(async function () {
+      beforeEach(function () {
         middleware.setSelectedLocation(req)
       })
 
-      it('it should delete the currentLocation', async function () {
+      it('it should delete the currentLocation', function () {
         expect(req.session).to.not.have.property('currentLocation')
       })
 
-      it('it should delete the currentRegion', async function () {
+      it('it should delete the currentRegion', function () {
         expect(req.session).to.not.have.property('currentRegion')
       })
     })
 
     context('when called with currentLocation as location type', function () {
-      beforeEach(async function () {
+      beforeEach(function () {
         middleware.setSelectedLocation(req, 'currentLocation', 'foo')
       })
 
-      it('it should set the currentLocation', async function () {
+      it('it should set the currentLocation', function () {
         expect(req.session.currentLocation).to.equal('foo')
       })
 
-      it('it should delete the currentRegion', async function () {
+      it('it should delete the currentRegion', function () {
         expect(req.session).to.not.have.property('currentRegion')
       })
     })
 
     context('when called with currentRegion as location type', function () {
-      beforeEach(async function () {
+      beforeEach(function () {
         middleware.setSelectedLocation(req, 'currentRegion', 'foo')
       })
 
-      it('it should set the currentRegion', async function () {
+      it('it should set the currentRegion', function () {
         expect(req.session.currentRegion).to.equal('foo')
       })
 
-      it('it should delete the currentLocation', async function () {
+      it('it should delete the currentLocation', function () {
         expect(req.session).to.not.have.property('currentLocation')
       })
     })

--- a/app/move/app/edit/controllers/assessment.test.js
+++ b/app/move/app/edit/controllers/assessment.test.js
@@ -133,6 +133,7 @@ describe('Move controllers', function () {
       let req, profileService
       const res = {}
       let nextSpy
+
       beforeEach(function () {
         profileService = {
           update: sinon.stub().resolves(),
@@ -235,7 +236,8 @@ describe('Move controllers', function () {
           req.form.values.violent = '#violent'
           await controller.saveValues(req, res, nextSpy)
         })
-        it('should update the profile data', async function () {
+
+        it('should update the profile data', function () {
           expect(profileService.update).to.be.calledOnceWithExactly({
             assessment_answers: [
               {
@@ -248,7 +250,7 @@ describe('Move controllers', function () {
           })
         })
 
-        it('should set the confirmation message', async function () {
+        it('should set the confirmation message', function () {
           expect(controller.setFlash).to.be.calledOnceWithExactly(req)
         })
       })
@@ -257,6 +259,7 @@ describe('Move controllers', function () {
         beforeEach(function () {
           req.form.values.violent = ''
         })
+
         it('should remove the comment from the assessment answer', async function () {
           await controller.saveValues(req, res, nextSpy)
           expect(profileService.update).to.be.calledOnceWithExactly({
@@ -277,6 +280,7 @@ describe('Move controllers', function () {
           req.form.values.risk.push('56826f64-da5d-42eb-b360-131e60bcc3d3')
           req.form.values.risk.push('4e7e54b4-a40c-488f-bdff-c6b2268ca4eb')
         })
+
         it('should add the assessment answer and order the assessments', async function () {
           await controller.saveValues(req, res, nextSpy)
           expect(profileService.update).to.be.calledOnceWithExactly({
@@ -306,6 +310,7 @@ describe('Move controllers', function () {
         beforeEach(function () {
           req.getProfile.returns({ id: '#profileId' })
         })
+
         it('should update the person data', async function () {
           await controller.saveValues(req, res, nextSpy)
           expect(profileService.update).to.be.calledOnceWithExactly({
@@ -327,6 +332,7 @@ describe('Move controllers', function () {
           req.form.values.violent = '#changeme'
           profileService.update.throws(err)
         })
+
         it('should call next with the error thrown', async function () {
           try {
             await controller.saveValues(req, res, nextSpy)

--- a/app/move/app/edit/controllers/base.test.js
+++ b/app/move/app/edit/controllers/base.test.js
@@ -268,12 +268,14 @@ describe('Move controllers', function () {
       })
 
       context('When a valid ', function () {
-        this.beforeEach(function () {
+        beforeEach(function () {
           controller.getUpdateValues(req)
         })
+
         it('should get person data', function () {
           expect(req.getPerson).to.be.calledOnceWithExactly()
         })
+
         it('should get person data', function () {
           expect(personService.unformat).to.be.calledOnceWithExactly(person, [
             'field1',
@@ -287,6 +289,7 @@ describe('Move controllers', function () {
       let req
       let nextSpy
       const res = {}
+
       beforeEach(function () {
         req = {
           get: sinon.stub(),
@@ -340,6 +343,7 @@ describe('Move controllers', function () {
           },
         },
       }
+
       beforeEach(function () {
         req = {
           models: {},
@@ -699,10 +703,12 @@ describe('Move controllers', function () {
       beforeEach(function () {
         req.initialStep = true
       })
+
       it('should call the getUpdateValues method with the correct args', function () {
         controller.getValues(req, res, callback)
         expect(controller.getUpdateValues).to.be.calledOnceWithExactly(req, res)
       })
+
       it('should call the protectReadOnlyFields method with the correct args', function () {
         controller.getValues(req, res, callback)
         expect(controller.protectReadOnlyFields).to.be.calledOnceWithExactly(
@@ -723,6 +729,7 @@ describe('Move controllers', function () {
 
     context('when super.getUpdateValues passes an error', function () {
       let err
+
       beforeEach(function () {
         err = new Error()
         getValuesStub.callsFake((req, res, valuesCallback) => {
@@ -738,6 +745,7 @@ describe('Move controllers', function () {
 
     context('when this.getUpdateValues throws an error', function () {
       let err
+
       beforeEach(function () {
         req.initialStep = true
         req.form.options.update = true
@@ -755,10 +763,12 @@ describe('Move controllers', function () {
 
   describe('#getUpdateValues()', function () {
     const req = { services: { person: personService } }
+
     beforeEach(function () {
       req.getPerson = sinon.stub()
       personService.unformat.resetHistory().returns({})
     })
+
     context('when default getUpdateValues method invoked', function () {
       it('should return an empty object', function () {
         const values = controller.getUpdateValues(req, {})
@@ -792,6 +802,7 @@ describe('Move controllers', function () {
       protectedNull: null,
       protected: 'protected-value',
     }
+
     beforeEach(function () {
       req = {
         form: {
@@ -807,16 +818,19 @@ describe('Move controllers', function () {
       const { unprotected } = req.form.options.fields
       expect(unprotected).to.deep.equal(fields.unprotected)
     })
+
     it('should leave protected fields that have no value unchanged', function () {
       controller.protectReadOnlyFields(req, values)
       const { protectedUndef } = req.form.options.fields
       expect(protectedUndef).to.deep.equal(fields.protectedUndef)
     })
+
     it('should leave protected fields that have null value unchanged', function () {
       controller.protectReadOnlyFields(req, values)
       const { protectedNull } = req.form.options.fields
       expect(protectedNull).to.deep.equal(fields.protectedNull)
     })
+
     it('should update component of protected fields that have a value', function () {
       controller.protectReadOnlyFields(req, values)
       const { protected: protectedField } = req.form.options.fields
@@ -830,7 +844,8 @@ describe('Move controllers', function () {
     let req
     const res = {}
     let nextSpy, moveService
-    beforeEach(async function () {
+
+    beforeEach(function () {
       sinon.stub(controller, 'setFlash')
       moveService = {
         update: sinon.stub().resolves(),
@@ -906,11 +921,13 @@ describe('Move controllers', function () {
 
     context('when an error is thrown', function () {
       let error
+
       beforeEach(async function () {
         error = new Error()
         req.services.move.update = sinon.stub().rejects(error)
         await controller.saveMove(req, res, nextSpy)
       })
+
       it('should invoke next with the error', function () {
         expect(nextSpy).to.be.calledOnceWithExactly(error)
       })
@@ -919,7 +936,8 @@ describe('Move controllers', function () {
 
   describe('#setFlash', function () {
     let req
-    beforeEach(async function () {
+
+    beforeEach(function () {
       req = {
         t: sinon.stub().returnsArg(0),
         flash: sinon.spy(),
@@ -937,8 +955,8 @@ describe('Move controllers', function () {
     })
 
     context('when the supplier is known', function () {
-      beforeEach(async function () {
-        await controller.setFlash(req, 'categoryKey')
+      beforeEach(function () {
+        controller.setFlash(req, 'categoryKey')
       })
 
       it('should output localised strings containing the suppliers', function () {
@@ -954,9 +972,9 @@ describe('Move controllers', function () {
     })
 
     context('when the supplier is not known', function () {
-      beforeEach(async function () {
+      beforeEach(function () {
         req.getMove = sinon.stub().returns({})
-        await controller.setFlash(req, 'categoryKey')
+        controller.setFlash(req, 'categoryKey')
       })
 
       it('should output localised strings containing generic supplier info', function () {
@@ -975,9 +993,9 @@ describe('Move controllers', function () {
     })
 
     context('when passed an explicit key', function () {
-      beforeEach(async function () {
+      beforeEach(function () {
         controller.flashKey = 'flashKey'
-        await controller.setFlash(req, 'categoryKey')
+        controller.setFlash(req, 'categoryKey')
       })
 
       it('should set confirmation message using explicit key', function () {
@@ -991,9 +1009,9 @@ describe('Move controllers', function () {
     context(
       'when passed no explicit key but has a flashKey property',
       function () {
-        beforeEach(async function () {
+        beforeEach(function () {
           controller.flashKey = 'flashKey'
-          await controller.setFlash(req)
+          controller.setFlash(req)
         })
 
         it('should set confirmation message using explicit key', function () {
@@ -1008,9 +1026,9 @@ describe('Move controllers', function () {
     context(
       'when passed no explicit key and has no flashKey property',
       function () {
-        beforeEach(async function () {
+        beforeEach(function () {
           delete controller.flashKey
-          await controller.setFlash(req)
+          controller.setFlash(req)
         })
 
         it('should set confirmation message using explicit key', function () {

--- a/app/move/app/edit/controllers/document.test.js
+++ b/app/move/app/edit/controllers/document.test.js
@@ -57,7 +57,7 @@ describe('Move controllers', function () {
       }
       const res = {}
       let nextSpy
-      beforeEach(async function () {
+      beforeEach(function () {
         sinon.stub(MixinProto, 'configure')
         nextSpy = sinon.spy()
       })
@@ -187,7 +187,7 @@ describe('Move controllers', function () {
       const profile = { id: '#profile', person: { id: '#person' } }
       const mockProfile = { ...profile, foo: 'bar' }
 
-      beforeEach(async function () {
+      beforeEach(function () {
         profileService = {
           update: sinon.stub().resolves({}),
         }
@@ -214,35 +214,37 @@ describe('Move controllers', function () {
         beforeEach(async function () {
           await controller.successHandler(req, res, nextSpy)
         })
-        it('should update the move', async function () {
+
+        it('should update the move', function () {
           expect(profileService.update).to.be.calledOnceWithExactly({
             ...profile,
             documents,
           })
         })
 
-        it('should redirect back to the move view', async function () {
+        it('should redirect back to the move view', function () {
           expect(controller.getBaseUrl).to.be.calledOnceWithExactly(req)
           expect(res.redirect).to.be.calledOnceWithExactly('__url__')
         })
 
-        it('should not invoke mixin’s successHandler', async function () {
+        it('should not invoke mixin’s successHandler', function () {
           expect(MixinProto.successHandler).not.to.be.called
         })
 
-        it('should not invoke next', async function () {
+        it('should not invoke next', function () {
           expect(nextSpy).not.to.be.called
         })
       })
 
       context('When saving fails', function () {
         const error = new Error('boom')
+
         beforeEach(async function () {
           profileService.update.throws(error)
           await controller.successHandler(req, res, nextSpy)
         })
 
-        it('should invoke next with error', async function () {
+        it('should invoke next with error', function () {
           expect(nextSpy).to.be.calledOnceWithExactly(error)
         })
       })
@@ -253,11 +255,11 @@ describe('Move controllers', function () {
           await controller.successHandler(req, res, nextSpy)
         })
 
-        it('should not update the move', async function () {
+        it('should not update the move', function () {
           expect(profileService.update).not.to.be.called
         })
 
-        it('should invoke mixin’s successHandler', async function () {
+        it('should invoke mixin’s successHandler', function () {
           expect(MixinProto.successHandler).to.be.calledOnceWithExactly(
             req,
             res,
@@ -265,7 +267,7 @@ describe('Move controllers', function () {
           )
         })
 
-        it('should not invoke next', async function () {
+        it('should not invoke next', function () {
           expect(nextSpy).not.to.be.called
         })
       })

--- a/app/move/app/edit/controllers/hospital.test.js
+++ b/app/move/app/edit/controllers/hospital.test.js
@@ -37,6 +37,7 @@ describe('Move controllers', function () {
         const ownProps = Object.getOwnPropertyNames(ownProto).filter(
           prop => !mixedinMethods.includes(prop) || ownMethods.includes(prop)
         )
+
         expect(ownProps).to.deep.equal(ownMethods)
       })
     })
@@ -46,6 +47,7 @@ describe('Move controllers', function () {
       const res = {}
       const values = {}
       const mockMove = {}
+
       beforeEach(function () {
         req = {
           getMove: sinon.stub().returns(mockMove),
@@ -62,6 +64,7 @@ describe('Move controllers', function () {
         beforeEach(function () {
           req.initialStep = true
         })
+
         it('should return the move', function () {
           expect(controller.getUpdateValues(req, res, values)).to.equal(
             mockMove
@@ -74,19 +77,20 @@ describe('Move controllers', function () {
       const req = {}
       const res = {}
       let nextSpy
-      beforeEach(async function () {
+
+      beforeEach(function () {
         sinon.stub(UpdateBaseController.prototype, 'saveMove')
         nextSpy = sinon.spy()
-        await controller.saveValues(req, res, nextSpy)
+        controller.saveValues(req, res, nextSpy)
       })
 
-      it('should call base’s saveMove', async function () {
+      it('should call base’s saveMove', function () {
         expect(
           UpdateBaseController.prototype.saveMove
         ).to.be.calledOnceWithExactly(req, res, nextSpy)
       })
 
-      it('should not invoke next itself', async function () {
+      it('should not invoke next itself', function () {
         expect(nextSpy).to.not.be.called
       })
     })

--- a/app/move/app/edit/controllers/move-date.test.js
+++ b/app/move/app/edit/controllers/move-date.test.js
@@ -45,6 +45,7 @@ describe('Move controllers', function () {
         const ownProps = Object.getOwnPropertyNames(ownProto).filter(
           prop => !mixedinMethods.includes(prop) || ownMethods.includes(prop)
         )
+
         expect(ownProps).to.deep.equal(ownMethods)
       })
     })
@@ -59,6 +60,7 @@ describe('Move controllers', function () {
           TOMORROW: tomorrow,
         },
       }
+
       beforeEach(function () {
         req = {
           form: {
@@ -78,9 +80,11 @@ describe('Move controllers', function () {
 
       context('When a move exists without a move type', function () {
         const move = { id: '#move', date: '2019-10-04' }
+
         beforeEach(function () {
           req.getMove.returns(move)
         })
+
         context('When not today or tomorrow', function () {
           it('should return just the move type', function () {
             expect(controller.getUpdateValues(req, res)).to.deep.equal({
@@ -89,10 +93,12 @@ describe('Move controllers', function () {
             })
           })
         })
+
         context('When a today', function () {
           beforeEach(function () {
             move.date = today
           })
+
           it('should return just the move type', function () {
             expect(controller.getUpdateValues(req, res)).to.deep.equal({
               date_type: 'today',
@@ -103,6 +109,7 @@ describe('Move controllers', function () {
           beforeEach(function () {
             move.date = tomorrow
           })
+
           it('should return just the move type', function () {
             expect(controller.getUpdateValues(req, res)).to.deep.equal({
               date_type: 'tomorrow',
@@ -116,19 +123,20 @@ describe('Move controllers', function () {
       const req = {}
       const res = {}
       let nextSpy
-      beforeEach(async function () {
+
+      beforeEach(function () {
         sinon.stub(UpdateBaseController.prototype, 'saveMove')
         nextSpy = sinon.spy()
-        await controller.saveValues(req, res, nextSpy)
+        controller.saveValues(req, res, nextSpy)
       })
 
-      it('should call base’s saveMove', async function () {
+      it('should call base’s saveMove', function () {
         expect(
           UpdateBaseController.prototype.saveMove
         ).to.be.calledOnceWithExactly(req, res, nextSpy)
       })
 
-      it('should not invoke next itself', async function () {
+      it('should not invoke next itself', function () {
         expect(nextSpy).to.not.be.called
       })
     })

--- a/app/move/app/edit/controllers/move-details.test.js
+++ b/app/move/app/edit/controllers/move-details.test.js
@@ -177,6 +177,7 @@ describe('Move controllers', function () {
             },
           ])
         })
+
         it('should call the next method', function () {
           expect(nextSpy).to.be.calledOnceWithExactly()
         })
@@ -187,7 +188,8 @@ describe('Move controllers', function () {
       let req = {}
       const res = {}
       let nextSpy, moveService
-      beforeEach(async function () {
+
+      beforeEach(function () {
         moveService = {
           redirect: sinon.stub(),
           update: sinon.stub(),
@@ -233,14 +235,14 @@ describe('Move controllers', function () {
               await controller.saveValues(req, res, nextSpy)
             })
 
-            it('should call set the notes property', async function () {
+            it('should call set the notes property', function () {
               expect(req.t).to.be.calledOnceWithExactly(
                 'moves::redirect_notes',
                 req.session.user
               )
             })
 
-            it('should call move service’s redirect method', async function () {
+            it('should call move service’s redirect method', function () {
               expect(moveService.redirect).to.be.calledOnceWithExactly({
                 id: '#moveId',
                 notes: 'moves::redirect_notes',
@@ -250,7 +252,7 @@ describe('Move controllers', function () {
               })
             })
 
-            it('should invoke next', async function () {
+            it('should invoke next', function () {
               expect(nextSpy).to.be.calledOnceWithExactly()
             })
           })
@@ -266,11 +268,11 @@ describe('Move controllers', function () {
               await controller.saveValues(req, res, nextSpy)
             })
 
-            it('should not call move service’s redirect method', async function () {
+            it('should not call move service’s redirect method', function () {
               expect(moveService.redirect).to.not.be.called
             })
 
-            it('should invoke next', async function () {
+            it('should invoke next', function () {
               expect(nextSpy).to.be.calledOnceWithExactly()
             })
           })
@@ -282,7 +284,7 @@ describe('Move controllers', function () {
               await controller.saveValues(req, res, nextSpy)
             })
 
-            it('should invoke next with error', async function () {
+            it('should invoke next with error', function () {
               expect(nextSpy).to.be.calledOnceWithExactly(error)
             })
           })
@@ -300,14 +302,14 @@ describe('Move controllers', function () {
               await controller.saveValues(req, res, nextSpy)
             })
 
-            it('should call move service’s update method', async function () {
+            it('should call move service’s update method', function () {
               expect(moveService.update).to.be.calledOnceWithExactly({
                 id: '#moveId',
                 additional_information: '#additionalInformation',
               })
             })
 
-            it('should invoke next', async function () {
+            it('should invoke next', function () {
               expect(nextSpy).to.be.calledOnceWithExactly()
             })
           })
@@ -321,17 +323,18 @@ describe('Move controllers', function () {
               await controller.saveValues(req, res, nextSpy)
             })
 
-            it('should not call move service’s update method', async function () {
+            it('should not call move service’s update method', function () {
               expect(moveService.update).to.not.be.called
             })
 
-            it('should invoke next', async function () {
+            it('should invoke next', function () {
               expect(nextSpy).to.be.calledOnceWithExactly()
             })
           })
 
           context('and the move service errors', function () {
             const error = new Error()
+
             beforeEach(async function () {
               req.getMove.returns({
                 move_type: moveType,
@@ -341,7 +344,7 @@ describe('Move controllers', function () {
               await controller.saveValues(req, res, nextSpy)
             })
 
-            it('should invoke next with error', async function () {
+            it('should invoke next with error', function () {
               expect(nextSpy).to.be.calledOnceWithExactly(error)
             })
           })
@@ -360,7 +363,7 @@ describe('Move controllers', function () {
           await controller.saveValues(req, res, nextSpy)
         })
 
-        it('should not call move service’s update method', async function () {
+        it('should not call move service’s update method', function () {
           expect(moveService.update).to.not.be.called
         })
       })

--- a/app/move/app/edit/controllers/personal-details.test.js
+++ b/app/move/app/edit/controllers/personal-details.test.js
@@ -41,7 +41,8 @@ describe('Move controllers', function () {
       let req
       const res = {}
       let nextSpy
-      beforeEach(async function () {
+
+      beforeEach(function () {
         sinon.stub(controller, 'setFlash')
         personService.unformat.returns({}).resetHistory()
         personService.update.resolves().resetHistory()
@@ -76,15 +77,15 @@ describe('Move controllers', function () {
           await controller.saveValues(req, res, nextSpy)
         })
 
-        it('should not call update', async function () {
+        it('should not call update', function () {
           expect(personService.update).to.not.be.called
         })
 
-        it('should set the confirmation message', async function () {
+        it('should set the confirmation message', function () {
           expect(controller.setFlash).to.not.be.called
         })
 
-        it('should invoke next with no error', async function () {
+        it('should invoke next with no error', function () {
           expect(nextSpy).to.be.calledOnceWithExactly()
         })
       })
@@ -93,7 +94,8 @@ describe('Move controllers', function () {
         beforeEach(async function () {
           await controller.saveValues(req, res, nextSpy)
         })
-        it('should call unformat with expected field keys', async function () {
+
+        it('should call unformat with expected field keys', function () {
           expect(personService.unformat).to.be.calledOnceWithExactly(
             {
               id: '#personId',
@@ -103,7 +105,7 @@ describe('Move controllers', function () {
           )
         })
 
-        it('should call update with expected data', async function () {
+        it('should call update with expected data', function () {
           expect(personService.update).to.be.calledOnceWithExactly({
             id: '#personId',
             foo: 'a',
@@ -111,23 +113,25 @@ describe('Move controllers', function () {
           })
         })
 
-        it('should set the confirmation message', async function () {
+        it('should set the confirmation message', function () {
           expect(controller.setFlash).to.be.calledOnceWithExactly(req)
         })
 
-        it('should invoke next with no error', async function () {
+        it('should invoke next with no error', function () {
           expect(nextSpy).to.be.calledOnceWithExactly()
         })
       })
 
       context('when an error is thrown', function () {
         let error
+
         beforeEach(async function () {
           error = new Error()
           personService.update.rejects(error)
           await controller.saveValues(req, res, nextSpy)
         })
-        it('should invoke next with the error', async function () {
+
+        it('should invoke next with the error', function () {
           expect(nextSpy).to.be.calledOnceWithExactly(error)
         })
       })

--- a/app/moves/middleware/set-download-results.moves.test.js
+++ b/app/moves/middleware/set-download-results.moves.test.js
@@ -13,7 +13,7 @@ describe('Moves middleware', function () {
   describe('#setDownloadResultsMoves()', function () {
     let req, res, nextSpy, moveService
 
-    beforeEach(async function () {
+    beforeEach(function () {
       moveService = {
         getDownload: sinon.stub().resolves(mockMoves),
       }

--- a/app/moves/middleware/set-filter.moves.test.js
+++ b/app/moves/middleware/set-filter.moves.test.js
@@ -81,17 +81,19 @@ describe('Moves middleware', function () {
           expect(req.filterBodyKey).to.deep.equal(filter)
         })
 
-        it('calls the servive with correct arguments', async function () {
+        it('calls the servive with correct arguments', function () {
           expect(moveService.getActive).to.have.been.calledWithExactly({
             ...req.body[mockBodyKey],
             isAggregation: true,
             status: 'pending',
           })
+
           expect(moveService.getActive).to.have.been.calledWithExactly({
             ...req.body[mockBodyKey],
             isAggregation: true,
             status: 'approved',
           })
+
           expect(moveService.getActive).to.have.been.calledWithExactly({
             ...req.body[mockBodyKey],
             isAggregation: true,
@@ -99,7 +101,7 @@ describe('Moves middleware', function () {
           })
         })
 
-        it('calls the service on each item', async function () {
+        it('calls the service on each item', function () {
           expect(moveService.getActive.callCount).to.equal(3)
         })
 

--- a/app/moves/middleware/set-filter.single-requests.test.js
+++ b/app/moves/middleware/set-filter.single-requests.test.js
@@ -80,7 +80,7 @@ describe('Moves middleware', function () {
           ])
         })
 
-        it('calls the servive with correct arguments', async function () {
+        it('calls the servive with correct arguments', function () {
           expect(singleRequestService.getAll).to.have.been.calledWithExactly({
             isAggregation: true,
             status: 'pending',
@@ -101,7 +101,7 @@ describe('Moves middleware', function () {
           })
         })
 
-        it('calls the service on each item', async function () {
+        it('calls the service on each item', function () {
           expect(singleRequestService.getAll.callCount).to.equal(3)
         })
 

--- a/app/moves/middleware/set-results.moves.test.js
+++ b/app/moves/middleware/set-results.moves.test.js
@@ -16,7 +16,7 @@ describe('Moves middleware', function () {
   describe('#setResultsMoves()', function () {
     let req, res, nextSpy, moveToCardComponentMapStub, moveService
 
-    beforeEach(async function () {
+    beforeEach(function () {
       moveService = {
         getActive: sinon.stub(),
       }

--- a/app/population/controllers/daily.js
+++ b/app/population/controllers/daily.js
@@ -1,6 +1,6 @@
 const populationToGrid = require('../../../common/presenters/population-to-grid')
 
-async function daily(req, res) {
+function daily(req, res) {
   const {
     population,
     transfers,

--- a/app/population/middleware/set-results.freespaces-and-transfers-tables.js
+++ b/app/population/middleware/set-results.freespaces-and-transfers-tables.js
@@ -5,7 +5,7 @@ const {
   locationsToPopulationAndTransfersTables,
 } = require('../../../common/presenters/date-table/locations-to-population-table-component')
 
-async function setResultsFreeSpaccesAndTransferTables(req, res, next) {
+function setResultsFreeSpaccesAndTransferTables(req, res, next) {
   try {
     const { dateRange, query } = req
 

--- a/app/population/middleware/set-results.freespaces-and-transfers-tables.test.js
+++ b/app/population/middleware/set-results.freespaces-and-transfers-tables.test.js
@@ -60,8 +60,8 @@ describe('Population middleware', function () {
     })
 
     context('by default', function () {
-      beforeEach(async function () {
-        await middleware(req, res, next)
+      beforeEach(function () {
+        middleware(req, res, next)
       })
 
       it('should call locationsToPopulationTable presenter', function () {
@@ -85,8 +85,8 @@ describe('Population middleware', function () {
     })
 
     context('on errors', function () {
-      it('should call next with missing resultsAsPopulation', async function () {
-        await middleware({}, res, next)
+      it('should call next with missing resultsAsPopulation', function () {
+        middleware({}, res, next)
 
         expect(next).to.have.been.calledWith(
           sinon.match(
@@ -97,12 +97,12 @@ describe('Population middleware', function () {
         )
       })
 
-      it('should call next with presenter errors', async function () {
+      it('should call next with presenter errors', function () {
         locationsToPopulationComponent.locationsToPopulationAndTransfersTables.throws(
           new Error('Presenter error')
         )
 
-        await middleware(req, res, next)
+        middleware(req, res, next)
 
         expect(next).to.have.been.calledWith(
           sinon.match(

--- a/app/population/middleware/set-results.freespaces-tables.js
+++ b/app/population/middleware/set-results.freespaces-tables.js
@@ -5,7 +5,7 @@ const {
   locationsToPopulationTable,
 } = require('../../../common/presenters/date-table/locations-to-population-table-component')
 
-async function setResultsPopulationTables(req, res, next) {
+function setResultsPopulationTables(req, res, next) {
   try {
     const { dateRange, query } = req
 

--- a/app/population/middleware/set-results.freespaces-tables.test.js
+++ b/app/population/middleware/set-results.freespaces-tables.test.js
@@ -59,8 +59,8 @@ describe('Population middleware', function () {
     })
 
     context('by default', function () {
-      beforeEach(async function () {
-        await middleware(req, res, next)
+      beforeEach(function () {
+        middleware(req, res, next)
       })
 
       it('should call locationsToPopulationTable presenter', function () {
@@ -84,8 +84,8 @@ describe('Population middleware', function () {
     })
 
     context('on errors', function () {
-      it('should call next with missing resultsAsPopulation', async function () {
-        await middleware({}, res, next)
+      it('should call next with missing resultsAsPopulation', function () {
+        middleware({}, res, next)
 
         expect(next).to.have.been.calledWith(
           sinon.match(
@@ -96,12 +96,12 @@ describe('Population middleware', function () {
         )
       })
 
-      it('should call next with presenter errors', async function () {
+      it('should call next with presenter errors', function () {
         locationsToPopulationComponent.locationsToPopulationTable.throws(
           new Error('Presenter error')
         )
 
-        await middleware(req, res, next)
+        middleware(req, res, next)
 
         expect(next).to.have.been.calledWith(
           sinon.match(

--- a/common/controllers/framework/confirm-assessment.test.js
+++ b/common/controllers/framework/confirm-assessment.test.js
@@ -213,7 +213,7 @@ describe('Framework controllers', function () {
     describe('#errorHandler', function () {
       let nextSpy
 
-      beforeEach(async function () {
+      beforeEach(function () {
         nextSpy = sinon.spy()
       })
 

--- a/common/lib/api-client/auth.test.js
+++ b/common/lib/api-client/auth.test.js
@@ -197,7 +197,7 @@ describe('API Client', function () {
       const mockResponse = {
         data: mockTokenResponse,
       }
-      beforeEach(async function () {
+      beforeEach(function () {
         sinon.stub(axios, 'post').resolves(mockResponse)
         sinon.stub(clientMetrics, 'recordSuccess')
         sinon.stub(clientMetrics, 'recordError')

--- a/common/lib/api-client/middleware/auth.test.js
+++ b/common/lib/api-client/middleware/auth.test.js
@@ -52,7 +52,7 @@ describe('API Client', function () {
     })
 
     context('when access token rejects', function () {
-      beforeEach(async function () {
+      beforeEach(function () {
         MockAuth.prototype.getAuthorizationHeader.rejects(new Error())
       })
 

--- a/common/lib/api-client/middleware/get-cache.test.js
+++ b/common/lib/api-client/middleware/get-cache.test.js
@@ -15,17 +15,16 @@ const mockResponse = {
 describe('API Client', function () {
   describe('Get cache middleware', function () {
     describe('#cache-key', function () {
-      let expectedPayload
       let payload
+
       beforeEach(function () {
         payload = {}
-        expectedPayload = { ...payload }
         cache.get.resetHistory()
       })
 
       context('when payload has no cache key', function () {
-        beforeEach(function () {
-          middleware().req(payload)
+        beforeEach(async function () {
+          await middleware().req(payload)
         })
 
         it('should not get the cached value', function () {
@@ -33,7 +32,7 @@ describe('API Client', function () {
         })
 
         it('should leave payload untouched', function () {
-          expect(payload).to.deep.equal(expectedPayload)
+          expect(payload).to.deep.equal({})
         })
       })
 
@@ -47,11 +46,7 @@ describe('API Client', function () {
         context('and a value has been cached', function () {
           beforeEach(async function () {
             cache.get.resolves(mockResponse)
-            expectedPayload = {
-              ...payload,
-              res: { body: mockResponse, data: mockResponse },
-            }
-            middleware().req(payload)
+            await middleware().req(payload)
           })
 
           it('should get the cached value', function () {
@@ -59,14 +54,18 @@ describe('API Client', function () {
           })
 
           it('should add the cached value as response to the payload', function () {
-            expect(payload).to.deep.equal(expectedPayload)
+            expect(payload).to.deep.equal({
+              cacheKey: 'cache-key',
+              res: { body: mockResponse, data: mockResponse },
+            })
           })
         })
 
         context('but no value has been cached', function () {
-          beforeEach(function () {
-            expectedPayload = { ...payload }
-            middleware().req(payload)
+          beforeEach(async function () {
+            await middleware().req({
+              cacheKey: 'cache-key',
+            })
           })
 
           it('should get the cached value', function () {
@@ -74,13 +73,15 @@ describe('API Client', function () {
           })
 
           it('should leave payload untouched', function () {
-            expect(payload).to.deep.equal(expectedPayload)
+            expect(payload).to.deep.equal({
+              cacheKey: 'cache-key',
+            })
           })
         })
 
         context('and redis is enabled', function () {
-          beforeEach(function () {
-            middleware({ useRedisCache: true }).req(payload)
+          beforeEach(async function () {
+            await middleware({ useRedisCache: true }).req(payload)
           })
 
           it('should tell cache module to use redis', function () {

--- a/common/lib/api-client/middleware/got-request.test.js
+++ b/common/lib/api-client/middleware/got-request.test.js
@@ -171,7 +171,7 @@ describe('API Client', function () {
     })
 
     context('when response should be cached', function () {
-      beforeEach(async function () {
+      beforeEach(function () {
         payload.cacheKey = 'cache-key'
       })
 
@@ -232,7 +232,7 @@ describe('API Client', function () {
       let thrownError
       let error
 
-      beforeEach(async function () {
+      beforeEach(function () {
         error = new Error('Mock error')
       })
 

--- a/common/lib/api-client/middleware/request.test.js
+++ b/common/lib/api-client/middleware/request.test.js
@@ -93,7 +93,7 @@ describe('API Client', function () {
     })
 
     context('when response should be cached', function () {
-      beforeEach(async function () {
+      beforeEach(function () {
         payload.cacheKey = 'cache-key'
       })
 

--- a/common/lib/api-client/rest-client.js
+++ b/common/lib/api-client/rest-client.js
@@ -30,7 +30,7 @@ const restClient = async (url, args, options = {}) => {
 
 restClient.get = restClient
 
-restClient.post = async (url, data, options) =>
+restClient.post = (url, data, options) =>
   restClient(url, data, { ...options, method: 'post' })
 
 module.exports = restClient

--- a/common/lib/api-client/rest-client.test.js
+++ b/common/lib/api-client/rest-client.test.js
@@ -22,16 +22,17 @@ const restClient = proxyquire('./rest-client', {
   axios: axiosStub,
 })
 
-describe('API Client', async function () {
-  describe('Rest client', async function () {
+describe('API Client', function () {
+  describe('Rest client', function () {
     beforeEach(function () {
       axiosStub.resetHistory()
       getAuthorizationHeaderStub.resetHistory()
       getRequestHeadersStub.resetHistory()
     })
 
-    context('when calling the API', async function () {
+    context('when calling the API', function () {
       let data
+
       beforeEach(async function () {
         data = await restClient('/foo')
       })
@@ -61,7 +62,7 @@ describe('API Client', async function () {
       })
     })
 
-    context('when calling the API with params', async function () {
+    context('when calling the API with params', function () {
       beforeEach(async function () {
         await restClient('/foo', { bar: 'baz' })
       })
@@ -80,7 +81,7 @@ describe('API Client', async function () {
       })
     })
 
-    context('when calling the API as a post with no data', async function () {
+    context('when calling the API as a post with no data', function () {
       beforeEach(async function () {
         await restClient('/foo', null, { method: 'post' })
       })
@@ -99,7 +100,7 @@ describe('API Client', async function () {
       })
     })
 
-    context('when calling the API as a post with data', async function () {
+    context('when calling the API as a post with data', function () {
       beforeEach(async function () {
         await restClient('/foo', { bar: 'baz' }, { method: 'post' })
       })
@@ -119,7 +120,7 @@ describe('API Client', async function () {
       })
     })
 
-    context('when calling the API - format', async function () {
+    context('when calling the API - format', function () {
       beforeEach(async function () {
         await restClient('/foo', { bar: 'baz' }, { format: 'application/foo' })
       })
@@ -131,7 +132,7 @@ describe('API Client', async function () {
       })
     })
 
-    context('when using get method', async function () {
+    context('when using get method', function () {
       beforeEach(async function () {
         await restClient.get('/foo', { bar: 'baz' })
       })
@@ -150,7 +151,7 @@ describe('API Client', async function () {
       })
     })
 
-    context('when using post method', async function () {
+    context('when using post method', function () {
       beforeEach(async function () {
         await restClient.post('/foo', { bar: 'baz' })
       })

--- a/common/middleware/framework/set-record.test.js
+++ b/common/middleware/framework/set-record.test.js
@@ -106,7 +106,7 @@ describe('Framework middleware', function () {
     })
 
     context('when record ID exists', function () {
-      beforeEach(async function () {
+      beforeEach(function () {
         mockReq.params = {
           resourceId: mockRecordId,
         }

--- a/common/services/allocation.test.js
+++ b/common/services/allocation.test.js
@@ -596,7 +596,7 @@ describe('Allocation service', function () {
     const getAllInclude = ['from_location', 'to_location']
     let results
 
-    beforeEach(async function () {
+    beforeEach(function () {
       sinon.stub(allocationService, 'get').resolves(mockAllocations)
     })
 

--- a/common/services/court-hearing.test.js
+++ b/common/services/court-hearing.test.js
@@ -96,7 +96,7 @@ describe('Court Hearing Service', function () {
     }
     let courtHearing
 
-    beforeEach(async function () {
+    beforeEach(function () {
       sinon.stub(apiClient, 'create').resolves(mockResponse)
       sinon.stub(courtHearingService, 'format').returns(mockData)
     })

--- a/common/services/move.test.js
+++ b/common/services/move.test.js
@@ -698,7 +698,7 @@ describe('Move Service', function () {
   describe('#getActive()', function () {
     let moves
 
-    beforeEach(async function () {
+    beforeEach(function () {
       sinon.stub(moveService, 'getAll').resolves(mockMoves)
     })
 
@@ -941,7 +941,7 @@ describe('Move Service', function () {
   describe('#getDownload()', function () {
     let moves
 
-    beforeEach(async function () {
+    beforeEach(function () {
       restClient.post.resetHistory()
       restClient.post.resolves('#download')
     })
@@ -1027,7 +1027,7 @@ describe('Move Service', function () {
       }
       let move
 
-      beforeEach(async function () {
+      beforeEach(function () {
         sinon.stub(apiClient, 'find').resolves(mockResponse)
       })
 
@@ -1067,7 +1067,7 @@ describe('Move Service', function () {
     const mockId = 'b695d0f0-af8e-4b97-891e-92020d6820b9'
     let move
 
-    beforeEach(async function () {
+    beforeEach(function () {
       sinon.stub(moveService, '_getById').resolves(mockMove)
     })
 
@@ -1117,7 +1117,7 @@ describe('Move Service', function () {
     }
     let move
 
-    beforeEach(async function () {
+    beforeEach(function () {
       sinon.stub(apiClient, 'create').resolves(mockResponse)
       sinon.stub(moveService, 'format').returnsArg(0)
     })
@@ -1181,7 +1181,7 @@ describe('Move Service', function () {
       }
       let move
 
-      beforeEach(async function () {
+      beforeEach(function () {
         sinon.stub(apiClient, 'post').resolves(mockResponse)
         sinon.spy(apiClient, 'one')
         sinon.spy(apiClient, 'all')
@@ -1264,7 +1264,7 @@ describe('Move Service', function () {
         },
       }
 
-      beforeEach(async function () {
+      beforeEach(function () {
         sinon.stub(moveService, 'update').resolves(mockResponse)
       })
 

--- a/common/services/person-escort-record.test.js
+++ b/common/services/person-escort-record.test.js
@@ -63,7 +63,7 @@ describe('Services', function () {
       let output
       const mockId = '8567f1a5-2201-4bc2-b655-f6526401303a'
 
-      beforeEach(async function () {
+      beforeEach(function () {
         sinon.stub(apiClient, 'update').resolves({
           data: mockRecord,
         })
@@ -143,7 +143,7 @@ describe('Services', function () {
       let output
       const mockId = '8567f1a5-2201-4bc2-b655-f6526401303a'
 
-      beforeEach(async function () {
+      beforeEach(function () {
         sinon.stub(apiClient, 'find').resolves({
           data: mockRecord,
         })
@@ -194,7 +194,7 @@ describe('Services', function () {
       const mockId = '8567f1a5-2201-4bc2-b655-f6526401303a'
       const mockResponses = [{ id: '1' }, { id: '2' }]
 
-      beforeEach(async function () {
+      beforeEach(function () {
         sinon.stub(apiClient, 'patch').resolves({
           data: [],
         })

--- a/common/services/person.test.js
+++ b/common/services/person.test.js
@@ -218,7 +218,7 @@ describe('Person Service', function () {
       }
       let person
 
-      beforeEach(async function () {
+      beforeEach(function () {
         sinon.stub(apiClient, 'find').resolves(mockResponse)
       })
 
@@ -296,7 +296,7 @@ describe('Person Service', function () {
     }
     let person
 
-    beforeEach(async function () {
+    beforeEach(function () {
       sinon.stub(apiClient, 'update').resolves(mockResponse)
       sinon.stub(personService, 'format').returnsArg(0)
     })
@@ -337,7 +337,7 @@ describe('Person Service', function () {
     }
     let imageUrl
 
-    beforeEach(async function () {
+    beforeEach(function () {
       sinon.stub(apiClient, 'one').returnsThis()
       sinon.stub(apiClient, 'all').returnsThis()
       sinon.stub(apiClient, 'get').resolves(mockResponse)
@@ -382,7 +382,7 @@ describe('Person Service', function () {
     }
     let imageUrl
 
-    beforeEach(async function () {
+    beforeEach(function () {
       sinon.stub(apiClient, 'one').returnsThis()
       sinon.stub(apiClient, 'all').returnsThis()
       sinon.stub(apiClient, 'get').resolves(mockResponse)
@@ -430,7 +430,7 @@ describe('Person Service', function () {
     }
     let imageUrl
 
-    beforeEach(async function () {
+    beforeEach(function () {
       sinon.stub(apiClient, 'one').returnsThis()
       sinon.stub(apiClient, 'all').returnsThis()
       sinon.stub(apiClient, 'get').resolves(mockResponse)
@@ -495,7 +495,7 @@ describe('Person Service', function () {
     }
     let person
 
-    beforeEach(async function () {
+    beforeEach(function () {
       sinon.stub(apiClient, 'findAll').resolves(mockResponse)
     })
 

--- a/common/services/profile.js
+++ b/common/services/profile.js
@@ -55,7 +55,7 @@ class ProfileService extends BaseService {
       .then(response => response.data)
   }
 
-  async update(data) {
+  update(data) {
     const personId = get(data, 'person.id')
 
     if (!personId) {

--- a/common/services/reference-data.test.js
+++ b/common/services/reference-data.test.js
@@ -149,7 +149,7 @@ describe('Reference Data Service', function () {
     }
     let response
 
-    beforeEach(async function () {
+    beforeEach(function () {
       sinon.stub(apiClient, 'findAll')
     })
 
@@ -431,7 +431,7 @@ describe('Reference Data Service', function () {
     const mockResponse = mockLocations
     let locations
 
-    beforeEach(async function () {
+    beforeEach(function () {
       sinon.stub(referenceDataService, 'getLocations').resolves(mockResponse)
     })
 
@@ -578,7 +578,7 @@ describe('Reference Data Service', function () {
     const mockResponse = mockLocations
     let locations
 
-    beforeEach(async function () {
+    beforeEach(function () {
       sinon.stub(referenceDataService, 'getLocations').resolves(mockResponse)
     })
 
@@ -672,7 +672,7 @@ describe('Reference Data Service', function () {
     const mockResponse = mockLocations
     let locations
 
-    beforeEach(async function () {
+    beforeEach(function () {
       restClient.resetHistory()
       restClient.resolves({ data: mockResponse })
     })

--- a/common/services/single-request.js
+++ b/common/services/single-request.js
@@ -92,7 +92,7 @@ class SingleRequestService extends BaseService {
     })
   }
 
-  async getDownload(args) {
+  getDownload(args) {
     return this.moveService.getDownload(args)
   }
 

--- a/common/services/single-request.test.js
+++ b/common/services/single-request.test.js
@@ -39,7 +39,7 @@ describe('Single request service', function () {
   describe('#getAll()', function () {
     let moves
 
-    beforeEach(async function () {
+    beforeEach(function () {
       sinon.stub(moveService, 'get').resolves(mockMoves)
     })
 
@@ -285,7 +285,7 @@ describe('Single request service', function () {
   describe('#getDownload()', function () {
     let moves
 
-    beforeEach(async function () {
+    beforeEach(function () {
       sinon.stub(moveService, 'getDownload').resolves('#download')
     })
 
@@ -327,7 +327,7 @@ describe('Single request service', function () {
       }
       let move
 
-      beforeEach(async function () {
+      beforeEach(function () {
         sinon.stub(apiClient, 'all').returns(apiClient)
         sinon.stub(apiClient, 'one').returns(apiClient)
         sinon.stub(apiClient, 'post').resolves(mockResponse)
@@ -393,7 +393,7 @@ describe('Single request service', function () {
       }
       let move
 
-      beforeEach(async function () {
+      beforeEach(function () {
         sinon.stub(apiClient, 'all').returns(apiClient)
         sinon.stub(apiClient, 'one').returns(apiClient)
         sinon.stub(apiClient, 'post').resolves(mockResponse)

--- a/common/services/user.test.js
+++ b/common/services/user.test.js
@@ -202,7 +202,7 @@ describe('User service', function () {
     })
 
     context('when supplier call errors', function () {
-      beforeEach(async function () {
+      beforeEach(function () {
         nock(configStub.AUTH_PROVIDERS.hmpps.groups_url('test'))
           .get('/')
           .reply(
@@ -312,7 +312,7 @@ describe('User service', function () {
         result = await getLocations(null, supplierStub.id, [])
       })
 
-      it('looks up locations for the supplier', async function () {
+      it('looks up locations for the supplier', function () {
         expect(
           referenceDataStub.getLocationsBySupplierId
         ).to.be.calledWithExactly(supplierStub.id)
@@ -327,7 +327,7 @@ describe('User service', function () {
         ])
       })
 
-      it('looks up locations for the supplier', async function () {
+      it('looks up locations for the supplier', function () {
         expect(referenceDataStub.getSuppliers).to.be.calledOnce
         expect(
           referenceDataStub.getLocationsBySupplierId

--- a/common/services/youth-risk-assessment.test.js
+++ b/common/services/youth-risk-assessment.test.js
@@ -63,7 +63,7 @@ describe('Services', function () {
       let output
       const mockId = '8567f1a5-2201-4bc2-b655-f6526401303a'
 
-      beforeEach(async function () {
+      beforeEach(function () {
         sinon.stub(apiClient, 'update').resolves({
           data: mockRecord,
         })
@@ -102,7 +102,7 @@ describe('Services', function () {
       let output
       const mockId = '8567f1a5-2201-4bc2-b655-f6526401303a'
 
-      beforeEach(async function () {
+      beforeEach(function () {
         sinon.stub(apiClient, 'find').resolves({
           data: mockRecord,
         })
@@ -153,7 +153,7 @@ describe('Services', function () {
       const mockId = '8567f1a5-2201-4bc2-b655-f6526401303a'
       const mockResponses = [{ id: '1' }, { id: '2' }]
 
-      beforeEach(async function () {
+      beforeEach(function () {
         sinon.stub(apiClient, 'patch').resolves({
           data: [],
         })

--- a/test/e2e/_helpers.js
+++ b/test/e2e/_helpers.js
@@ -186,7 +186,7 @@ export async function createPersonFixture(overrides = {}) {
  *
  * @returns {object} - profile data
  */
-export async function generateProfile(personId, overrides = {}) {
+export function generateProfile(personId, overrides = {}) {
   return {
     assessment_answers: [],
     person: {
@@ -421,7 +421,7 @@ export async function fillAutocomplete({ selector, value }) {
  *
  * @returns {string|array} - value of the selected item or array of items selected
  */
-export async function fillRadioOrCheckbox({ selector, value }) {
+export function fillRadioOrCheckbox({ selector, value }) {
   const options = selector
     .parent('fieldset')
     .nth(0)

--- a/test/e2e/_move.js
+++ b/test/e2e/_move.js
@@ -96,7 +96,7 @@ export function createCourtMove(options = {}) {
  *
  * @returns {undefined}
  */
-export async function checkUpdateLink(page) {
+export function checkUpdateLink(page) {
   return moveDetailPage.checkUpdateLink(page)
 }
 
@@ -107,7 +107,7 @@ export async function checkUpdateLink(page) {
  *
  * @returns {undefined}
  */
-export async function checkNoUpdateLink(page) {
+export function checkNoUpdateLink(page) {
   return moveDetailPage.checkNoUpdateLink(page)
 }
 
@@ -118,7 +118,7 @@ export async function checkNoUpdateLink(page) {
  *
  * @returns {undefined}
  */
-export async function checkCancelLink() {
+export function checkCancelLink() {
   return moveDetailPage.checkCancelLink()
 }
 
@@ -129,7 +129,7 @@ export async function checkCancelLink() {
  *
  * @returns {undefined}
  */
-export async function checkNoCancelLink() {
+export function checkNoCancelLink() {
   return moveDetailPage.checkCancelLink(false)
 }
 

--- a/test/e2e/pages/cancel-move.js
+++ b/test/e2e/pages/cancel-move.js
@@ -24,7 +24,7 @@ class CancelMovePage extends Page {
    *
    * @returns {Promise}
    */
-  async selectReason(reason, comment) {
+  selectReason(reason, comment) {
     const fields = {
       cancellation_reason: {
         selector: this.fields.cancellationReason,

--- a/test/e2e/pages/page.js
+++ b/test/e2e/pages/page.js
@@ -116,7 +116,7 @@ export default class Page {
    *
    * @returns {Promise}
    */
-  async chooseAllLocations() {
+  chooseAllLocations() {
     const allLocationsLink = Selector('a').withAttribute(
       'href',
       '/locations/all'

--- a/test/e2e/pages/population-edit.js
+++ b/test/e2e/pages/population-edit.js
@@ -25,7 +25,7 @@ class PopulationEditPage extends Page {
     }
   }
 
-  async fill() {
+  fill() {
     const operationalCapacityValue = faker.datatype.number({
       min: 950,
       max: 1000,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

This adds a rule to ensure that asynchronous functions contain
asynchronous code in the form of an `await` or returning a promise.

This also includes the fixes required to pass this new rule.

### Why did it change

We spotted a number of functions, initially within tests, that were using an `async` definition
when there was no need.

Tidying this up ensures we only use `async` for asynchronous functions and means tests are less
likely to hang when failing.

## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed
