### PR TITLE
Patch new design move page navigation

### DIFF
--- a/app/move/app/view/views/_layout.njk
+++ b/app/move/app/view/views/_layout.njk
@@ -17,6 +17,16 @@
   </section>
 {% endmacro %}
 
+{% block breadcrumbs %}
+  <div class="govuk-width-container">
+    {{ govukBackLink({
+      text: t("actions::back_to_dashboard"),
+      classes: "app-print--hide",
+      href: MOVES_URL
+    }) }}
+  </div>
+{% endblock %}
+
 {% block content %}
   {% if messageBanner %}
     <div class="govuk-!-margin-bottom-5">

--- a/common/templates/layouts/base.njk
+++ b/common/templates/layouts/base.njk
@@ -136,17 +136,19 @@
     {% endif %}
   {% endblock %}
 
-  {% set breadcrumbs = getBreadcrumbs() %}
-  {% if breadcrumbs|length > 1 %}
-    <div class="govuk-width-container">
-      {{ govukBreadcrumbs({
-        items: breadcrumbs,
-        attributes: {
-          'data-auto-id': 'breadcrumbs'
-        }
-      }) }}
-    </div>
-  {% endif %}
+  {% block breadcrumbs %}
+    {% set breadcrumbs = getBreadcrumbs() %}
+    {% if breadcrumbs|length > 1 %}
+      <div class="govuk-width-container">
+        {{ govukBreadcrumbs({
+          items: breadcrumbs,
+          attributes: {
+            'data-auto-id': 'breadcrumbs'
+          }
+        }) }}
+      </div>
+    {% endif %}
+  {% endblock %}
 {% endblock %}
 
 {% block beforeContent %}


### PR DESCRIPTION
This slightly changes the navigation in the new design on how to get back to the dashboard. This is temporary as it was identified as a blocker for launching the new design, and will be improved in the future.

## Screenshots

### Old

![Screenshot 2022-01-06 at 09 47 23](https://user-images.githubusercontent.com/510498/148365799-d544e3a0-64fd-47e3-9403-c6cb4936e04f.png)

### New

![Screenshot 2022-01-06 at 09 50 33](https://user-images.githubusercontent.com/510498/148365849-751f8c3d-14f3-4812-aed3-57d6806649ed.png)

[Jira Ticket](https://dsdmoj.atlassian.net/browse/P4-3354)