### PR TITLE
Improve assessment call to actions

### DIFF
--- a/app/move/app/view/controllers/render-details.js
+++ b/app/move/app/view/controllers/render-details.js
@@ -25,6 +25,7 @@ function renderDetails(req, res) {
 
   const moveSummary = presenters.moveToSummaryListComponent(move, {
     updateUrls,
+    canAccess,
   })
 
   const additionalInfo = presenters.moveToAdditionalInfoListComponent(move)
@@ -63,9 +64,6 @@ function renderDetails(req, res) {
     allocation: move.allocation,
     isEditable: move._canEdit,
     isAllocationMove: !isNil(move.allocation),
-    hasYouthRiskAssessment: !isNil(move.profile?.youth_risk_assessment),
-    hasPersonEscortRecord: !isNil(move.profile?.person_escort_record),
-    moveId: move.id,
     moveSummary,
     sections: {
       uneditable: uneditableSections

--- a/app/move/app/view/controllers/render-details.test.js
+++ b/app/move/app/view/controllers/render-details.test.js
@@ -124,87 +124,6 @@ describe('Move view app', function () {
           })
         })
 
-        describe('hasYouthRiskAssessment', function () {
-          context('with youth risk assessment', function () {
-            beforeEach(function () {
-              req.move.profile = {
-                youth_risk_assessment: {
-                  id: '12345',
-                },
-              }
-
-              controller(req, res)
-            })
-
-            it('should set hasYouthRiskAssessment property', function () {
-              const locals = res.render.args[0][1]
-              expect(locals.hasYouthRiskAssessment).to.be.true
-            })
-          })
-
-          context('without youth risk assessment', function () {
-            beforeEach(function () {
-              req.move.profile = {
-                youth_risk_assessment: null,
-              }
-
-              controller(req, res)
-            })
-
-            it('should set hasYouthRiskAssessment property', function () {
-              const locals = res.render.args[0][1]
-              expect(locals.hasYouthRiskAssessment).to.be.false
-            })
-          })
-        })
-
-        describe('hasPersonEscortRecord', function () {
-          context('with person escort record', function () {
-            beforeEach(function () {
-              req.move.profile = {
-                person_escort_record: {
-                  id: '12345',
-                },
-              }
-
-              controller(req, res)
-            })
-
-            it('should set hasYouthRiskAssessment property', function () {
-              const locals = res.render.args[0][1]
-              expect(locals.hasPersonEscortRecord).to.be.true
-            })
-          })
-
-          context('without person escort record', function () {
-            beforeEach(function () {
-              req.move.profile = {
-                person_escort_record: null,
-              }
-
-              controller(req, res)
-            })
-
-            it('should set hasYouthRiskAssessment property', function () {
-              const locals = res.render.args[0][1]
-              expect(locals.hasPersonEscortRecord).to.be.false
-            })
-          })
-        })
-
-        describe('moveId', function () {
-          beforeEach(function () {
-            req.move.id = '_move_id_'
-
-            controller(req, res)
-          })
-
-          it('should set moveId property', function () {
-            const locals = res.render.args[0][1]
-            expect(locals.moveId).to.equal('_move_id_')
-          })
-        })
-
         describe('moveSummary', function () {
           beforeEach(function () {
             controller(req, res)
@@ -215,6 +134,7 @@ describe('Move view app', function () {
               presenters.moveToSummaryListComponent
             ).to.be.calledOnceWithExactly(req.move, {
               updateUrls: mockUpdateUrls,
+              canAccess: req.canAccess,
             })
           })
 

--- a/app/move/app/view/views/details.njk
+++ b/app/move/app/view/views/details.njk
@@ -76,30 +76,6 @@
     {% endcall %}
   {% endfor %}
 
-  {% if hasYouthRiskAssessment or hasPersonEscortRecord %}
-    <div class="govuk-!-margin-top-5">
-      {% if canAccess("youth_risk_assessment:view") and hasYouthRiskAssessment %}
-        <p class="govuk-!-font-size-16 govuk-!-margin-bottom-2">
-          <a href="/move/{{moveId}}/youth-risk-assessment">
-            {{ t("actions::view_assessment", {
-              context: "youth_risk_assessment"
-            }) }}
-          </a>
-        </p>
-      {% endif %}
-
-      {% if canAccess("person_escort_record:view") and hasPersonEscortRecord %}
-        <p class="govuk-!-font-size-16">
-          <a href="/move/{{moveId}}/person-escort-record">
-            {{ t("actions::view_assessment", {
-              context: "person_escort_record"
-            }) }}
-          </a>
-        </p>
-      {% endif %}
-    </div>
-  {% endif %}
-
   {% if sections.uneditable %}
     {% set detailsHtml %}
       {{ govukWarningText({

--- a/common/components/identity-bar/_identity-bar.scss
+++ b/common/components/identity-bar/_identity-bar.scss
@@ -19,6 +19,11 @@
   }
 }
 
+.app-identity-bar__row {
+  display: flex;
+  align-items: center;
+}
+
 .app-identity-bar__caption {
   margin: 0;
 

--- a/common/components/identity-bar/template.njk
+++ b/common/components/identity-bar/template.njk
@@ -1,6 +1,6 @@
 <div class="app-identity-bar{%- if params.classes %} {{ params.classes }}{% endif %}">
   <div class="app-identity-bar__inner">
-    <div class="govuk-grid-row">
+    <div class="govuk-grid-row app-identity-bar__row">
       <div class="govuk-grid-column-two-thirds">
         {% if params.caption.html or params.caption.text %}
           <span class="govuk-caption-l app-identity-bar__caption">

--- a/common/controllers/framework/framework-overview.js
+++ b/common/controllers/framework/framework-overview.js
@@ -4,7 +4,7 @@ const moveHelpers = require('../../helpers/move')
 const presenters = require('../../presenters')
 
 function frameworkOverview(req, res) {
-  const { originalUrl, assessment = {}, move } = req
+  const { originalUrl, assessment = {}, move, canAccess, baseUrl } = req
   const moveId = move?.id
   const profile = move?.profile || assessment.profile
   const fullname = profile?.person?._fullname
@@ -15,12 +15,19 @@ function frameworkOverview(req, res) {
   })
   const i18nContext = snakeCase(assessment.framework?.name || '')
 
+  const canPrint =
+    canAccess(`${i18nContext}:print`) &&
+    (['confirmed', 'completed'].includes(assessment.status) ||
+      !!assessment.handover_occurred_at)
+
   res.render('framework-overview', {
     ...moveHelpers.getMoveSummary(move),
     i18nContext,
     moveId,
     taskList,
     fullname,
+    canPrint,
+    baseUrl,
   })
 }
 

--- a/common/controllers/framework/framework-overview.test.js
+++ b/common/controllers/framework/framework-overview.test.js
@@ -25,6 +25,8 @@ describe('Framework controllers', function () {
 
       mockReq = {
         originalUrl: '/person-escort-record/1',
+        baseUrl: '/person-escort-record/1',
+        canAccess: () => true,
       }
       mockRes = {
         render: sinon.spy(),
@@ -54,7 +56,7 @@ describe('Framework controllers', function () {
         })
 
         it('should pass correct number of params to template', function () {
-          expect(Object.keys(params)).to.have.length(6)
+          expect(Object.keys(params)).to.have.length(8)
         })
 
         it('should set move', function () {
@@ -85,6 +87,16 @@ describe('Framework controllers', function () {
         it('should not set i18nContext', function () {
           expect(params).to.have.property('i18nContext')
           expect(params.i18nContext).to.equal('')
+        })
+
+        it('should set canPrint', function () {
+          expect(params).to.have.property('canPrint')
+          expect(params.canPrint).to.be.false
+        })
+
+        it('should set canPrint', function () {
+          expect(params).to.have.property('baseUrl')
+          expect(params.baseUrl).to.equal('/person-escort-record/1')
         })
       })
 
@@ -126,6 +138,7 @@ describe('Framework controllers', function () {
                   _fullname: 'John Doe',
                 },
               },
+              status: 'completed',
             },
           },
           mockRes
@@ -166,6 +179,11 @@ describe('Framework controllers', function () {
         it('should set i18nContext', function () {
           expect(params).to.have.property('i18nContext')
           expect(params.i18nContext).to.equal('person_escort_record')
+        })
+
+        it('should set canPrint', function () {
+          expect(params).to.have.property('canPrint')
+          expect(params.canPrint).to.be.true
         })
       })
     })

--- a/common/presenters/move-to-identity-bar-actions/assessment-actions.js
+++ b/common/presenters/move-to-identity-bar-actions/assessment-actions.js
@@ -20,14 +20,6 @@ function assessmentActions(move = {}, { canAccess } = {}) {
   const context = assessmentType
 
   if (assessment.status === 'confirmed' || assessment.handover_occurred_at) {
-    if (canAccess(`${context}:print`)) {
-      actions.push({
-        html: `<a href="${baseUrl}/print" class="app-icon app-icon--print">
-          ${i18n.t('actions::print_assessment', { context })}
-        </a>`,
-      })
-    }
-
     return actions
   }
 
@@ -68,14 +60,6 @@ function assessmentActions(move = {}, { canAccess } = {}) {
           preventDoubleClick: true,
           href: `${baseUrl}/confirm`,
         }),
-      })
-    }
-
-    if (canAccess(`${context}:print`)) {
-      actions.push({
-        html: `<a href="${baseUrl}/print" class="app-icon app-icon--print">
-          ${i18n.t('actions::print_assessment', { context })}
-        </a>`,
       })
     }
   }

--- a/common/presenters/move-to-identity-bar-actions/assessment-actions.js
+++ b/common/presenters/move-to-identity-bar-actions/assessment-actions.js
@@ -19,10 +19,6 @@ function assessmentActions(move = {}, { canAccess } = {}) {
   const baseUrl = `/move/${move.id}/${kebabCase(assessmentType)}`
   const context = assessmentType
 
-  if (assessment.status === 'confirmed' || assessment.handover_occurred_at) {
-    return actions
-  }
-
   if (
     ['requested', 'booked'].includes(move.status) &&
     canAccess(`${context}:create`)
@@ -39,7 +35,11 @@ function assessmentActions(move = {}, { canAccess } = {}) {
       return actions
     }
 
-    if (assessment.status !== 'completed') {
+    if (
+      assessment.status !== 'completed' &&
+      assessment.status !== 'confirmed' &&
+      !assessment.handover_occurred_at
+    ) {
       actions.push({
         html: componentService.getComponent('govukButton', {
           text: i18n.t('actions::continue_assessment', { context }),
@@ -61,6 +61,25 @@ function assessmentActions(move = {}, { canAccess } = {}) {
           href: `${baseUrl}/confirm`,
         }),
       })
+    }
+  }
+
+  if (assessmentType === 'person_escort_record') {
+    if (
+      assessment.status === 'completed' ||
+      assessment.status === 'confirmed' ||
+      assessment.handover_occurred_at
+    ) {
+      if (canAccess(`${context}:view`)) {
+        actions.push({
+          html: componentService.getComponent('govukButton', {
+            text: i18n.t('actions::view_assessment', { context }),
+            classes: 'govuk-button--secondary',
+            preventDoubleClick: true,
+            href: baseUrl,
+          }),
+        })
+      }
     }
   }
 

--- a/common/presenters/move-to-identity-bar-actions/assessment-actions.test.js
+++ b/common/presenters/move-to-identity-bar-actions/assessment-actions.test.js
@@ -153,7 +153,7 @@ describe('Presenters', function () {
               output = presenter(mockMove, { canAccess: canAccessStub })
             })
 
-            it('should return confirm and print action', function () {
+            it('should return confirm action', function () {
               expect(output).to.deep.equal([
                 {
                   html: {
@@ -163,9 +163,6 @@ describe('Presenters', function () {
                       text: 'actions::provide_confirmation',
                     },
                   },
-                },
-                {
-                  html: '<a href="/move/12345/youth-risk-assessment/print" class="app-icon app-icon--print">\n          actions::print_assessment\n        </a>',
                 },
               ])
             })
@@ -177,7 +174,7 @@ describe('Presenters', function () {
               output = presenter(mockMove, { canAccess: canAccessStub })
             })
 
-            it('should return confirm and print actions', function () {
+            it('should return confirm action', function () {
               expect(output).to.deep.equal([
                 {
                   html: {
@@ -187,9 +184,6 @@ describe('Presenters', function () {
                       text: 'actions::provide_confirmation',
                     },
                   },
-                },
-                {
-                  html: '<a href="/move/12345/youth-risk-assessment/print" class="app-icon app-icon--print">\n          actions::print_assessment\n        </a>',
                 },
               ])
             })
@@ -371,7 +365,7 @@ describe('Presenters', function () {
               output = presenter(mockMove, { canAccess: canAccessStub })
             })
 
-            it('should return confirm and print actions', function () {
+            it('should return confirm action', function () {
               expect(output).to.deep.equal([
                 {
                   html: {
@@ -381,9 +375,6 @@ describe('Presenters', function () {
                       text: 'actions::provide_confirmation',
                     },
                   },
-                },
-                {
-                  html: '<a href="/move/12345/person-escort-record/print" class="app-icon app-icon--print">\n          actions::print_assessment\n        </a>',
                 },
               ])
             })
@@ -395,7 +386,7 @@ describe('Presenters', function () {
               output = presenter(mockMove, { canAccess: canAccessStub })
             })
 
-            it('should return confirm and print actions', function () {
+            it('should return confirm action', function () {
               expect(output).to.deep.equal([
                 {
                   html: {
@@ -405,9 +396,6 @@ describe('Presenters', function () {
                       text: 'actions::provide_confirmation',
                     },
                   },
-                },
-                {
-                  html: '<a href="/move/12345/person-escort-record/print" class="app-icon app-icon--print">\n          actions::print_assessment\n        </a>',
                 },
               ])
             })
@@ -435,12 +423,8 @@ describe('Presenters', function () {
             output = presenter(mockMove, { canAccess: canAccessStub })
           })
 
-          it('should not return print action', function () {
-            expect(output).to.deep.equal([
-              {
-                html: '<a href="/move/12345/person-escort-record/print" class="app-icon app-icon--print">\n          actions::print_assessment\n        </a>',
-              },
-            ])
+          it('should not return any actions', function () {
+            expect(output).to.deep.equal([])
           })
         })
       })

--- a/common/presenters/move-to-identity-bar-actions/assessment-actions.test.js
+++ b/common/presenters/move-to-identity-bar-actions/assessment-actions.test.js
@@ -365,7 +365,7 @@ describe('Presenters', function () {
               output = presenter(mockMove, { canAccess: canAccessStub })
             })
 
-            it('should return confirm action', function () {
+            it('should return confirm and view action', function () {
               expect(output).to.deep.equal([
                 {
                   html: {
@@ -373,6 +373,16 @@ describe('Presenters', function () {
                       href: `/move/${mockMove.id}/person-escort-record/confirm`,
                       preventDoubleClick: true,
                       text: 'actions::provide_confirmation',
+                    },
+                  },
+                },
+                {
+                  html: {
+                    govukButton: {
+                      href: `/move/${mockMove.id}/person-escort-record`,
+                      preventDoubleClick: true,
+                      text: 'actions::view_assessment',
+                      classes: 'govuk-button--secondary',
                     },
                   },
                 },
@@ -386,7 +396,7 @@ describe('Presenters', function () {
               output = presenter(mockMove, { canAccess: canAccessStub })
             })
 
-            it('should return confirm action', function () {
+            it('should return confirm and view action', function () {
               expect(output).to.deep.equal([
                 {
                   html: {
@@ -394,6 +404,16 @@ describe('Presenters', function () {
                       href: `/move/${mockMove.id}/person-escort-record/confirm`,
                       preventDoubleClick: true,
                       text: 'actions::provide_confirmation',
+                    },
+                  },
+                },
+                {
+                  html: {
+                    govukButton: {
+                      href: `/move/${mockMove.id}/person-escort-record`,
+                      preventDoubleClick: true,
+                      text: 'actions::view_assessment',
+                      classes: 'govuk-button--secondary',
                     },
                   },
                 },
@@ -409,8 +429,40 @@ describe('Presenters', function () {
               output = presenter(mockMove, { canAccess: canAccessStub })
             })
 
-            it('should not return any actions', function () {
-              expect(output).to.deep.equal([])
+            it('should return view action', function () {
+              expect(output).to.deep.equal([
+                {
+                  html: {
+                    govukButton: {
+                      href: `/move/${mockMove.id}/person-escort-record`,
+                      preventDoubleClick: true,
+                      text: 'actions::view_assessment',
+                      classes: 'govuk-button--secondary',
+                    },
+                  },
+                },
+              ])
+            })
+          })
+
+          context('without assessment view access', function () {
+            beforeEach(function () {
+              canAccessStub.withArgs('person_escort_record:view').returns(false)
+              output = presenter(mockMove, { canAccess: canAccessStub })
+            })
+
+            it('should return confirm action', function () {
+              expect(output).to.deep.equal([
+                {
+                  html: {
+                    govukButton: {
+                      href: `/move/${mockMove.id}/person-escort-record/confirm`,
+                      preventDoubleClick: true,
+                      text: 'actions::provide_confirmation',
+                    },
+                  },
+                },
+              ])
             })
           })
         })
@@ -423,8 +475,19 @@ describe('Presenters', function () {
             output = presenter(mockMove, { canAccess: canAccessStub })
           })
 
-          it('should not return any actions', function () {
-            expect(output).to.deep.equal([])
+          it('should return view action', function () {
+            expect(output).to.deep.equal([
+              {
+                html: {
+                  govukButton: {
+                    href: `/move/${mockMove.id}/person-escort-record`,
+                    preventDoubleClick: true,
+                    text: 'actions::view_assessment',
+                    classes: 'govuk-button--secondary',
+                  },
+                },
+              },
+            ])
           })
         })
       })

--- a/common/presenters/move-to-summary-list-component.test.js
+++ b/common/presenters/move-to-summary-list-component.test.js
@@ -14,6 +14,7 @@ const moveToSummaryListComponent = proxyquire(
 )
 
 const mockMove = {
+  id: 'abc',
   date: '2019-06-09',
   time_due: '2000-01-01T14:00:00Z',
   move_type: 'court_appearance',
@@ -213,6 +214,66 @@ describe('Presenters', function () {
           },
           undefined,
         ])
+      })
+    })
+
+    context('with a youth risk assessment', function () {
+      beforeEach(function () {
+        const canAccess = sinon
+          .stub()
+          .withArgs('youth_risk_assessment.view')
+          .returns(true)
+
+        transformedResponse = moveToSummaryListComponent(
+          {
+            ...mockMove,
+            profile: {
+              youth_risk_assessment: {},
+            },
+          },
+          { canAccess }
+        )
+      })
+
+      describe('response', function () {
+        it('should contain a link to the PER', function () {
+          const html =
+            transformedResponse.rows[transformedResponse.rows.length - 1].value
+              .html
+          expect(html).to.equal(
+            '<ul class="govuk-list govuk-!-font-size-16"><li><a class="govuk-link" href="/move/abc/youth-risk-assessment">youth_risk_assessment</a></li></ul>'
+          )
+        })
+      })
+    })
+
+    context('with a person escort record', function () {
+      beforeEach(function () {
+        const canAccess = sinon
+          .stub()
+          .withArgs('person_escort_record.view')
+          .returns(true)
+
+        transformedResponse = moveToSummaryListComponent(
+          {
+            ...mockMove,
+            profile: {
+              person_escort_record: {},
+            },
+          },
+          { canAccess }
+        )
+      })
+
+      describe('response', function () {
+        it('should contain a link to the PER', function () {
+          const html =
+            transformedResponse.rows[transformedResponse.rows.length - 1].value
+              .html
+          expect(html).to.equal(
+            '<ul class="govuk-list govuk-!-font-size-16"><li><a class="govuk-link" href="/move/abc/person-escort-record">person_escort_record</a></li></ul>'
+          )
+        })
       })
     })
   })

--- a/common/templates/framework-overview.njk
+++ b/common/templates/framework-overview.njk
@@ -30,8 +30,13 @@
   <section class="app-!-position-relative govuk-!-margin-bottom-8">
     {{ appTaskList(taskList) }}
   </section>
-{% endblock %}
 
+  {% if canPrint %}
+    <a href="{{ baseUrl }}/print" class="app-icon app-icon--print">
+      {{ i18n.t('actions::print_assessment', { context: i18nContext }) }}
+    </a>
+  {% endif %}
+{% endblock %}
 
 {% block contentSidebar %}
   {% include "includes/move-summary.njk" %}

--- a/locales/en/fields.json
+++ b/locales/en/fields.json
@@ -344,7 +344,8 @@
   "documents": {
     "heading": "Only include documents that will help plan the move.",
     "label": "Upload a file (optional)",
-    "hint": "You can upload Word, Excel, PDF and JPEG documents up to 50 megabytes"
+    "hint": "You can upload Word, Excel, PDF and JPEG documents up to 50 megabytes",
+    "short_label": "Documents"
   },
   "prison_transfer_type": {
     "label": "Reason for move"


### PR DESCRIPTION
This improves the journey for how to access parts of an assessment (youth risk assessment and person escort record). Specifically this moves the print button to the overview page, adds a link to the PER in the identity bar and moves the assessment links to a documents section in the details tab.

[Jira Ticket](https://dsdmoj.atlassian.net/browse/P4-3136)

## Screenshots

### Old

![Screenshot 2021-09-16 at 09 26 11](https://user-images.githubusercontent.com/510498/133580562-3f229eb7-b4a0-4a9a-896d-a9843d9b91de.png)

![Screenshot 2021-09-16 at 09 26 17](https://user-images.githubusercontent.com/510498/133580578-94b4e2c3-dd90-4d4f-987d-3ec345112cdd.png)

![Screenshot 2021-09-16 at 09 26 26](https://user-images.githubusercontent.com/510498/133580595-8a73c8ed-2b64-4fe2-9188-e972705a353e.png)

### New

![Screenshot 2021-09-16 at 09 25 58](https://user-images.githubusercontent.com/510498/133580527-3518ca8a-9f74-47b5-8100-fa6389c965bd.png)

![Screenshot 2021-09-16 at 09 25 48](https://user-images.githubusercontent.com/510498/133580585-8c0b3b5e-f223-427f-a48d-07bac957c5a7.png)

![Screenshot 2021-09-16 at 09 25 38](https://user-images.githubusercontent.com/510498/133580608-2e414082-5bd4-48eb-b6f7-dfef64247bb8.png)