### PR TITLE
Make it possible to edit personal details in new design

### DIFF
--- a/app/move/app/view/middleware/locals.person-summary.js
+++ b/app/move/app/view/middleware/locals.person-summary.js
@@ -1,7 +1,10 @@
+const moveHelpers = require('../../../../../common/helpers/move')
 const presenters = require('../../../../../common/presenters')
 
 function localsMoveDetails(req, res, next) {
-  const profile = req.move?.profile
+  const { canAccess, move } = req
+
+  const profile = move?.profile
 
   if (!profile) {
     return next()
@@ -9,6 +12,7 @@ function localsMoveDetails(req, res, next) {
 
   const person = profile.person
   const metaList = presenters.personToMetaListComponent(person)
+  const updateUrls = moveHelpers.getUpdateUrls(move, canAccess)
 
   res.locals.personSummary = {
     metaList,
@@ -17,6 +21,7 @@ function localsMoveDetails(req, res, next) {
       alt: person._fullname,
     },
     profileLink: `/person/${person.id}?move=${req.move.id}`,
+    updateLink: updateUrls.personal_details,
   }
 
   next()

--- a/app/move/app/view/middleware/locals.person-summary.test.js
+++ b/app/move/app/view/middleware/locals.person-summary.test.js
@@ -52,12 +52,35 @@ describe('Move view app', function () {
                 alt: 'DOE, JOHN',
               },
               profileLink: '/person/__profile12345__?move=__move1__',
+              updateLink: undefined,
             },
           })
         })
 
         it('should call next', function () {
           expect(nextSpy).to.be.calledOnceWithExactly()
+        })
+      })
+
+      context('with profile and permission to edit', function () {
+        beforeEach(function () {
+          req.canAccess = () => true
+          req.move._canEdit = true
+          middleware(req, res, nextSpy)
+        })
+
+        it('should set locals correctly', function () {
+          expect(res.locals).to.be.deep.equal({
+            personSummary: {
+              metaList: mockMetaListComponent,
+              image: {
+                url: '/person/image/__profile12345__',
+                alt: 'DOE, JOHN',
+              },
+              profileLink: '/person/__profile12345__?move=__move1__',
+              updateLink: '/move/__move1__/edit/personal-details',
+            },
+          })
         })
       })
 

--- a/common/templates/includes/person-summary.njk
+++ b/common/templates/includes/person-summary.njk
@@ -30,5 +30,13 @@
         </a>
       </p>
     {% endif %}
+
+    {% if personSummary.updateLink %}
+      <p class="govuk-!-margin-top-1 govuk-!-margin-bottom-0 govuk-!-font-size-16">
+        <a href="{{ personSummary.updateLink }}" data-update-link="personal_details">
+          {{ t("actions::edit_profile") }}
+        </a>
+      </p>
+    {% endif %}
   </div>
 {% endif %}

--- a/locales/en/actions.json
+++ b/locales/en/actions.json
@@ -50,6 +50,7 @@
   "print_assessment": "Print $t({{context}})",
   "view_assessment": "View $t({{context}})",
   "view_profile": "View profile",
+  "edit_profile": "Edit personal details",
   "provide_confirmation": "Provide confirmation",
   "provide_confirmation_youth_risk_assessment": "Confirm $t({{context}})",
   "provide_confirmation_person_escort_record": "Record handover",


### PR DESCRIPTION
We've spotted an issue with the new move page design where it's no longer possible to change the person details of a person from the move page. This behaviour has been lost from the old design, so we're putting in a quick fix now to allow us to continue with the launch.

## Screenshots

### Old

![Screenshot 2022-01-19 at 17 58 36](https://user-images.githubusercontent.com/510498/150187383-df0c85da-54fe-4f8d-bbf3-838bc47a929c.png)

### New

![Screenshot 2022-01-19 at 17 53 14](https://user-images.githubusercontent.com/510498/150187397-d83d56e0-af6a-42d5-a983-bd453e5759ff.png)