### PR TITLE
Remove duplicate breadcrumb from frameworks

### DIFF
--- a/common/middleware/framework/set-breadcrumbs.js
+++ b/common/middleware/framework/set-breadcrumbs.js
@@ -3,14 +3,7 @@ const { snakeCase } = require('lodash')
 function setBreadcrumbs(req, res, next) {
   const { assessment = {}, move, originalUrl = '' } = req
   const moveId = move?.id || assessment?.move?.id
-  const moveReference = move?.reference || assessment?.move?.reference
-  const profile = move?.profile || assessment?.profile
   const frameworkName = assessment.framework.name
-
-  res.breadcrumb({
-    text: `${profile.person._fullname} (${moveReference})`,
-    href: `/move/${moveId}`,
-  })
 
   if (!originalUrl.includes('/handover')) {
     res.breadcrumb({

--- a/common/middleware/framework/set-breadcrumbs.test.js
+++ b/common/middleware/framework/set-breadcrumbs.test.js
@@ -38,13 +38,6 @@ describe('Framework middleware', function () {
           middleware(mockReq, mockRes, nextSpy)
         })
 
-        it('should set move breadcrumb item', function () {
-          expect(mockRes.breadcrumb).to.have.been.calledWithExactly({
-            text: 'DOE, JOHN (PFX7536F)',
-            href: '/move/__move_12345__',
-          })
-        })
-
         it('should set assessment breadcrumb item', function () {
           expect(mockRes.breadcrumb).to.have.been.calledWithExactly({
             text: 'assessment::page_title',
@@ -70,13 +63,6 @@ describe('Framework middleware', function () {
         beforeEach(function () {
           mockReq.originalUrl = 'confirm/handover'
           middleware(mockReq, mockRes, nextSpy)
-        })
-
-        it('should set move breadcrumb item', function () {
-          expect(mockRes.breadcrumb).to.have.been.calledWithExactly({
-            text: 'DOE, JOHN (PFX7536F)',
-            href: '/move/__move_12345__',
-          })
         })
 
         it('should set not assessment breadcrumb item', function () {
@@ -110,13 +96,6 @@ describe('Framework middleware', function () {
           },
         }
         middleware(mockReq, mockRes, nextSpy)
-      })
-
-      it('should set move breadcrumb item', function () {
-        expect(mockRes.breadcrumb).to.have.been.calledWithExactly({
-          text: 'DOE, JOHN (PFX7536F)',
-          href: '/move/__move_12345__',
-        })
       })
 
       it('should set assessment breadcrumb item', function () {


### PR DESCRIPTION
The breadcrumbs middleware for frameworks (person escort record and youth risk assessment) include an entry for the move itself. We don't need to do this, as the middleware for the move will do this.

## Screenshots

### Old

![Screenshot 2022-02-09 at 08 43 18](https://user-images.githubusercontent.com/510498/153158187-a0f1176c-dc68-4286-8976-886d5c5fe4a6.png)

### New

![Screenshot 2022-02-09 at 08 43 08](https://user-images.githubusercontent.com/510498/153158194-0dfcdb1d-5c8d-4b3a-a880-bd8478c501ee.png)

[Jira Ticket](https://dsdmoj.atlassian.net/browse/P4-3449)