### PR TITLE
Build Docker container with Python 2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM node:14.18.1-alpine as build-stage
 
 WORKDIR /home/node/app
 
-RUN apk add --no-cache python3 git build-base nasm zlib-dev libpng-dev autoconf automake
+RUN apk add --no-cache python2 git build-base nasm zlib-dev libpng-dev autoconf automake
 RUN mkdir -p /home/node/app/node_modules && chown -R node:node /home/node/app
 
 COPY package*.json ./


### PR DESCRIPTION
In 841ad36b359aefe10e063d5ec2ef784bff5cb12d I changed the Python package name from `python` to `python3` to fix the package being missing, but actually it looks like the correct solution would have been to change this to `python2` instead.