### PR TITLE
Fix the person name missing on cancel form

### DIFF
--- a/app/move/app/cancel/controllers.js
+++ b/app/move/app/cancel/controllers.js
@@ -7,6 +7,7 @@ class CancelController extends FormWizardController {
   middlewareLocals() {
     super.middlewareLocals()
     this.use(middleware.setMoveSummary)
+    this.use(this.setMoveLocal)
   }
 
   middlewareChecks() {
@@ -32,6 +33,11 @@ class CancelController extends FormWizardController {
       return res.redirect(`/move/${moveId}`)
     }
 
+    next()
+  }
+
+  setMoveLocal(req, res, next) {
+    res.locals.move = req.move
     next()
   }
 

--- a/app/move/app/cancel/controllers.test.js
+++ b/app/move/app/cancel/controllers.test.js
@@ -55,6 +55,7 @@ describe('Move controllers', function () {
         sinon.stub(FormWizardController.prototype, 'middlewareLocals')
         sinon.stub(controller, 'use')
         sinon.stub(middleware, 'setMoveSummary')
+        sinon.stub(controller, 'setMoveLocal')
 
         controller.middlewareLocals()
       })
@@ -70,8 +71,14 @@ describe('Move controllers', function () {
         )
       })
 
+      it('should call setMoveSummary middleware', function () {
+        expect(controller.use.secondCall).to.have.been.calledWith(
+          controller.setMoveLocal
+        )
+      })
+
       it('should call correct number of middleware', function () {
-        expect(controller.use.callCount).to.equal(1)
+        expect(controller.use.callCount).to.equal(2)
       })
     })
 
@@ -176,6 +183,28 @@ describe('Move controllers', function () {
         it('should not call next', function () {
           expect(nextSpy).not.to.be.called
         })
+      })
+    })
+
+    describe('#setMoveLocal()', function () {
+      let mockReq, mockRes, nextSpy
+
+      beforeEach(function () {
+        nextSpy = sinon.spy()
+        mockReq = { move: { id: '12345' } }
+        mockRes = { locals: {} }
+      })
+
+      beforeEach(function () {
+        controller.setMoveLocal(mockReq, mockRes, nextSpy)
+      })
+
+      it('should set the move on locals', function () {
+        expect(mockRes.locals.move).to.deep.equal(mockReq.move)
+      })
+
+      it('should call next', function () {
+        expect(nextSpy).to.be.calledOnceWithExactly()
       })
     })
 


### PR DESCRIPTION
There is a bug where the move information is not passed to the view on the form to cancel a move, so sentences which rely on this information aren't formatted correctly.

Notably, this affected the title of the page, and the warning message.

## Screenshots

### Old

![Screenshot 2022-01-10 at 12 37 22](https://user-images.githubusercontent.com/510498/148767414-ec446f69-ee5d-4235-8003-c4e8bc6203ac.png)

### New

![Screenshot 2022-01-10 at 12 38 02](https://user-images.githubusercontent.com/510498/148767422-0429fd3a-1683-490f-8056-e9207f3e2a5f.png)