### PR TITLE
Don't allow HTML in move additional information

### DIFF
--- a/common/presenters/move-to-additional-info-list-component.js
+++ b/common/presenters/move-to-additional-info-list-component.js
@@ -29,7 +29,7 @@ function moveToAdditionalInfoListComponent({
       },
       value: {
         classes: !additionalInformation ? 'app-secondary-text-colour' : '',
-        html: additionalInformation || i18n.t('not_provided'),
+        text: additionalInformation || i18n.t('not_provided'),
       },
     },
   ].filter(row => row.value.text || row.value.html)

--- a/common/presenters/move-to-additional-info-list-component.test.js
+++ b/common/presenters/move-to-additional-info-list-component.test.js
@@ -56,9 +56,8 @@ describe('Presenters', function () {
         })
 
         it('should contain correct values', function () {
-          const keys = transformedResponse.rows.map(
-            row => row.value.text || row.value.html
-          )
+          const keys = transformedResponse.rows.map(row => row.value.text)
+
           expect(keys).to.deep.equal([
             mockMove.time_due,
             mockMove.additional_information,


### PR DESCRIPTION
This prevents users from inputting HTML and it being output on the page directly. Currently the behaviour of rendering the input as HTML opens up a potential HTML injection vulnerability.

[Jira Ticket](https://dsdmoj.atlassian.net/browse/P4-3204)

## Screenshots

### Old

![Screenshot 2021-11-18 at 11 33 01](https://user-images.githubusercontent.com/510498/142408182-e7cfe38d-79f7-41ee-8872-9e6b925ca67c.png)

### New

![Screenshot 2021-11-18 at 11 29 37](https://user-images.githubusercontent.com/510498/142408198-24b1634c-8551-43ad-ae51-23c66db1a96d.png)