### PR TITLE
chore: Create temporary error routes to debug Sentry

### DIFF
--- a/server.js
+++ b/server.js
@@ -267,7 +267,23 @@ if (config.ENABLE_DEVELOPMENT_TOOLS) {
   app.use(setDevelopmentTools)
 }
 
+app.get('/null-property-error-before', (req, res) => {
+  const nullValue = null
+  // eslint-disable-next-line no-unused-vars
+  const property = nullValue.missingProperty
+
+  res.send('Error debug')
+})
+
 app.use(router)
+
+app.get('/null-property-error', (req, res) => {
+  const anotherNullValue = null
+  // eslint-disable-next-line no-unused-vars
+  const property = anotherNullValue.anotherMissingProperty
+
+  res.send('Error debug')
+})
 
 // error handling
 app.use(Sentry.Handlers.errorHandler())


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

This creates 2 new routes to intentionally trigger an error when
accessing a property of `null`.

This change should be reverted once this problem has been resolved.

### Why did it change

We have seen an [error in production](https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/pull/1875) but it was not captured in
Sentry. In order to rule out anything to do with limits or new errors
not being captured this change adds a way to throw a similar error.

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

- [P4-XXXX]()

## Checklists

### Testing

#### Automated testing

- [ ] ~Added unit tests to cover changes~
- [ ] ~Added end-to-end tests to cover any journey changes~

#### Manual testing

Has been tested in the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed
