### PR TITLE
Update deps using npm audit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10810,7 +10810,6 @@
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/css-select/-/css-select-4.1.3.tgz",
       "integrity": "sha512-gT3wBNd9Nj49rAbmtFHj1cljIAOLYSX1nZ8CB7TBO3INYckygm5B7LISU/szY//YmdiSLbJvDLOx9VnMVpMBxA==",
-      "dev": true,
       "requires": {
         "boolbase": "^1.0.0",
         "css-what": "^5.0.0",
@@ -10822,8 +10821,7 @@
         "css-what": {
           "version": "5.0.1",
           "resolved": "https://registry.npmjs.org/css-what/-/css-what-5.0.1.tgz",
-          "integrity": "sha512-FYDTSHb/7KXsWICVsxdmiExPjCfRC4qRFBdVwv7Ax9hMnvMmEjP9RfxTEZ3qPZGmADDn2vAKSo9UcN1jKVYscg==",
-          "dev": true
+          "integrity": "sha512-FYDTSHb/7KXsWICVsxdmiExPjCfRC4qRFBdVwv7Ax9hMnvMmEjP9RfxTEZ3qPZGmADDn2vAKSo9UcN1jKVYscg=="
         }
       }
     },
@@ -10842,11 +10840,6 @@
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         }
       }
-    },
-    "css-what": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/css-what/-/css-what-4.0.0.tgz",
-      "integrity": "sha512-teijzG7kwYfNVsUh2H/YN62xW3KK9YhXEgSlbxMlcyjPNvdKJqFx5lrwlJgoFP1ZHlB89iGDlo/JyshKeRhv5A=="
     },
     "csscolorparser": {
       "version": "1.0.3",
@@ -15036,7 +15029,6 @@
           "version": "2.3.5",
           "resolved": false,
           "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -15234,8 +15226,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "resolved": false,
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "optional": true
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -15326,8 +15317,7 @@
         "yallist": {
           "version": "3.0.3",
           "resolved": false,
-          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
-          "optional": true
+          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
         }
       }
     },
@@ -28310,14 +28300,14 @@
       }
     },
     "svgo": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/svgo/-/svgo-2.3.0.tgz",
-      "integrity": "sha512-fz4IKjNO6HDPgIQxu4IxwtubtbSfGEAJUq/IXyTPIkGhWck/faiiwfkvsB8LnBkKLvSoyNNIY6d13lZprJMc9Q==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-2.3.1.tgz",
+      "integrity": "sha512-riDDIQgXpEnn0BEl9Gvhh1LNLIyiusSpt64IR8upJu7MwxnzetmF/Y57pXQD2NMX2lVyMRzXt5f2M5rO4wG7Dw==",
       "requires": {
         "@trysound/sax": "0.1.1",
         "chalk": "^4.1.0",
         "commander": "^7.1.0",
-        "css-select": "^3.1.2",
+        "css-select": "^4.1.3",
         "css-tree": "^1.1.2",
         "csso": "^4.2.0",
         "stable": "^0.1.8"
@@ -28357,18 +28347,6 @@
           "version": "7.2.0",
           "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
           "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw=="
-        },
-        "css-select": {
-          "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/css-select/-/css-select-3.1.2.tgz",
-          "integrity": "sha512-qmss1EihSuBNWNNhHjxzxSfJoFBM/lERB/Q4EnsJQQC62R2evJDW481091oAdOr9uh46/0n4nrg0It5cAnj1RA==",
-          "requires": {
-            "boolbase": "^1.0.0",
-            "css-what": "^4.0.0",
-            "domhandler": "^4.0.0",
-            "domutils": "^2.4.3",
-            "nth-check": "^2.0.0"
-          }
         },
         "has-flag": {
           "version": "4.0.0",


### PR DESCRIPTION
This runs the `npm audit fix` command to update some of the
app dependencies that contain vulnerabilities.