### PR TITLE
fix: Fixing wording in identity bar for proposed moves

### DIFF
--- a/app/move/app/view/middleware/locals.identity-bar.js
+++ b/app/move/app/view/middleware/locals.identity-bar.js
@@ -22,6 +22,7 @@ function localsIdentityCard(req, res, next) {
     },
     summary: {
       html: req.t('moves::detail.page_heading_summary', {
+        context: move.status,
         fromLocation: move.from_location?.title,
         toLocation: move.to_location?.title,
         date: filters.formatDate(move.date),

--- a/app/move/app/view/middleware/locals.identity-bar.test.js
+++ b/app/move/app/view/middleware/locals.identity-bar.test.js
@@ -30,6 +30,7 @@ describe('Move view app', function () {
             id: '12345',
             reference: 'AB1234XY',
             date: '2020-10-07',
+            status: 'requested',
             profile: {
               person: {
                 _fullname: 'DOE, JOHN',
@@ -67,6 +68,7 @@ describe('Move view app', function () {
             expect(req.t).to.be.calledWithExactly(
               'moves::detail.page_heading_summary',
               {
+                context: 'requested',
                 fromLocation: 'Guildford Custody Suite',
                 toLocation: 'HMP Brixton',
                 date: '2020-10-07',
@@ -112,6 +114,7 @@ describe('Move view app', function () {
             id: '12345',
             reference: 'AB1234XY',
             date: '2020-10-07',
+            status: 'requested',
             profile: null,
             from_location: {
               title: 'Guildford Custody Suite',
@@ -145,9 +148,64 @@ describe('Move view app', function () {
             expect(req.t).to.be.calledWithExactly(
               'moves::detail.page_heading_summary',
               {
+                context: 'requested',
                 fromLocation: 'Guildford Custody Suite',
                 toLocation: 'HMP Brixton',
                 date: '2020-10-07',
+              }
+            )
+          })
+        })
+
+        it('should call next', function () {
+          expect(nextSpy).to.be.calledOnceWithExactly()
+        })
+      })
+
+      context('without profile', function () {
+        beforeEach(function () {
+          req.move = {
+            id: '12345',
+            reference: 'AB1234XY',
+            date: null,
+            status: 'proposed',
+            profile: null,
+            from_location: {
+              title: 'Guildford Custody Suite',
+            },
+            to_location: {
+              title: 'HMP Brixton',
+            },
+            foo: 'bar',
+          }
+
+          middleware(req, res, nextSpy)
+        })
+
+        describe('translations', function () {
+          it('should translate caption', function () {
+            expect(req.t).to.be.calledWithExactly('moves::detail.page_caption')
+          })
+
+          it('should translate heading', function () {
+            expect(req.t).to.be.calledWithExactly(
+              'moves::detail.page_heading',
+              {
+                name: 'awaiting_person',
+                reference: 'AB1234XY',
+              }
+            )
+            expect(req.t).to.be.calledWithExactly('awaiting_person')
+          })
+
+          it('should translate summary proposed', function () {
+            expect(req.t).to.be.calledWithExactly(
+              'moves::detail.page_heading_summary',
+              {
+                context: 'proposed',
+                fromLocation: 'Guildford Custody Suite',
+                toLocation: 'HMP Brixton',
+                date: null,
               }
             )
           })

--- a/locales/en/moves.json
+++ b/locales/en/moves.json
@@ -109,6 +109,7 @@
     "page_caption": "Move for",
     "page_heading": "{{-name}} ({{-reference}})",
     "page_heading_summary": "From <strong>{{ fromLocation }}</strong> to <strong>{{ toLocation }}</strong> on <strong>{{ date }}</strong>",
+    "page_heading_summary_proposed": "From <strong>{{ fromLocation }}</strong> to <strong>{{ toLocation }}",
     "page_title": "Move for {{-name}}",
     "court_hearings": {
       "heading": "Court hearing",


### PR DESCRIPTION
If a move was in proposed state it would not have a move date.  The original summary header message being displayed expected a date to be present ergo it did not read correctly.

**Before any changes:**

![image](https://user-images.githubusercontent.com/60104344/143233158-5de8ac7e-a700-44ef-850f-82f1f0909c7a.png)

**After (move pending review):**

![image](https://user-images.githubusercontent.com/60104344/143233058-9304379c-462f-41b9-93ff-3eb39d91cd5c.png)

**After (move reviewed):**

![image](https://user-images.githubusercontent.com/60104344/143233096-745cfd24-f8eb-46d1-ab44-a2e5c8c6d9fe.png)
