### PR TITLE
Increase e2e CI resource class

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -219,7 +219,7 @@ jobs:
 
   end-to-end-test:
     <<: *circle_container
-    resource_class: xlarge
+    resource_class: 2xlarge
     steps:
       - checkout
       - browser-tools/install-browser-tools


### PR DESCRIPTION
The end to end tests are often failing with a bad gateway error. This suggests the server is unable to handle the request.

I think increasing the resource class might solve this problem, but I'll monitor to see if it's improved.

The last time this was increased was in June: https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/pull/1736/commits/13017e5247dabe7710c6ad69c5933f68a91b3347