### PR TITLE
Don't collect locations in Sentry issues

### DIFF
--- a/server.js
+++ b/server.js
@@ -97,7 +97,7 @@ if (config.SENTRY.DSN) {
     Sentry.Handlers.requestHandler({
       // Ensure we don't include `data` to avoid sending any PPI
       request: ['cookies', 'headers', 'method', 'query_string', 'url'],
-      user: ['id', 'username', 'permissions', 'locations'],
+      user: ['id', 'username', 'permissions'],
     })
   )
   app.use(sentryRequestId)

--- a/server.js
+++ b/server.js
@@ -268,23 +268,7 @@ if (config.ENABLE_DEVELOPMENT_TOOLS) {
   app.use(setDevelopmentTools)
 }
 
-app.get('/null-property-error-before', (req, res) => {
-  const nullValue = null
-  // eslint-disable-next-line no-unused-vars
-  const property = nullValue.missingProperty
-
-  res.send('Error debug')
-})
-
 app.use(router)
-
-app.get('/null-property-error', (req, res) => {
-  const anotherNullValue = null
-  // eslint-disable-next-line no-unused-vars
-  const property = anotherNullValue.anotherMissingProperty
-
-  res.send('Error debug')
-})
 
 // error handling
 app.use(Sentry.Handlers.errorHandler())


### PR DESCRIPTION
This partially reverts a9f1f53 to stop sending location information to Sentry. We've discovered that Sentry errors triggered from members of our team have so many locations that the payload is too big to be accepted by Sentry, so we get 413 errors and no issue appearing in Sentry.

We only added this extra information to debug a separate issue which has since been fixed, so I think we can remove it. If we ever need it back again we should think about only exporting the IDs of the locations rather than the whole object.

I've also reverted https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/commit/522bd18c413da60ee2c5bd7d752f8a7b5d7397cc because I'm very confident this is the problem, but if we want to keep them, I'm okay with that too.