### PR TITLE
Only show warnings once the Person Escort Record has been started

### DIFF
--- a/app/move/app/view/middleware/locals.warnings.js
+++ b/app/move/app/view/middleware/locals.warnings.js
@@ -9,35 +9,14 @@ function setWarnings(req, res, next) {
     return next()
   }
 
-  const assessmentAnswers = profile.assessment_answers || []
+  let tagList
   const personEscortRecord = profile.person_escort_record
-  const youthRiskAssessment = profile.youth_risk_assessment
-  const requiresYouthRiskAssessment = profile.requires_youth_risk_assessment
-
-  const assessment = presenters
-    .assessmentAnswersByCategory(assessmentAnswers)
-    .filter(category => category.key !== 'court')
-    .map(presenters.assessmentCategoryToPanelComponent)
-
-  const youthAssessmentSections = map(
-    youthRiskAssessment?._framework?.sections,
-    presenters.frameworkSectionToPanelList({
-      baseUrl: `/move/${moveId}/youth-risk-assessment`,
-    })
-  )
   const perAssessmentSections = map(
     personEscortRecord?._framework?.sections,
     presenters.frameworkSectionToPanelList({
       baseUrl: `/move/${moveId}/person-escort-record`,
     })
   )
-
-  const assessmentSections =
-    !isEmpty(personEscortRecord) || !requiresYouthRiskAssessment
-      ? sortBy(perAssessmentSections, 'order')
-      : sortBy(youthAssessmentSections, 'order')
-
-  let tagList
   const personEscortRecordIsCompleted =
     !isEmpty(personEscortRecord) &&
     !['not_started', 'in_progress'].includes(personEscortRecord.status)
@@ -51,10 +30,9 @@ function setWarnings(req, res, next) {
   }
 
   res.locals.warnings = {
-    sections:
-      !isEmpty(assessmentSections) || requiresYouthRiskAssessment
-        ? assessmentSections
-        : assessment,
+    sections: personEscortRecord
+      ? sortBy(perAssessmentSections, 'order')
+      : undefined,
     tagList,
   }
 

