### PR TITLE
fix: Include journey information in move events

### DIFF
--- a/common/services/move.js
+++ b/common/services/move.js
@@ -308,6 +308,8 @@ class MoveService extends BaseService {
       ...this.defaultInclude(),
       'timeline_events',
       'timeline_events.eventable',
+      'journeys.to_location',
+      'journeys.from_location',
     ]
 
     return this._getById(id, { include })

--- a/common/services/move.test.js
+++ b/common/services/move.test.js
@@ -1099,6 +1099,8 @@ describe('Move Service', function () {
             ...moveService.defaultInclude(),
             'timeline_events',
             'timeline_events.eventable',
+            'journeys.to_location',
+            'journeys.from_location',
           ],
         })
       })


### PR DESCRIPTION
This includes the journey location information (to and from location) in the timeline events for the moves. We need this because the timeline events sometimes contain references to journeys which are cancelled, and therefore we have no way of including the `to_location` and `from_location` fields of those journeys. This means the timeline view on the frontend is sometimes missing information (this is the case where a journey has a different `to_location` or `from_location` of the move and therefore isn't included).

This might have a performance impact on the page, but we can monitor closely if this becomes a problem. I don't expect many moves to have multiple journeys.

Depends on https://github.com/ministryofjustice/hmpps-book-secure-move-api/pull/1554.

[Jira Ticket](https://dsdmoj.atlassian.net/browse/P4-2988)