### PR TITLE
Remove youth_risk_assessment:print permission

### DIFF
--- a/common/lib/permissions.js
+++ b/common/lib/permissions.js
@@ -42,7 +42,6 @@ const contractDeliveryManagerPermissions = [
   'person_escort_record:view',
   'person_escort_record:print',
   'youth_risk_assessment:view',
-  'youth_risk_assessment:print',
 ]
 
 const readOnlyPermissions = [
@@ -57,7 +56,6 @@ const readOnlyPermissions = [
   'person_escort_record:view',
   'person_escort_record:print',
   'youth_risk_assessment:view',
-  'youth_risk_assessment:print',
 ]
 
 const secureChildrensHomePermissions = [
@@ -87,7 +85,6 @@ const secureChildrensHomePermissions = [
   'youth_risk_assessment:create',
   'youth_risk_assessment:update',
   'youth_risk_assessment:confirm',
-  'youth_risk_assessment:print',
 ]
 const secureTrainingCentrePermissions = [
   'dashboard:view',
@@ -116,7 +113,6 @@ const secureTrainingCentrePermissions = [
   'youth_risk_assessment:create',
   'youth_risk_assessment:update',
   'youth_risk_assessment:confirm',
-  'youth_risk_assessment:print',
 ]
 
 const supplierPermissions = [
@@ -128,7 +124,6 @@ const supplierPermissions = [
   'person_escort_record:view',
   'person_escort_record:print',
   'youth_risk_assessment:view',
-  'youth_risk_assessment:print',
 ]
 const prisonPermissions = [
   'dashboard:view',
@@ -149,7 +144,6 @@ const prisonPermissions = [
   'youth_risk_assessment:create',
   'youth_risk_assessment:update',
   'youth_risk_assessment:confirm',
-  'youth_risk_assessment:print',
 ]
 const ocaPermissions = [
   'dashboard:view',
@@ -182,7 +176,6 @@ const pmuPermissions = [
   'person_escort_record:view',
   'person_escort_record:print',
   'youth_risk_assessment:view',
-  'youth_risk_assessment:print',
 ]
 const courtPermissions = [
   'dashboard:view',
@@ -192,7 +185,6 @@ const courtPermissions = [
   'move:view',
   'person_escort_record:view',
   'youth_risk_assessment:view',
-  'youth_risk_assessment:print',
 ]
 const personEscortRecordAuthorPermissions = [
   'person_escort_record:view',

--- a/common/lib/permissions.test.js
+++ b/common/lib/permissions.test.js
@@ -78,7 +78,6 @@ describe('Permissions', function () {
           'youth_risk_assessment:create',
           'youth_risk_assessment:update',
           'youth_risk_assessment:confirm',
-          'youth_risk_assessment:print',
         ])
       })
     })
@@ -116,7 +115,6 @@ describe('Permissions', function () {
           'youth_risk_assessment:create',
           'youth_risk_assessment:update',
           'youth_risk_assessment:confirm',
-          'youth_risk_assessment:print',
         ]
 
         expect(permissions).to.have.members(stcPermissions)
@@ -156,7 +154,6 @@ describe('Permissions', function () {
           'youth_risk_assessment:create',
           'youth_risk_assessment:update',
           'youth_risk_assessment:confirm',
-          'youth_risk_assessment:print',
         ])
       })
     })
@@ -186,7 +183,6 @@ describe('Permissions', function () {
           'youth_risk_assessment:create',
           'youth_risk_assessment:update',
           'youth_risk_assessment:confirm',
-          'youth_risk_assessment:print',
         ])
       })
     })
@@ -237,7 +233,6 @@ describe('Permissions', function () {
           'person_escort_record:view',
           'person_escort_record:print',
           'youth_risk_assessment:view',
-          'youth_risk_assessment:print',
         ])
       })
     })
@@ -257,7 +252,6 @@ describe('Permissions', function () {
           'person_escort_record:view',
           'person_escort_record:print',
           'youth_risk_assessment:view',
-          'youth_risk_assessment:print',
         ])
       })
     })
@@ -276,7 +270,6 @@ describe('Permissions', function () {
           'move:view',
           'person_escort_record:view',
           'youth_risk_assessment:view',
-          'youth_risk_assessment:print',
         ])
       })
     })
@@ -320,7 +313,6 @@ describe('Permissions', function () {
           'person_escort_record:view',
           'person_escort_record:print',
           'youth_risk_assessment:view',
-          'youth_risk_assessment:print',
         ])
       })
     })
@@ -343,7 +335,6 @@ describe('Permissions', function () {
           'person_escort_record:view',
           'person_escort_record:print',
           'youth_risk_assessment:view',
-          'youth_risk_assessment:print',
         ])
       })
     })
@@ -412,7 +403,6 @@ describe('Permissions', function () {
           'youth_risk_assessment:create',
           'youth_risk_assessment:update',
           'youth_risk_assessment:confirm',
-          'youth_risk_assessment:print',
         ]
 
         expect(permissions).to.have.members(allPermissions)


### PR DESCRIPTION
This isn't an action that can be performed on youth risk assessments, so there's no reason to have a permission for it.

By removing this permission it should avoid the "Print Youth Risk Assessment" links from appearing on the frontend as they only render if the user has the permission. This fixes a bug where pressing that link would take the user to a 404 page.

## Before

![Screenshot 2021-09-08 at 15 54 25](https://user-images.githubusercontent.com/510498/132533457-693eae8d-0c1b-43f4-82a9-ecd6ea7da7c8.png)

## After

![Screenshot 2021-09-08 at 15 56 03](https://user-images.githubusercontent.com/510498/132533465-84d6c621-a0f0-4ea1-b477-74471daced9a.png)

[Jira Ticket](https://dsdmoj.atlassian.net/browse/P4-3137)