### PR TITLE
Downgrade to Alpine 3.13

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14.18.1-alpine as build-stage
+FROM node:14.18.1-alpine3.13 as build-stage
 
 WORKDIR /home/node/app
 
@@ -23,7 +23,7 @@ ENV API_VERSION default
 RUN NODE_ENV=production npm run build
 ############### End of Build step ###############
 
-FROM node:14.18.1-alpine
+FROM node:14.18.1-alpine3.13
 
 WORKDIR /home/node/app
 USER 1000


### PR DESCRIPTION
There appears to be an issue in Alpine 3.14 related to the version of Docker we're using. There's more information about this issue here: https://wiki.alpinelinux.org/wiki/Release_Notes_for_Alpine_3.14.0#faccessat2

For now, the suggested fix might be to downgrade to the previous version of Alpine Linux. Once the build is working again, we might think about switching to a more familiar Debian base.