### PR TITLE
fix: Removing blue line appearing to the right on allocation pages

### DIFF
--- a/common/templates/includes/move-summary.njk
+++ b/common/templates/includes/move-summary.njk
@@ -1,6 +1,8 @@
-<section class="app-border-top-2 app-border--blue govuk-!-padding-top-3 govuk-!-margin-bottom-7">
-  {% include "includes/person-summary.njk" %}
-</section>
+{% if personSummary %}
+  <section class="app-border-top-2 app-border--blue govuk-!-padding-top-3 govuk-!-margin-bottom-7">
+    {% include "includes/person-summary.njk" %}
+  </section>
+{% endif %}
 
 {% if moveSummary %}
   <section class="app-border-top-1 govuk-!-padding-top-3" data-move-summary>


### PR DESCRIPTION
Small change to prevent a (random) blue line from appearing on the allocations pages.  This was being included as part of a person summary being present and in this case there isn't one. [JIRA](https://dsdmoj.atlassian.net/browse/P4-3118)

**Before:**

![blue-line-before](https://user-images.githubusercontent.com/60104344/143593547-73b1b0b8-bfdf-4a32-8c20-bacd452e39aa.png)

**After:**

![blue-line-after](https://user-images.githubusercontent.com/60104344/143593571-0bc2051b-b126-471a-812b-445fefc66b0a.png)

