### PR TITLE
Improve framework button navigation

### DIFF
--- a/common/controllers/framework/framework-step.js
+++ b/common/controllers/framework/framework-step.js
@@ -190,10 +190,19 @@ class FrameworkStepController extends FormWizardController {
       isLastStep,
       frameworkSection: { key: currentSection },
       body: { save_and_return_to_overview: goToOverview },
+      moveDesignPreview,
+      assessment: {
+        framework: { name: frameworkName },
+      },
     } = req
 
     if (goToOverview || isLastStep) {
-      const overviewUrl = req.baseUrl.replace(`/${currentSection}`, '')
+      let overviewUrl = req.baseUrl.replace(`/${currentSection}`, '')
+
+      if (!moveDesignPreview) {
+        overviewUrl = overviewUrl.replace(`/${frameworkName}`, '')
+      }
+
       return res.redirect(overviewUrl)
     }
 

--- a/common/controllers/framework/framework-step.js
+++ b/common/controllers/framework/framework-step.js
@@ -78,12 +78,12 @@ class FrameworkStepController extends FormWizardController {
 
   setButtonText(req, res, next) {
     const { stepType } = req.form.options
-    const { isLastStep, nextFrameworkSection } = req
+    const { hasNextSteps, nextFrameworkSection } = req
     const isInterruptionCard = stepType === 'interruption-card'
 
     if (isInterruptionCard) {
       req.form.options.buttonText = 'actions::continue'
-    } else if (isLastStep && !nextFrameworkSection) {
+    } else if (!hasNextSteps && !nextFrameworkSection) {
       req.form.options.buttonText = 'actions::save_and_return_to_overview'
     } else {
       req.form.options.buttonText = 'actions::save_and_continue'
@@ -151,7 +151,7 @@ class FrameworkStepController extends FormWizardController {
 
   setShowReturnToOverviewButton(req, res, next) {
     res.locals.showReturnToOverviewButton =
-      !req.isLastStep || !!req.nextFrameworkSection
+      req.hasNextSteps || !!req.nextFrameworkSection
     next()
   }
 

--- a/common/controllers/framework/framework-step.js
+++ b/common/controllers/framework/framework-step.js
@@ -28,7 +28,6 @@ class FrameworkStepController extends FormWizardController {
     this.use(this.setupConditionalFields)
     super.middlewareSetup()
     this.use(this.setValidationRules)
-    this.use(this.setIsLastStep)
     this.use(this.setHasNextSteps)
     this.use(this.setButtonText)
   }
@@ -55,15 +54,6 @@ class FrameworkStepController extends FormWizardController {
     if (req.form.options.fullPath !== req.journeyModel.get('lastVisited')) {
       req.sessionModel.set(savedValues)
     }
-
-    next()
-  }
-
-  setIsLastStep(req, res, next) {
-    const { route: currentStep } = req?.form?.options || {}
-    const nextStep = this.getNextStep(req, res)
-
-    req.isLastStep = nextStep.endsWith(currentStep)
 
     next()
   }
@@ -187,14 +177,19 @@ class FrameworkStepController extends FormWizardController {
 
   successHandler(req, res, next) {
     const {
-      isLastStep,
       frameworkSection: { key: currentSection },
       body: { save_and_return_to_overview: goToOverview },
       moveDesignPreview,
       assessment: {
         framework: { name: frameworkName },
       },
+      form: {
+        options: { route: currentStep },
+      },
     } = req
+
+    const nextStep = this.getNextStep(req, res)
+    const isLastStep = nextStep.endsWith(currentStep)
 
     if (goToOverview || isLastStep) {
       let overviewUrl = req.baseUrl.replace(`/${currentSection}`, '')

--- a/common/controllers/framework/framework-step.js
+++ b/common/controllers/framework/framework-step.js
@@ -31,6 +31,7 @@ class FrameworkStepController extends FormWizardController {
     this.use(this.setValidationRules)
     this.use(setPreviousNextFrameworkSection)
     this.use(this.setIsLastStep)
+    this.use(this.setHasNextSteps)
     this.use(this.setButtonText)
   }
 
@@ -66,6 +67,12 @@ class FrameworkStepController extends FormWizardController {
 
     req.isLastStep = nextStep.endsWith(currentStep)
 
+    next()
+  }
+
+  setHasNextSteps(req, res, next) {
+    const { next: nextSteps = [] } = req?.form?.options || {}
+    req.hasNextSteps = !!nextSteps.length
     next()
   }
 

--- a/common/controllers/framework/framework-step.test.js
+++ b/common/controllers/framework/framework-step.test.js
@@ -422,6 +422,7 @@ describe('Framework controllers', function () {
         nextSpy = sinon.spy()
         mockReq = {
           form: { options: {} },
+          hasNextSteps: true,
         }
       })
 
@@ -458,7 +459,7 @@ describe('Framework controllers', function () {
 
       context('when last step and no next section', function () {
         beforeEach(function () {
-          mockReq.isLastStep = true
+          mockReq.hasNextSteps = false
           mockReq.nextFrameworkSection = null
           controller.setButtonText(mockReq, {}, nextSpy)
         })
@@ -748,7 +749,7 @@ describe('Framework controllers', function () {
       let mockReq, mockRes, nextSpy
 
       beforeEach(function () {
-        mockReq = { isLastStep: false, nextFrameworkSection: null }
+        mockReq = { hasNextSteps: true, nextFrameworkSection: null }
         mockRes = { locals: {} }
         nextSpy = sinon.stub()
       })
@@ -769,7 +770,7 @@ describe('Framework controllers', function () {
 
       context('when last step', function () {
         beforeEach(function () {
-          mockReq.isLastStep = true
+          mockReq.hasNextSteps = false
         })
 
         context('and no next section', function () {

--- a/common/controllers/framework/framework-step.test.js
+++ b/common/controllers/framework/framework-step.test.js
@@ -786,7 +786,10 @@ describe('Framework controllers', function () {
       beforeEach(function () {
         mockReq = {
           body: {},
-          baseUrl: '/base-url/section',
+          baseUrl: '/base-url/framework/section',
+          assessment: {
+            framework: { name: 'framework' },
+          },
           frameworkSection: {
             key: 'section',
           },
@@ -804,19 +807,43 @@ describe('Framework controllers', function () {
           mockReq.body = {
             save_and_return_to_overview: '1',
           }
-          controller.successHandler(mockReq, mockRes, nextSpy)
         })
 
-        it('should redirect to base URL without the section', function () {
-          expect(mockRes.redirect).to.have.been.calledOnceWithExactly(
-            '/base-url'
-          )
+        context('with old move design', function () {
+          beforeEach(function () {
+            controller.successHandler(mockReq, mockRes, nextSpy)
+          })
+
+          it('should redirect to base URL without the framework and section', function () {
+            expect(mockRes.redirect).to.have.been.calledOnceWithExactly(
+              '/base-url'
+            )
+          })
+
+          it('should not call parent success handler', function () {
+            expect(
+              FormWizardController.prototype.successHandler
+            ).not.to.have.been.called
+          })
         })
 
-        it('should not call parent success handler', function () {
-          expect(
-            FormWizardController.prototype.successHandler
-          ).not.to.have.been.called
+        context('with new move design preview', function () {
+          beforeEach(function () {
+            mockReq.moveDesignPreview = true
+            controller.successHandler(mockReq, mockRes, nextSpy)
+          })
+
+          it('should redirect to base URL without the section', function () {
+            expect(mockRes.redirect).to.have.been.calledOnceWithExactly(
+              '/base-url/framework'
+            )
+          })
+
+          it('should not call parent success handler', function () {
+            expect(
+              FormWizardController.prototype.successHandler
+            ).not.to.have.been.called
+          })
         })
       })
 
@@ -838,22 +865,46 @@ describe('Framework controllers', function () {
           })
         })
 
-        context('with last framework step and a next section', function () {
+        context('with last framework step', function () {
           beforeEach(function () {
             mockReq.isLastStep = true
-            controller.successHandler(mockReq, mockRes, nextSpy)
           })
 
-          it('should redirect to base URL without the section', function () {
-            expect(mockRes.redirect).to.have.been.calledOnceWithExactly(
-              '/base-url'
-            )
+          context('with old move design', function () {
+            beforeEach(function () {
+              controller.successHandler(mockReq, mockRes, nextSpy)
+            })
+
+            it('should redirect to base URL without the framework and section', function () {
+              expect(mockRes.redirect).to.have.been.calledOnceWithExactly(
+                '/base-url'
+              )
+            })
+
+            it('should not call parent success handler', function () {
+              expect(
+                FormWizardController.prototype.successHandler
+              ).not.to.have.been.called
+            })
           })
 
-          it('should not call parent success handler', function () {
-            expect(
-              FormWizardController.prototype.successHandler
-            ).not.to.have.been.called
+          context('with new move design preview', function () {
+            beforeEach(function () {
+              mockReq.moveDesignPreview = true
+              controller.successHandler(mockReq, mockRes, nextSpy)
+            })
+
+            it('should redirect to base URL without the section', function () {
+              expect(mockRes.redirect).to.have.been.calledOnceWithExactly(
+                '/base-url/framework'
+              )
+            })
+
+            it('should not call parent success handler', function () {
+              expect(
+                FormWizardController.prototype.successHandler
+              ).not.to.have.been.called
+            })
           })
         })
       })

--- a/common/controllers/framework/framework-step.test.js
+++ b/common/controllers/framework/framework-step.test.js
@@ -4,12 +4,9 @@ const FormWizardController = require('../../../common/controllers/form-wizard')
 const fieldHelpers = require('../../../common/helpers/field')
 const frameworksHelpers = require('../../../common/helpers/frameworks')
 
-const setPreviousNextFrameworkSection = sinon.stub()
 const setMoveSummary = sinon.stub()
 
 const Controller = proxyquire('./framework-step', {
-  '../../middleware/framework/set-previous-next-framework-section':
-    setPreviousNextFrameworkSection,
   '../../middleware/set-move-summary': setMoveSummary,
 })
 
@@ -74,30 +71,24 @@ describe('Framework controllers', function () {
 
       it('should call set button text method', function () {
         expect(controller.use.getCall(2)).to.have.been.calledWithExactly(
-          setPreviousNextFrameworkSection
-        )
-      })
-
-      it('should call set button text method', function () {
-        expect(controller.use.getCall(3)).to.have.been.calledWithExactly(
           controller.setIsLastStep
         )
       })
 
       it('should call set button text method', function () {
-        expect(controller.use.getCall(4)).to.have.been.calledWithExactly(
+        expect(controller.use.getCall(3)).to.have.been.calledWithExactly(
           controller.setHasNextSteps
         )
       })
 
       it('should call set button text method', function () {
-        expect(controller.use.getCall(5)).to.have.been.calledWithExactly(
+        expect(controller.use.getCall(4)).to.have.been.calledWithExactly(
           controller.setButtonText
         )
       })
 
       it('should call correct number of middleware', function () {
-        expect(controller.use).to.be.callCount(6)
+        expect(controller.use).to.be.callCount(5)
       })
     })
 
@@ -786,21 +777,6 @@ describe('Framework controllers', function () {
             expect(nextSpy).to.be.calledOnceWithExactly()
           })
         })
-
-        context('and a next section', function () {
-          beforeEach(function () {
-            mockReq.nextFrameworkSection = { key: 'section' }
-            controller.setShowReturnToOverviewButton(mockReq, mockRes, nextSpy)
-          })
-
-          it('should show the return to overview button', function () {
-            expect(mockRes.locals.showReturnToOverviewButton).to.be.true
-          })
-
-          it('should call next without an error', function () {
-            expect(nextSpy).to.be.calledOnceWithExactly()
-          })
-        })
       })
     })
 
@@ -865,27 +841,6 @@ describe('Framework controllers', function () {
         context('with last framework step and a next section', function () {
           beforeEach(function () {
             mockReq.isLastStep = true
-            mockReq.nextFrameworkSection = { key: 'next-section' }
-            controller.successHandler(mockReq, mockRes, nextSpy)
-          })
-
-          it('should redirect to base URL with the section', function () {
-            expect(mockRes.redirect).to.have.been.calledOnceWithExactly(
-              '/base-url/next-section/start'
-            )
-          })
-
-          it('should not call parent success handler', function () {
-            expect(
-              FormWizardController.prototype.successHandler
-            ).not.to.have.been.called
-          })
-        })
-
-        context('with last framework step and no next section', function () {
-          beforeEach(function () {
-            mockReq.isLastStep = true
-            mockReq.nextFrameworkSection = null
             controller.successHandler(mockReq, mockRes, nextSpy)
           })
 

--- a/common/controllers/framework/framework-step.test.js
+++ b/common/controllers/framework/framework-step.test.js
@@ -50,6 +50,7 @@ describe('Framework controllers', function () {
         sinon.stub(controller, 'setButtonText')
         sinon.stub(controller, 'setValidationRules')
         sinon.stub(controller, 'setIsLastStep')
+        sinon.stub(controller, 'setHasNextSteps')
 
         controller.middlewareSetup()
       })
@@ -85,12 +86,18 @@ describe('Framework controllers', function () {
 
       it('should call set button text method', function () {
         expect(controller.use.getCall(4)).to.have.been.calledWithExactly(
+          controller.setHasNextSteps
+        )
+      })
+
+      it('should call set button text method', function () {
+        expect(controller.use.getCall(5)).to.have.been.calledWithExactly(
           controller.setButtonText
         )
       })
 
       it('should call correct number of middleware', function () {
-        expect(controller.use).to.be.callCount(5)
+        expect(controller.use).to.be.callCount(6)
       })
     })
 
@@ -363,6 +370,47 @@ describe('Framework controllers', function () {
 
         it('should not be the last step', function () {
           expect(mockReq.isLastStep).to.be.false
+        })
+      })
+    })
+
+    describe('#setHasNextSteps', function () {
+      let mockReq, nextSpy
+
+      beforeEach(function () {
+        nextSpy = sinon.spy()
+        mockReq = { form: { options: {} } }
+      })
+
+      context('with step that has undefined next steps', function () {
+        beforeEach(function () {
+          controller.setHasNextSteps(mockReq, {}, nextSpy)
+        })
+
+        it('should not have next steps', function () {
+          expect(mockReq.hasNextSteps).to.be.false
+        })
+      })
+
+      context('with step that has no next steps', function () {
+        beforeEach(function () {
+          mockReq.form.options.next = []
+          controller.setHasNextSteps(mockReq, {}, nextSpy)
+        })
+
+        it('should not have next steps', function () {
+          expect(mockReq.hasNextSteps).to.be.false
+        })
+      })
+
+      context('with step that has next steps', function () {
+        beforeEach(function () {
+          mockReq.form.options.next = ['next']
+          controller.setHasNextSteps(mockReq, {}, nextSpy)
+        })
+
+        it('should not be the last step', function () {
+          expect(mockReq.hasNextSteps).to.be.true
         })
       })
     })

--- a/common/controllers/framework/framework-step.test.js
+++ b/common/controllers/framework/framework-step.test.js
@@ -46,7 +46,6 @@ describe('Framework controllers', function () {
         sinon.stub(controller, 'use')
         sinon.stub(controller, 'setButtonText')
         sinon.stub(controller, 'setValidationRules')
-        sinon.stub(controller, 'setIsLastStep')
         sinon.stub(controller, 'setHasNextSteps')
 
         controller.middlewareSetup()
@@ -71,24 +70,18 @@ describe('Framework controllers', function () {
 
       it('should call set button text method', function () {
         expect(controller.use.getCall(2)).to.have.been.calledWithExactly(
-          controller.setIsLastStep
-        )
-      })
-
-      it('should call set button text method', function () {
-        expect(controller.use.getCall(3)).to.have.been.calledWithExactly(
           controller.setHasNextSteps
         )
       })
 
       it('should call set button text method', function () {
-        expect(controller.use.getCall(4)).to.have.been.calledWithExactly(
+        expect(controller.use.getCall(3)).to.have.been.calledWithExactly(
           controller.setButtonText
         )
       })
 
       it('should call correct number of middleware', function () {
-        expect(controller.use).to.be.callCount(5)
+        expect(controller.use).to.be.callCount(4)
       })
     })
 
@@ -300,67 +293,6 @@ describe('Framework controllers', function () {
 
         it('should not call next', function () {
           expect(nextSpy).not.to.be.called
-        })
-      })
-    })
-
-    describe('#setIsLastStep', function () {
-      let mockReq, nextSpy
-
-      beforeEach(function () {
-        nextSpy = sinon.spy()
-        mockReq = { form: { options: {} } }
-        sinon.stub(FormWizardController.prototype, 'getNextStep').returns('/')
-      })
-
-      context('with step that is last step', function () {
-        beforeEach(function () {
-          mockReq.form.options.route = '/two'
-          FormWizardController.prototype.getNextStep.returns('/two')
-          controller.setIsLastStep(mockReq, {}, nextSpy)
-        })
-
-        it('should be the last step', function () {
-          expect(mockReq.isLastStep).to.be.true
-        })
-      })
-
-      context('with step that contains last step', function () {
-        beforeEach(function () {
-          mockReq.form.options.route = '/two'
-          FormWizardController.prototype.getNextStep.returns(
-            '/full/path/to/step/two-continued'
-          )
-          controller.setIsLastStep(mockReq, {}, nextSpy)
-        })
-
-        it('should not be the last step', function () {
-          expect(mockReq.isLastStep).to.be.false
-        })
-      })
-
-      context('with step that contains same end as last step', function () {
-        beforeEach(function () {
-          mockReq.form.options.route = '/continued'
-          FormWizardController.prototype.getNextStep.returns(
-            '/full/path/to/step/two-continued'
-          )
-          controller.setIsLastStep(mockReq, {}, nextSpy)
-        })
-
-        it('should not be the last step', function () {
-          expect(mockReq.isLastStep).to.be.false
-        })
-      })
-
-      context('with all other steps', function () {
-        beforeEach(function () {
-          FormWizardController.prototype.getNextStep.returns('/two')
-          controller.setIsLastStep(mockReq, {}, nextSpy)
-        })
-
-        it('should not be the last step', function () {
-          expect(mockReq.isLastStep).to.be.false
         })
       })
     })
@@ -793,6 +725,7 @@ describe('Framework controllers', function () {
           frameworkSection: {
             key: 'section',
           },
+          form: { options: {} },
         }
         mockRes = {
           redirect: sinon.stub(),
@@ -800,6 +733,7 @@ describe('Framework controllers', function () {
         nextSpy = sinon.stub()
 
         sinon.stub(FormWizardController.prototype, 'successHandler')
+        sinon.stub(FormWizardController.prototype, 'getNextStep').returns('/')
       })
 
       context('with save and return submission', function () {
@@ -850,7 +784,6 @@ describe('Framework controllers', function () {
       context('with standard submission', function () {
         context('with middle framework step', function () {
           beforeEach(function () {
-            mockReq.isLastStep = false
             controller.successHandler(mockReq, mockRes, nextSpy)
           })
 
@@ -867,7 +800,8 @@ describe('Framework controllers', function () {
 
         context('with last framework step', function () {
           beforeEach(function () {
-            mockReq.isLastStep = true
+            mockReq.form.options.route = '/two'
+            FormWizardController.prototype.getNextStep.returns('/two')
           })
 
           context('with old move design', function () {


### PR DESCRIPTION
This follows on from #1965 following some feedback, while also trying to reduce unexpected changes to users who haven't opted-in to the new move design.

- The "Save and continue" button is not shown on the last possible step of a section (it is shown if there are conditional next steps).
  - This fixes a bug in production right now where the last property page is difficult to fill in.
- Users who haven't opted in to the new move design will be taken to the move record page if they click on "Save and return to overview" rather than the framework overview page

[Jira Ticket](https://dsdmoj.atlassian.net/browse/P4-3198)

## Screenshots

![Screenshot 2021-09-22 at 11 53 06](https://user-images.githubusercontent.com/510498/134331535-a33dbef3-6cfc-40ba-88cb-477a0f1ff3dc.png)

![Screenshot 2021-09-22 at 11 53 15](https://user-images.githubusercontent.com/510498/134331542-980e1adc-3611-42e0-ae35-e217d40929a8.png)