### PR TITLE
Focus on warnings when clicked using anchors

### DIFF
--- a/common/components/panel/_panel.scss
+++ b/common/components/panel/_panel.scss
@@ -9,6 +9,10 @@ $_border-width: 2px;
   & + & {
     margin-top: govuk-spacing(2);
   }
+
+  &:focus {
+    outline: $govuk-focus-width solid $govuk-focus-colour;
+  }
 }
 
 // If panel contains a tag component, style based on this parent

--- a/common/components/panel/panel.yaml
+++ b/common/components/panel/panel.yaml
@@ -1,4 +1,8 @@
 params:
+  - name: isFocusable
+    type: boolean
+    required: false
+    description: Determines whether the panel will have a tabindex to allow it to be focused. Defaults to `false`.
   - name: classes
     type: string
     required: false

--- a/common/components/panel/template.njk
+++ b/common/components/panel/template.njk
@@ -2,8 +2,10 @@
 
 {% set element = params.element | default('div') %}
 {% set content = params.html | safe if params.html else params.text %}
+{% set isFocusable = params.isFocusable | default(false) %}
 
 <{{ element }}
+  {% if isFocusable %}tabindex="-1"{% endif %}"
   class="app-panel{% if params.classes %} {{ params.classes }}{% endif %}"
   {%- for attribute, value in params.attributes %}
     {{ attribute }}="{{ value }}"

--- a/common/components/panel/template.test.js
+++ b/common/components/panel/template.test.js
@@ -27,6 +27,10 @@ describe('Panel component', function () {
     it('should not render tag component', function () {
       expect($component.find('.app-tag').length).to.equal(0)
     })
+
+    it('should not render tabindex', function () {
+      expect($component.attr('tabindex')).not.to.exist
+    })
   })
 
   context('with classes param', function () {
@@ -37,6 +41,17 @@ describe('Panel component', function () {
 
       const $component = $('.app-panel')
       expect($component.hasClass('app-panel--inactive')).to.be.true
+    })
+  })
+
+  context('with focusable option', function () {
+    it('should render add tabindex', function () {
+      const $ = renderComponentHtmlToCheerio('panel', {
+        isFocusable: true,
+      })
+
+      const $component = $('.app-panel')
+      expect($component.attr('tabindex')).to.equal('-1')
     })
   })
 

--- a/common/presenters/assessment-category-to-panel-component.js
+++ b/common/presenters/assessment-category-to-panel-component.js
@@ -14,11 +14,12 @@ function assessmentCategoryToPanelListComponent(category) {
       attributes: {
         id: kebabCase(title),
       },
-      tag: {
-        text: title,
-        classes: tagClass,
-      },
       html: componentService.getComponent('appMetaList', metaList),
+      isFocusable: true,
+      tag: {
+        classes: tagClass,
+        text: title,
+      },
     }
   })
 

--- a/common/presenters/assessment-category-to-panel-component.test.js
+++ b/common/presenters/assessment-category-to-panel-component.test.js
@@ -111,6 +111,7 @@ describe('Presenters', function () {
               classes: mockAssessmentCategory.tagClass,
             },
             html: 'appMetaList',
+            isFocusable: true,
           },
           {
             attributes: {
@@ -121,6 +122,7 @@ describe('Presenters', function () {
               classes: mockAssessmentCategory.tagClass,
             },
             html: 'appMetaList',
+            isFocusable: true,
           },
           {
             attributes: {
@@ -131,6 +133,7 @@ describe('Presenters', function () {
               classes: mockAssessmentCategory.tagClass,
             },
             html: 'appMetaList',
+            isFocusable: true,
           },
         ])
       })

--- a/common/presenters/framework-section-to-panel-list.js
+++ b/common/presenters/framework-section-to-panel-list.js
@@ -54,6 +54,7 @@ function frameworkSectionToPanelList({ baseUrl = '' } = {}) {
 
       return {
         tag,
+        isFocusable: true,
         attributes: { id: kebabCase(tag.text) },
         html: componentService.getComponent('appMetaList', metaList),
       }

--- a/common/presenters/framework-section-to-panel-list.test.js
+++ b/common/presenters/framework-section-to-panel-list.test.js
@@ -155,6 +155,7 @@ const expectedOutput = {
         id: 'concealed-items',
       },
       html: 'appMetaList',
+      isFocusable: true,
     },
     {
       tag: {
@@ -167,6 +168,7 @@ const expectedOutput = {
         id: 'escape',
       },
       html: 'appMetaList',
+      isFocusable: true,
     },
     {
       tag: {
@@ -179,6 +181,7 @@ const expectedOutput = {
         id: 'hold-separately',
       },
       html: 'appMetaList',
+      isFocusable: true,
     },
   ],
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

This adds a change to allow panels to be focusable, specifically in the scenario where they are used to display warnings
such as risk and health information.

It also includes a change to offset the scroll position when these elements are clicked so that content isn't hidden by placing
them at the top of the window.

### Why did it change

The alert badges can be clicked either from the listing pages (incoming/outgoing) or the header of a move. Currently there is not focus which means it visually hard to see which has been selected, and also will prevent content being read by assistive technology.

In some cases, like the framework steps a form field will also be highlighted, but the question and hint text can sometimes
be visually out of view.

## Screenshots
<!--- (Optional) Include screenshots if changes update interfaces or components -->
<!--- Delete/copy as appropriate --->

| Before | After |
| ------ | ----- |
| <kbd>![image](https://user-images.githubusercontent.com/3327997/129941895-df5ebe57-235b-410c-a4f1-fc0b7cc9d02d.png)</kbd> | <kbd>![image](https://user-images.githubusercontent.com/3327997/129941231-0986badc-1eb0-43b9-8814-8854541b246a.png)</kbd> |
| <kbd>![image](https://user-images.githubusercontent.com/3327997/129941808-b9eaa618-244d-427e-a920-2b71b0967e44.png)</kbd> | <kbd>![image](https://user-images.githubusercontent.com/3327997/129941321-093abdc5-003b-4a5e-8d6f-a8decfa5095f.png)</kbd> |
| <kbd>![image](https://user-images.githubusercontent.com/3327997/129941740-f45bc719-e854-47f8-bb0b-faa00678f7f0.png)</kbd> | <kbd>![image](https://user-images.githubusercontent.com/3327997/129941452-b970bc51-7405-40c7-9336-2f50b122880a.png)</kbd> |


## Checklists

### Testing

#### Automated testing

- [ ] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [x] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed
