### PR TITLE
Add database correction cancellation reason

### DIFF
--- a/locales/en/fields.json
+++ b/locales/en/fields.json
@@ -290,6 +290,9 @@
       "cancelled_by_pmu": {
         "label": "Cancelled by Population Management Unit (PMU)"
       },
+      "database_correction": {
+        "label": "Actual cancellation reason and time unknown due to missing supplier data"
+      },
       "other": {
         "label": "Another reason"
       }

--- a/locales/en/statuses.json
+++ b/locales/en/statuses.json
@@ -25,6 +25,7 @@
   "description_made_in_error": "Reason — $t(fields::cancellation_reason.items.made_in_error.label)",
   "description_supplier_declined_to_move": "Reason — $t(fields::cancellation_reason.items.supplier_declined_to_move.label)",
   "description_cancelled_by_pmu": "Reason — $t(fields::cancellation_reason.items.cancelled_by_pmu.label) — {{comment}}",
+  "description_database_correction": "Reason — $t(fields::cancellation_reason.items.database_correction.label)",
   "description_other": "Reason — {{comment}}",
   "description_rejected": "Comments — {{comment}}",
   "description_no_transport_available": "<p>Reason — $t(fields::rejection_reason.items.no_transport_available)</p> $t(statuses::description_cancelled_rejected)",


### PR DESCRIPTION
This is a new cancellation reason that we're adding to the API to support manual corrections of the data. We're not going to allow users of the frontend to pick this option, but we will need to display it when it's set in the backend.

Depends on https://github.com/ministryofjustice/hmpps-book-secure-move-api/pull/1678.

## Screenshot

![8b64ea49-fff2-4e5e-85c0-508560449d62](https://user-images.githubusercontent.com/510498/148763161-3032e92a-fa29-46f2-9d7c-ad44b059db04.png)