### PR TITLE
Revert "fix: Remove style override on cancel allocation banner so uses default style"

### DIFF
--- a/app/allocation/views/view.njk
+++ b/app/allocation/views/view.njk
@@ -31,6 +31,7 @@
   {% if messageTitle %}
     {{ appMessage({
       allowDismiss: false,
+      classes: "app-message--temporary",
       title: {
         text: messageTitle
       },

--- a/test/e2e/pages/page.js
+++ b/test/e2e/pages/page.js
@@ -23,8 +23,8 @@ export default class Page {
       username: Selector('#navigation li:nth-child(1)'),
       signOutLink: Selector('#navigation li a').withExactText('Sign out'),
       submitButton: Selector('button[type="submit"]'),
-      bannerHeading: Selector('.app-message .app-message__heading'),
-      bannerContent: Selector('.app-message .app-message__content'),
+      bannerHeading: Selector('.app-message--temporary .app-message__heading'),
+      bannerContent: Selector('.app-message--temporary .app-message__content'),
       instructionBanner: Selector('.app-message--instruction'),
       locationsList: Selector(
         'ul[data-location-type="locations"] li a'


### PR DESCRIPTION
Reverts ministryofjustice/hmpps-book-secure-move-frontend#2196

Reverting as this impacts the old design and we do not want this.  Will address this in another PR.