### PR TITLE
fix: Show the flash banner when the to location is changed on a move

### DIFF
--- a/app/move/app/edit/controllers/move-details.js
+++ b/app/move/app/edit/controllers/move-details.js
@@ -82,6 +82,8 @@ class UpdateMoveDetailsController extends UpdateBase {
             id: toLocation,
           },
         })
+
+        this.setFlash(req, 'move')
       }
 
       if (

--- a/app/move/app/edit/controllers/move-details.test.js
+++ b/app/move/app/edit/controllers/move-details.test.js
@@ -286,6 +286,7 @@ describe('Move controllers', function () {
       let nextSpy, moveService
 
       beforeEach(function () {
+        sinon.stub(controller, 'setFlash')
         moveService = {
           redirect: sinon.stub(),
           update: sinon.stub(),
@@ -415,6 +416,13 @@ describe('Move controllers', function () {
                   id: '#toLocation',
                 },
               })
+            })
+
+            it('should set the confirmation message', function () {
+              expect(controller.setFlash).to.be.calledOnceWithExactly(
+                req,
+                'move'
+              )
             })
 
             it('should not call move service’s update method', function () {


### PR DESCRIPTION
Prior to this change no flash banner was presented to the end user when the to location was changed.  Now the following is displayed to the user upon changing the to location:

![image](https://user-images.githubusercontent.com/60104344/145406574-3703bb97-df9f-4417-a595-a17a0b94b6e2.png)
