### PR TITLE
Add supplier incidents to warnings tab

### DIFF
--- a/app/move/app/view/index.js
+++ b/app/move/app/view/index.js
@@ -33,10 +33,10 @@ router.get('/', (req, res) => res.redirect(`${req.baseUrl}/warnings`))
 
 // Define shared middleware
 
-// For all non-timeline routes use standard move middleware
-router.use(/\/((?!timeline).)*/, setMove)
-// For all timeline route use move events middleware
-router.use('/timeline', setMoveWithEvents)
+// For all non-timeline/warning routes use standard move middleware
+router.use(/\/((?!timeline|warnings).)*/, setMove)
+// For all timeline/warning route use move events middleware
+router.use(/\/(timeline|warnings).*/, setMoveWithEvents)
 
 router.use(breadcrumbs.setHome())
 router.use(setPersonEscortRecord)

--- a/app/move/app/view/middleware/locals.warnings.js
+++ b/app/move/app/view/middleware/locals.warnings.js
@@ -3,7 +3,11 @@ const { isEmpty, map, sortBy } = require('lodash')
 const presenters = require('../../../../../common/presenters')
 
 function setWarnings(req, res, next) {
-  const { profile, id: moveId } = req.move || {}
+  const {
+    profile,
+    id: moveId,
+    important_events: importantEvents,
+  } = req.move || {}
 
   if (!profile) {
     return next()
@@ -37,7 +41,7 @@ function setWarnings(req, res, next) {
     ? sortBy(perAssessmentSections, 'order')
     : []
 
-  if (req.move.important_events) {
+  if (importantEvents?.length) {
     sections.unshift(presenters.moveToInTransitEventsPanelList(req.move))
   }
 

--- a/app/move/app/view/middleware/locals.warnings.js
+++ b/app/move/app/view/middleware/locals.warnings.js
@@ -33,10 +33,16 @@ function setWarnings(req, res, next) {
     )
   }
 
+  const sections = personEscortRecord
+    ? sortBy(perAssessmentSections, 'order')
+    : []
+
+  if (req.move.important_events) {
+    sections.unshift(presenters.moveToInTransitEventsPanelList(req.move))
+  }
+
   res.locals.warnings = {
-    sections: personEscortRecord
-      ? sortBy(perAssessmentSections, 'order')
-      : undefined,
+    sections,
     tagList,
     importantEventsTagList,
   }

--- a/app/move/app/view/middleware/locals.warnings.js
+++ b/app/move/app/view/middleware/locals.warnings.js
@@ -28,7 +28,8 @@ function setWarnings(req, res, next) {
       includeLink: true,
     })
     importantEventsTagList = presenters.moveToImportantEventsTagListComponent(
-      req.move
+      req.move,
+      true
     )
   }
 

--- a/app/move/app/view/middleware/locals.warnings.js
+++ b/app/move/app/view/middleware/locals.warnings.js
@@ -9,7 +9,7 @@ function setWarnings(req, res, next) {
     return next()
   }
 
-  let tagList
+  let tagList, importantEventsTagList
   const personEscortRecord = profile.person_escort_record
   const perAssessmentSections = map(
     personEscortRecord?._framework?.sections,
@@ -27,6 +27,9 @@ function setWarnings(req, res, next) {
       hrefPrefix: req.originalUrl,
       includeLink: true,
     })
+    importantEventsTagList = presenters.moveToImportantEventsTagListComponent(
+      req.move
+    )
   }
 
   res.locals.warnings = {
@@ -34,6 +37,7 @@ function setWarnings(req, res, next) {
       ? sortBy(perAssessmentSections, 'order')
       : undefined,
     tagList,
+    importantEventsTagList,
   }
 
   next()

--- a/app/move/app/view/middleware/locals.warnings.test.js
+++ b/app/move/app/view/middleware/locals.warnings.test.js
@@ -13,6 +13,9 @@ describe('Move view app', function () {
           .stub(presenters, 'frameworkFlagsToTagList')
           .returns('__frameworkFlagsToTagList__')
         sinon
+          .stub(presenters, 'moveToImportantEventsTagListComponent')
+          .returns('__moveToImportantEventsTagListComponent__')
+        sinon
           .stub(presenters, 'frameworkSectionToPanelList')
           .returns(frameworkSectionStub)
         sinon.stub(presenters, 'assessmentAnswersByCategory').returnsArg(0)
@@ -142,6 +145,76 @@ describe('Move view app', function () {
           it('should set tagList variable as undefined', function () {
             expect(res.locals.warnings).to.have.property('tagList')
             expect(res.locals.warnings.tagList).to.be.undefined
+          })
+        })
+      })
+
+      describe('importantEventsTagList', function () {
+        context('when Person Escort Record is completed', function () {
+          beforeEach(function () {
+            req.move.profile.person_escort_record = {
+              status: 'completed',
+              flags: ['foo', 'bar'],
+            }
+            middleware(req, res, nextSpy)
+          })
+
+          it('should call correct presenter', function () {
+            expect(
+              presenters.moveToImportantEventsTagListComponent
+            ).to.have.been.calledOnceWithExactly(req.move)
+          })
+
+          it('should set importantEventsTagList variable', function () {
+            expect(res.locals.warnings).to.have.property(
+              'importantEventsTagList'
+            )
+            expect(res.locals.warnings.importantEventsTagList).to.equal(
+              '__moveToImportantEventsTagListComponent__'
+            )
+          })
+        })
+
+        context('when Person Escort Record is not completed', function () {
+          beforeEach(function () {
+            req.move.profile.person_escort_record = {
+              status: 'in_progress',
+              flags: ['foo', 'bar'],
+            }
+            middleware(req, res, nextSpy)
+          })
+
+          it('should call correct presenter', function () {
+            expect(
+              presenters.moveToImportantEventsTagListComponent
+            ).not.to.have.been.called
+          })
+
+          it('should set tagList variable as undefined', function () {
+            expect(res.locals.warnings).to.have.property(
+              'importantEventsTagList'
+            )
+            expect(res.locals.warnings.importantEventsTagList).to.be.undefined
+          })
+        })
+
+        context('without Person Escort Record', function () {
+          beforeEach(function () {
+            req.move.profile = {}
+            middleware(req, res, nextSpy)
+          })
+
+          it('should call correct presenter', function () {
+            expect(
+              presenters.moveToImportantEventsTagListComponent
+            ).not.to.have.been.called
+          })
+
+          it('should set tagList variable as undefined', function () {
+            expect(res.locals.warnings).to.have.property(
+              'importantEventsTagList'
+            )
+            expect(res.locals.warnings.importantEventsTagList).to.be.undefined
           })
         })
       })

--- a/app/move/app/view/middleware/locals.warnings.test.js
+++ b/app/move/app/view/middleware/locals.warnings.test.js
@@ -80,7 +80,7 @@ describe('Move view app', function () {
 
           it('should set sections variable to undefined', function () {
             expect(res.locals.warnings).to.have.property('sections')
-            expect(res.locals.warnings.sections).to.be.undefined
+            expect(res.locals.warnings.sections).to.be.empty
           })
         })
       })

