### PR TITLE
docs: Improve .env.example defaults

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,21 +1,31 @@
-SESSION_SECRET=example-secret
+## Database
 REDIS_URL=//localhost:6379
-API_BASE_URL=http://localhost:3000
-API_PATH=/api/v1
+
+## Book a Secure Move API
+API_PATH=/api
 API_HEALTHCHECK_PATH=/ping.xml
 API_AUTH_PATH=/oauth/token
-API_CLIENT_ID=
+
+API_BASE_URL=http://localhost:3000
+API_VERSION=2  # 2 is the latest version
+API_CLIENT_ID=  # generate these using auth:create_client_application Rake task
 API_SECRET=
+
+## HMPPS SSO
+AUTH_PROVIDER_URL=
 AUTH_PROVIDER_KEY=
 AUTH_PROVIDER_SECRET=
-AUTH_PROVIDER_URL=
 SERVER_HOST=localhost:3000
+SESSION_SECRET=example-secret
+
+# HMPPS Elite2 API
 NOMIS_ELITE2_API_URL=https://gateway.t3.nomis-api.hmpps.dsd.io/elite2api
 
-## Development only
+## Development
 # BYPASS_SSO=true
 # USER_PERMISSIONS=moves:view:by_location,moves:download:by_location,move:view,move:create,move:cancel,moves:view:all,moves:download:all
 
+## End to end tests
 E2E_BASE_URL= # defaults to $SERVER_HOST
 E2E_POLICE_USERNAME=
 E2E_POLICE_PASSWORD=


### PR DESCRIPTION
This adds a few more useful environment variables that need to be set to run the app, re-orders and groups them into sections, and documents where to get a suitable value for a few of them.

Specifically I've removed "v1" from API_PATH as this is determined from API_VERSION now, and I've set it to a meaningful value.