### PR TITLE
Improve framework button navigation

### DIFF
--- a/common/controllers/framework/framework-section.js
+++ b/common/controllers/framework/framework-section.js
@@ -1,6 +1,7 @@
-const { filter, findIndex, snakeCase, sortBy } = require('lodash')
+const { filter, snakeCase } = require('lodash')
 
 const i18n = require('../../../config/i18n')
+const setPreviousNextFrameworkSection = require('../../middleware/framework/set-previous-next-framework-section')
 const setMoveSummary = require('../../middleware/set-move-summary')
 const presenters = require('../../presenters')
 const FormWizardController = require('../form-wizard')
@@ -12,6 +13,7 @@ class FrameworkSectionController extends FormWizardController {
     this.use(this.setMoveId)
     this.use(this.setEditableStatus)
     this.use(this.seti18nContext)
+    this.use(setPreviousNextFrameworkSection)
     this.use(this.setPagination)
     this.use(setMoveSummary)
   }
@@ -22,31 +24,28 @@ class FrameworkSectionController extends FormWizardController {
   }
 
   setPagination(req, res, next) {
-    const { assessment, baseUrl } = req
-    const currentSection = req.frameworkSection.key
-    const frameworkSections = sortBy(assessment._framework.sections, ['order'])
-    const currentIndex = findIndex(frameworkSections, { key: currentSection })
+    const {
+      previousFrameworkSection,
+      nextFrameworkSection,
+      frameworkSection: { key: currentSection },
+    } = req
 
     const pagination = {
       classes: 'app-pagination--split govuk-!-margin-top-6',
     }
 
-    if (currentIndex > 0) {
-      const prevSection = frameworkSections[currentIndex - 1]
-
+    if (previousFrameworkSection) {
       pagination.previous = {
-        href: baseUrl.replace(currentSection, prevSection.key),
-        label: prevSection.name,
+        href: req.baseUrl.replace(currentSection, previousFrameworkSection.key),
+        label: previousFrameworkSection.name,
         text: i18n.t('pagination.previous_section'),
       }
     }
 
-    if (currentIndex + 1 < frameworkSections.length) {
-      const nextSection = frameworkSections[currentIndex + 1]
-
+    if (nextFrameworkSection) {
       pagination.next = {
-        href: baseUrl.replace(currentSection, nextSection.key),
-        label: nextSection.name,
+        href: req.baseUrl.replace(currentSection, nextFrameworkSection.key),
+        label: nextFrameworkSection.name,
         text: i18n.t('pagination.next_section'),
       }
     }

--- a/common/controllers/framework/framework-step.js
+++ b/common/controllers/framework/framework-step.js
@@ -57,6 +57,15 @@ class FrameworkStepController extends FormWizardController {
     next()
   }
 
+  setIsLastStep(req, res, next) {
+    const { route: currentStep } = req?.form?.options || {}
+    const nextStep = this.getNextStep(req, res)
+
+    req.isLastStep = nextStep.endsWith(currentStep)
+
+    next()
+  }
+
   setButtonText(req, res, next) {
     const { stepType } = req.form.options
     const isInterruptionCard = stepType === 'interruption-card'

--- a/common/controllers/framework/framework-step.js
+++ b/common/controllers/framework/framework-step.js
@@ -28,6 +28,7 @@ class FrameworkStepController extends FormWizardController {
     this.use(this.setupConditionalFields)
     super.middlewareSetup()
     this.use(this.setValidationRules)
+    this.use(this.setIsLastStep)
     this.use(this.setButtonText)
   }
 
@@ -168,17 +169,16 @@ class FrameworkStepController extends FormWizardController {
   }
 
   successHandler(req, res, next) {
-    const { route: currentStep } = req?.form?.options || {}
-    const goToOverview = req.body.save_and_return_to_overview
+    const {
+      isLastStep,
+      body: { save_and_return_to_overview: goToOverview },
+    } = req
 
     if (goToOverview) {
       const currentSection = req.frameworkSection.key
       const overviewUrl = req.baseUrl.replace(`/${currentSection}`, '')
       return res.redirect(overviewUrl)
     }
-
-    const nextStep = this.getNextStep(req, res)
-    const isLastStep = nextStep.endsWith(currentStep)
 
     if (isLastStep) {
       return res.redirect(req.baseUrl)

--- a/common/controllers/framework/framework-step.js
+++ b/common/controllers/framework/framework-step.js
@@ -184,18 +184,22 @@ class FrameworkStepController extends FormWizardController {
   successHandler(req, res, next) {
     const {
       isLastStep,
+      frameworkSection: { key: currentSection },
       nextFrameworkSection,
       body: { save_and_return_to_overview: goToOverview },
     } = req
 
     if (goToOverview || (isLastStep && !nextFrameworkSection)) {
-      const currentSection = req.frameworkSection.key
       const overviewUrl = req.baseUrl.replace(`/${currentSection}`, '')
       return res.redirect(overviewUrl)
     }
 
     if (isLastStep && nextFrameworkSection) {
-      return res.redirect(req.baseUrl)
+      const nextSectionUrl = req.baseUrl.replace(
+        `/${currentSection}`,
+        `/${nextFrameworkSection.key}`
+      )
+      return res.redirect(`${nextSectionUrl}/start`)
     }
 
     super.successHandler(req, res, next)

--- a/common/controllers/framework/framework-step.test.js
+++ b/common/controllers/framework/framework-step.test.js
@@ -816,13 +816,13 @@ describe('Framework controllers', function () {
         context('with last framework step and a next section', function () {
           beforeEach(function () {
             mockReq.isLastStep = true
-            mockReq.nextFrameworkSection = {}
+            mockReq.nextFrameworkSection = { key: 'next-section' }
             controller.successHandler(mockReq, mockRes, nextSpy)
           })
 
           it('should redirect to base URL with the section', function () {
             expect(mockRes.redirect).to.have.been.calledOnceWithExactly(
-              '/base-url/section'
+              '/base-url/next-section/start'
             )
           })
 

--- a/common/controllers/framework/framework-step.test.js
+++ b/common/controllers/framework/framework-step.test.js
@@ -283,6 +283,67 @@ describe('Framework controllers', function () {
       })
     })
 
+    describe('#setIsLastStep', function () {
+      let mockReq, nextSpy
+
+      beforeEach(function () {
+        nextSpy = sinon.spy()
+        mockReq = { form: { options: {} } }
+        sinon.stub(FormWizardController.prototype, 'getNextStep').returns('/')
+      })
+
+      context('with step that is last step', function () {
+        beforeEach(function () {
+          mockReq.form.options.route = '/two'
+          FormWizardController.prototype.getNextStep.returns('/two')
+          controller.setIsLastStep(mockReq, {}, nextSpy)
+        })
+
+        it('should be the last step', function () {
+          expect(mockReq.isLastStep).to.be.true
+        })
+      })
+
+      context('with step that contains last step', function () {
+        beforeEach(function () {
+          mockReq.form.options.route = '/two'
+          FormWizardController.prototype.getNextStep.returns(
+            '/full/path/to/step/two-continued'
+          )
+          controller.setIsLastStep(mockReq, {}, nextSpy)
+        })
+
+        it('should not be the last step', function () {
+          expect(mockReq.isLastStep).to.be.false
+        })
+      })
+
+      context('with step that contains same end as last step', function () {
+        beforeEach(function () {
+          mockReq.form.options.route = '/continued'
+          FormWizardController.prototype.getNextStep.returns(
+            '/full/path/to/step/two-continued'
+          )
+          controller.setIsLastStep(mockReq, {}, nextSpy)
+        })
+
+        it('should not be the last step', function () {
+          expect(mockReq.isLastStep).to.be.false
+        })
+      })
+
+      context('with all other steps', function () {
+        beforeEach(function () {
+          FormWizardController.prototype.getNextStep.returns('/two')
+          controller.setIsLastStep(mockReq, {}, nextSpy)
+        })
+
+        it('should not be the last step', function () {
+          expect(mockReq.isLastStep).to.be.false
+        })
+      })
+    })
+
     describe('#setButtonText', function () {
       let mockReq, nextSpy
 

--- a/common/middleware/framework/set-previous-next-framework-section.js
+++ b/common/middleware/framework/set-previous-next-framework-section.js
@@ -1,0 +1,25 @@
+const { sortBy, findIndex } = require('lodash')
+
+module.exports = function (req, res, next) {
+  const {
+    assessment,
+    frameworkSection: { key: currentSection },
+  } = req
+
+  const frameworkSections = sortBy(assessment._framework.sections, ['order'])
+  const currentIndex = findIndex(frameworkSections, { key: currentSection })
+
+  if (currentIndex > 0) {
+    req.previousFrameworkSection = frameworkSections[currentIndex - 1]
+  } else {
+    req.previousFrameworkSection = null
+  }
+
+  if (currentIndex + 1 < frameworkSections.length) {
+    req.nextFrameworkSection = frameworkSections[currentIndex + 1]
+  } else {
+    req.nextFrameworkSection = null
+  }
+
+  next()
+}

--- a/common/middleware/framework/set-previous-next-framework-section.test.js
+++ b/common/middleware/framework/set-previous-next-framework-section.test.js
@@ -1,0 +1,116 @@
+const middleware = require('./set-previous-next-framework-section')
+
+describe('Framework middleware', function () {
+  describe('#setPreviousNextFrameworkSection', function () {
+    let req, res, nextSpy
+
+    const mockSections = {
+      'health-information': {
+        key: 'health-information',
+        name: 'Health information',
+        order: 2,
+      },
+      'offence-information': {
+        key: 'offence-information',
+        name: 'Offence information',
+        order: 4,
+      },
+      'property-information': {
+        key: 'property-information',
+        name: 'Property information',
+        order: 3,
+      },
+      'risk-information': {
+        key: 'risk-information',
+        name: 'Risk information',
+        order: 1,
+      },
+    }
+
+    beforeEach(function () {
+      nextSpy = sinon.spy()
+
+      req = {
+        assessment: {
+          _framework: {
+            sections: mockSections,
+          },
+        },
+        frameworkSection: {},
+      }
+
+      res = {}
+    })
+
+    context('when current section is first section', function () {
+      beforeEach(function () {
+        req.frameworkSection.key = 'risk-information'
+        req.baseUrl = `/move/person-escort-record/${req.frameworkSection.key}`
+
+        middleware(req, res, nextSpy)
+      })
+
+      it('should not set the previous section', function () {
+        expect(req.previousFrameworkSection).to.be.null
+      })
+
+      it('should set the next section', function () {
+        expect(req.nextFrameworkSection).to.deep.equal(
+          mockSections['health-information']
+        )
+      })
+
+      it('should call next', function () {
+        expect(nextSpy).to.be.calledOnceWithExactly()
+      })
+    })
+
+    context('when current section is middle section', function () {
+      beforeEach(function () {
+        req.frameworkSection.key = 'property-information'
+        req.baseUrl = `/move/person-escort-record/${req.frameworkSection.key}`
+
+        middleware(req, res, nextSpy)
+      })
+
+      it('should set the previous section', function () {
+        expect(req.previousFrameworkSection).to.deep.equal(
+          mockSections['health-information']
+        )
+      })
+
+      it('should set the next section', function () {
+        expect(req.nextFrameworkSection).to.deep.equal(
+          mockSections['offence-information']
+        )
+      })
+
+      it('should call next', function () {
+        expect(nextSpy).to.be.calledOnceWithExactly()
+      })
+    })
+
+    context('when current section is last section', function () {
+      beforeEach(function () {
+        req.frameworkSection.key = 'offence-information'
+        req.baseUrl = `/move/person-escort-record/${req.frameworkSection.key}`
+
+        middleware(req, res, nextSpy)
+      })
+
+      it('should set the previous section', function () {
+        expect(req.previousFrameworkSection).to.deep.equal(
+          mockSections['property-information']
+        )
+      })
+
+      it('should not set the next section', function () {
+        expect(req.nextFrameworkSection).to.be.null
+      })
+
+      it('should call next', function () {
+        expect(nextSpy).to.be.calledOnceWithExactly()
+      })
+    })
+  })
+})

--- a/common/templates/framework-step.njk
+++ b/common/templates/framework-step.njk
@@ -56,7 +56,7 @@
 {% block submitAction %}
   {{ super() }}
 
-  {% if options.stepType != 'interruption-card' %}
+  {% if showReturnToOverviewButton and options.stepType != 'interruption-card' %}
     {{ govukButton({
       text: t("actions::save_and_return_to_overview"),
       name: "save_and_return_to_overview",


### PR DESCRIPTION
This improves the framework button navigation to make it easier for users to complete an entire PER/YRA in one go. Specifically this:

- Removes section summary screens from the end of each section and instead takes users straight to the first question of the next section.
- Removes the ‘Save and continue’ button from the final question screen as this is the end of the framework. Instead this is replaced by the existing ‘Save and return to overview button’.

See individual commits for more details as I had to do some refactoring before making the implementation changes.

[Jira Ticket](https://dsdmoj.atlassian.net/browse/P4-3142)

## Screenshots

This is mostly not a visual change, except for the button on the last question.

### Old
![Screenshot 2021-09-14 at 09 52 56](https://user-images.githubusercontent.com/510498/133227246-766c9718-e012-40a1-b586-d12bb758fb6e.png)

### New
![Screenshot 2021-09-14 at 09 52 47](https://user-images.githubusercontent.com/510498/133227248-b50050ad-74c7-4206-b63c-b926f6a48623.png)