### PR TITLE
[P4-3026] Support prison recall moves that also have a destination

### DIFF
--- a/common/presenters/move-to-meta-list-component.js
+++ b/common/presenters/move-to-meta-list-component.js
@@ -38,12 +38,16 @@ function moveToMetaListComponent(
     reference,
     status,
   } = move || {}
-  const destination = get(toLocation, 'title', 'Unknown')
+  const destinationTitle = get(toLocation, 'title', 'Unknown')
+  const destinationId = get(toLocation, 'id')
   const useLabel = ['prison_recall', 'video_remand']
   const hasAdditionalInfo = useLabel
   const destinationLabel = useLabel.includes(moveType)
-    ? i18n.t(`fields::move_type.items.${moveType}.label`)
-    : destination
+    ? `${i18n.t(`fields::move_type.items.${moveType}.label`, {
+        context: destinationId ? 'with_location' : '',
+        location: destinationTitle,
+      })}`
+    : destinationTitle
   const destinationSuffix =
     additionalInfo && hasAdditionalInfo.includes(moveType)
       ? ` — ${additionalInfo}`

--- a/common/presenters/move-to-meta-list-component.test.js
+++ b/common/presenters/move-to-meta-list-component.test.js
@@ -35,9 +35,11 @@ describe('Presenters', function () {
           },
         },
         from_location: {
+          id: '12345',
           title: 'HMP Leeds',
         },
         to_location: {
+          id: '67890',
           title: 'Barrow in Furness County Court',
         },
       }
@@ -383,7 +385,57 @@ describe('Presenters', function () {
             'fields::move_type.items.prison_recall.label — Some additional information about this move'
           )
         })
+
+        it('should call translation correctly', function () {
+          expect(i18n.t).to.be.calledWithExactly(
+            'fields::move_type.items.prison_recall.label',
+            {
+              context: 'with_location',
+              location: 'Barrow in Furness County Court',
+            }
+          )
+        })
       })
