### PR TITLE
Swap individual links in move summary for single link

### DIFF
--- a/app/move/app/view/controllers/index.js
+++ b/app/move/app/view/controllers/index.js
@@ -1,9 +1,9 @@
-const renderAssessments = require('./render-assessments')
+const renderDetails = require('./render-details')
 const renderTimeline = require('./render-timeline')
 const renderWarnings = require('./render-warnings')
 
 module.exports = {
-  renderAssessments,
+  renderDetails,
   renderTimeline,
   renderWarnings,
 }

--- a/app/move/app/view/controllers/render-assessments.js
+++ b/app/move/app/view/controllers/render-assessments.js
@@ -1,7 +1,0 @@
-function renderAssessments(req, res) {
-  const locals = {}
-
-  res.render('move/app/view/views/assessments', locals)
-}
-
-module.exports = renderAssessments

--- a/app/move/app/view/controllers/render-details.js
+++ b/app/move/app/view/controllers/render-details.js
@@ -1,0 +1,7 @@
+function renderDetails(req, res) {
+  const locals = {}
+
+  res.render('move/app/view/views/details', locals)
+}
+
+module.exports = renderDetails

--- a/app/move/app/view/controllers/render-details.test.js
+++ b/app/move/app/view/controllers/render-details.test.js
@@ -1,8 +1,8 @@
-const controller = require('./render-assessments')
+const controller = require('./render-details')
 
 describe('Move view app', function () {
   describe('Controllers', function () {
-    describe('#renderAssessments()', function () {
+    describe('#renderDetails()', function () {
       let req, res
 
       beforeEach(function () {
@@ -22,9 +22,7 @@ describe('Move view app', function () {
       })
 
       it('should render a template', function () {
-        expect(res.render.args[0][0]).to.equal(
-          'move/app/view/views/assessments'
-        )
+        expect(res.render.args[0][0]).to.equal('move/app/view/views/details')
       })
     })
   })

--- a/app/move/app/view/index.js
+++ b/app/move/app/view/index.js
@@ -22,6 +22,7 @@ const {
   localsMoveDetails,
   localsPersonSummary,
   localsTabs,
+  localsUrls,
   localsWarnings,
   setBreadcrumb,
 } = require('./middleware')
@@ -39,6 +40,7 @@ router.use(breadcrumbs.setHome())
 router.use(setPersonEscortRecord)
 router.use(setYouthRiskAssessment)
 router.use(setBreadcrumb)
+router.use(localsUrls)
 router.use(localsActions({ previewPrefix: PREVIEW_PREFIX }))
 router.use(localsIdentityBar)
 router.use(localsMoveDetails)

--- a/app/move/app/view/index.js
+++ b/app/move/app/view/index.js
@@ -12,7 +12,7 @@ const {
 
 const { PREVIEW_PREFIX } = require('./constants')
 const {
-  renderAssessments,
+  renderDetails,
   renderTimeline,
   renderWarnings,
 } = require('./controllers')
@@ -47,7 +47,7 @@ router.use(localsTabs)
 
 // Define routes
 router.get('/warnings', localsWarnings, renderWarnings)
-router.get('/assessments', renderAssessments)
+router.get('/details', renderDetails)
 router.get('/timeline', renderTimeline)
 
 // Export

--- a/app/move/app/view/middleware/index.js
+++ b/app/move/app/view/middleware/index.js
@@ -3,6 +3,7 @@ const localsIdentityBar = require('./locals.identity-bar')
 const localsMoveDetails = require('./locals.move-details')
 const localsPersonSummary = require('./locals.person-summary')
 const localsTabs = require('./locals.tabs')
+const localsUrls = require('./locals.urls')
 const localsWarnings = require('./locals.warnings')
 const setBreadcrumb = require('./set-breadcrumb')
 
@@ -12,6 +13,7 @@ module.exports = {
   localsMoveDetails,
   localsPersonSummary,
   localsTabs,
+  localsUrls,
   localsWarnings,
   setBreadcrumb,
 }

--- a/app/move/app/view/middleware/locals.move-details.js
+++ b/app/move/app/view/middleware/locals.move-details.js
@@ -1,13 +1,10 @@
-const moveHelpers = require('../../../../../common/helpers/move')
 const presenters = require('../../../../../common/presenters')
 
 function localsMoveDetails(req, res, next) {
-  const { canAccess, move } = req
-  const updateUrls = moveHelpers.getUpdateUrls(move, canAccess)
+  const { move } = req
 
   const moveDetails = presenters.moveToMetaListComponent(move, {
     showPerson: false,
-    updateUrls,
   })
 
   res.locals.moveDetails = moveDetails

--- a/app/move/app/view/middleware/locals.move-details.test.js
+++ b/app/move/app/view/middleware/locals.move-details.test.js
@@ -1,9 +1,6 @@
-const moveHelpers = require('../../../../../common/helpers/move')
 const presenters = require('../../../../../common/presenters')
 
 const middleware = require('./locals.move-details')
-
-const mockUpdateUrls = { stepOne: '/', stepTwo: '/two' }
 
 describe('Move view app', function () {
   describe('Middleware', function () {
@@ -23,17 +20,9 @@ describe('Move view app', function () {
         }
         nextSpy = sinon.spy()
 
-        sinon.stub(moveHelpers, 'getUpdateUrls').returns(mockUpdateUrls)
         sinon.stub(presenters, 'moveToMetaListComponent').returnsArg(0)
 
         middleware(req, res, nextSpy)
-      })
-
-      it('should call helper', function () {
-        expect(moveHelpers.getUpdateUrls).to.be.calledOnceWithExactly(
-          req.move,
-          req.canAccess
-        )
       })
 
       it('should call presenter', function () {
@@ -41,7 +30,6 @@ describe('Move view app', function () {
           req.move,
           {
             showPerson: false,
-            updateUrls: mockUpdateUrls,
           }
         )
       })

--- a/app/move/app/view/middleware/locals.tabs.js
+++ b/app/move/app/view/middleware/locals.tabs.js
@@ -1,16 +1,17 @@
 function setTabs(req, res, next) {
+  const urls = res.locals.urls
   const tabs = [
     {
       text: 'moves::tabs.warnings',
-      url: `${req.baseUrl}/warnings`,
+      url: urls.move.warnings,
     },
     {
       text: 'moves::tabs.details',
-      url: `${req.baseUrl}/details`,
+      url: urls.move.details,
     },
     {
       text: 'moves::tabs.timeline',
-      url: `${req.baseUrl}/timeline`,
+      url: urls.move.timeline,
     },
   ]
 

--- a/app/move/app/view/middleware/locals.tabs.js
+++ b/app/move/app/view/middleware/locals.tabs.js
@@ -5,8 +5,8 @@ function setTabs(req, res, next) {
       url: `${req.baseUrl}/warnings`,
     },
     {
-      text: 'moves::tabs.assessments',
-      url: `${req.baseUrl}/assessments`,
+      text: 'moves::tabs.details',
+      url: `${req.baseUrl}/details`,
     },
     {
       text: 'moves::tabs.timeline',

--- a/app/move/app/view/middleware/locals.tabs.test.js
+++ b/app/move/app/view/middleware/locals.tabs.test.js
@@ -7,11 +7,18 @@ describe('Move view app', function () {
 
       beforeEach(function () {
         req = {
-          baseUrl: '/base-url',
           originalUrl: '/',
         }
         res = {
-          locals: {},
+          locals: {
+            urls: {
+              move: {
+                warnings: '/base-url/warnings',
+                details: '/base-url/details',
+                timeline: '/base-url/timeline',
+              },
+            },
+          },
         }
         nextSpy = sinon.spy()
       })
@@ -21,6 +28,7 @@ describe('Move view app', function () {
           middleware(req, res, nextSpy)
 
           expect(res.locals).to.deep.equal({
+            urls: res.locals.urls,
             tabs: [
               {
                 text: 'moves::tabs.warnings',
@@ -48,6 +56,7 @@ describe('Move view app', function () {
           middleware(req, res, nextSpy)
 
           expect(res.locals).to.deep.equal({
+            urls: res.locals.urls,
             tabs: [
               {
                 text: 'moves::tabs.warnings',

--- a/app/move/app/view/middleware/locals.tabs.test.js
+++ b/app/move/app/view/middleware/locals.tabs.test.js
@@ -28,8 +28,8 @@ describe('Move view app', function () {
                 isActive: false,
               },
               {
-                text: 'moves::tabs.assessments',
-                url: '/base-url/assessments',
+                text: 'moves::tabs.details',
+                url: '/base-url/details',
                 isActive: false,
               },
               {
@@ -55,8 +55,8 @@ describe('Move view app', function () {
                 isActive: true,
               },
               {
-                text: 'moves::tabs.assessments',
-                url: '/base-url/assessments',
+                text: 'moves::tabs.details',
+                url: '/base-url/details',
                 isActive: false,
               },
               {

--- a/app/move/app/view/middleware/locals.urls.js
+++ b/app/move/app/view/middleware/locals.urls.js
@@ -1,0 +1,18 @@
+function setUrls(req, res, next) {
+  const { id: moveId } = req.move
+  const urls = {
+    warnings: `${req.baseUrl}/warnings`,
+    details: `${req.baseUrl}/details`,
+    timeline: `${req.baseUrl}/timeline`,
+    person_escort_record: `/move/${moveId}/person-escort-record`,
+    youth_risk_assessment: `/move/${moveId}/youth-risk-assessment`,
+  }
+
+  res.locals.urls = {
+    move: urls,
+  }
+
+  next()
+}
+
+module.exports = setUrls

--- a/app/move/app/view/middleware/locals.urls.test.js
+++ b/app/move/app/view/middleware/locals.urls.test.js
@@ -1,0 +1,39 @@
+const middleware = require('./locals.urls')
+
+describe('Move view app', function () {
+  describe('Middleware', function () {
+    describe('#localsUrls()', function () {
+      let req, res, nextSpy
+
+      beforeEach(function () {
+        req = {
+          move: {
+            id: '__move_12345__',
+          },
+          baseUrl: '/base-url',
+        }
+        res = {
+          locals: {},
+        }
+        nextSpy = sinon.spy()
+      })
+
+      it('should set urls to locals', function () {
+        middleware(req, res, nextSpy)
+
+        expect(res.locals).to.deep.equal({
+          urls: {
+            move: {
+              warnings: '/base-url/warnings',
+              details: '/base-url/details',
+              timeline: '/base-url/timeline',
+              person_escort_record: '/move/__move_12345__/person-escort-record',
+              youth_risk_assessment:
+                '/move/__move_12345__/youth-risk-assessment',
+            },
+          },
+        })
+      })
+    })
+  })
+})

--- a/app/move/app/view/views/_layout.njk
+++ b/app/move/app/view/views/_layout.njk
@@ -53,6 +53,12 @@
           </h3>
 
           {{ appMetaList(moveDetails) }}
+
+          <p class="govuk-!-margin-top-3 govuk-!-margin-bottom-0 govuk-!-font-size-16">
+            <a href="{{ urls.move.details }}#tabs">
+              {{ t("actions::change_move_details") }}
+            </a>
+          </p>
         {% endcall %}
 
         {% if actions | length %}

--- a/app/move/app/view/views/details.njk
+++ b/app/move/app/view/views/details.njk
@@ -1,7 +1,7 @@
 {% extends "./_layout.njk" %}
 
 {% block customGtagConfig %}
-  gtag('set', {'page_title': 'Assessments – Move details'});
+  gtag('set', {'page_title': 'Details – Move'});
 {% endblock %}
 
 {% block tabContent %}

--- a/app/move/app/view/views/timeline.njk
+++ b/app/move/app/view/views/timeline.njk
@@ -1,7 +1,7 @@
 {% extends "./_layout.njk" %}
 
 {% block customGtagConfig %}
-  gtag('set', {'page_title': 'History of events – Move details'});
+  gtag('set', {'page_title': 'History of events – Move'});
 {% endblock %}
 
 {% block tabContent %}

--- a/app/move/app/view/views/warnings.njk
+++ b/app/move/app/view/views/warnings.njk
@@ -1,7 +1,7 @@
 {% extends "./_layout.njk" %}
 
 {% block customGtagConfig %}
-  gtag('set', {'page_title': 'Warnings – Move details'});
+  gtag('set', {'page_title': 'Warnings – Move'});
 {% endblock %}
 
 {% macro renderAssessmentComponent(assessment) %}

--- a/common/templates/includes/tabs.njk
+++ b/common/templates/includes/tabs.njk
@@ -1,10 +1,10 @@
 {# Expects a variable named `tabs` as a list of objects with fields `url`, `text` and `isActive`. #}
 
 {% if tabs %}
-  <div class="govuk-tabs">
+  <div class="govuk-tabs" id="tabs">
     <ul class="govuk-tabs__list">
       {% for item in tabs %}
-        <li class="govuk-tabs__list-item {{- ' govuk-tabs__list-item--selected' if item.isActive }}">
+        <li class="govuk-tabs__list-item {{- ' govuk-tabs__list-item--selected' if item.isActive }}" id="tab-{{ t(item.text) | kebabcase }}">
           <a class="govuk-tabs__tab" href="{{ item.url }}">
             {{ t(item.text) }}
           </a>

--- a/locales/en/actions.json
+++ b/locales/en/actions.json
@@ -58,5 +58,6 @@
   "add_item_with_items": "Add another {{name}}",
   "remove_item": "Remove <span class=\"govuk-visually-hidden\">{{name}} {{index}}</span>",
   "save_and_calculate": "Save and calculate",
-  "view_old_move_design": "Use the old design of this page"
+  "view_old_move_design": "Use the old design of this page",
+  "change_move_details": "Change or view move details"
 }

--- a/locales/en/moves.json
+++ b/locales/en/moves.json
@@ -194,7 +194,7 @@
   "tabs": {
     "view": "Record",
     "warnings": "Warnings",
-    "assessments": "Assessments",
+    "details": "Details",
     "timeline": "History of events"
   },
   "update_link": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

This contains changes to rename the "Assessments" tab to "Details" as well as reducing the links in the move summary side panel.

### Why did it change

During research the "Assessments" tab didn't test so well with a task list. Users also struggled finding any of the move information or changing any of it.

These changes bring the move information up a level to one of the tabs and provide a single call to action from the move summary panel to both view or change any of that information.

(Details tab is yet to be built out)

## Screenshots
<!--- (Optional) Include screenshots if changes update interfaces or components -->
<!--- Delete/copy as appropriate --->

| Before | After |
| ------ | ----- |
| <kbd>![image](https://user-images.githubusercontent.com/3327997/129946447-28d98ef0-a485-4175-82f5-46ffcd24996d.png)</kbd> | <kbd>![image](https://user-images.githubusercontent.com/3327997/129946272-3c01a0fb-d39c-4f93-85d8-82edce48114e.png)</kbd> |
| <kbd>![image](https://user-images.githubusercontent.com/3327997/129946476-11085397-3060-4bdc-8d6f-ce55d0d26ae1.png)</kbd> | <kbd>![image](https://user-images.githubusercontent.com/3327997/129946325-8648a26f-bb02-4ef5-bc48-f0cc5a8c82c9.png)</kbd> |

## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [x] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed
