### PR TITLE
fix: Removes additional info from side panel when prison remand

### DIFF
--- a/common/presenters/move-to-meta-list-component.js
+++ b/common/presenters/move-to-meta-list-component.js
@@ -36,7 +36,6 @@ function moveToMetaListComponent(move, { updateUrls = {} } = {}) {
   const destinationTitle = get(toLocation, 'title', 'Unknown')
   const destinationId = get(toLocation, 'id')
   const useLabel = ['prison_recall', 'video_remand']
-  const hasAdditionalInfo = useLabel
   const destinationLabel = useLabel.includes(moveType)
     ? `${i18n.t(`fields::move_type.items.${moveType}.label`, {
         context: destinationId ? 'with_location' : '',
@@ -44,9 +43,7 @@ function moveToMetaListComponent(move, { updateUrls = {} } = {}) {
       })}`
     : destinationTitle
   const destinationSuffix =
-    additionalInfo && hasAdditionalInfo.includes(moveType)
-      ? ` — ${additionalInfo}`
-      : ''
+    additionalInfo && moveType === 'prison_recall' ? ` — ${additionalInfo}` : ''
   const prisonTransferReasonTitle = prisonTransferReason
     ? prisonTransferReason.title
     : ''

--- a/common/presenters/move-to-meta-list-component.test.js
+++ b/common/presenters/move-to-meta-list-component.test.js
@@ -408,8 +408,11 @@ describe('Presenters', function () {
           const values = transformedResponse.items.map(
             item => item.value.text || item.value.html
           )
-          expect(values).to.include(
+          expect(values).to.not.include(
             'fields::move_type.items.video_remand.label — Some additional information about this move'
+          )
+          expect(values).to.include(
+            'fields::move_type.items.video_remand.label'
           )
         })
       })


### PR DESCRIPTION
This no longer displays additional information for prison remand moves as this is repeating what is already on screen.

**Before:**

![prison-remand-before](https://user-images.githubusercontent.com/60104344/144881100-08435b1e-4c74-4ee4-8fa5-467fdb28800f.png)

**After:**

![prison-remand-after](https://user-images.githubusercontent.com/60104344/144881149-62b15d26-4fcf-4c5b-b718-6420650e1f2a.png)