--- a/app/move/app/view/middleware/locals.warnings.test.js
+++ b/app/move/app/view/middleware/locals.warnings.test.js
@@ -54,7 +54,7 @@ describe('Move view app', function () {
 
           it('should call frameworkSectionToPanelList presenter for each section', function () {
             expect(frameworkSectionStub.callCount).to.equal(2)
-            expect(presenters.frameworkSectionToPanelList).to.be.calledTwice
+            expect(presenters.frameworkSectionToPanelList).to.be.calledOnce
             expect(presenters.frameworkSectionToPanelList).to.be.calledWith({
               baseUrl: `/move/${req.move.id}/person-escort-record`,
             })
@@ -69,117 +69,16 @@ describe('Move view app', function () {
           })
         })
 
-        context('with Youth Risk Assessment', function () {
+        context('without Person Escort Record', function () {
           beforeEach(function () {
-            req.move.profile.requires_youth_risk_assessment = true
-            req.move.profile.youth_risk_assessment = {
-              _framework: {
-                sections: [
-                  { name: 'fizz', order: 2 },
-                  { name: 'buzz', order: 1 },
-                ],
-              },
-              id: 'yra_12345',
-            }
+            req.move.profile.person_escort_record = null
+            middleware(req, res, nextSpy)
           })
 
-          context('with Person Escort Record', function () {
-            beforeEach(function () {
-              req.move.profile.person_escort_record = {
-                _framework: {
-                  sections: [
-                    { name: 'foo', order: 2 },
-                    { name: 'bar', order: 1 },
-                  ],
-                },
-                id: 'per_12345',
-              }
-              middleware(req, res, nextSpy)
-            })
-
-            it('should call frameworkSectionToPanelList presenter for each section', function () {
-              expect(frameworkSectionStub.callCount).to.equal(4)
-              expect(presenters.frameworkSectionToPanelList).to.be.calledTwice
-              expect(presenters.frameworkSectionToPanelList).to.be.calledWith({
-                baseUrl: `/move/${req.move.id}/person-escort-record`,
-              })
-            })
-
-            it('should set sections variable to PER sections correctly ordered', function () {
-              expect(res.locals.warnings).to.have.property('sections')
-              expect(res.locals.warnings.sections).to.deep.equal([
-                { name: 'bar', order: 1 },
-                { name: 'foo', order: 2 },
-              ])
-            })
+          it('should set sections variable to undefined', function () {
+            expect(res.locals.warnings).to.have.property('sections')
+            expect(res.locals.warnings.sections).to.be.undefined
           })
-
-          context('without Person Escort Record', function () {
-            beforeEach(function () {
-              middleware(req, res, nextSpy)
-            })
-
-            it('should call frameworkSectionToPanelList presenter for each section', function () {
-              expect(frameworkSectionStub.callCount).to.equal(2)
-              expect(presenters.frameworkSectionToPanelList).to.be.calledTwice
-              expect(presenters.frameworkSectionToPanelList).to.be.calledWith({
-                baseUrl: `/move/${req.move.id}/person-escort-record`,
-              })
-              expect(presenters.frameworkSectionToPanelList).to.be.calledWith({
-                baseUrl: `/move/${req.move.id}/youth-risk-assessment`,
-              })
-            })
-
-            it('should set sections variable to YRA sections correctly ordered', function () {
-              expect(res.locals.warnings).to.have.property('sections')
-              expect(res.locals.warnings.sections).to.deep.equal([
-                { name: 'buzz', order: 1 },
-                { name: 'fizz', order: 2 },
-              ])
-            })
-          })
-        })
-
-        context('with assessment answers', function () {
-          beforeEach(function () {
-            req.move.profile.assessment_answers = [
-              { name: 'buzz', order: 3, key: 'risk' },
-              { name: 'fizz', order: 7, key: 'health' },
-              { name: 'foo', order: 2, key: 'risk' },
-              { name: 'bar', order: 1, key: 'court' },
-            ]
-          })
-
-          context('when move requires youth risk assessment', function () {
-            beforeEach(function () {
-              req.move.profile.requires_youth_risk_assessment = true
-              middleware(req, res, nextSpy)
-            })
-
-            it('should set sections variable to empty array', function () {
-              expect(res.locals.warnings).to.have.property('sections')
-              expect(res.locals.warnings.sections).to.deep.equal([])
-            })
-          })
-
-          context(
-            'when move does not require youth risk assessment',
-            function () {
-              beforeEach(function () {
-                req.move.profile.requires_youth_risk_assessment = false
-                middleware(req, res, nextSpy)
-              })
-
-              it('should set sections variable to assessment answers', function () {
-                expect(res.locals.warnings).to.have.property('sections')
-                expect(res.locals.warnings.sections).to.deep.equal([
-                  { name: 'buzz', order: 3, key: 'risk' },
-                  { name: 'fizz', order: 7, key: 'health' },
-                  { name: 'foo', order: 2, key: 'risk' },
-                ])
-              })
-            }
-          )
         })
       })
 

--- a/app/move/app/view/views/warnings.njk
+++ b/app/move/app/view/views/warnings.njk
@@ -7,7 +7,7 @@
 {% macro renderAssessmentComponent(assessment) %}
   {% if assessment.isCompleted == false %}
     {{ govukInsetText({
-      classes: "govuk-inset-text--compact govuk-!-margin-0",
+      classes: "govuk-!-font-size-16 govuk-!-margin-0",
       text: t("assessment::section_incomplete")
     }) }}
   {% elif assessment.count > 0 %}
@@ -23,47 +23,64 @@
       classes: "app-message--muted govuk-!-margin-top-2",
       allowDismiss: false,
       content: {
+        classes: "govuk-!-font-size-16",
         html: t('assessment::no_items.text', {
           context: assessment.context or assessment.key,
-          name: assessment.name,
+          name: assessment.name | lower,
           url: assessment.url
         })
       }
     }) }}
   {% endif %}
+
+  {% if (assessment.url and assessment.isCompleted) %}
+    <p class="govuk-!-font-size-16 govuk-!-margin-top-2">
+      <a href="{{ assessment.url }}">
+        {{ t("assessment::view_framework_section", {
+          name: assessment.name | lower
+        }) }}
+      </a>
+    </p>
+  {% endif %}
 {% endmacro %}
 
 {% block tabContent %}
