### PR TITLE
fix: Removes superfluous back link from the PER

### DIFF
--- a/common/templates/framework-section.njk
+++ b/common/templates/framework-section.njk
@@ -56,12 +56,4 @@
 
   </div>
 
-  {% if moveId %}
-    <p class="govuk-!-margin-top-6 govuk-!-margin-bottom-0">
-      {{ govukBackLink({
-        text: t("actions::back_to_move"),
-        href: "/move/" + moveId
-      }) }}
-    </p>
-  {% endif %}
 {% endblock %}


### PR DESCRIPTION
Removes superfluous 'Back to move' link from the PER.  You can get back to the move via the breadcrumb trail.

**Before:**

![back-link-with](https://user-images.githubusercontent.com/60104344/143883618-c1099045-9380-433c-84d8-dbe165f30b41.png)

**After:**

![back-link-without](https://user-images.githubusercontent.com/60104344/143883653-34f4e5fe-db2f-4604-85e5-c51dc24c3c4b.png)