### PR TITLE
Hide moves tab for non-CDM users

### DIFF
--- a/app/person/middleware/locals.tabs.js
+++ b/app/person/middleware/locals.tabs.js
@@ -1,14 +1,23 @@
+const { get } = require('lodash')
+
+const { check } = require('../../../common/middleware/permissions')
+
 module.exports = (req, res, next) => {
   const tabs = [
     {
       text: 'person::tabs.personal_details',
       url: `${req.baseUrl}/personal-details`,
     },
-    {
+  ]
+
+  const userPermissions = get(req.session, 'user.permissions')
+
+  if (check('locations:contract_delivery_manager', userPermissions)) {
+    tabs.push({
       text: 'person::tabs.moves',
       url: `${req.baseUrl}/moves`,
-    },
-  ]
+    })
+  }
 
   res.locals.tabs = tabs.map(item => ({
     ...item,

--- a/app/person/middleware/locals.tabs.test.js
+++ b/app/person/middleware/locals.tabs.test.js
@@ -29,11 +29,6 @@ describe('Person app', function () {
                 url: '/base-url/personal-details',
                 isActive: false,
               },
-              {
-                text: 'person::tabs.moves',
-                url: '/base-url/moves',
-                isActive: false,
-              },
             ],
           })
         })
@@ -56,6 +51,33 @@ describe('Person app', function () {
                 text: 'person::tabs.personal_details',
                 url: '/base-url/personal-details',
                 isActive: true,
+              },
+            ],
+          })
+        })
+
+        it('should call next', function () {
+          expect(nextSpy).to.be.calledOnceWithExactly()
+        })
+      })
+
+      context('with a CDM user', function () {
+        beforeEach(function () {
+          req.session = {
+            user: {
+              permissions: ['locations:contract_delivery_manager'],
+            },
+          }
+          setTabs(req, res, nextSpy)
+        })
+
+        it('should contain the moves tab', function () {
+          expect(res.locals).to.deep.equal({
+            tabs: [
+              {
+                text: 'person::tabs.personal_details',
+                url: '/base-url/personal-details',
+                isActive: false,
               },
               {
                 text: 'person::tabs.moves',

--- a/common/presenters/moves-to-table-component.js
+++ b/common/presenters/moves-to-table-component.js
@@ -48,7 +48,7 @@ function movesToTableComponent({ query } = {}) {
         sortKey: 'date',
         html: 'collections::labels.move_date',
         attributes: {
-          width: '135',
+          width: '145',
         },
       },
       row: {

--- a/common/presenters/moves-to-table-component.js
+++ b/common/presenters/moves-to-table-component.js
@@ -66,20 +66,9 @@ function movesToTableComponent({ query } = {}) {
       },
       row: {
         html: data => {
-          const classes = {
-            proposed: 'govuk-tag--grey',
-            requested: 'govuk-tag--purple',
-            booked: 'govuk-tag--blue',
-            in_transit: 'govuk-tag--yellow',
-            completed: 'govuk-tag--green',
-            cancelled: 'govuk-tag--red',
-            default: 'govuk-tag--blue',
-          }
-
           const opts = { context: data.status }
-          return componentService.getComponent('govukTag', {
+          return componentService.getComponent('mojBadge', {
             text: i18n.t('collections::labels.move_status', opts),
-            classes: classes[opts.context] || classes.default,
           })
         },
       },

--- a/common/presenters/moves-to-table-component.test.js
+++ b/common/presenters/moves-to-table-component.test.js
@@ -128,7 +128,7 @@ describe('#movesToTableComponent', function () {
             isSortable: true,
             sortKey: 'date',
             attributes: {
-              width: '135',
+              width: '145',
             },
           },
           {

--- a/common/presenters/moves-to-table-component.test.js
+++ b/common/presenters/moves-to-table-component.test.js
@@ -172,7 +172,7 @@ describe('#movesToTableComponent', function () {
                 text: mockMoves[0].date,
               },
               {
-                html: 'govukTag',
+                html: 'mojBadge',
               },
             ])
           })
@@ -180,8 +180,7 @@ describe('#movesToTableComponent', function () {
           it('should call tag component correctly', function () {
             expect(
               componentService.getComponent.getCall(0)
-            ).to.be.calledWithExactly('govukTag', {
-              classes: 'govuk-tag--blue',
+            ).to.be.calledWithExactly('mojBadge', {
               text: 'collections::labels.move_status',
             })
           })
@@ -213,7 +212,7 @@ describe('#movesToTableComponent', function () {
                 text: mockMoves[3].date,
               },
               {
-                html: 'govukTag',
+                html: 'mojBadge',
               },
             ])
           })
@@ -221,8 +220,7 @@ describe('#movesToTableComponent', function () {
           it('should call tag component correctly', function () {
             expect(
               componentService.getComponent.getCall(3)
-            ).to.be.calledWithExactly('govukTag', {
-              classes: 'govuk-tag--red',
+            ).to.be.calledWithExactly('mojBadge', {
               text: 'collections::labels.move_status',
             })
           })


### PR DESCRIPTION
This hides the moves tab on the profile page for non-CDM users, since they can't access the page anyway. I've also change the tag style to the standard MoJ badge until we're confident on the colours we want.

## Without permission

![Screenshot 2021-09-09 at 13 27 14](https://user-images.githubusercontent.com/510498/132695391-801b20f7-6c0e-428a-a40e-702ffb857f03.png)

## With permission

![Screenshot 2021-09-09 at 14 55 10](https://user-images.githubusercontent.com/510498/132699249-6f02aa14-7224-47b8-ae5c-275bd29bc164.png)

[Jira Ticket](https://dsdmoj.atlassian.net/browse/P4-3131)