### PR TITLE
fix: Removes the person details side panel when nothing to show

### DIFF
--- a/common/templates/includes/move-summary.njk
+++ b/common/templates/includes/move-summary.njk
@@ -1,15 +1,20 @@
-{% if personSummary %}
+{% macro _moveSummarySection(class = 'app-border-top-1') %}
+  {% if moveSummary %}
+    <section class="{{ class }} govuk-!-padding-top-3" data-move-summary>
+      <h3 class="govuk-heading-s govuk-!-margin-bottom-2">
+        {{ t("moves::move_details") }}
+      </h3>
+
+      {{ appMetaList(moveSummary) }}
+    </section>
+  {% endif %}
+{% endmacro %}
+
+{% if personSummary.image.url or personSummary.metaList or personSummary.profileLink %}
   <section class="app-border-top-2 app-border--blue govuk-!-padding-top-3 govuk-!-margin-bottom-7">
     {% include "includes/person-summary.njk" %}
   </section>
-{% endif %}
-
-{% if moveSummary %}
-  <section class="app-border-top-1 govuk-!-padding-top-3" data-move-summary>
-    <h3 class="govuk-heading-s govuk-!-margin-bottom-2">
-      {{ t("moves::move_details") }}
-    </h3>
-
-    {{ appMetaList(moveSummary) }}
-  </section>
+  {{ _moveSummarySection() }}
+{% else %}
+  {{ _moveSummarySection('app-border-top-2 app-border--blue') }}
 {% endif %}


### PR DESCRIPTION
When the personal details have not yet been provided we do not want to show side panel (to avoid clutter). 

**Before:**

![person-details-before](https://user-images.githubusercontent.com/60104344/144060195-aa1d113b-22fc-42a1-b4e0-5b12d933b734.png)

**After:**

![person-details-after](https://user-images.githubusercontent.com/60104344/144060277-3ebea35e-b6b5-4e6b-ba1f-edfc256301ed.png)

