### PR TITLE
Fix when medication while moving warning is displayed

### DIFF
--- a/app/person-escort-record/views/print-record.njk
+++ b/app/person-escort-record/views/print-record.njk
@@ -50,7 +50,7 @@
         </p>
       {% endif %}
 
-      {% if hasSelfHarmWarning %}
+      {% if requiresMedicationDuringTransport %}
         {% set html %}
           {{ govukWarningText({
             text: "See “Health Information” for details",


### PR DESCRIPTION
This feature was added in e7e4f8574da5d7f4af5af423da94cd3791a7a153 but it was accidentally tied to whether a person has a self harm warning, rather than if they require medication during transport. I've fixed it now so the warning shows up during the correct conditions.

We don't have any tests currently which check what is showing in the print PER view in different situations. It requires a further refactor as we should most likely extract sections of this out in to individual components and test those individually. Since this bug is currently live and means the PER print out could be incorrect, I've opted to fix the issue quickly now, and I'll refactor the view later and write comprehensive tests as part of that.

[Jira Ticket](https://dsdmoj.atlassian.net/browse/P4-2731)