### PR TITLE
Stringify unpopulated resources context

### DIFF
--- a/common/lib/populate-resources.js
+++ b/common/lib/populate-resources.js
@@ -23,7 +23,7 @@ const populateResources = (obj, req, options, processed = []) => {
         scope.setLevel('warning')
         scope.setContext('Events', {
           'All events': JSON.stringify(cleanedObj),
-          'Unpopulated resources': processed,
+          'Unpopulated resources': JSON.stringify(processed),
         })
         Sentry.captureException(unprocessedError)
       })


### PR DESCRIPTION
This should ensure the data appears in Sentry in a clearer way. At the moment it ends up showing up as `[ [Object], [Object] ]` whereas we want to see the full details.

[Example Sentry issue](https://sentry.io/organizations/ministryofjustice/issues/2196140978/?project=2014813&query=is%3Aunresolved)

![Screenshot 2021-10-28 at 15 42 10](https://user-images.githubusercontent.com/510498/139279362-54a1b3c7-b915-462c-9a03-3f4d87304440.png)