--- a/app/move/app/view/middleware/locals.warnings.test.js
+++ b/app/move/app/view/middleware/locals.warnings.test.js
@@ -162,7 +162,7 @@ describe('Move view app', function () {
           it('should call correct presenter', function () {
             expect(
               presenters.moveToImportantEventsTagListComponent
-            ).to.have.been.calledOnceWithExactly(req.move)
+            ).to.have.been.calledOnceWithExactly(req.move, true)
           })
 
           it('should set importantEventsTagList variable', function () {

--- a/app/move/app/view/views/warnings.njk
+++ b/app/move/app/view/views/warnings.njk
@@ -27,13 +27,14 @@
         html: t('assessment::no_items.text', {
           context: assessment.context or assessment.key,
           name: assessment.name | lower,
+          type: 'warnings' if assessment.key != 'in-transit-events' else '',
           url: assessment.url
         })
       }
     }) }}
   {% endif %}
 
-  {% if (assessment.url and assessment.isCompleted) %}
+  {% if (assessment.url and assessment.isCompleted and assessment.key != 'in-transit-events') %}
     <p class="govuk-!-font-size-16 govuk-!-margin-top-2">
       <a href="{{ assessment.url }}">
         {{ t("assessment::view_framework_section", {

--- a/app/move/app/view/views/warnings.njk
+++ b/app/move/app/view/views/warnings.njk
@@ -51,14 +51,24 @@
     </h2>
 
     <div data-tag-list-source="person-escort-record">
-      {% for tag in warnings.tagList %}
-        {{ appTag(tag) }}
+      {% if warnings.tagList | length or warnings.importantEventsTagList | length %}
+        {% for tag in warnings.tagList %}
+          {{ appTag(tag) }}
+        {% endfor %}
+
+        {% if warnings.importantEventsTagList | length %}
+          <div class="govuk-!-margin-top-2" data-tag-list-source="move-important-events">
+            {% for tag in warnings.importantEventsTagList %}
+              {{ appTag(tag) }}
+            {% endfor %}
+          </div>
+        {% endif %}
       {% else %}
         {{ govukInsetText({
           classes: "govuk-!-font-size-16 govuk-!-margin-top-0",
           text: t("assessment::incomplete_overview")
         }) }}
-      {% endfor %}
+      {% endif %}
     </div>
 
     {% if warnings.sections | length %}

--- a/app/move/app/view/views/warnings.njk
+++ b/app/move/app/view/views/warnings.njk
@@ -27,7 +27,6 @@
         html: t('assessment::no_items.text', {
           context: assessment.context or assessment.key,
           name: assessment.name | lower,
-          type: 'warnings' if assessment.key != 'in-transit-events' else '',
           url: assessment.url
         })
       }

--- a/common/presenters/event-to-tag-component.js
+++ b/common/presenters/event-to-tag-component.js
@@ -1,11 +1,12 @@
 const eventHelpers = require('../helpers/events')
 
-const eventToTagComponent = (event, moveId) => {
+const eventToTagComponent = (event, moveId, linkToLocal = false) => {
   const { id } = event
   const html = eventHelpers.getHeading(event)
   const flag = eventHelpers.getFlag(event)
   const classes = eventHelpers.getHeaderClasses(event)
-  const href = `/move/${moveId}/timeline#${id}`
+
+  const href = linkToLocal ? `#${id}` : `/move/${moveId}/timeline#${id}`
 
   return {
     id,

--- a/common/presenters/event-to-timeline-panel.js
+++ b/common/presenters/event-to-timeline-panel.js
@@ -1,0 +1,29 @@
+const filters = require('../../config/nunjucks/filters')
+const eventHelpers = require('../helpers/events')
+
+const eventToTagComponent = require('./event-to-tag-component')
+
+module.exports = (moveEvent, move) => {
+  const event = eventHelpers.setEventDetails(moveEvent, move)
+  const { id, occurred_at: timestamp } = event
+  const description = eventHelpers.getDescription(event)
+
+  const tag = eventToTagComponent(event)
+  delete tag.href
+
+  const formattedDate = filters.formatDateWithTimeAndDay(timestamp)
+
+  const html = `
+    <div class="app-timeline__description">${description}</div>
+    <div class="app-timeline__date">
+      <time datetime="${timestamp}">${formattedDate}</time>
+    </div>
+  `
+
+  return {
+    tag,
+    html,
+    isFocusable: true,
+    attributes: { id },
+  }
+}

--- a/common/presenters/event-to-timeline-panel.test.js
+++ b/common/presenters/event-to-timeline-panel.test.js
@@ -1,0 +1,45 @@
+const eventToTimelinePanel = require('./event-to-timeline-panel')
+
+describe('Presenters', function () {
+  describe('#eventToTimelinePanel()', function () {
+    const event = {
+      id: 'event',
+      classification: 'incident',
+      event_type: 'eventType',
+      occurred_at: '2020-01-01T10:00:00Z',
+    }
+
+    const move = { id: 'move' }
+
+    let timelinePanel
+    beforeEach(function () {
+      timelinePanel = eventToTimelinePanel(event, move)
+    })
+
+    it('should return tag for the event', function () {
+      expect(timelinePanel.tag).to.deep.equal({
+        classes: 'app-tag app-tag--destructive',
+        flag: {
+          html: 'Serious incident',
+          type: 'incident',
+        },
+        html: 'eventType.heading',
+        id: 'event',
+      })
+    })
+
+    it('should return html for the event', function () {
+      expect(timelinePanel.html).to.equal(
+        '\n    <div class="app-timeline__description">eventType.description</div>\n    <div class="app-timeline__date">\n      <time datetime="2020-01-01T10:00:00Z">10:00a.m. on Wednesday 1 Jan 2020</time>\n    </div>\n  '
+      )
+    })
+
+    it('should return attributes for the event', function () {
+      expect(timelinePanel.attributes).to.deep.equal({ id: 'event' })
+    })
+
+    it('should return isFocusable for the event', function () {
+      expect(timelinePanel.isFocusable).to.be.true
+    })
+  })
+})

--- a/common/presenters/framework-section-to-panel-list.js
+++ b/common/presenters/framework-section-to-panel-list.js
@@ -65,7 +65,8 @@ function frameworkSectionToPanelList({ baseUrl = '' } = {}) {
       name: section.name,
       order: section.order,
       url: `${baseUrl}/${section.key}`,
-      isCompleted: section.progress === 'completed',
+      isCompleted:
+        section.progress === 'completed' || section.key === 'in-transit-events',
       count: panels.length,
       context: 'framework',
       panels,

--- a/common/presenters/index.js
+++ b/common/presenters/index.js
@@ -22,6 +22,7 @@ const moveToAdditionalInfoListComponent = require('./move-to-additional-info-lis
 const moveToCardComponent = require('./move-to-card-component')
 const moveToIdentityBarActions = require('./move-to-identity-bar-actions')
 const moveToImportantEventsTagListComponent = require('./move-to-important-events-tag-list-component')
+const moveToInTransitEventsPanelList = require('./move-to-in-transit-events-panel-list')
 const moveToMetaListComponent = require('./move-to-meta-list-component')
 const moveToSummaryListComponent = require('./move-to-summary-list-component')
 const moveToTimelineComponent = require('./move-to-timeline-component')
@@ -65,6 +66,7 @@ module.exports = {
   moveToCardComponent,
   moveToIdentityBarActions,
   moveToImportantEventsTagListComponent,
+  moveToInTransitEventsPanelList,
   moveToMessageBannerComponent,
   moveToMetaListComponent,
   moveToSummaryListComponent,

--- a/common/presenters/index.js
+++ b/common/presenters/index.js
@@ -10,6 +10,7 @@ const courtCaseToCardComponent = require('./court-case-to-card-component')
 const courtHearingToSummaryListComponent = require('./court-hearing-to-summary-list-component')
 const eventToTagComponent = require('./event-to-tag-component')
 const eventToTimelineItemComponent = require('./event-to-timeline-item-component')
+const eventToTimelinePanel = require('./event-to-timeline-panel')
 const frameworkFieldToSummaryListRow = require('./framework-field-summary-list-row')
 const frameworkFlagsToTagList = require('./framework-flags-to-tag-list')
 const frameworkNomisMappingsToPanel = require('./framework-nomis-mappings-to-panel')
@@ -50,6 +51,7 @@ module.exports = {
   courtHearingToSummaryListComponent,
   eventToTagComponent,
   eventToTimelineItemComponent,
+  eventToTimelinePanel,
   frameworkFieldToSummaryListRow,
   frameworkFlagsToTagList,
   frameworkNomisMappingsToPanel,

--- a/common/presenters/move-to-important-events-tag-list-component.js
+++ b/common/presenters/move-to-important-events-tag-list-component.js
@@ -1,8 +1,13 @@
 const eventToTagComponent = require('./event-to-tag-component')
 
-const moveToImportantEventsTagListComponent = (move = {}) => {
+const moveToImportantEventsTagListComponent = (
+  move = {},
+  linkToLocal = false
+) => {
   const { important_events: importantEvents = [] } = move
-  return importantEvents.map(event => eventToTagComponent(event, move.id))
+  return importantEvents.map(event =>
+    eventToTagComponent(event, move.id, linkToLocal)
+  )
 }
 
 module.exports = moveToImportantEventsTagListComponent

--- a/common/presenters/move-to-important-events-tag-list-component.test.js
+++ b/common/presenters/move-to-important-events-tag-list-component.test.js
@@ -25,11 +25,13 @@ describe('Presenters', function () {
       expect(eventToTagComponent.callCount).to.equal(2)
       expect(eventToTagComponent.firstCall).to.be.calledWithExactly(
         'a',
-        '#move'
+        '#move',
+        false
       )
       expect(eventToTagComponent.secondCall).to.be.calledWithExactly(
         'b',
-        '#move'
+        '#move',
+        false
       )
     })
 

--- a/common/presenters/move-to-in-transit-events-panel-list.js
+++ b/common/presenters/move-to-in-transit-events-panel-list.js
@@ -1,0 +1,22 @@
+const eventToTimelinePanel = require('./event-to-timeline-panel')
+
+function toPanelList(events, move) {
+  const panels = events.map(event => eventToTimelinePanel(event, move))
+
+  return {
+    key: 'in-transit-events',
+    name: 'In transit information',
+    isCompleted: true,
+    count: panels.length,
+    context: 'framework',
+    panels: panels,
+  }
+}
+
+module.exports = function (move = {}) {
+  const { timeline_events: timelineEvents = [] } = move
+  const importantEvents = timelineEvents.filter(
+    ({ classification }) => classification === 'incident'
+  )
+  return toPanelList(importantEvents, move)
+}

--- a/common/presenters/move-to-in-transit-events-panel-list.test.js
+++ b/common/presenters/move-to-in-transit-events-panel-list.test.js
@@ -1,0 +1,40 @@
+const proxyquire = require('proxyquire')
+
+const eventToTimelinePanel = sinon.stub().returns('panel')
+
+const moveToInTransitEventsPanelList = proxyquire(
+  './move-to-in-transit-events-panel-list',
+  { './event-to-timeline-panel': eventToTimelinePanel }
+)
+
+describe('Presenters', function () {
+  describe('#moveToInTransitEventsPanelList()', function () {
+    const move = {
+      id: 'abc',
+      timeline_events: [
+        {
+          classification: 'incident',
+        },
+        {
+          classification: 'default',
+        },
+      ],
+    }
+
+    let panelList
+    beforeEach(function () {
+      panelList = moveToInTransitEventsPanelList(move)
+    })
+
+    it('should return panels for incident events', function () {
+      expect(panelList).to.deep.equal({
+        context: 'framework',
+        count: 1,
+        isCompleted: true,
+        key: 'in-transit-events',
+        name: 'In transit information',
+        panels: ['panel'],
+      })
+    })
+  })
+})

--- a/locales/en/assessment.json
+++ b/locales/en/assessment.json
@@ -28,7 +28,7 @@
     "text_health_nomis": "There is no health information",
     "text_court": "No information for the court",
     "text_release_status": "There is no active release status information",
-    "text_framework": "No {{name}} warnings"
+    "text_framework": "No {{name}} {{type}}"
   },
   "retrieved_from_nomis": {
     "details": {

--- a/locales/en/assessment.json
+++ b/locales/en/assessment.json
@@ -28,7 +28,7 @@
     "text_health_nomis": "There is no health information",
     "text_court": "No information for the court",
     "text_release_status": "There is no active release status information",
-    "text_framework": "No {{name}} {{type}}"
+    "text_framework": "No {{name}} warnings"
   },
   "retrieved_from_nomis": {
     "details": {


### PR DESCRIPTION
This adds suppliers incidents to the new move design warnings tab in a similar way to https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/pull/1096 for the old design.

See individual commits for more details.

### Screenshots

<img width="1280" alt="Screenshot 2021-09-21 at 16 14 53" src="https://user-images.githubusercontent.com/510498/134198206-7532c91c-325d-42d3-bda3-b7848b98b4a3.png">
