### PR TITLE
fix: Prevent journeys without a vehicle throwing an error

### DIFF
--- a/common/presenters/journeys-to-meta-list-component.js
+++ b/common/presenters/journeys-to-meta-list-component.js
@@ -6,7 +6,7 @@ function _mapJourney({
   state,
   from_location: fromLocation,
   to_location: toLocation,
-  vehicle = {},
+  vehicle,
 } = {}) {
   const rows = [
     {
@@ -28,8 +28,9 @@ function _mapJourney({
       },
       value: {
         html: i18n.t('moves::map.labels.vehicle.text', {
-          registration: vehicle.registration,
-          id: vehicle.id,
+          context: vehicle ? '' : 'unknown',
+          registration: vehicle?.registration,
+          id: vehicle?.id,
         }),
       },
     },

--- a/common/presenters/journeys-to-meta-list-component.test.js
+++ b/common/presenters/journeys-to-meta-list-component.test.js
@@ -21,7 +21,7 @@ describe('Presenters', function () {
         },
         vehicle: {
           id: '1234',
-          title: 'JM18 AHI',
+          registration: 'JM18 AHI',
         },
       },
       {
@@ -38,7 +38,7 @@ describe('Presenters', function () {
         },
         vehicle: {
           id: '1AG',
-          title: 'XK21 HUA',
+          registration: 'XK21 HUA',
         },
       },
       {
@@ -53,6 +53,7 @@ describe('Presenters', function () {
           id: 'ABADCAFE',
           title: 'HMP Pentonville',
         },
+        vehicle: null,
       },
       {
         state: 'completed',
@@ -65,10 +66,6 @@ describe('Presenters', function () {
         to_location: {
           id: 'LLEEEEDS',
           title: 'HMP Leeds',
-        },
-        vehicle: {
-          id: '555',
-          title: 'UH22 KAN',
         },
       },
     ]
@@ -141,6 +138,45 @@ describe('Presenters', function () {
                 },
               },
             ],
+          })
+        })
+
+        it('should pass correct information to translation', function () {
+          mockJourneys.forEach((journey, index) => {
+            expect(i18n.t).to.be.calledWithExactly(
+              'moves::map.labels.route.heading'
+            )
+            expect(i18n.t).to.be.calledWithExactly(
+              'moves::map.labels.route.text',
+              {
+                from: journey.from_location.title,
+                to: journey.to_location.title,
+              }
+            )
+
+            expect(i18n.t).to.be.calledWithExactly(
+              'moves::map.labels.vehicle.heading'
+            )
+
+            if (journey.vehicle) {
+              expect(i18n.t).to.be.calledWithExactly(
+                'moves::map.labels.vehicle.text',
+                {
+                  context: '',
+                  registration: journey.vehicle.registration,
+                  id: journey.vehicle.id,
+                }
+              )
+            } else {
+              expect(i18n.t).to.be.calledWithExactly(
+                'moves::map.labels.vehicle.text',
+                {
+                  context: 'unknown',
+                  registration: undefined,
+                  id: undefined,
+                }
+              )
+            }
           })
         })
       })

--- a/locales/en/moves.json
+++ b/locales/en/moves.json
@@ -263,7 +263,8 @@
       },
       "vehicle": {
         "heading": "Vehicle",
-        "text": "{{registration}} ({{id}})"
+        "text": "{{registration}} ({{id}})",
+        "text_unknown": "Unknown"
       }
     },
     "journey_overview": "Journeys for {{name}}",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

This change ensures the presenter doesn't error when missing a vehicle
or when the vehicle value is set to `null`.

It also adds fallback text for when there is no vehicle.

We don't need to do the same for `from_location` and `to_location`
as the API will not accept a journey without these values.

fixes BOOK-A-SECURE-MOVE-FRONTEND-51

### Why did it change

When this code was first implemented it was using destructuring for
vehicle fallback.

But in the cases where a vehicle doesn't exist in the API it can
return a value of `null` which prevents the fallback object from being
set as the value.

This meant that the rest of the presenter would error trying to access
properties of a `null` value.

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

- [BOOK-A-SECURE-MOVE-FRONTEND-51](https://sentry.io/organizations/ministryofjustice/issues/2443987548/?project=2014813&query=is%3Aunresolved&statsPeriod=7d)

## Screenshots
<!--- (Optional) Include screenshots if changes update interfaces or components -->
<!--- Delete/copy as appropriate --->

<kbd>![image](https://user-images.githubusercontent.com/3327997/128172750-67fea232-91fa-443c-9382-8869a66fa348.png)</kbd>

## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [x] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed

<!--- Delete if changes DO NOT include new environment variables -->
- [ ] Documented in the [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/main/README.md)
- [ ] Added to [continous integration](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-book-secure-move-frontend)
- [ ] Added to staging environment (deployment repository)
- [ ] Added to preproduction environment (deployment repository)
- [ ] Added to production environment (deployment repository)

### Other considerations

Commit messages with a `fix` or `feat` type are automatically used to generate the [changelog](ministryofjustice/hmpps-book-secure-move-frontend/blob/main/CHANGELOG.md) and
[GitHub release notes](https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/releases) during the release task. Please make sure they will read well on their own in a
summary of changes and that the commit body gives a more detailed description of those changes if necessary.

- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
- [x] Update [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/main/README.md) with any new instructions or tasks
