### PR TITLE
Explicitly install Python 3 in Docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM node:14.18.1-alpine as build-stage
 
 WORKDIR /home/node/app
 
-RUN apk add --no-cache python git build-base nasm zlib-dev libpng-dev autoconf automake
+RUN apk add --no-cache python3 git build-base nasm zlib-dev libpng-dev autoconf automake
 RUN mkdir -p /home/node/app/node_modules && chown -R node:node /home/node/app
 
 COPY package*.json ./


### PR DESCRIPTION
This should fix an issue where Alpine Linux no longer has a `python` package available and instead requires an explicit version.

See https://github.com/docker-library/docker/issues/240 for more information.