### PR TITLE
fix: Cope with result.moves being undefined

### DIFF
--- a/common/services/allocation.js
+++ b/common/services/allocation.js
@@ -45,7 +45,7 @@ class AllocationService extends BaseService {
     return function transformAllocation(result) {
       // TODO: Remove when individual allocations return meta.moves info
       // TODO: see moves filtering below too
-      if (!result.meta?.moves && result.moves.length) {
+      if (!result.meta?.moves && result.moves?.length) {
         set(result, 'meta.moves.total', result.moves.length)
 
         if (result.status !== 'cancelled') {


### PR DESCRIPTION
This uses the safe navigation operator to ensure that `result.moves.length` doesn't raise a `TypeError` when `result.moves` is undefined. This appears to be happening occasionally as we've received a Sentry issue for it: https://sentry.io/organizations/ministryofjustice/issues/2582039703/

It looks like the code is only temporary anyway since there's a TODO block around it, but since we're getting Sentry issues for it today I figure there's no harm in fixing it now.