### PR TITLE
Improve Sentry performance tracing

### DIFF
--- a/server.js
+++ b/server.js
@@ -70,17 +70,12 @@ if (config.SENTRY.DSN) {
     dsn: config.SENTRY.DSN,
     environment: config.SENTRY.ENVIRONMENT,
     release: config.SENTRY.RELEASE,
-    integrations:
-      config.SENTRY.ENVIRONMENT === 'production'
-        ? [
-            // enable HTTP calls tracing
-            new Sentry.Integrations.Http({ tracing: true }),
-            // enable Express.js middleware tracing
-            new Tracing.Integrations.Express({
-              app,
-            }),
-          ]
-        : [],
+    integrations: [
+      // enable HTTP calls tracing
+      new Sentry.Integrations.Http({ tracing: true }),
+      // enable Express.js middleware tracing
+      new Tracing.Integrations.Express({ app }),
+    ],
     // Quarter of all requests will be used for performance sampling
     tracesSampler: samplingContext => {
       const transactionName =
@@ -88,9 +83,7 @@ if (config.SENTRY.DSN) {
         samplingContext.transactionContext &&
         samplingContext.transactionContext.name
 
-      if (config.SENTRY.ENVIRONMENT !== 'production') {
-        return 0
-      } else if (transactionName && transactionName.includes('ping')) {
+      if (transactionName && transactionName.includes('ping')) {
         return 0
       } else {
         // Default sample rate
@@ -108,9 +101,7 @@ if (config.SENTRY.DSN) {
   )
   app.use(sentryRequestId)
 
-  if (config.SENTRY.ENVIRONMENT === 'production') {
-    app.use(Sentry.Handlers.tracingHandler())
-  }
+  app.use(Sentry.Handlers.tracingHandler())
 }
 
 // Configure prometheus to handle metrics

--- a/server.js
+++ b/server.js
@@ -81,7 +81,7 @@ if (config.SENTRY.DSN) {
             }),
           ]
         : [],
-    // Half of all requests will be used for performance sampling
+    // Quarter of all requests will be used for performance sampling
     tracesSampler: samplingContext => {
       const transactionName =
         samplingContext &&
@@ -94,7 +94,7 @@ if (config.SENTRY.DSN) {
         return 0
       } else {
         // Default sample rate
-        return 0.5
+        return 0.25
       }
     },
   })


### PR DESCRIPTION
This reduces the number of traces we record in Sentry, to avoid hitting rate limits. It also sends all traces to Sentry, rather than not just production.

See individual commits for more details on the changes.

Related to https://github.com/ministryofjustice/hmpps-book-secure-move-api/pull/1529