### PR TITLE
build: Add latest frameworks package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4298,6 +4298,10 @@
       "version": "git+https://github.com/ministryofjustice/hmpps-book-secure-move-frameworks.git#43d1a12f16ffcb6de66af00d8a18b5c2bc8d2d45",
       "from": "git+https://github.com/ministryofjustice/hmpps-book-secure-move-frameworks.git#v2.3.0"
     },
+    "@hmpps-book-secure-move-frameworks/2.3.1": {
+      "version": "git+https://github.com/ministryofjustice/hmpps-book-secure-move-frameworks.git#b70b59648d8f2b8b7730e327d08df317b8d6f62c",
+      "from": "git+https://github.com/ministryofjustice/hmpps-book-secure-move-frameworks.git#v2.3.1"
+    },
     "@humanwhocodes/config-array": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.5.0.tgz",

--- a/package.json
+++ b/package.json
@@ -104,6 +104,7 @@
     "@hmpps-book-secure-move-frameworks/2.1.0": "git+https://github.com/ministryofjustice/hmpps-book-secure-move-frameworks.git#v2.1.0",
     "@hmpps-book-secure-move-frameworks/2.2.0": "git+https://github.com/ministryofjustice/hmpps-book-secure-move-frameworks.git#v2.2.0",
     "@hmpps-book-secure-move-frameworks/2.3.0": "git+https://github.com/ministryofjustice/hmpps-book-secure-move-frameworks.git#v2.3.0",
+    "@hmpps-book-secure-move-frameworks/2.3.1": "git+https://github.com/ministryofjustice/hmpps-book-secure-move-frameworks.git#v2.3.1",
     "@ministryofjustice/frontend": "1.0.0",
     "@promster/express": "7.0.0",
     "@sentry/node": "6.14.1",


### PR DESCRIPTION
This includes a fix for missing NOMIS assessment codes for cell share risk assessments.

[Jira Ticket](https://dsdmoj.atlassian.net/browse/P4-3326)