### PR TITLE
fix: Small tweak to package.json to allow greater then or equal to versions of node and npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -245,8 +245,8 @@
     "webpack-merge": "5.7.3"
   },
   "engines": {
-    "node": "16.13.0",
-    "npm": "8.1.0"
+    "node": "16",
+    "npm": "8"
   },
   "files": [],
   "scripts": {


### PR DESCRIPTION
Small chore to the package.json to bring inline with the readme.md.  I was unable to install the application with node 16.13.1 for example.