### PR TITLE
Ensure text is escaped before being rendered

### DIFF
--- a/common/presenters/assessment-answers-to-meta-list-component.js
+++ b/common/presenters/assessment-answers-to-meta-list-component.js
@@ -1,3 +1,5 @@
+const { escape } = require('lodash')
+
 const i18n = require('../../config/i18n')
 const filters = require('../../config/nunjucks/filters')
 
@@ -43,13 +45,13 @@ function _mapAnswer({
   if (description) {
     html = `
       <h4 class="govuk-heading-s govuk-!-font-size-16 govuk-!-margin-top-0 govuk-!-margin-bottom-2">
-        ${description}
+        ${escape(description)}
       </h4>
     `
   }
 
   html += comments
-    ? `<span class="app-!-text-colour-black">${comments}</span>`
+    ? `<span class="app-!-text-colour-black">${escape(comments)}</span>`
     : `<span class="app-secondary-text-colour">${i18n.t(
         'empty_details'
       )}</span>`


### PR DESCRIPTION
This prevents potential XSS security vulnerabilities where users can enter HTML in to a field and then that HTML is rendered on the frontend. This is particularly dangerous if a user inputs a `<script>` tag in to the field.

The vulnerability is limited because you have to be authenticated to access the page.

[Jira Ticket](https://dsdmoj.atlassian.net/browse/P4-3159)

## Screenshots

### Old

![Screenshot 2021-10-22 at 11 59 35](https://user-images.githubusercontent.com/510498/138443041-fba47714-1553-4533-a077-ec3cda87d5ba.png)

### New

![Screenshot 2021-10-22 at 11 59 22](https://user-images.githubusercontent.com/510498/138443059-bac6d11d-da53-4744-8e13-830b05fb758a.png)