### PR TITLE
fix: Display correct vehicle registration in events

### DIFF
--- a/locales/en/events.json
+++ b/locales/en/events.json
@@ -51,7 +51,7 @@
   },
   "JourneyChangeVehicle": {
     "heading": "Vehicle changed",
-    "description": "$t(events::person) moved from {{previous_vehicle_reg}} to {{journey.vehicle.registration}}"
+    "description": "$t(events::person) moved from {{previous_vehicle_reg}} to {{vehicle_reg}}"
   },
   "JourneyComplete": {
     "heading": "Journey completed",


### PR DESCRIPTION
At the moment, when a vehicle changes in a journey we show the registration number of the journey, rather than of the event. This means that if a vehicle changes twice in one journey the previous events start showing the incorrect information.

https://github.com/ministryofjustice/hmpps-book-secure-move-api/blob/d61bd961b1df994526bb3d6204916df51a309af7/app/models/generic_event/journey_change_vehicle.rb#L3 is where the fields on the event are defined.

[Jira Ticket](https://dsdmoj.atlassian.net/browse/P4-2989)