### PR TITLE
Move design style tweaks

### DIFF
--- a/app/move/app/new/controllers/person-search-results.js
+++ b/app/move/app/new/controllers/person-search-results.js
@@ -40,9 +40,8 @@ class PersonSearchResultsController extends PersonController {
       const card = presenters.profileToCardComponent({
         locationType,
         showTags: false,
-      })({
-        person,
-      })
+      })({ profile: { person } })
+
       return {
         html: componentService.getComponent('appCard', card),
         value: person.id,

--- a/app/move/app/new/controllers/person-search-results.test.js
+++ b/app/move/app/new/controllers/person-search-results.test.js
@@ -235,13 +235,13 @@ describe('Move controllers', function () {
               ).to.be.calledWithExactly({ locationType, showTags: false })
               expect(
                 profileToCardComponentStub.firstCall
-              ).to.be.calledWithExactly({ person: mockPeople[0] })
+              ).to.be.calledWithExactly({ profile: { person: mockPeople[0] } })
               expect(
                 presenters.profileToCardComponent.secondCall
               ).to.be.calledWithExactly({ locationType, showTags: false })
               expect(
                 profileToCardComponentStub.secondCall
-              ).to.be.calledWithExactly({ person: mockPeople[1] })
+              ).to.be.calledWithExactly({ profile: { person: mockPeople[1] } })
             })
 
             it('should call component service correct number of times', function () {
@@ -251,10 +251,14 @@ describe('Move controllers', function () {
             it('should call component service correctly', function () {
               expect(
                 componentService.getComponent.firstCall
-              ).to.be.calledWithExactly('appCard', { person: mockPeople[0] })
+              ).to.be.calledWithExactly('appCard', {
+                profile: { person: mockPeople[0] },
+              })
               expect(
                 componentService.getComponent.secondCall
-              ).to.be.calledWithExactly('appCard', { person: mockPeople[1] })
+              ).to.be.calledWithExactly('appCard', {
+                profile: { person: mockPeople[1] },
+              })
             })
 
             it('should call next', function () {
@@ -295,7 +299,7 @@ describe('Move controllers', function () {
               ).to.be.calledWithExactly({ locationType, showTags: false })
               expect(
                 profileToCardComponentStub.firstCall
-              ).to.be.calledWithExactly({ person: mockPeople[0] })
+              ).to.be.calledWithExactly({ profile: { person: mockPeople[0] } })
             })
 
             it('should call component service correct number of times', function () {
@@ -305,7 +309,9 @@ describe('Move controllers', function () {
             it('should call component service correctly', function () {
               expect(
                 componentService.getComponent.firstCall
-              ).to.be.calledWithExactly('appCard', { person: mockPeople[0] })
+              ).to.be.calledWithExactly('appCard', {
+                profile: { person: mockPeople[0] },
+              })
             })
 
             it('should call next', function () {

--- a/app/move/app/view/views/warnings.njk
+++ b/app/move/app/view/views/warnings.njk
@@ -79,7 +79,7 @@
   {% else %}
     {{ govukInsetText({
       classes: "govuk-!-font-size-16",
-      text: t("assessment::incomplete")
+      text: t("assessment::warnings_started")
     }) }}
   {% endif %}
 

--- a/common/presenters/move-to-card-component.js
+++ b/common/presenters/move-to-card-component.js
@@ -49,16 +49,14 @@ function moveToCardComponent({
     const statusBadge = showStatusBadge
       ? { text: i18n.t(`statuses::${status}`) }
       : undefined
+
     const personCardComponent = profileToCardComponent({
       locationType,
       meta: moveMetaItems,
       showImage: isCompact ? false : showImage,
       showMeta: isCompact ? false : showMeta,
       showTags,
-    })({
-      ...profile,
-      href,
-    })
+    })({ profile, href })
 
     let tags
 

--- a/common/presenters/move-to-card-component.js
+++ b/common/presenters/move-to-card-component.js
@@ -56,7 +56,7 @@ function moveToCardComponent({
       showImage: isCompact ? false : showImage,
       showMeta: isCompact ? false : showMeta,
       showTags,
-    })({ profile, href })
+    })({ profile, href, reference })
 
     let tags
 
@@ -66,17 +66,17 @@ function moveToCardComponent({
       tags.push({ items: importantEventsTagList })
     }
 
+    const caption = profile
+      ? undefined
+      : { text: i18n.t('moves::move_reference', { reference }) }
+
     return {
       ...personCardComponent,
       status: statusBadge,
       classes: isCompact
         ? `app-card--compact ${personCardComponent.classes || ''}`
         : personCardComponent.classes || '',
-      caption: {
-        text: i18n.t('moves::move_reference', {
-          reference,
-        }),
-      },
+      caption: caption,
       ...(tags ? { tags } : undefined),
     }
   }

--- a/common/presenters/move-to-card-component.test.js
+++ b/common/presenters/move-to-card-component.test.js
@@ -60,6 +60,7 @@ describe('Presenters', function () {
             expect(profileToCardComponentItemStub).to.be.calledWithExactly({
               profile: mockMove.profile,
               href: '/move/12345',
+              reference: 'AB12FS45',
             })
             expect(profileToCardComponentStub).to.be.calledWithExactly({
               locationType: undefined,
@@ -77,32 +78,19 @@ describe('Presenters', function () {
               status: {
                 text: '__translated__',
               },
-              caption: {
-                text: '__translated__',
-              },
+              caption: undefined,
               tags: [{ items: 'moveToImportantEventsTagListComponent' }],
             })
           })
         })
 
-        describe('translations', function () {
-          it('should translate status', function () {
-            expect(i18n.t).to.be.calledWithExactly(
-              `statuses::${mockMove.status}`
-            )
-          })
-
-          it('should translate move reference', function () {
-            expect(i18n.t).to.be.calledWithExactly('moves::move_reference', {
-              reference: 'AB12FS45',
-            })
-          })
-
-          it('should translate correct number of times', function () {
-            expect(i18n.t).to.be.callCount(2)
-          })
+        it('should translate status', function () {
+          expect(i18n.t).to.be.calledOnceWithExactly(
+            `statuses::${mockMove.status}`
+          )
         })
       })
+
       context('when no person is associated to the move', function () {
         beforeEach(function () {
           transformedResponse = moveToCardComponent()({
@@ -112,10 +100,24 @@ describe('Presenters', function () {
             profile: null,
           })
         })
+
         it('does not create the link on the card', function () {
           expect(profileToCardComponentItemStub).to.be.calledWithExactly({
             profile: null,
             href: '',
+            reference: 'AB12FG',
+          })
+        })
+
+        it('should translate move reference', function () {
+          expect(i18n.t).to.be.calledWithExactly('moves::move_reference', {
+            reference: 'AB12FG',
+          })
+        })
+
+        it('should contain the reference in the caption', function () {
+          expect(transformedResponse.caption).to.deep.equal({
+            text: '__translated__',
           })
         })
       })
@@ -132,6 +134,7 @@ describe('Presenters', function () {
         expect(profileToCardComponentItemStub).to.be.calledWithExactly({
           profile: mockMove.profile,
           href: '/move/12345/path/to/somewhere',
+          reference: 'AB12FS45',
         })
         expect(profileToCardComponentStub).to.be.calledWithExactly({
           locationType: undefined,
@@ -154,6 +157,7 @@ describe('Presenters', function () {
         expect(profileToCardComponentItemStub).to.be.calledWithExactly({
           profile: mockMove.profile,
           href: '/move/12345',
+          reference: 'AB12FS45',
         })
         expect(profileToCardComponentStub).to.be.calledWithExactly({
           locationType: undefined,
@@ -176,6 +180,7 @@ describe('Presenters', function () {
         expect(profileToCardComponentItemStub).to.be.calledWithExactly({
           profile: mockMove.profile,
           href: '/move/12345',
+          reference: 'AB12FS45',
         })
         expect(profileToCardComponentStub).to.be.calledWithExactly({
           locationType: undefined,
@@ -198,6 +203,7 @@ describe('Presenters', function () {
         expect(profileToCardComponentItemStub).to.be.calledWithExactly({
           profile: mockMove.profile,
           href: '/move/12345',
+          reference: 'AB12FS45',
         })
         expect(profileToCardComponentStub).to.be.calledWithExactly({
           locationType: undefined,
@@ -220,6 +226,7 @@ describe('Presenters', function () {
         expect(profileToCardComponentItemStub).to.be.calledWithExactly({
           profile: mockMove.profile,
           href: '/move/12345',
+          reference: 'AB12FS45',
         })
         expect(profileToCardComponentStub).to.be.calledWithExactly({
           locationType: undefined,
@@ -246,6 +253,7 @@ describe('Presenters', function () {
         expect(profileToCardComponentItemStub).to.be.calledWithExactly({
           profile: mockMove.profile,
           href: '/move/12345',
+          reference: 'AB12FS45',
         })
         expect(profileToCardComponentStub).to.be.calledWithExactly({
           locationType: undefined,
@@ -261,9 +269,7 @@ describe('Presenters', function () {
           ...mockPersonCardComponent,
           classes: 'app-card--compact ',
           status: undefined,
-          caption: {
-            text: '__translated__',
-          },
+          caption: undefined,
         })
       })
     })
@@ -282,6 +288,7 @@ describe('Presenters', function () {
         expect(profileToCardComponentItemStub).to.be.calledWithExactly({
           profile: mockMove.profile,
           href: '/move/12345',
+          reference: 'AB12FS45',
         })
         expect(profileToCardComponentStub).to.be.calledWithExactly({
           locationType: undefined,
@@ -297,9 +304,7 @@ describe('Presenters', function () {
           ...mockPersonCardComponent,
           classes: 'app-card--compact ',
           status: undefined,
-          caption: {
-            text: '__translated__',
-          },
+          caption: undefined,
         })
       })
     })
@@ -326,9 +331,7 @@ describe('Presenters', function () {
             ...mockPersonCardComponent,
             classes: '',
             status: undefined,
-            caption: {
-              text: '__translated__',
-            },
+            caption: undefined,
             tags: [{ items: 'moveToImportantEventsTagListComponent' }],
           })
         })
@@ -363,9 +366,7 @@ describe('Presenters', function () {
             ...mockPersonCardComponent,
             classes: `app-card--compact ${mockClasses}`,
             status: undefined,
-            caption: {
-              text: '__translated__',
-            },
+            caption: undefined,
           })
         })
       })
@@ -382,9 +383,7 @@ describe('Presenters', function () {
             status: {
               text: '__translated__',
             },
-            caption: {
-              text: '__translated__',
-            },
+            caption: undefined,
             tags: [{ items: 'moveToImportantEventsTagListComponent' }],
           })
         })
@@ -404,6 +403,7 @@ describe('Presenters', function () {
           expect(profileToCardComponentItemStub).to.be.calledWithExactly({
             profile: mockMove.profile,
             href: '/move/12345',
+            reference: 'AB12FS45',
           })
           expect(profileToCardComponentStub).to.be.calledWithExactly({
             locationType: undefined,
@@ -432,6 +432,7 @@ describe('Presenters', function () {
           expect(profileToCardComponentItemStub).to.be.calledWithExactly({
             profile: mockMove.profile,
             href: '/move/12345',
+            reference: 'AB12FS45',
           })
           expect(profileToCardComponentStub).to.be.calledWithExactly({
             locationType: undefined,
@@ -461,6 +462,7 @@ describe('Presenters', function () {
           expect(profileToCardComponentItemStub).to.be.calledWithExactly({
             profile: mockMove.profile,
             href: '/move/12345',
+            reference: 'AB12FS45',
           })
           expect(profileToCardComponentStub).to.be.calledWithExactly({
             locationType: undefined,
@@ -497,6 +499,7 @@ describe('Presenters', function () {
           expect(profileToCardComponentItemStub).to.be.calledWithExactly({
             profile: mockMove.profile,
             href: '/move/12345',
+            reference: 'AB12FS45',
           })
           expect(profileToCardComponentStub).to.be.calledWithExactly({
             locationType: 'prison',

--- a/common/presenters/move-to-card-component.test.js
+++ b/common/presenters/move-to-card-component.test.js
@@ -58,7 +58,7 @@ describe('Presenters', function () {
         describe('response', function () {
           it('should call profile to card component', function () {
             expect(profileToCardComponentItemStub).to.be.calledWithExactly({
-              ...mockMove.profile,
+              profile: mockMove.profile,
               href: '/move/12345',
             })
             expect(profileToCardComponentStub).to.be.calledWithExactly({
@@ -109,11 +109,12 @@ describe('Presenters', function () {
             id: '12345',
             reference: 'AB12FG',
             status: 'proposed',
-            person: null,
+            profile: null,
           })
         })
         it('does not create the link on the card', function () {
           expect(profileToCardComponentItemStub).to.be.calledWithExactly({
+            profile: null,
             href: '',
           })
         })
@@ -129,7 +130,7 @@ describe('Presenters', function () {
 
       it('should call profile to card component correctly', function () {
         expect(profileToCardComponentItemStub).to.be.calledWithExactly({
-          ...mockMove.profile,
+          profile: mockMove.profile,
           href: '/move/12345/path/to/somewhere',
         })
         expect(profileToCardComponentStub).to.be.calledWithExactly({
@@ -151,7 +152,7 @@ describe('Presenters', function () {
 
       it('should call profile to card component correctly', function () {
         expect(profileToCardComponentItemStub).to.be.calledWithExactly({
-          ...mockMove.profile,
+          profile: mockMove.profile,
           href: '/move/12345',
         })
         expect(profileToCardComponentStub).to.be.calledWithExactly({
@@ -173,7 +174,7 @@ describe('Presenters', function () {
 
       it('should call profile to card component correctly', function () {
         expect(profileToCardComponentItemStub).to.be.calledWithExactly({
-          ...mockMove.profile,
+          profile: mockMove.profile,
           href: '/move/12345',
         })
         expect(profileToCardComponentStub).to.be.calledWithExactly({
@@ -195,7 +196,7 @@ describe('Presenters', function () {
 
       it('should call profile to card component correctly', function () {
         expect(profileToCardComponentItemStub).to.be.calledWithExactly({
-          ...mockMove.profile,
+          profile: mockMove.profile,
           href: '/move/12345',
         })
         expect(profileToCardComponentStub).to.be.calledWithExactly({
@@ -217,7 +218,7 @@ describe('Presenters', function () {
 
       it('should call profile to card component correctly', function () {
         expect(profileToCardComponentItemStub).to.be.calledWithExactly({
-          ...mockMove.profile,
+          profile: mockMove.profile,
           href: '/move/12345',
         })
         expect(profileToCardComponentStub).to.be.calledWithExactly({
@@ -243,7 +244,7 @@ describe('Presenters', function () {
 
       it('should call profile to card component correctly', function () {
         expect(profileToCardComponentItemStub).to.be.calledWithExactly({
-          ...mockMove.profile,
+          profile: mockMove.profile,
           href: '/move/12345',
         })
         expect(profileToCardComponentStub).to.be.calledWithExactly({
@@ -279,7 +280,7 @@ describe('Presenters', function () {
 
       it('should call profile to card component correctly', function () {
         expect(profileToCardComponentItemStub).to.be.calledWithExactly({
-          ...mockMove.profile,
+          profile: mockMove.profile,
           href: '/move/12345',
         })
         expect(profileToCardComponentStub).to.be.calledWithExactly({
@@ -401,7 +402,7 @@ describe('Presenters', function () {
 
         it('should call profile to card component correctly', function () {
           expect(profileToCardComponentItemStub).to.be.calledWithExactly({
-            ...mockMove.profile,
+            profile: mockMove.profile,
             href: '/move/12345',
           })
           expect(profileToCardComponentStub).to.be.calledWithExactly({
@@ -429,7 +430,7 @@ describe('Presenters', function () {
 
         it('should call profile to card component correctly', function () {
           expect(profileToCardComponentItemStub).to.be.calledWithExactly({
-            ...mockMove.profile,
+            profile: mockMove.profile,
             href: '/move/12345',
           })
           expect(profileToCardComponentStub).to.be.calledWithExactly({
@@ -458,7 +459,7 @@ describe('Presenters', function () {
 
         it('should call profile to card component correctly', function () {
           expect(profileToCardComponentItemStub).to.be.calledWithExactly({
-            ...mockMove.profile,
+            profile: mockMove.profile,
             href: '/move/12345',
           })
           expect(profileToCardComponentStub).to.be.calledWithExactly({
@@ -494,7 +495,7 @@ describe('Presenters', function () {
 
         it('should call profile to card component correctly', function () {
           expect(profileToCardComponentItemStub).to.be.calledWithExactly({
-            ...mockMove.profile,
+            profile: mockMove.profile,
             href: '/move/12345',
           })
           expect(profileToCardComponentStub).to.be.calledWithExactly({

--- a/common/presenters/profile-to-card-component.js
+++ b/common/presenters/profile-to-card-component.js
@@ -12,12 +12,10 @@ function profileToCardComponent({
   showMeta = true,
   showTags = true,
 } = {}) {
-  return function item(profile) {
-    const {
-      href,
-      person = {},
-      person_escort_record: personEscortRecord,
-    } = profile || {}
+  return function item({ profile, href } = {}) {
+    const { person = {}, person_escort_record: personEscortRecord } =
+      profile || {}
+
     const {
       id,
       gender,
@@ -25,6 +23,7 @@ function profileToCardComponent({
       _image_url: imageUrl,
       date_of_birth: dateOfBirth,
     } = person
+
     const card = {
       href,
       title: {

--- a/common/presenters/profile-to-card-component.js
+++ b/common/presenters/profile-to-card-component.js
@@ -12,7 +12,7 @@ function profileToCardComponent({
   showMeta = true,
   showTags = true,
 } = {}) {
-  return function item({ profile, href } = {}) {
+  return function item({ profile, href, reference } = {}) {
     const { person = {}, person_escort_record: personEscortRecord } =
       profile || {}
 
@@ -24,11 +24,14 @@ function profileToCardComponent({
       date_of_birth: dateOfBirth,
     } = person
 
+    const title =
+      reference && fullname
+        ? `${fullname} (${reference})`
+        : fullname || i18n.t('awaiting_person')
+
     const card = {
       href,
-      title: {
-        text: fullname || i18n.t('awaiting_person'),
-      },
+      title: { text: title },
     }
 
     if (!id) {

--- a/common/presenters/profile-to-card-component.test.js
+++ b/common/presenters/profile-to-card-component.test.js
@@ -8,8 +8,6 @@ const profileToCardComponent = proxyquire('./profile-to-card-component', {
   './framework-flags-to-tag-list': frameworkFlagsToTagListStub,
 })
 
-const mockHref = '/move/12345'
-
 const mockProfile = {
   id: '12345',
   person: {
@@ -25,7 +23,14 @@ const mockProfile = {
   },
 }
 
-const mockArgs = { href: mockHref, profile: mockProfile }
+const mockHref = '/move/12345'
+const mockReference = 'ABC'
+
+const mockArgs = {
+  profile: mockProfile,
+  href: mockHref,
+  reference: mockReference,
+}
 
 describe('Presenters', function () {
   describe('#profileToCardComponent()', function () {
@@ -52,7 +57,7 @@ describe('Presenters', function () {
           it('should contain a title', function () {
             expect(transformedResponse).to.have.property('title')
             expect(transformedResponse.title).to.deep.equal({
-              text: mockProfile.person._fullname,
+              text: `${mockProfile.person._fullname} (${mockReference})`,
             })
           })
 

--- a/common/presenters/profile-to-card-component.test.js
+++ b/common/presenters/profile-to-card-component.test.js
@@ -8,9 +8,10 @@ const profileToCardComponent = proxyquire('./profile-to-card-component', {
   './framework-flags-to-tag-list': frameworkFlagsToTagListStub,
 })
 
+const mockHref = '/move/12345'
+
 const mockProfile = {
   id: '12345',
-  href: '/move/12345',
   person: {
     id: '12345',
     _fullname: 'Name, Full',
@@ -23,6 +24,8 @@ const mockProfile = {
     police_national_computer: '321CBA',
   },
 }
+
+const mockArgs = { href: mockHref, profile: mockProfile }
 
 describe('Presenters', function () {
   describe('#profileToCardComponent()', function () {
@@ -37,13 +40,13 @@ describe('Presenters', function () {
     context('with default options', function () {
       context('with mock person', function () {
         beforeEach(function () {
-          transformedResponse = profileToCardComponent()(mockProfile)
+          transformedResponse = profileToCardComponent()(mockArgs)
         })
 
         describe('response', function () {
           it('should contain a href', function () {
             expect(transformedResponse).to.have.property('href')
-            expect(transformedResponse.href).to.equal(mockProfile.href)
+            expect(transformedResponse.href).to.equal(mockHref)
           })
 
           it('should contain a title', function () {
@@ -138,9 +141,11 @@ describe('Presenters', function () {
       context('when meta contains falsey values', function () {
         it('should correctly remove false items', function () {
           const transformedResponse = profileToCardComponent()({
-            date_of_birth: '',
-            gender: '',
-            ethnicity: '',
+            profile: {
+              date_of_birth: '',
+              gender: '',
+              ethnicity: '',
+            },
           })
 
           expect(transformedResponse).to.have.property('meta')
@@ -149,9 +154,11 @@ describe('Presenters', function () {
 
         it('should correctly remove false items', function () {
           const transformedResponse = profileToCardComponent()({
-            date_of_birth: null,
-            gender: null,
-            ethnicity: null,
+            profile: {
+              date_of_birth: null,
+              gender: null,
+              ethnicity: null,
+            },
           })
 
           expect(transformedResponse).to.have.property('meta')
@@ -160,9 +167,11 @@ describe('Presenters', function () {
 
         it('should correctly remove false items', function () {
           const transformedResponse = profileToCardComponent()({
-            date_of_birth: undefined,
-            gender: undefined,
-            ethnicity: undefined,
+            profile: {
+              date_of_birth: undefined,
+              gender: undefined,
+              ethnicity: undefined,
+            },
           })
 
           expect(transformedResponse).to.have.property('meta')
@@ -175,11 +184,13 @@ describe('Presenters', function () {
 
         beforeEach(function () {
           transformedResponse = profileToCardComponent()({
-            person: {
-              date_of_birth: '',
-              gender: mockProfile.person.gender,
+            profile: {
+              person: {
+                date_of_birth: '',
+                gender: mockProfile.person.gender,
+              },
+              assessment_answers: [],
             },
-            assessment_answers: [],
           })
         })
 
@@ -201,9 +212,11 @@ describe('Presenters', function () {
         context('with `not_started` PER', function () {
           beforeEach(function () {
             transformedResponse = profileToCardComponent()({
-              ...mockProfile,
-              person_escort_record: {
-                status: 'not_started',
+              profile: {
+                ...mockProfile,
+                person_escort_record: {
+                  status: 'not_started',
+                },
               },
             })
           })
@@ -230,9 +243,11 @@ describe('Presenters', function () {
         context('with `in_progress` PER', function () {
           beforeEach(function () {
             transformedResponse = profileToCardComponent()({
-              ...mockProfile,
-              person_escort_record: {
-                status: 'in_progress',
+              profile: {
+                ...mockProfile,
+                person_escort_record: {
+                  status: 'in_progress',
+                },
               },
             })
           })
@@ -259,10 +274,13 @@ describe('Presenters', function () {
         context('with `completed` PER', function () {
           beforeEach(function () {
             transformedResponse = profileToCardComponent()({
-              ...mockProfile,
-              person_escort_record: {
-                status: 'completed',
-                flags: ['foo', 'bar'],
+              href: mockHref,
+              profile: {
+                ...mockProfile,
+                person_escort_record: {
+                  status: 'completed',
+                  flags: ['foo', 'bar'],
+                },
               },
             })
           })
@@ -293,7 +311,7 @@ describe('Presenters', function () {
       beforeEach(function () {
         transformedResponse = profileToCardComponent({
           showMeta: false,
-        })(mockProfile)
+        })(mockArgs)
       })
 
       it('should not contain meta items', function () {
@@ -313,7 +331,7 @@ describe('Presenters', function () {
       beforeEach(function () {
         transformedResponse = profileToCardComponent({
           showTags: false,
-        })(mockProfile)
+        })(mockArgs)
       })
 
       it('should not contain tags items', function () {
@@ -338,7 +356,7 @@ describe('Presenters', function () {
       beforeEach(function () {
         transformedResponse = profileToCardComponent({
           showImage: false,
-        })(mockProfile)
+        })(mockArgs)
       })
 
       it('should not contain an image path', function () {
@@ -386,9 +404,9 @@ describe('Presenters', function () {
       })
     })
 
-    context('with null', function () {
+    context('with empty object', function () {
       beforeEach(function () {
-        transformedResponse = profileToCardComponent()(null)
+        transformedResponse = profileToCardComponent()({})
       })
 
       it('should use fallback values', function () {
@@ -410,7 +428,7 @@ describe('Presenters', function () {
                 text: 'Buzz',
               },
             ],
-          })(mockProfile)
+          })(mockArgs)
         })
 
         it('should prepend existing meta', function () {
@@ -463,7 +481,7 @@ describe('Presenters', function () {
         context(`when profile.${property} is populated`, function () {
           beforeEach(function () {
             transformedResponse = profileToCardComponent({ locationType })(
-              mockProfile
+              mockArgs
             )
           })
 
@@ -490,7 +508,7 @@ describe('Presenters', function () {
           beforeEach(function () {
             mockProfile.person[property] = undefined
             transformedResponse = profileToCardComponent({ locationType })(
-              mockProfile
+              mockArgs
             )
           })
 

--- a/locales/en/assessment.json
+++ b/locales/en/assessment.json
@@ -60,6 +60,7 @@
   "incomplete": "Warnings will display once a Person Escort Record has been completed",
   "incomplete_overview": "This will display once a Person Escort Record has been completed",
   "section_incomplete": "Warnings will display once this section has been completed",
+  "warnings_started": "Warnings will display once a Person Escort Record has been started",
   "prefilled_banner": {
     "title": "Some answers on this page need to be reviewed. They are from the last $t({{context}}) confirmed on {{date}}."
   },

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -73,7 +73,7 @@
   },
   "preview_new_feature": {
     "heading":"There is a new version of this page",
-    "content":"<p>Use the new version and help us improve it with your feedback. You will be able to return to the current version at any time.</p>",
+    "content":"<p>Use the new version and help us improve it with your feedback.<br />You will be able to return to the current version at any time.</p>",
     "actions": {
       "yes": "Try the new version",
       "no": "Keep the current version",


### PR DESCRIPTION
This makes a few changes to the new move pages following further design refinements. See individual commits for more details.

## Old

![Screenshot 2021-09-13 at 10 30 49](https://user-images.githubusercontent.com/510498/133060135-a2b35108-992e-46d6-ab94-11a38d1f1575.png)

![Screenshot 2021-09-10 at 13 33 30](https://user-images.githubusercontent.com/510498/132854049-303a27d1-947b-413e-a2ad-556bc80b7d41.png)

![Screenshot 2021-09-13 at 10 17 38](https://user-images.githubusercontent.com/510498/133058268-be0c400f-4cc6-4141-b13f-5c2dd28f0d48.png)

## New

![Screenshot 2021-09-13 at 10 31 03](https://user-images.githubusercontent.com/510498/133060186-cd06a20a-f8e2-45f5-8a7a-79718bedf8bf.png)

![Screenshot 2021-09-10 at 13 33 47](https://user-images.githubusercontent.com/510498/132854078-5d9bd11d-be63-4d74-89f9-db80015b81dd.png)

![Screenshot 2021-09-13 at 10 17 25](https://user-images.githubusercontent.com/510498/133058285-4c9f0493-4b5b-45ca-ba9e-1e45ef6b7043.png)

[Jira Ticket](https://dsdmoj.atlassian.net/browse/P4-3133)