### PR TITLE
Fix incorrect use of strings which expect data

### DIFF
--- a/app/moves/constants.js
+++ b/app/moves/constants.js
@@ -95,7 +95,7 @@ const FILTERS = {
       status: 'rejected',
     },
     {
-      label: 'collections::cancelled',
+      label: 'statuses::cancelled_filter',
       status: 'cancelled',
     },
   ],

--- a/common/templates/framework-overview.njk
+++ b/common/templates/framework-overview.njk
@@ -15,9 +15,7 @@
   <header class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <span class="govuk-caption-xl">
-        {{ t("assessment::page_title_with_name", {
-          context: i18nContext
-        }) }}
+        {{ t("assessment::page_title", { context: i18nContext }) }}
       </span>
       <h1 class="govuk-heading-xl">
         {{ fullname }}


### PR DESCRIPTION
We're using strings which expect data to to be passed with them but without actually passing any data. This leads to the placeholder text remaining visible for users.

[Jira Ticket](https://dsdmoj.atlassian.net/browse/P4-3546)

## Screenshots

### Old

<img width="539" alt="Screenshot 2022-03-08 at 15 04 22" src="https://user-images.githubusercontent.com/510498/157266567-6f46905d-8d9b-472b-a78f-92c824b00a15.png">
<img width="616" alt="Screenshot 2022-03-08 at 15 04 37" src="https://user-images.githubusercontent.com/510498/157266573-d7b282b5-22d2-4793-bf95-becfd1455063.png">

### New

<img width="436" alt="Screenshot 2022-03-08 at 15 04 49" src="https://user-images.githubusercontent.com/510498/157266596-836fafb3-ab94-46fc-b7fd-44bdbdcea942.png">
<img width="609" alt="Screenshot 2022-03-08 at 15 04 56" src="https://user-images.githubusercontent.com/510498/157266602-f87aedae-f36f-4969-bcd5-5b07d5005b92.png">
