### PR TITLE
Handle case when field doesn't have an id

### DIFF
--- a/common/helpers/field/add-errorlist-to-errors.js
+++ b/common/helpers/field/add-errorlist-to-errors.js
@@ -9,7 +9,7 @@ function addErrorListToErrors(errors = {}, fields) {
         ...field,
         ...error,
       }),
-      href: `#${field.id}`,
+      href: field.id ? `#${field.id}` : undefined,
     }
   })
 


### PR DESCRIPTION
This is sometimes the case, particularly with a radio buttons where there isn't a single element with a single ID. Instead of having a link which doesn't go anywhere, we don't need to have a link.

[Jira Ticket](https://dsdmoj.atlassian.net/browse/P4-3493)