### PR TITLE
fix: Remove style override on cancel allocation banner so uses default style

### DIFF
--- a/app/allocation/views/view.njk
+++ b/app/allocation/views/view.njk
@@ -31,7 +31,6 @@
   {% if messageTitle %}
     {{ appMessage({
       allowDismiss: false,
-      classes: "app-message--temporary",
       title: {
         text: messageTitle
       },

--- a/test/e2e/pages/page.js
+++ b/test/e2e/pages/page.js
@@ -23,8 +23,8 @@ export default class Page {
       username: Selector('#navigation li:nth-child(1)'),
       signOutLink: Selector('#navigation li a').withExactText('Sign out'),
       submitButton: Selector('button[type="submit"]'),
-      bannerHeading: Selector('.app-message--temporary .app-message__heading'),
-      bannerContent: Selector('.app-message--temporary .app-message__content'),
+      bannerHeading: Selector('.app-message .app-message__heading'),
+      bannerContent: Selector('.app-message .app-message__content'),
       instructionBanner: Selector('.app-message--instruction'),
       locationsList: Selector(
         'ul[data-location-type="locations"] li a'


### PR DESCRIPTION
**Before:**

![allocation-cancel-before](https://user-images.githubusercontent.com/60104344/144256699-c1bf721a-30af-4055-9f0e-cdef2fde5e51.png)

**After:**

![allocation-cancel-after](https://user-images.githubusercontent.com/60104344/144256733-a48dda27-6134-4557-a60f-1e9422074a33.png)
