### PR TITLE
chore: Reduce Sentry transaction sample rate

### DIFF
--- a/server.js
+++ b/server.js
@@ -79,7 +79,7 @@ if (config.SENTRY.DSN) {
       // enable Express.js middleware tracing
       new Tracing.Integrations.Express({ app }),
     ],
-    // Quarter of all requests will be used for performance sampling
+    // 10% of all requests will be used for performance sampling
     tracesSampler: samplingContext => {
       const transactionName =
         samplingContext &&
@@ -89,8 +89,7 @@ if (config.SENTRY.DSN) {
       if (transactionName && transactionName.includes('ping')) {
         return 0
       } else {
-        // Default sample rate
-        return 0.25
+        return 0.1
       }
     },
   })


### PR DESCRIPTION
We're still experiencing a problem where the MoJ Sentry account gets rate limited after a couple of weeks because too many transactions are being reported.

This reduces the sample rate from 25% to 10%.