### PR TITLE
chore: Bump dockerfile to node 16.13.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ aliases:
   # Shared containers
   - &circle_container
     docker:
-      - image: cimg/node:16.13.0-browsers
+      - image: cimg/node:16.13.1-browsers
   - &cloud_container
     docker:
       - image: ${ECR_ENDPOINT}/cloud-platform/tools:circleci

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM node:14.18.1-alpine3.13 as build-stage
+FROM node:16.13.1-alpine3.13 as build-stage
 
 WORKDIR /home/node/app
 
 RUN apk add --no-cache python2 git build-base nasm zlib-dev libpng-dev autoconf automake
 RUN mkdir -p /home/node/app/node_modules && chown -R node:node /home/node/app
 
-COPY package*.json ./
+COPY --chown=node:node package*.json ./
 USER 1000
 RUN npm install
 
@@ -23,7 +23,7 @@ ENV API_VERSION default
 RUN NODE_ENV=production npm run build
 ############### End of Build step ###############
 
-FROM node:14.18.1-alpine3.13
+FROM node:16.13.1-alpine3.13
 
 WORKDIR /home/node/app
 USER 1000

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ There are three main repositories that comprise the Book a secure move service:
 
 ### Major Dependencies
 
-- [Node.js](https://nodejs.org/en/) (>= 16.13.0)
+- [Node.js](https://nodejs.org/en/) (>= 16.13.1)
 - [NPM](https://www.npmjs.com/) (>= 8.1.0)
 - [Redis](https://redis.io/) (>= 5.0.5)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Dockerfile node version has been updated to 16.13.1

### Why did it change

So that the frontend portal runs on the latest LTS node version.

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

- P4-3286