### PR TITLE
fix: Ensure cache is cleared on errors during deserialization

### DIFF
--- a/common/lib/api-client/transformers/transform-resource.js
+++ b/common/lib/api-client/transformers/transform-resource.js
@@ -2,23 +2,28 @@ const { cloneDeep } = require('lodash')
 
 module.exports = function transformResource(transformer) {
   return function deserializer(item, included) {
-    const _this = cloneDeep(this)
-    const modelName = _this.pluralize.singular(item.type)
+    try {
+      const _this = cloneDeep(this)
+      const modelName = _this.pluralize.singular(item.type)
 
-    // Ensure we remove this deserializer to avoid infinite loop
-    delete _this.models[modelName].options.deserializer
+      // Ensure we remove this deserializer to avoid infinite loop
+      delete _this.models[modelName].options.deserializer
 
-    // call devour deserializer
-    const deserializedData = _this.deserialize.resource.call(
-      _this,
-      item,
-      included
-    )
+      // call devour deserializer
+      const deserializedData = _this.deserialize.resource.call(
+        _this,
+        item,
+        included
+      )
 
-    if (transformer) {
-      transformer(deserializedData)
+      if (transformer) {
+        transformer(deserializedData)
+      }
+
+      return deserializedData
+    } catch (error) {
+      this.deserialize.cache.clear()
+      throw error
     }
-
-    return deserializedData
   }
 }

--- a/common/lib/api-client/transformers/transform-resource.test.js
+++ b/common/lib/api-client/transformers/transform-resource.test.js
@@ -24,6 +24,7 @@ describe('API Client', function () {
                 },
               ],
               set: sinon.stub().returnsArg(1),
+              clear: sinon.stub().returns(true),
             },
             resource: sinon.stub().returnsArg(0),
           },
@@ -111,6 +112,34 @@ describe('API Client', function () {
         it('should delete model deserializer', function () {
           const _that = _this.deserialize.resource.firstCall.thisValue
           expect(_that.models.book.options.deserializer).to.be.undefined
+        })
+      })
+
+      context('when transformer throws an error', function () {
+        const errorMock = new Error('Transformer error')
+        let transformer
+
+        beforeEach(function () {
+          transformer = sinon.stub().throws(errorMock)
+
+          _this.models.book.options.deserializer = transformer
+        })
+
+        it('should throw error', function () {
+          expect(() =>
+            transformResource(transformer).call(_this, item, included)
+          ).to.throw(errorMock)
+        })
+
+        it('should clear the cache', function (done) {
+          try {
+            transformResource(transformer).call(_this, item, included)
+          } catch {
+            expect(
+              _this.deserialize.cache.clear
+            ).to.have.been.calledOnceWithExactly()
+            done()
+          }
         })
       })
     })


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Currently devour, the JSON:API client will build a cached of
deserialized resources. We have added a transformation layer to help
with certain things the frontend requires for these resources.

However, if an error occurs, the cache remains in tact which will
mean that in some cases, on a refresh of the page the app will use
the cached version.

This can lead to some unexpected renders so this fix calls the `clear()`
method on the cache to ensure on the next request it will begin again
from the start.

## Screenshots
<!--- (Optional) Include screenshots if changes update interfaces or components -->
<!--- Delete/copy as appropriate --->

| Before | After |
| ------ | ----- |
| <kbd>![before](https://user-images.githubusercontent.com/3327997/127046342-a88ffdb1-94a1-48a5-9238-527061e6f2ee.gif)</kbd> | <kbd>![after](https://user-images.githubusercontent.com/3327997/127046184-e7a07ea4-0913-4c6d-aa45-8a8f6b2b557e.gif)</kbd> |

## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed
