### PR TITLE
Remove extra line when there are no actions

### DIFF
--- a/app/move/app/view/middleware/locals.actions.js
+++ b/app/move/app/view/middleware/locals.actions.js
@@ -22,7 +22,7 @@ function setActions({ previewPrefix = '' } = {}) {
         actions.length !== 0
           ? 'app-border-top-1 govuk-!-padding-top-4 govuk-!-margin-top-4'
           : undefined,
-      classes: 'govuk-button govuk-button--secondary',
+      classes: 'govuk-button govuk-button--secondary govuk-!-margin-top-4',
       url: `/move${previewPrefix}/opt-out?move_id=${move.id}`,
     })
 

--- a/app/move/app/view/middleware/locals.actions.test.js
+++ b/app/move/app/view/middleware/locals.actions.test.js
@@ -43,7 +43,8 @@ describe('Move view app', function () {
             text: 'messages::preview_new_feature.actions.return',
             itemClasses:
               'app-border-top-1 govuk-!-padding-top-4 govuk-!-margin-top-4',
-            classes: 'govuk-button govuk-button--secondary',
+            classes:
+              'govuk-button govuk-button--secondary govuk-!-margin-top-4',
             url: '/move/opt-out?move_id=12345',
           })
         })
@@ -68,7 +69,8 @@ describe('Move view app', function () {
           expect(res.locals.actions).to.deep.include({
             text: 'messages::preview_new_feature.actions.return',
             itemClasses: undefined,
-            classes: 'govuk-button govuk-button--secondary',
+            classes:
+              'govuk-button govuk-button--secondary govuk-!-margin-top-4',
             url: '/move/opt-out?move_id=12345',
           })
         })
@@ -93,7 +95,8 @@ describe('Move view app', function () {
             text: 'messages::preview_new_feature.actions.return',
             itemClasses:
               'app-border-top-1 govuk-!-padding-top-4 govuk-!-margin-top-4',
-            classes: 'govuk-button govuk-button--secondary',
+            classes:
+              'govuk-button govuk-button--secondary govuk-!-margin-top-4',
             url: '/move/opt-out?move_id=12345',
           })
         })
@@ -117,7 +120,8 @@ describe('Move view app', function () {
           expect(res.locals.actions).to.deep.include({
             text: 'messages::preview_new_feature.actions.return',
             itemClasses: undefined,
-            classes: 'govuk-button govuk-button--secondary',
+            classes:
+              'govuk-button govuk-button--secondary govuk-!-margin-top-4',
             url: '/move/opt-out?move_id=12345',
           })
         })
@@ -132,7 +136,8 @@ describe('Move view app', function () {
           expect(res.locals.actions).to.deep.include({
             text: 'messages::preview_new_feature.actions.return',
             itemClasses: undefined,
-            classes: 'govuk-button govuk-button--secondary',
+            classes:
+              'govuk-button govuk-button--secondary govuk-!-margin-top-4',
             url: '/move/preview-path/opt-out?move_id=12345',
           })
         })


### PR DESCRIPTION
This fixes how the line on the "Return to the old version" is generated to make sure the line doesn't appear unnecessarily when there are no actions above it.

## Before

<img width="423" alt="Screenshot 2021-08-26 at 10 45 11" src="https://user-images.githubusercontent.com/510498/130942307-fa0a30d7-0c8c-4fe3-9962-8cc13d0a38b6.png">

## After

<img width="421" alt="Screenshot 2021-08-26 at 10 45 01" src="https://user-images.githubusercontent.com/510498/130942326-e3e091c5-7226-4b1f-874f-d359a33dbfdc.png">

[Jira Ticket](https://dsdmoj.atlassian.net/browse/P4-3119)