### PR TITLE
Remove alt text on person image

### DIFF
--- a/common/presenters/profile-to-card-component.js
+++ b/common/presenters/profile-to-card-component.js
@@ -107,7 +107,7 @@ function profileToCardComponent({
 
     if (showImage) {
       card.image_path = imageUrl
-      card.image_alt = fullname || i18n.t('awaiting_person')
+      card.image_alt = ''
     }
 
     return card

--- a/common/presenters/profile-to-card-component.test.js
+++ b/common/presenters/profile-to-card-component.test.js
@@ -72,11 +72,9 @@ describe('Presenters', function () {
             )
           })
 
-          it('should contain image alt', function () {
+          it('should not contain image alt', function () {
             expect(transformedResponse).to.have.property('image_alt')
-            expect(transformedResponse.image_alt).to.equal(
-              mockProfile.person._fullname
-            )
+            expect(transformedResponse.image_alt).to.equal('')
           })
 
           it('should contain correct meta data', function () {
@@ -396,7 +394,7 @@ describe('Presenters', function () {
       title: { text: '__translated__' },
       meta: { items: [] },
       image_path: undefined,
-      image_alt: '__translated__',
+      image_alt: '',
     }
 
     context('with no arguments', function () {


### PR DESCRIPTION
It's not useful to include the alt text on this image as it's not a visual description of the image, and instead has the person's name which is already accessible in the heading.

[Jira Ticket](https://dsdmoj.atlassian.net/browse/P4-3492)