### PR TITLE
Hide framework from handover breadcrumbs

### DIFF
--- a/common/middleware/framework/set-breadcrumbs.js
+++ b/common/middleware/framework/set-breadcrumbs.js
@@ -1,18 +1,19 @@
 const { snakeCase } = require('lodash')
 
 function setBreadcrumbs(req, res, next) {
-  const { assessment = {}, move } = req
+  const { assessment = {}, move, originalUrl = '' } = req
   const moveId = move?.id || assessment?.move?.id
   const moveReference = move?.reference || assessment?.move?.reference
   const profile = move?.profile || assessment?.profile
   const frameworkName = assessment.framework.name
 
-  res
-    .breadcrumb({
-      text: `${profile.person._fullname} (${moveReference})`,
-      href: `/move/${moveId}`,
-    })
-    .breadcrumb({
+  res.breadcrumb({
+    text: `${profile.person._fullname} (${moveReference})`,
+    href: `/move/${moveId}`,
+  })
+
+  if (!originalUrl.includes('/handover')) {
+    res.breadcrumb({
       text: req.t('assessment::page_title', {
         context: snakeCase(frameworkName),
       }),
@@ -20,6 +21,7 @@ function setBreadcrumbs(req, res, next) {
         ? `/move/${moveId}/${frameworkName}`
         : `/${frameworkName}/${assessment.id}`,
     })
+  }
 
   next()
 }

--- a/common/middleware/framework/set-breadcrumbs.test.js
+++ b/common/middleware/framework/set-breadcrumbs.test.js
@@ -31,34 +31,64 @@ describe('Framework middleware', function () {
             },
           },
         }
-        middleware(mockReq, mockRes, nextSpy)
       })
 
-      it('should set move breadcrumb item', function () {
-        expect(mockRes.breadcrumb).to.have.been.calledWithExactly({
-          text: 'DOE, JOHN (PFX7536F)',
-          href: '/move/__move_12345__',
+      context('when not handing over', function () {
+        beforeEach(function () {
+          middleware(mockReq, mockRes, nextSpy)
+        })
+
+        it('should set move breadcrumb item', function () {
+          expect(mockRes.breadcrumb).to.have.been.calledWithExactly({
+            text: 'DOE, JOHN (PFX7536F)',
+            href: '/move/__move_12345__',
+          })
+        })
+
+        it('should set assessment breadcrumb item', function () {
+          expect(mockRes.breadcrumb).to.have.been.calledWithExactly({
+            text: 'assessment::page_title',
+            href: '/move/__move_12345__/assessment-name',
+          })
+        })
+
+        it('should translate correctly', function () {
+          expect(mockReq.t).to.have.been.calledWithExactly(
+            'assessment::page_title',
+            {
+              context: 'assessment_name',
+            }
+          )
+        })
+
+        it('should call next without error', function () {
+          expect(nextSpy).to.be.calledOnceWithExactly()
         })
       })
 
-      it('should set assessment breadcrumb item', function () {
-        expect(mockRes.breadcrumb).to.have.been.calledWithExactly({
-          text: 'assessment::page_title',
-          href: '/move/__move_12345__/assessment-name',
+      context('when handing over', function () {
+        beforeEach(function () {
+          mockReq.originalUrl = 'confirm/handover'
+          middleware(mockReq, mockRes, nextSpy)
         })
-      })
 
-      it('should translate correctly', function () {
-        expect(mockReq.t).to.have.been.calledWithExactly(
-          'assessment::page_title',
-          {
-            context: 'assessment_name',
-          }
-        )
-      })
+        it('should set move breadcrumb item', function () {
+          expect(mockRes.breadcrumb).to.have.been.calledWithExactly({
+            text: 'DOE, JOHN (PFX7536F)',
+            href: '/move/__move_12345__',
+          })
+        })
 
-      it('should call next without error', function () {
-        expect(nextSpy).to.be.calledOnceWithExactly()
+        it('should set not assessment breadcrumb item', function () {
+          expect(mockRes.breadcrumb).to.not.have.been.calledWith({
+            text: 'assessment::page_title',
+            href: '/move/__move_12345__/assessment-name',
+          })
+        })
+
+        it('should call next without error', function () {
+          expect(nextSpy).to.be.calledOnceWithExactly()
+        })
       })
     })
 


### PR DESCRIPTION
This hides the framework assessment item from the breadcrumbs of a page if the user is performing a handover.

## Screenshots

### Old

<img width="731" alt="Screenshot 2021-09-23 at 08 13 31" src="https://user-images.githubusercontent.com/510498/134467835-8a2f5ac2-70c5-45b2-af7c-86a4532e41b7.png">

### New

<img width="724" alt="Screenshot 2021-09-23 at 08 13 09" src="https://user-images.githubusercontent.com/510498/134467843-aef57471-5a3e-41f7-afaf-456f3e2d526e.png">