### PR TITLE
Always show filter boxes in a collection view

### DIFF
--- a/common/templates/layouts/collection.njk
+++ b/common/templates/layouts/collection.njk
@@ -105,11 +105,7 @@
   {% endblock %}
 
   {% block filter %}
-    {% if totalResults > 0 %}
-      {{ appFilter({
-        items: filter
-      }) }}
-    {% endif %}
+    {{ appFilter({ items: filter }) }}
   {% endblock %}
 
   {% block pageContent %}{% endblock %}


### PR DESCRIPTION
The current behaviour hides the filter boxes when there are no results, but this can be confusing for users as there's no indication that there are no results elsewhere on the page. By keeping the filter boxes shown, the page looks the same regardless of how many results there are.

## Screenshots

### Old

![Screenshot 2021-10-13 at 09 22 35](https://user-images.githubusercontent.com/510498/137096031-c28c80ce-95df-4e75-b9c9-448125805086.png)

### New

![Screenshot 2021-10-13 at 09 23 02](https://user-images.githubusercontent.com/510498/137096038-2832dae8-c7ca-4b97-acbf-e39d812e74cf.png)
