### PR TITLE
fix: Remove style override on cancel allocation banner so uses default style on new design

### DIFF
--- a/app/allocation/controllers/view.js
+++ b/app/allocation/controllers/view.js
@@ -3,7 +3,7 @@ const { sortBy } = require('lodash')
 const presenters = require('../../../common/presenters')
 
 function viewAllocation(req, res) {
-  const { allocation, canAccess } = req
+  const { allocation, canAccess, moveDesignPreview } = req
   const { moves, status, totalSlots, from_location: fromLocation } = allocation
   const bannerStatuses = ['cancelled']
   const movesWithoutProfile = moves.filter(move => !move.profile)
@@ -26,6 +26,7 @@ function viewAllocation(req, res) {
   }
 
   const locals = {
+    isMoveDesignPreview: moveDesignPreview,
     allocation,
     // TODO: Find way to store the actual URL they came from: See similar solution within moves app
     dashboardUrl: '/allocations',

--- a/app/allocation/controllers/view.test.js
+++ b/app/allocation/controllers/view.test.js
@@ -186,7 +186,7 @@ describe('Allocation controllers', function () {
         })
 
         it('should contain correct number of locals', function () {
-          expect(Object.keys(locals)).to.have.length(10)
+          expect(Object.keys(locals)).to.have.length(11)
         })
       })
 
@@ -196,14 +196,19 @@ describe('Allocation controllers', function () {
       })
     })
 
-    context('with cancelled allocation', function () {
+    context('with cancelled allocation (and old design)', function () {
       let locals
 
       beforeEach(function () {
         mockReq.allocation.status = 'cancelled'
+        mockReq.moveDesignPreview = false
 
         controller(mockReq, mockRes)
         locals = mockRes.render.firstCall.lastArg
+      })
+
+      it('is not new design', function () {
+        expect(locals.isMoveDesignPreview).to.equal(false)
       })
 
       it('does create a message banner title', function () {
@@ -230,13 +235,18 @@ describe('Allocation controllers', function () {
       })
     })
 
-    context('when user has permission to assign', function () {
+    context('when user has permission to assign (and new design)', function () {
       let locals
 
       beforeEach(function () {
         mockReq.canAccess.returns(true)
+        mockReq.moveDesignPreview = true
         controller(mockReq, mockRes)
         locals = mockRes.render.firstCall.lastArg
+      })
+
+      it('is new design', function () {
+        expect(locals.isMoveDesignPreview).to.equal(true)
       })
 
       it('should filter out moves without a person', function () {

--- a/app/allocation/views/view.njk
+++ b/app/allocation/views/view.njk
@@ -31,7 +31,7 @@
   {% if messageTitle %}
     {{ appMessage({
       allowDismiss: false,
-      classes: "app-message--temporary",
+      classes: "app-message--temporary" if not isMoveDesignPreview,
       title: {
         text: messageTitle
       },


### PR DESCRIPTION
You will only see this change on the new design.

**Before: (old design)**

![image](https://user-images.githubusercontent.com/60104344/145196375-d125f4d5-1889-4cce-a804-a341da758d3c.png)

**After: (new design)**

![image](https://user-images.githubusercontent.com/60104344/145196443-a7cc5f08-ede8-41eb-851c-4a9a021026e2.png)
