### PR TITLE
Make it possible to debug Sentry

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -123,6 +123,7 @@ module.exports = {
   },
   ASSETS_HOST: process.env.ASSETS_HOST || '',
   SENTRY: {
+    DEBUG: /true/i.test(process.env.SENTRY_DEBUG),
     DSN: process.env.SENTRY_DSN,
     ENVIRONMENT: process.env.SENTRY_ENVIRONMENT || 'production',
     RELEASE: process.env.APP_GIT_COMMIT,

--- a/server.js
+++ b/server.js
@@ -67,6 +67,7 @@ app.use(setTransactionId)
 
 if (config.SENTRY.DSN) {
   Sentry.init({
+    debug: config.SENTRY.DEBUG,
     dsn: config.SENTRY.DSN,
     environment: config.SENTRY.ENVIRONMENT,
     release: config.SENTRY.RELEASE,


### PR DESCRIPTION
This adds an optional environment variable (`SENTRY_DEBUG`) which can be set to `true` and will turn on Sentry debugging. This allows us to investigate why issues might not be appearing in Sentry.

It's not good practice to set this in production for long periods of time, but it doesn't pose any risk of leaking information.

See https://docs.sentry.io/platforms/javascript/configuration/options/#debug for more information on the option.