### PR TITLE
Hide record handover button if move is cancelled

### DIFF
--- a/common/presenters/move-to-identity-bar-actions/assessment-actions.js
+++ b/common/presenters/move-to-identity-bar-actions/assessment-actions.js
@@ -52,16 +52,18 @@ function assessmentActions(move = {}, { canAccess } = {}) {
     }
   }
 
-  if (assessment.status === 'completed' && canAccess(`${context}:confirm`)) {
-    if (canAccess(`${context}:confirm`)) {
-      actions.push({
-        html: componentService.getComponent('govukButton', {
-          text: i18n.t('actions::provide_confirmation', { context }),
-          preventDoubleClick: true,
-          href: `${baseUrl}/confirm`,
-        }),
-      })
-    }
+  if (
+    assessment.status === 'completed' &&
+    move.status !== 'cancelled' &&
+    canAccess(`${context}:confirm`)
+  ) {
+    actions.push({
+      html: componentService.getComponent('govukButton', {
+        text: i18n.t('actions::provide_confirmation', { context }),
+        preventDoubleClick: true,
+        href: `${baseUrl}/confirm`,
+      }),
+    })
   }
 
   if (assessmentType === 'person_escort_record') {

--- a/common/presenters/move-to-identity-bar-actions/assessment-actions.test.js
+++ b/common/presenters/move-to-identity-bar-actions/assessment-actions.test.js
@@ -421,6 +421,28 @@ describe('Presenters', function () {
             })
           })
 
+          context('with cancelled move', function () {
+            beforeEach(function () {
+              mockMove.status = 'cancelled'
+              output = presenter(mockMove, { canAccess: canAccessStub })
+            })
+
+            it('should return view action', function () {
+              expect(output).to.deep.equal([
+                {
+                  html: {
+                    govukButton: {
+                      href: `/move/${mockMove.id}/person-escort-record`,
+                      preventDoubleClick: true,
+                      text: 'actions::view_assessment',
+                      classes: 'govuk-button--secondary',
+                    },
+                  },
+                },
+              ])
+            })
+          })
+
           context('without assessment confirm access', function () {
             beforeEach(function () {
               canAccessStub


### PR DESCRIPTION
It doesn't make sense that the handover can be recorded once a move has been cancelled, so the button shouldn't be visible.

## Screenshots

### Old

![Screenshot 2022-01-10 at 13 30 50](https://user-images.githubusercontent.com/510498/148774862-3e3f3ed3-17af-4a52-918c-11cc9a9731bc.png)

### New

![Screenshot 2022-01-10 at 13 31 01](https://user-images.githubusercontent.com/510498/148774869-919086a6-384b-4e9e-a73d-3df126df998a.png)