### PR TITLE
Revert "fix: Changes to remove of handover notification banner, information availble in history of events"

### DIFF
--- a/app/move/app/view/middleware/locals.message-banner.js
+++ b/app/move/app/view/middleware/locals.message-banner.js
@@ -1,5 +1,11 @@
+const { kebabCase } = require('lodash')
+
+const assessmentToHandedOverBanner = require('../../../../../common/presenters/message-banner/assessment-to-handed-over-banner')
+
 module.exports = async (req, res, next) => {
-  const { move } = req
+  const { canAccess, move } = req
+  const isPERHandedOver =
+    move.profile?.person_escort_record?.handover_occurred_at
 
   let messageBanner
 
@@ -52,6 +58,15 @@ module.exports = async (req, res, next) => {
         }),
       },
     }
+  } else if (isPERHandedOver) {
+    const assessmentType = 'person_escort_record'
+
+    messageBanner = assessmentToHandedOverBanner({
+      assessment: move.profile[assessmentType],
+      baseUrl: `/move/${move.id}/${kebabCase(assessmentType)}`,
+      canAccess,
+      context: assessmentType,
+    })
   }
 
   if (messageBanner) {

--- a/common/presenters/message-banner/assessment-to-handed-over-banner.js
+++ b/common/presenters/message-banner/assessment-to-handed-over-banner.js
@@ -1,0 +1,58 @@
+const i18n = require('../../../config/i18n')
+const filters = require('../../../config/nunjucks/filters')
+const componentService = require('../../services/component')
+const assessmentPrintButton = require('../assessment-print-button')
+
+module.exports = function assessmentToHandedOverBanner({
+  assessment,
+  baseUrl,
+  canAccess,
+  context,
+} = {}) {
+  if (!assessment) {
+    return {}
+  }
+
+  let content = `
+    <p>
+      ${i18n.t('messages::assessment.handed_over.content', {
+        context,
+        date: filters.formatDateWithTimeAndDay(assessment.handover_occurred_at),
+        details: assessment.handover_details,
+      })}
+    </p>
+
+    ${componentService.getComponent('govukWarningText', {
+      html: i18n.t('messages::assessment.handed_over.warning', {
+        details: assessment.handover_details,
+      }),
+      iconFallbackText: 'Warning',
+    })}
+    `
+
+  content += assessmentPrintButton({ baseUrl, canAccess, context })
+
+  content += `
+    <p class="govuk-!-font-size-16 govuk-!-margin-top-1">
+      ${i18n.t('handed_over_at', {
+        date: filters.formatDateWithTimeAndDay(
+          assessment.handover_occurred_at,
+          true
+        ),
+      })}
+    </p>
+  `
+
+  return {
+    allowDismiss: false,
+    classes: 'app-message--instruction govuk-!-padding-right-0',
+    title: {
+      text: i18n.t('messages::assessment.handed_over.heading', {
+        context,
+      }),
+    },
+    content: {
+      html: content,
+    },
+  }
+}

--- a/common/presenters/message-banner/assessment-to-handed-over-banner.test.js
+++ b/common/presenters/message-banner/assessment-to-handed-over-banner.test.js
@@ -1,0 +1,129 @@
+const i18n = require('../../../config/i18n')
+const filters = require('../../../config/nunjucks/filters')
+const componentService = require('../../services/component')
+
+const presenter = require('./assessment-to-handed-over-banner')
+
+describe('Presenters', function () {
+  describe('Message banner presenters', function () {
+    describe('#assessmentToHandedOverBanner', function () {
+      let output
+
+      beforeEach(function () {
+        sinon.stub(i18n, 't').returnsArg(0)
+        sinon.stub(componentService, 'getComponent').returnsArg(0)
+        sinon.stub(filters, 'formatDateWithTimeAndDay').returnsArg(0)
+      })
+
+      context('without args', function () {
+        it('should return empty object', function () {
+          output = presenter()
+          expect(output).to.deep.equal({})
+        })
+      })
+
+      context('with args', function () {
+        const mockArgs = {
+          assessment: {
+            status: 'completed',
+            confirmed_at: '2020-10-10',
+            handover_details: {
+              foo: 'bar',
+            },
+          },
+          baseUrl: '/base-url',
+          canAccess: sinon.stub().returns(true),
+          context: 'person_escort_record',
+        }
+
+        beforeEach(function () {
+          output = presenter(mockArgs)
+        })
+
+        it('should return message component', function () {
+          expect(output).to.deep.equal({
+            allowDismiss: false,
+            classes: 'app-message--instruction govuk-!-padding-right-0',
+            title: {
+              text: 'messages::assessment.handed_over.heading',
+            },
+            content: {
+              html: '\n    <p>\n      messages::assessment.handed_over.content\n    </p>\n\n    govukWarningText\n    \n      <p>\n        <a href="/base-url/print" class="app-icon app-icon--print">\n          actions::print_assessment\n        </a>\n      </p>\n    \n    <p class="govuk-!-font-size-16 govuk-!-margin-top-1">\n      handed_over_at\n    </p>\n  ',
+            },
+          })
+        })
+
+        it('should translate with correct context', function () {
+          expect(i18n.t).to.be.calledWithExactly(
+            'messages::assessment.handed_over.heading',
+            {
+              context: 'person_escort_record',
+            }
+          )
+          expect(i18n.t).to.be.calledWithExactly(
+            'messages::assessment.handed_over.content',
+            {
+              context: 'person_escort_record',
+              date: mockArgs.assessment.handover_occurred_at,
+              details: mockArgs.assessment.handover_details,
+            }
+          )
+          expect(i18n.t).to.be.calledWithExactly(
+            'messages::assessment.handed_over.warning',
+            {
+              details: mockArgs.assessment.handover_details,
+            }
+          )
+          expect(i18n.t).to.be.calledWithExactly('actions::print_assessment', {
+            context: 'person_escort_record',
+          })
+          expect(i18n.t).to.be.calledWithExactly('handed_over_at', {
+            date: mockArgs.assessment.handover_occurred_at,
+          })
+        })
+
+        it('should format date', function () {
+          expect(filters.formatDateWithTimeAndDay).to.be.calledWithExactly(
+            mockArgs.assessment.handover_occurred_at
+          )
+        })
+      })
+
+      context('without print permission', function () {
+        const mockArgs = {
+          assessment: {
+            status: 'completed',
+            confirmed_at: '2020-10-10',
+            handover_details: {
+              foo: 'bar',
+            },
+          },
+          baseUrl: '/base-url',
+          canAccess: sinon
+            .stub()
+            .returns(true)
+            .withArgs('person_escort_record:print')
+            .returns(false),
+          context: 'person_escort_record',
+        }
+
+        beforeEach(function () {
+          output = presenter(mockArgs)
+        })
+
+        it('should return message component without print button', function () {
+          expect(output).to.deep.equal({
+            allowDismiss: false,
+            classes: 'app-message--instruction govuk-!-padding-right-0',
+            title: {
+              text: 'messages::assessment.handed_over.heading',
+            },
+            content: {
+              html: '\n    <p>\n      messages::assessment.handed_over.content\n    </p>\n\n    govukWarningText\n    \n    <p class="govuk-!-font-size-16 govuk-!-margin-top-1">\n      handed_over_at\n    </p>\n  ',
+            },
+          })
+        })
+      })
+    })
+  })
+})

--- a/common/presenters/message-banner/move-to-message-banner-component.js
+++ b/common/presenters/message-banner/move-to-message-banner-component.js
@@ -1,5 +1,6 @@
 const { isEmpty, kebabCase } = require('lodash')
 
+const assessmentToHandedOverBanner = require('./assessment-to-handed-over-banner')
 const assessmentToStartBanner = require('./assessment-to-start-banner')
 const assessmentToUnconfirmedBanner = require('./assessment-to-unconfirmed-banner')
 
@@ -23,7 +24,12 @@ function moveToMessageBannerComponent({ move = {}, moveUrl, canAccess } = {}) {
   }
 
   if (assessment?.status === 'confirmed' && assessment.handover_occurred_at) {
-    return
+    return assessmentToHandedOverBanner({
+      assessment,
+      baseUrl,
+      canAccess,
+      context,
+    })
   }
 
   return assessmentToUnconfirmedBanner({

--- a/common/presenters/message-banner/move-to-message-banner-component.test.js
+++ b/common/presenters/message-banner/move-to-message-banner-component.test.js
@@ -6,10 +6,14 @@ const assessmentToStartBannerStub = sinon
 const assessmentToUnconfirmedBannerStub = sinon
   .stub()
   .returns('__assessmentToUnconfirmedBanner__')
+const assessmentToHandedOverBannerStub = sinon
+  .stub()
+  .returns('__assessmentToHandedOverBanner__')
 
 const presenter = proxyquire('./move-to-message-banner-component', {
   './assessment-to-start-banner': assessmentToStartBannerStub,
   './assessment-to-unconfirmed-banner': assessmentToUnconfirmedBannerStub,
+  './assessment-to-handed-over-banner': assessmentToHandedOverBannerStub,
 })
 
 describe('Presenters', function () {
@@ -20,6 +24,7 @@ describe('Presenters', function () {
       beforeEach(function () {
         assessmentToStartBannerStub.resetHistory()
         assessmentToUnconfirmedBannerStub.resetHistory()
+        assessmentToHandedOverBannerStub.resetHistory()
       })
 
       context('without args', function () {
@@ -87,7 +92,24 @@ describe('Presenters', function () {
                 })
 
                 it('should return handed over banner', function () {
-                  expect(output).to.deep.equal(undefined)
+                  expect(output).to.deep.equal(
+                    '__assessmentToHandedOverBanner__'
+                  )
+                })
+
+                it('should call presenter', function () {
+                  expect(
+                    assessmentToHandedOverBannerStub
+                  ).to.have.been.calledOnceWithExactly({
+                    assessment: {
+                      id: '12345',
+                      status: 'confirmed',
+                      handover_occurred_at: '2018-10-10T14:30:00Z',
+                    },
+                    baseUrl: '/move/12345/person-escort-record',
+                    canAccess: mockArgs.canAccess,
+                    context: 'person_escort_record',
+                  })
                 })
               })
 
@@ -124,6 +146,45 @@ describe('Presenters', function () {
                     baseUrl: '/move/12345/person-escort-record',
                     canAccess: mockArgs.canAccess,
                     context: 'person_escort_record',
+                  })
+                })
+
+                context('with handover', function () {
+                  beforeEach(function () {
+                    output = presenter({
+                      ...mockArgs,
+                      move: {
+                        ...mockMove,
+                        profile: {
+                          person_escort_record: {
+                            id: '12345',
+                            status: 'confirmed',
+                            handover_occurred_at: '2020-10-10T14:20:00Z',
+                          },
+                        },
+                      },
+                    })
+                  })
+
+                  it('should return handed over banner', function () {
+                    expect(output).to.deep.equal(
+                      '__assessmentToHandedOverBanner__'
+                    )
+                  })
+
+                  it('should call presenter', function () {
+                    expect(
+                      assessmentToHandedOverBannerStub
+                    ).to.have.been.calledOnceWithExactly({
+                      assessment: {
+                        id: '12345',
+                        status: 'confirmed',
+                        handover_occurred_at: '2020-10-10T14:20:00Z',
+                      },
+                      baseUrl: '/move/12345/person-escort-record',
+                      canAccess: mockArgs.canAccess,
+                      context: 'person_escort_record',
+                    })
                   })
                 })
               })

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -45,6 +45,11 @@
     "confirmed": {
       "heading": "$t({{context}}) has been confirmed",
       "content": "All information in this $t({{context}}) was confirmed at <strong>{{date}}</strong>."
+    },
+    "handed_over": {
+      "heading": "Person has been handed over",
+      "content": "This person was handed over to {{details.receiving_organisation}}.",
+      "warning": "Contact relevant parties if you have any additional risk or health information to share about this person:<br><br>{{details.dispatching_officer}} — {{details.dispatching_officer_contact}}<br>{{details.receiving_officer}}, {{details.receiving_organisation}} — {{details.receiving_officer_contact}}"
     }
   },
   "cancel_allocation_move": {

--- a/test/e2e/pages/move-detail.js
+++ b/test/e2e/pages/move-detail.js
@@ -71,7 +71,6 @@ class MoveDetailPage extends Page {
       getUpdateLink: category => {
         return Selector(`[data-update-link="${category}"]`)
       },
-      getHandoverSuccess: Selector('[id="app-message__heading"]'),
     }
   }
 

--- a/test/e2e/person-escort-record.new.test.js
+++ b/test/e2e/person-escort-record.new.test.js
@@ -98,16 +98,31 @@ test('Start new Record', async t => {
     .expect(moveDetailPage.getCurrentUrl())
     .contains('/person-escort-record/confirm/handover')
 
-  await confirmPersonEscortRecordPage.fillIn()
+  const handoverDetails = await confirmPersonEscortRecordPage.fillIn()
 
   await moveDetailPage.submitForm()
 
   // Check "confirmed" state
   await t
-    .expect(moveDetailPage.nodes.getHandoverSuccess.innerText)
+    .expect(moveDetailPage.nodes.instructionBanner.innerText)
     .contains(
-      'Handover recorded successfully',
-      'Should show handover recorded successfully'
+      'Person has been handed over',
+      'Should contain handed over PER banner'
+    )
+    .expect(moveDetailPage.nodes.instructionBanner.innerText)
+    .contains(
+      handoverDetails.handoverDispatchingOfficer,
+      'Should contain dispatching officer'
+    )
+    .expect(moveDetailPage.nodes.instructionBanner.innerText)
+    .contains(
+      handoverDetails.handoverReceivingOfficer,
+      'Should contain receiving officer'
+    )
+    .expect(moveDetailPage.nodes.instructionBanner.innerText)
+    .contains(
+      handoverDetails.handoverOtherOrganisation,
+      'Should contain receiving organisation'
     )
     .expect(moveDetailPage.nodes.personEscortRecordSectionStatuses.count)
     .eql(0, 'Should not show PER sections')


### PR DESCRIPTION
Reverts ministryofjustice/hmpps-book-secure-move-frontend#2182

This has a knock on effect with the old design hence the revert.