+  {% if warnings.sections %}
+    <h2 class="govuk-heading-m govuk-!-margin-bottom-2">
+      {{ t("assessment::overview") }}
+    </h2>
 
-  <h2 class="govuk-heading-m govuk-!-margin-bottom-2">
-    {{ t("assessment::overview") }}
-  </h2>
+    <div data-tag-list-source="person-escort-record">
+      {% for tag in warnings.tagList %}
+        {{ appTag(tag) }}
+      {% else %}
+        {{ govukInsetText({
+          classes: "govuk-!-font-size-16 govuk-!-margin-top-0",
+          text: t("assessment::incomplete_overview")
+        }) }}
+      {% endfor %}
+    </div>
 
-  <div data-tag-list-source="person-escort-record">
-    {% for tag in warnings.tagList %}
-      {{ appTag(tag) }}
-    {% else %}
-      {{ govukInsetText({
-        classes: "govuk-inset-text--compact govuk-!-margin-0",
-        text: t("assessment::incomplete")
-      }) }}
-    {% endfor %}
-  </div>
+    {% if warnings.sections | length %}
 
-  {% if warnings.sections | length %}
+      {% for section in warnings.sections %}
+        <section class="app-!-position-relative govuk-!-margin-top-7">
+          <h2 class="govuk-heading-m govuk-!-margin-bottom-2">
+            {{ section.name or t('assessment::heading.text', {
+              context: section.key
+            }) }}
+          </h2>
 
-    {% for section in warnings.sections %}
-      <section class="app-!-position-relative govuk-!-margin-top-7">
-        <h2 class="govuk-heading-m govuk-!-margin-bottom-2">
-          {{ section.name or t('assessment::heading.text', {
-            context: section.key
-          }) }}
-        </h2>
+          {{ renderAssessmentComponent(section) }}
+        </section>
+      {% endfor %}
 
-        {{ renderAssessmentComponent(section) }}
-      </section>
-    {% endfor %}
-
+    {% endif %}
+  {% else %}
+    {{ govukInsetText({
+      classes: "govuk-!-font-size-16",
+      text: t("assessment::incomplete")
+    }) }}
   {% endif %}
 
 {% endblock %}

--- a/app/move/index.js
+++ b/app/move/index.js
@@ -48,7 +48,7 @@ router.get('/preview/opt-out', previewOptOut)
 
 router.use(`/:moveId(${uuidRegex})`, moveRouter)
 
-moveRouter.use(['/', '/timeline', '/journeys'], checkPreviewChoice)
+moveRouter.use(checkPreviewChoice({ '/': '/', '/timeline': '/timeline' }))
 // For all non-timeline routes use standard move middleware
 moveRouter.use(/\/((?!timeline).)*/, setMove)
 // For all timeline route use move events middleware

