### PR TITLE
feat: Change journey events to display details reg

### DIFF
--- a/common/helpers/events/get-description.js
+++ b/common/helpers/events/get-description.js
@@ -2,6 +2,9 @@ const i18n = require('../../../config/i18n')
 
 const getDescription = event => {
   const { event_type: eventType, details } = event
+  details.vehicle_reg =
+    details.vehicle_reg || details.journey?.vehicle?.registration
+
   const description = i18n
     .t(`events::${eventType}.description`, details)
     .replace(/^(\s*<br>)+/, '')

--- a/common/helpers/events/get-description.test.js
+++ b/common/helpers/events/get-description.test.js
@@ -7,7 +7,10 @@ describe('Helpers', function () {
     const mockEvent = {
       id: 'eventId',
       event_type: 'eventType',
-      details: 'details',
+      details: {
+        aDetail: 'details',
+        journey: { vehicle: { registration: 'fallback reg' } },
+      },
     }
 
     beforeEach(function () {
@@ -27,12 +30,18 @@ describe('Helpers', function () {
         it('should get description string', function () {
           expect(i18n.t).to.be.calledOnceWithExactly(
             'events::eventType.description',
-            'details'
+            mockEvent.details
           )
         })
 
         it('should strip any leading <br>s and return the description', function () {
           expect(description).to.equal('description<br>more description')
+        })
+
+        it('should set vehicle_reg in details', function () {
+          expect(mockEvent.details.vehicle_reg).to.equal(
+            mockEvent.details.journey.vehicle.registration
+          )
         })
       })
     })

--- a/locales/en/events.json
+++ b/locales/en/events.json
@@ -35,15 +35,15 @@
   },
   "JourneyAdmitToReception": {
     "heading": "Admitted to reception",
-    "description": "Vehicle {{journey.vehicle.registration}} admitted to reception of {{location.title}}"
+    "description": "Vehicle {{vehicle_reg}} admitted to reception of {{location.title}}"
   },
   "JourneyAdmitThroughOuterGate": {
     "heading": "Admitted through outer gate",
-    "description": "Vehicle {{journey.vehicle.registration}} admitted through outer gate of {{location.title}}"
+    "description": "Vehicle {{vehicle_reg}} admitted through outer gate of {{location.title}}"
   },
   "JourneyArriveAtOuterGate": {
     "heading": "Arrived at outer gate",
-    "description": "Vehicle {{journey.vehicle.registration}} arrived at outer gate of {{location.title}}"
+    "description": "Vehicle {{vehicle_reg}} arrived at outer gate of {{location.title}}"
   },
   "JourneyCancel": {
     "heading": "Journey cancelled",
@@ -63,7 +63,7 @@
   },
   "JourneyExitThroughOuterGate": {
     "heading": "Exited from outer gate",
-    "description": "Vehicle {{journey.vehicle.registration}} exited through outer gate of {{journey.from_location.title}}"
+    "description": "Vehicle {{vehicle_reg}} exited through outer gate of {{journey.from_location.title}}"
   },
   "JourneyHandoverToDestination": {
     "heading": "Handover to establishment",
@@ -75,15 +75,15 @@
   },
   "JourneyPersonBoardsVehicle": {
     "heading": "Boarded escort vehicle",
-    "description": "$t(events::person) boarded escort vehicle {{journey.vehicle.registration}}"
+    "description": "$t(events::person) boarded escort vehicle {{vehicle_reg}}"
   },
   "JourneyPersonLeaveVehicle": {
     "heading": "Left escort vehicle",
-    "description": "$t(events::person) left escort vehicle {{journey.vehicle.registration}}"
+    "description": "$t(events::person) left escort vehicle {{vehicle_reg}}"
   },
   "JourneyReadyToExit": {
     "heading": "Ready to exit",
-    "description": "Escort vehicle {{journey.vehicle.registration}} boarding complete, ready to exit from {{journey.from_location.title}}"
+    "description": "Escort vehicle {{vehicle_reg}} boarding complete, ready to exit from {{journey.from_location.title}}"
   },
   "JourneyReject": {
     "heading": "Journey rejected",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

<!--- Describe the changes in detail - the "what"-->
Journey events have been changed to display `vehicle_reg` from the event details, or the journey registration, if `vehicle_reg` is not present.

### Why did it change

<!--- Describe the reason these changes were made - the "why" -->
This has changed because currently, if a vehicle changes midway through a journey, the old journey events will display the new vehicle registration.

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

- P4-3233

## Screenshots
<!--- (Optional) Include screenshots if changes update interfaces or components -->
<!--- Delete/copy as appropriate --->

| Before | After |
| ------ | ----- |
| <kbd><img src=""></kbd> | <kbd><img src=""></kbd> |

## Checklists

### Testing

#### Automated testing

- [ ] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [ ] Chrome
- [x] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed

<!--- Delete if changes DO NOT include new environment variables -->
- [ ] Documented in the [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/main/README.md)
- [ ] Added to [continous integration](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-book-secure-move-frontend)
- [ ] Added to staging environment (deployment repository)
- [ ] Added to preproduction environment (deployment repository)
- [ ] Added to production environment (deployment repository)

### Other considerations

Commit messages with a `fix` or `feat` type are automatically used to generate the [changelog](ministryofjustice/hmpps-book-secure-move-frontend/blob/main/CHANGELOG.md) and
[GitHub release notes](https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/releases) during the release task. Please make sure they will read well on their own in a
summary of changes and that the commit body gives a more detailed description of those changes if necessary.

- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
- [ ] Update [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/main/README.md) with any new instructions or tasks