+
+      context(
+        'with prison recall move type and without to_location',
+        function () {
+          beforeEach(function () {
+            transformedResponse = moveToMetaListComponent({
+              ...mockMove,
+              to_location: null,
+              move_type: 'prison_recall',
+              additional_information: mockAdditionalInformation,
+            })
+          })
+
+          it('should contain correct key', function () {
+            const keys = transformedResponse.items.map(
+              item => item.key.text || item.key.html
+            )
+            expect(keys).to.include('fields::move_type.short_label')
+          })
+
+          it('should contain correct value', function () {
+            const values = transformedResponse.items.map(
+              item => item.value.text || item.value.html
+            )
+            expect(values).to.include(
+              'fields::move_type.items.prison_recall.label — Some additional information about this move'
+            )
+          })
+
+          it('should call translation correctly', function () {
+            expect(i18n.t).to.be.calledWithExactly(
+              'fields::move_type.items.prison_recall.label',
+              {
+                context: '',
+                location: 'Unknown',
+              }
+            )
+          })
+        }
+      )
 
       context('with video remand move type', function () {
         beforeEach(function () {

--- a/common/presenters/move-to-summary-list-component.js
+++ b/common/presenters/move-to-summary-list-component.js
@@ -9,11 +9,6 @@ function moveToSummaryListComponent({
   to_location: toLocation,
 } = {}) {
   const pickup = fromLocation?.title
-  const destination = toLocation?.title || 'Unknown'
-  const useLabel = ['prison_recall', 'video_remand']
-  const destinationLabel = useLabel.includes(moveType)
-    ? i18n.t(`fields::move_type.items.${moveType}.label`)
-    : destination
 
   const rows = [
     {
@@ -29,7 +24,7 @@ function moveToSummaryListComponent({
         text: i18n.t('fields::to_location.label'),
       },
       value: {
-        text: pickup ? destinationLabel : undefined,
+        text: pickup ? toLocation?.title : undefined,
       },
     },
     {

--- a/common/presenters/move-to-summary-list-component.test.js
+++ b/common/presenters/move-to-summary-list-component.test.js
@@ -109,6 +109,9 @@ describe('Presenters', function () {
         transformedResponse = moveToSummaryListComponent({
           ...mockMove,
           move_type: 'prison_recall',
+          to_location: {
+            title: 'Prison recall',
+          },
         })
       })
 
@@ -117,18 +120,10 @@ describe('Presenters', function () {
           const keys = transformedResponse.rows.map(row => row.value.text)
           expect(keys).to.deep.equal([
             mockMove.from_location.title,
-            'fields::move_type.items.prison_recall.label',
+            'Prison recall',
             mockMove.date,
             mockMove.time_due,
           ])
-        })
-      })
-
-      describe('translataion', function () {
-        it('should translate label', function () {
-          expect(i18n.t).to.be.calledWithExactly(
-            'fields::move_type.items.prison_recall.label'
-          )
         })
       })
     })
@@ -138,6 +133,9 @@ describe('Presenters', function () {
         transformedResponse = moveToSummaryListComponent({
           ...mockMove,
           move_type: 'video_remand',
+          to_location: {
+            title: 'Video remand',
+          },
         })
       })
 
@@ -146,36 +144,7 @@ describe('Presenters', function () {
           const keys = transformedResponse.rows.map(row => row.value.text)
           expect(keys).to.deep.equal([
             mockMove.from_location.title,
-            'fields::move_type.items.video_remand.label',
-            mockMove.date,
-            mockMove.time_due,
-          ])
-        })
-      })
-
-      describe('translataion', function () {
-        it('should translate label', function () {
-          expect(i18n.t).to.be.calledWithExactly(
-            'fields::move_type.items.video_remand.label'
-          )
-        })
-      })
-    })
-
-    context('with unknown to location', function () {
-      beforeEach(function () {
-        transformedResponse = moveToSummaryListComponent({
-          ...mockMove,
-          to_location: null,
-        })
-      })
-
-      describe('response', function () {
-        it('should contain unknown as destination label', function () {
-          const keys = transformedResponse.rows.map(row => row.value.text)
-          expect(keys).to.deep.equal([
-            mockMove.from_location.title,
-            'Unknown',
+            'Video remand',
             mockMove.date,
             mockMove.time_due,
           ])

--- a/locales/en/fields.json
+++ b/locales/en/fields.json
@@ -83,7 +83,8 @@
         "label": "Prison or young offender institution (YOI)"
       },
       "prison_recall": {
-        "label": "Prison recall"
+        "label": "Prison recall",
+        "label_with_location": "Prison recall to {{location}}"
       },
       "police_transfer": {
         "label": "Police custody (In force moves only)"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

This updates the presenters where a destination is shown as well
as the move details edit step.

### Why did it change

Previously prison recall moves were created without a destination (or
`to_location`).

So most of the logic on the frontend was driven just by `move_type`.

However, now suppliers are updating the API with the actual end
destination we need to adapt the logic on the frontend for both
rendering and editing to cater for scenarios where `prison_recall`
moves have a `to_location`.

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

- [P4-3026](https://dsdmoj.atlassian.net/browse/P4-3026)
- [BOOK-A-SECURE-MOVE-FRONTEND-55](https://sentry.io/organizations/ministryofjustice/issues/2494793865/?project=2014813&query=is%3Aignored&statsPeriod=14d)

## Screenshots
<!--- (Optional) Include screenshots if changes update interfaces or components -->
<!--- Delete/copy as appropriate --->

| Before | After |
| ------ | ----- |
| <kbd>![image](https://user-images.githubusercontent.com/3327997/127349575-68718bd0-8b47-4575-8e59-d842d201d797.png)</kbd> | <kbd>![image](https://user-images.githubusercontent.com/3327997/127349538-05f57e9f-dc92-4c83-87ba-cb344c84375f.png)</kbd> |
| <kbd>![image](https://user-images.githubusercontent.com/3327997/127349569-11bbe669-698a-43ac-80ef-412d7177b500.png)</kbd> | <kbd>![image](https://user-images.githubusercontent.com/3327997/127349558-151f1c09-bd18-4a89-8f3d-9b74a1ba201c.png)</kbd> |
| <kbd>![image](https://user-images.githubusercontent.com/3327997/127350793-9fb9eff6-de1e-4a87-9119-5e1128867222.png)</kbd> | <kbd>![image](https://user-images.githubusercontent.com/3327997/127350742-15fa10f1-5daf-4a3c-976a-c95263dd4a24.png)</kbd> |


## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [x] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed

### Other considerations

Commit messages with a `fix` or `feat` type are automatically used to generate the [changelog](ministryofjustice/hmpps-book-secure-move-frontend/blob/main/CHANGELOG.md) and
[GitHub release notes](https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/releases) during the release task. Please make sure they will read well on their own in a
summary of changes and that the commit body gives a more detailed description of those changes if necessary.

- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
- [x] Update [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/main/README.md) with any new instructions or tasks