--- a/app/move/middleware.js
+++ b/app/move/middleware.js
@@ -8,18 +8,23 @@ const { COOKIES } = require('../../config')
 const { PREVIEW_PREFIX } = require('./app/view/constants')
 
 module.exports = {
-  checkPreviewChoice(req, res, next) {
-    const moveId = req.params.moveId
-    const cookieName = COOKIES.MOVE_DESIGN_PREVIEW.name(req.user.userId)
-    const cookie = req.cookies[cookieName]
+  checkPreviewChoice(pathMap = {}) {
+    return (req, res, next) => {
+      const moveId = req.params.moveId
+      const cookieName = COOKIES.MOVE_DESIGN_PREVIEW.name(req.user.userId)
+      const cookie = req.cookies[cookieName]
+      const pathsToRedirect = Object.keys(pathMap)
 
-    if (cookie === '1') {
-      return res.redirect(`/move${PREVIEW_PREFIX}/${moveId}${req.path}`)
-    } else if (cookie === '0') {
-      req.hidePreviewOptInBanner = true
+      if (cookie === '1' && pathsToRedirect.includes(req.path)) {
+        return res.redirect(
+          `/move${PREVIEW_PREFIX}/${moveId}${pathMap[req.path]}`
+        )
+      } else if (cookie === '0') {
+        req.hidePreviewOptInBanner = true
+      }
+
+      next()
     }
-
-    next()
   },
 
   setMove: async (req, res, next) => {

--- a/common/components/message/message.yaml
+++ b/common/components/message/message.yaml
@@ -29,6 +29,10 @@ params:
   required: false
   description: Content to use below the heading.
   params:
+  - name: classes
+    type: string
+    required: false
+    description: Classes to add to the content element.
   - name: text
     type: string
     required: true

--- a/common/components/message/template.njk
+++ b/common/components/message/template.njk
@@ -18,7 +18,7 @@
   {% endif %}
 
   {% if params.content.html or params.content.text %}
-    <div class="app-message__content">
+    <div class="app-message__content{% if params.content.classes %} {{ params.content.classes }}{% endif %}">
       {{ params.content.html | safe if params.content.html else params.content.text }}
     </div>
   {% endif %}

--- a/common/components/message/template.test.js
+++ b/common/components/message/template.test.js
@@ -159,6 +159,25 @@ describe('Message component', function () {
       })
     })
 
+    context('with content classes', function () {
+      it('should render class attribute', function () {
+        const $ = renderComponentHtmlToCheerio('message', {
+          content: {
+            classes: 'an-example-class',
+            html: 'A message with <strong>bold text</strong>',
+          },
+        })
+
+        const $component = $('.app-message')
+        expect($component.html()).to.contain(
+          'A message with <strong>bold text</strong>'
+        )
+        expect(
+          $('.app-message__content').hasClass('an-example-class')
+        ).to.be.true
+      })
+    })
+
     context('when dismiss is prevented', function () {
       it('should not render dismissable attribute', function () {
         const $ = renderComponentHtmlToCheerio(

--- a/locales/en/assessment.json
+++ b/locales/en/assessment.json
@@ -28,7 +28,7 @@
     "text_health_nomis": "There is no health information",
     "text_court": "No information for the court",
     "text_release_status": "There is no active release status information",
-    "text_framework": "No {{name}} warnings. View <a href=\"{{url}}\">all answers</a>."
+    "text_framework": "No {{name}} warnings"
   },
   "retrieved_from_nomis": {
     "details": {
@@ -53,9 +53,11 @@
       }
     }
   },
+  "view_framework_section": "View all {{name}}",
   "view_previous_assessment": "View information provided when move was requested",
   "view_previous_assessment_framework": "View information provided in youth risk assessment",
   "incomplete": "Warnings will display once a Person Escort Record has been completed",
+  "incomplete_overview": "This will display once a Person Escort Record has been completed",
   "section_incomplete": "Warnings will display once this section has been completed",
   "prefilled_banner": {
     "title": "Some answers on this page need to be reviewed. They are from the last $t({{context}}) confirmed on {{date}}."


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

This changes the logic around the warnings tab for the new profile page design. When there is no Person Escort Record (PER) it won't show any warnings, instead a message will be shown saying what needs to happen.

Once the PER has been started and sections become complete, it will show the warnings for this information.

### Why did it change

When people use this section to determine how a person should be moved they should use the latest information from the PER. Therefore, we have reduced the logic around this section to only show once the PER has been started and sections become complete.

## Screenshots
<!--- (Optional) Include screenshots if changes update interfaces or components -->
<!--- Delete/copy as appropriate --->

### Without a Person Escort Record (PER)

<kbd><img width="914" alt="Screenshot 2021-08-20 at 16 22 57" src="https://user-images.githubusercontent.com/3327997/130248574-ab62fdff-1ce3-452c-83ec-b576fdcdf520.png"></kbd>

### With partially completed PER
<kbd><img width="617" alt="Screenshot 2021-08-20 at 16 23 09" src="https://user-images.githubusercontent.com/3327997/130248206-2a0d4c2a-bb8f-4f61-88e0-6831601e2b13.png"></kbd>

### With completed PER

<kbd><img width="619" alt="Screenshot 2021-08-20 at 16 23 23" src="https://user-images.githubusercontent.com/3327997/130248203-96d961dc-90e1-4120-bca2-acdb6232835e.png"></kbd>

## Checklists

### Testing

#### Automated testing

- [ ] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [x] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed
