### PR TITLE
Refactor tab templates

### DIFF
--- a/app/move/app/view/views/_layout.njk
+++ b/app/move/app/view/views/_layout.njk
@@ -29,19 +29,7 @@
       {% block contentMain %}
 
         {% block tabsList %}
-          {% if tabs %}
-            <div class="govuk-tabs">
-              <ul class="govuk-tabs__list">
-                {% for item in tabs %}
-                  <li class="govuk-tabs__list-item {{- ' govuk-tabs__list-item--selected' if item.isActive }}">
-                    <a class="govuk-tabs__tab" href="{{ item.url }}">
-                      {{ t(item.text) }}
-                    </a>
-                  </li>
-                {% endfor %}
-              </ul>
-            </div>
-          {% endif %}
+          {% include 'includes/tabs.njk' %}
         {% endblock %}
 
         {% block tabContent %}

--- a/app/move/views/timeline.njk
+++ b/app/move/views/timeline.njk
@@ -5,7 +5,8 @@
 {% endblock %}
 
 {% block contentMain %}
-  {{ tabs(urls, 'timeline') }}
+  {{ renderTabs(urls, 'timeline') }}
+
   {% if timeline.items.length %}
     {{ appTimeline(timeline) }}
   {% else %}

--- a/app/move/views/view.njk
+++ b/app/move/views/view.njk
@@ -182,23 +182,25 @@
   {% endif %}
 {% endmacro %}
 
-{% macro tabs(urls, active) %}
-{% set tabItems = ['view', 'timeline'] %}
-<div class="govuk-tabs">
-  <ul class="govuk-tabs__list">
-    {% for item in tabItems %}
-      <li class="govuk-tabs__list-item {{- ' govuk-tabs__list-item--selected' if active == item}}">
-        <a class="govuk-tabs__tab" href="{{ urls.tabs[item] }}">
-          {{ t("moves::tabs."+item) }}
-        </a>
-      </li>
-    {% endfor %}
-  </ul>
-</div>
+{% macro renderTabs(urls, active) %}
+  {% set tabs = [
+    {
+      text: 'moves::tabs.view',
+      url: urls.tabs['view'],
+      isActive: active == 'view'
+    },
+    {
+      text: 'moves::tabs.timeline',
+      url: urls.tabs['timeline'],
+      isActive: active == 'timeline'
+    }
+  ] %}
+  {% include 'includes/tabs.njk' %}
 {% endmacro %}
 
 {% block contentMain %}
-  {{ tabs(urls, 'view') }}
+  {{ renderTabs(urls, 'view') }}
+
   {% if move.profile %}
     <div class="govuk-!-margin-bottom-9">
       <section class="app-!-position-relative">

--- a/common/templates/includes/tabs.njk
+++ b/common/templates/includes/tabs.njk
@@ -1,0 +1,15 @@
+{# Expects a variable named `tabs` as a list of objects with fields `url`, `text` and `isActive`. #}
+
+{% if tabs %}
+  <div class="govuk-tabs">
+    <ul class="govuk-tabs__list">
+      {% for item in tabs %}
+        <li class="govuk-tabs__list-item {{- ' govuk-tabs__list-item--selected' if item.isActive }}">
+          <a class="govuk-tabs__tab" href="{{ item.url }}">
+            {{ t(item.text) }}
+          </a>
+        </li>
+      {% endfor %}
+    </ul>
+  </div>
+{% endif %}


### PR DESCRIPTION
This refactors how tabs are rendered so there's a common template we can use in as many views as we like. We can't, unfortunately, use the component provided by `govuk-frontend` as it expects all the panels to be rendered at the same time, and then JS is used to switch between the tabs.

I've made this change ahead of needing to use the tabs template for the new profile page, so I decided to split it out into its own PR.