### PR TITLE
Revert PER navigation behaviour for old move design

### DIFF
--- a/common/controllers/framework/framework-step.js
+++ b/common/controllers/framework/framework-step.js
@@ -187,19 +187,27 @@ class FrameworkStepController extends FormWizardController {
       frameworkSection: { key: currentSection },
       nextFrameworkSection,
       body: { save_and_return_to_overview: goToOverview },
+      moveDesignPreview,
     } = req
 
-    if (goToOverview || (isLastStep && !nextFrameworkSection)) {
+    if (
+      goToOverview ||
+      (moveDesignPreview && isLastStep && !nextFrameworkSection)
+    ) {
       const overviewUrl = req.baseUrl.replace(`/${currentSection}`, '')
       return res.redirect(overviewUrl)
     }
 
-    if (isLastStep && nextFrameworkSection) {
+    if (moveDesignPreview && isLastStep && nextFrameworkSection) {
       const nextSectionUrl = req.baseUrl.replace(
         `/${currentSection}`,
         `/${nextFrameworkSection.key}`
       )
       return res.redirect(`${nextSectionUrl}/start`)
+    }
+
+    if (isLastStep) {
+      return res.redirect(req.baseUrl)
     }
 
     super.successHandler(req, res, next)

--- a/common/controllers/framework/framework-step.test.js
+++ b/common/controllers/framework/framework-step.test.js
@@ -817,19 +817,44 @@ describe('Framework controllers', function () {
           beforeEach(function () {
             mockReq.isLastStep = true
             mockReq.nextFrameworkSection = { key: 'next-section' }
-            controller.successHandler(mockReq, mockRes, nextSpy)
           })
 
-          it('should redirect to base URL with the section', function () {
-            expect(mockRes.redirect).to.have.been.calledOnceWithExactly(
-              '/base-url/next-section/start'
-            )
+          context('with new move design', function () {
+            beforeEach(function () {
+              mockReq.moveDesignPreview = true
+              controller.successHandler(mockReq, mockRes, nextSpy)
+            })
+
+            it('should redirect to base URL with the next section', function () {
+              expect(mockRes.redirect).to.have.been.calledOnceWithExactly(
+                '/base-url/next-section/start'
+              )
+            })
+
+            it('should not call parent success handler', function () {
+              expect(
+                FormWizardController.prototype.successHandler
+              ).not.to.have.been.called
+            })
           })
 
-          it('should not call parent success handler', function () {
-            expect(
-              FormWizardController.prototype.successHandler
-            ).not.to.have.been.called
+          context('without new move design', function () {
+            beforeEach(function () {
+              mockReq.moveDesignPreview = false
+              controller.successHandler(mockReq, mockRes, nextSpy)
+            })
+
+            it('should redirect to base URL with the section', function () {
+              expect(mockRes.redirect).to.have.been.calledOnceWithExactly(
+                '/base-url/section'
+              )
+            })
+
+            it('should not call parent success handler', function () {
+              expect(
+                FormWizardController.prototype.successHandler
+              ).not.to.have.been.called
+            })
           })
         })
 
@@ -837,19 +862,44 @@ describe('Framework controllers', function () {
           beforeEach(function () {
             mockReq.isLastStep = true
             mockReq.nextFrameworkSection = null
-            controller.successHandler(mockReq, mockRes, nextSpy)
           })
 
-          it('should redirect to base URL without the section', function () {
-            expect(mockRes.redirect).to.have.been.calledOnceWithExactly(
-              '/base-url'
-            )
+          context('with new move design', function () {
+            beforeEach(function () {
+              mockReq.moveDesignPreview = true
+              controller.successHandler(mockReq, mockRes, nextSpy)
+            })
+
+            it('should redirect to base URL without the section', function () {
+              expect(mockRes.redirect).to.have.been.calledOnceWithExactly(
+                '/base-url'
+              )
+            })
+
+            it('should not call parent success handler', function () {
+              expect(
+                FormWizardController.prototype.successHandler
+              ).not.to.have.been.called
+            })
           })
 
-          it('should not call parent success handler', function () {
-            expect(
-              FormWizardController.prototype.successHandler
-            ).not.to.have.been.called
+          context('without new move design', function () {
+            beforeEach(function () {
+              mockReq.moveDesignPreview = false
+              controller.successHandler(mockReq, mockRes, nextSpy)
+            })
+
+            it('should redirect to base URL with the section', function () {
+              expect(mockRes.redirect).to.have.been.calledOnceWithExactly(
+                '/base-url/section'
+              )
+            })
+
+            it('should not call parent success handler', function () {
+              expect(
+                FormWizardController.prototype.successHandler
+              ).not.to.have.been.called
+            })
           })
         })
       })


### PR DESCRIPTION
This ties the button navigation behaviour with whether the user has opted in to the new move page design, and reverts some of the logic if the user has not.

This is in a response to a question of whether we definitely want this design.

See #1965 for the original changes.