### PR TITLE
fix: Adds the PER section status tag to the top of section pages

### DIFF
--- a/common/controllers/framework/framework-section.js
+++ b/common/controllers/framework/framework-section.js
@@ -70,6 +70,12 @@ class FrameworkSectionController extends FormWizardController {
   }
 
   setSectionSummary(req, res, next) {
+    const tagClasses = {
+      not_started: 'govuk-tag--grey',
+      in_progress: 'govuk-tag--blue',
+      default: '',
+    }
+
     const { frameworkSection, assessment, baseUrl, form } = req
     const { name, steps } = frameworkSection
     const stepSummaries = Object.entries(steps).map(
@@ -79,8 +85,15 @@ class FrameworkSectionController extends FormWizardController {
         `${baseUrl}/`
       )
     )
+    const sectionProgress = assessment.meta?.section_progress.filter(
+      status => status.key === frameworkSection.key
+    )[0]
 
     res.locals.sectionTitle = name
+    res.locals.sectionProgress = {
+      text: i18n.t(`assessment::statuses.${sectionProgress.status}`),
+      classes: tagClasses[sectionProgress.status] || tagClasses.default,
+    }
     res.locals.summarySteps = filter(stepSummaries)
 
     next()

--- a/common/controllers/framework/framework-section.test.js
+++ b/common/controllers/framework/framework-section.test.js
@@ -366,6 +366,7 @@ describe('Framework controllers', function () {
             },
           },
           frameworkSection: {
+            key: 'risk-information',
             name: 'Foo',
             steps: {
               '/step-1': {},
@@ -375,6 +376,14 @@ describe('Framework controllers', function () {
           },
           assessment: {
             responses: [{ id: '1' }, { id: '2' }, { id: '3' }],
+            meta: {
+              section_progress: [
+                {
+                  key: 'risk-information',
+                  status: 'in_progress',
+                },
+              ],
+            },
           },
         }
         mockRes = {
@@ -395,6 +404,16 @@ describe('Framework controllers', function () {
 
       it('should set section title', function () {
         expect(mockRes.locals.sectionTitle).to.equal('Foo')
+      })
+
+      it('should set section progress text to in progress', function () {
+        expect(mockRes.locals.sectionProgress.text).to.equal('In progress')
+      })
+
+      it('should set section progress classes gov tag blue', function () {
+        expect(mockRes.locals.sectionProgress.classes).to.equal(
+          'govuk-tag--blue'
+        )
       })
 
       it('should call presenter', function () {

--- a/common/templates/framework-section.njk
+++ b/common/templates/framework-section.njk
@@ -11,6 +11,7 @@
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-l govuk-!-margin-bottom-9">
         {{ sectionTitle }}
+        <span class="govuk-tag {{ sectionProgress.classes }} app-!-float-right govuk-!-margin-top-2">{{ sectionProgress.text }}</span>
       </h1>
     </div>
   </header>

--- a/package-lock.json
+++ b/package-lock.json
@@ -160,8 +160,8 @@
         "webpack-merge": "5.7.3"
       },
       "engines": {
-        "node": "16.13.0",
-        "npm": "8.1.0"
+        "node": "16",
+        "npm": "8"
       }
     },
     "node_modules/@babel/code-frame": {


### PR DESCRIPTION
Changes shows the PER section status tag on the individual PER section pages. [JIRA](https://dsdmoj.atlassian.net/browse/P4-3157).

**Before:**

![per-section-tag-before](https://user-images.githubusercontent.com/60104344/144849604-0367c512-9282-4063-9d9f-492886d18519.png)

**After:**

![per-section-tag-after](https://user-images.githubusercontent.com/60104344/144849619-08a19247-b722-4964-abb1-e8ab97421fe0.png)

