### PR TITLE
Add journey dates to journeys view

### DIFF
--- a/common/lib/api-client/models/journey.js
+++ b/common/lib/api-client/models/journey.js
@@ -4,6 +4,7 @@ module.exports = {
     billable: '',
     vehicle: '',
     timestamp: '',
+    date: '',
     from_location: {
       jsonApi: 'hasOne',
       type: 'locations',

--- a/common/presenters/journeys-to-meta-list-component.js
+++ b/common/presenters/journeys-to-meta-list-component.js
@@ -1,6 +1,7 @@
 const { sortBy } = require('lodash')
 
 const i18n = require('../../config/i18n')
+const { formatDate } = require('../../config/nunjucks/filters')
 
 function _mapJourney({
   state,
@@ -30,7 +31,7 @@ function _mapJourney({
       value: {
         text: i18n.t('moves::map.labels.date.text', {
           context: date ? '' : 'unknown',
-          date,
+          date: formatDate(date),
         }),
       },
     },

--- a/common/presenters/journeys-to-meta-list-component.js
+++ b/common/presenters/journeys-to-meta-list-component.js
@@ -6,6 +6,7 @@ function _mapJourney({
   state,
   from_location: fromLocation,
   to_location: toLocation,
+  date,
   vehicle,
 } = {}) {
   const rows = [
@@ -18,6 +19,18 @@ function _mapJourney({
         text: i18n.t('moves::map.labels.route.text', {
           from: fromLocation.title,
           to: toLocation.title,
+        }),
+      },
+    },
+    {
+      classes: 'govuk-!-font-size-16',
+      key: {
+        text: i18n.t('moves::map.labels.date.heading'),
+      },
+      value: {
+        text: i18n.t('moves::map.labels.date.text', {
+          context: date ? '' : 'unknown',
+          date,
         }),
       },
     },

--- a/common/presenters/journeys-to-meta-list-component.test.js
+++ b/common/presenters/journeys-to-meta-list-component.test.js
@@ -23,6 +23,7 @@ describe('Presenters', function () {
           id: '1234',
           registration: 'JM18 AHI',
         },
+        date: '2020-01-01',
       },
       {
         state: 'proposed',
@@ -40,6 +41,7 @@ describe('Presenters', function () {
           id: '1AG',
           registration: 'XK21 HUA',
         },
+        date: '2020-01-02',
       },
       {
         state: 'in_progress',
@@ -54,6 +56,7 @@ describe('Presenters', function () {
           title: 'HMP Pentonville',
         },
         vehicle: null,
+        date: null,
       },
       {
         state: 'completed',
@@ -131,6 +134,15 @@ describe('Presenters', function () {
               {
                 classes: 'govuk-!-font-size-16',
                 key: {
+                  text: 'moves::map.labels.date.heading',
+                },
+                value: {
+                  text: 'moves::map.labels.date.text',
+                },
+              },
+              {
+                classes: 'govuk-!-font-size-16',
+                key: {
                   text: 'moves::map.labels.vehicle.heading',
                 },
                 value: {
@@ -153,6 +165,28 @@ describe('Presenters', function () {
                 to: journey.to_location.title,
               }
             )
+
+            expect(i18n.t).to.be.calledWithExactly(
+              'moves::map.labels.date.heading'
+            )
+
+            if (journey.date) {
+              expect(i18n.t).to.be.calledWithExactly(
+                'moves::map.labels.date.text',
+                {
+                  context: '',
+                  date: journey.date,
+                }
+              )
+            } else {
+              expect(i18n.t).to.be.calledWithExactly(
+                'moves::map.labels.date.text',
+                {
+                  context: 'unknown',
+                  date: undefined,
+                }
+              )
+            }
 
             expect(i18n.t).to.be.calledWithExactly(
               'moves::map.labels.vehicle.heading'

--- a/common/presenters/journeys-to-meta-list-component.test.js
+++ b/common/presenters/journeys-to-meta-list-component.test.js
@@ -175,7 +175,7 @@ describe('Presenters', function () {
                 'moves::map.labels.date.text',
                 {
                   context: '',
-                  date: journey.date,
+                  date: '2 Jan 2020',
                 }
               )
             } else {

--- a/locales/en/moves.json
+++ b/locales/en/moves.json
@@ -260,6 +260,11 @@
         "heading": "Route",
         "text": "{{from}} to {{to}}"
       },
+      "date": {
+        "heading": "Date",
+        "text": "{{date}}",
+        "text_unknown": "Unknown"
+      },
       "vehicle": {
         "heading": "Vehicle",
         "text": "{{registration}} ({{id}})",


### PR DESCRIPTION
This adds the ability to see the journey dates when viewing journeys on a move. This hasn't been designed in particular, but since the view is limited only to CDMs at the moment I think that's okay.

## Screenshots

### Before

<img width="395" alt="Screenshot 2022-02-03 at 08 03 22" src="https://user-images.githubusercontent.com/510498/152303793-8870c1d0-5af7-43a6-837e-ae465e04715d.png">

### After

<img width="393" alt="Screenshot 2022-02-03 at 08 03 06" src="https://user-images.githubusercontent.com/510498/152303800-4986d301-5c21-43c8-b2b8-8b64c2eef5dd.png">

[Jira Ticket](https://dsdmoj.atlassian.net/browse/P4-3337)