### PR TITLE
Correct logic for record handover button

### DIFF
--- a/common/presenters/move-to-identity-bar-actions/assessment-actions.js
+++ b/common/presenters/move-to-identity-bar-actions/assessment-actions.js
@@ -53,8 +53,10 @@ function assessmentActions(move = {}, { canAccess } = {}) {
   }
 
   if (
-    assessment.status === 'completed' &&
     move.status !== 'cancelled' &&
+    (assessment.status === 'completed' ||
+      (assessment.status === 'confirmed' &&
+        !assessment.handover_occurred_at)) &&
     canAccess(`${context}:confirm`)
   ) {
     actions.push({

--- a/common/presenters/move-to-identity-bar-actions/assessment-actions.test.js
+++ b/common/presenters/move-to-identity-bar-actions/assessment-actions.test.js
@@ -493,6 +493,7 @@ describe('Presenters', function () {
           beforeEach(function () {
             mockMove.profile.person_escort_record = {
               status: 'confirmed',
+              handover_occurred_at: '2020-01-01',
             }
             output = presenter(mockMove, { canAccess: canAccessStub })
           })


### PR DESCRIPTION
We want to show the button if no handover has occurred, so we need to check the occurred at time of the handover rather than relying just on the state of the assessment.

[Jira Ticket](https://dsdmoj.atlassian.net/browse/P4-3474)