### PR TITLE
fix: Adding right hand padding to the message banner as there was no  spacing when text was wrapped

### DIFF
--- a/app/move/app/view/middleware/locals.message-banner.js
+++ b/app/move/app/view/middleware/locals.message-banner.js
@@ -73,7 +73,7 @@ module.exports = async (req, res, next) => {
     res.locals.messageBanner = {
       ...messageBanner,
       allowDismiss: false,
-      classes: 'govuk-!-padding-right-0',
+      classes: 'govuk-!-padding-right-3',
     }
   }
 

--- a/app/move/app/view/middleware/locals.message-banner.test.js
+++ b/app/move/app/view/middleware/locals.message-banner.test.js
@@ -88,7 +88,7 @@ describe('Move view app', function () {
               html: 'messages::pending_review.content',
             },
             allowDismiss: false,
-            classes: 'govuk-!-padding-right-0',
+            classes: 'govuk-!-padding-right-3',
           })
         })
 
@@ -138,7 +138,7 @@ describe('Move view app', function () {
                   html: 'statuses::description',
                 },
                 allowDismiss: false,
-                classes: 'govuk-!-padding-right-0',
+                classes: 'govuk-!-padding-right-3',
               })
             })
 
@@ -197,7 +197,7 @@ describe('Move view app', function () {
                 html: 'statuses::description',
               },
               allowDismiss: false,
-              classes: 'govuk-!-padding-right-0',
+              classes: 'govuk-!-padding-right-3',
             })
           })
 
@@ -262,7 +262,7 @@ describe('Move view app', function () {
               expect(res.locals.messageBanner).to.deep.equal({
                 foo: 'bar',
                 allowDismiss: false,
-                classes: 'govuk-!-padding-right-0',
+                classes: 'govuk-!-padding-right-3',
               })
             })
 


### PR DESCRIPTION
This fixes an issue in the message banner where text was wrapping without any right spacing/padding to the surrounding DIV.

[JIRA P4-3135 ](https://dsdmoj.atlassian.net/browse/P4-3135) 

**Old:**

![image](https://user-images.githubusercontent.com/60104344/142430408-dfc83c07-9a38-4518-b328-fcd4726389b1.png)

**New:**

![image](https://user-images.githubusercontent.com/60104344/142430290-cec4de07-f4f2-439c-af69-723373418860.png)
