### PR TITLE
Hide handover placeholder strings

### DIFF
--- a/common/presenters/message-banner/assessment-to-handed-over-banner.js
+++ b/common/presenters/message-banner/assessment-to-handed-over-banner.js
@@ -1,3 +1,5 @@
+const { isEmpty } = require('lodash')
+
 const i18n = require('../../../config/i18n')
 const filters = require('../../../config/nunjucks/filters')
 const componentService = require('../../services/component')
@@ -13,32 +15,38 @@ module.exports = function assessmentToHandedOverBanner({
     return {}
   }
 
-  let content = `
-    <p>
-      ${i18n.t('messages::assessment.handed_over.content', {
-        context,
-        date: filters.formatDateWithTimeAndDay(assessment.handover_occurred_at),
-        details: assessment.handover_details,
-      })}
-    </p>
+  const {
+    handover_details: handoverDetails,
+    handover_occurred_at: handoverOccurredAt,
+  } = assessment
 
-    ${componentService.getComponent('govukWarningText', {
-      html: i18n.t('messages::assessment.handed_over.warning', {
-        details: assessment.handover_details,
-      }),
-      iconFallbackText: 'Warning',
-    })}
-    `
+  let content = ''
+
+  if (!isEmpty(handoverDetails)) {
+    content += `
+      <p>
+        ${i18n.t('messages::assessment.handed_over.content', {
+          context,
+          date: filters.formatDateWithTimeAndDay(handoverOccurredAt),
+          details: handoverDetails,
+        })}
+      </p>
+
+      ${componentService.getComponent('govukWarningText', {
+        html: i18n.t('messages::assessment.handed_over.warning', {
+          details: handoverDetails,
+        }),
+        iconFallbackText: 'Warning',
+      })}
+     `
+  }
 
   content += assessmentPrintButton({ baseUrl, canAccess, context })
 
   content += `
     <p class="govuk-!-font-size-16 govuk-!-margin-top-1">
       ${i18n.t('handed_over_at', {
-        date: filters.formatDateWithTimeAndDay(
-          assessment.handover_occurred_at,
-          true
-        ),
+        date: filters.formatDateWithTimeAndDay(handoverOccurredAt, true),
       })}
     </p>
   `

--- a/common/presenters/message-banner/assessment-to-handed-over-banner.test.js
+++ b/common/presenters/message-banner/assessment-to-handed-over-banner.test.js
@@ -48,7 +48,7 @@ describe('Presenters', function () {
               text: 'messages::assessment.handed_over.heading',
             },
             content: {
-              html: '\n    <p>\n      messages::assessment.handed_over.content\n    </p>\n\n    govukWarningText\n    \n      <p>\n        <a href="/base-url/print" class="app-icon app-icon--print">\n          actions::print_assessment\n        </a>\n      </p>\n    \n    <p class="govuk-!-font-size-16 govuk-!-margin-top-1">\n      handed_over_at\n    </p>\n  ',
+              html: '\n      <p>\n        messages::assessment.handed_over.content\n      </p>\n\n      govukWarningText\n     \n      <p>\n        <a href="/base-url/print" class="app-icon app-icon--print">\n          actions::print_assessment\n        </a>\n      </p>\n    \n    <p class="govuk-!-font-size-16 govuk-!-margin-top-1">\n      handed_over_at\n    </p>\n  ',
             },
           })
         })
@@ -119,7 +119,7 @@ describe('Presenters', function () {
               text: 'messages::assessment.handed_over.heading',
             },
             content: {
-              html: '\n    <p>\n      messages::assessment.handed_over.content\n    </p>\n\n    govukWarningText\n    \n    <p class="govuk-!-font-size-16 govuk-!-margin-top-1">\n      handed_over_at\n    </p>\n  ',
+              html: '\n      <p>\n        messages::assessment.handed_over.content\n      </p>\n\n      govukWarningText\n     \n    <p class="govuk-!-font-size-16 govuk-!-margin-top-1">\n      handed_over_at\n    </p>\n  ',
             },
           })
         })

--- a/locales/en/events.json
+++ b/locales/en/events.json
@@ -415,6 +415,10 @@
   },
   "PerHandover": {
     "heading": "Person handed over",
-    "description": "This person was handed over to <strong>{{receiving_officer}} ({{receiving_officer_id}}), {{receiving_organisation}}</strong> by <strong>{{dispatching_officer}} ({{dispatching_officer_id}})</strong>"
+    "description": "This person was handed over $t(events::PerHandover.receiving, {\"context\": \"{{receiving_officer, exists}}\"}) $t(events::PerHandover.dispatching, {\"context\": \"{{dispatching_officer, exists}}\"})",
+    "receiving_true": "to <strong>{{receiving_officer}} ({{receiving_officer_id}}), {{receiving_organisation}}</strong>",
+    "receiving_false": "",
+    "dispatching_true": "by <strong>{{dispatching_officer}} ({{dispatching_officer_id}})</strong>",
+    "dispatching_false": ""
   }
 }


### PR DESCRIPTION
This improves the design of the handover box and events, when the handover details haven't been provided.

[Jira Ticket](https://dsdmoj.atlassian.net/browse/P4-3546)

## Screenshots

### Old

<img width="796" alt="Screenshot 2022-03-10 at 09 34 43" src="https://user-images.githubusercontent.com/510498/157655057-996f2cc8-af67-4e77-81b3-d8554203cb9f.png">
<img width="1194" alt="Screenshot 2022-03-10 at 09 34 35" src="https://user-images.githubusercontent.com/510498/157655050-f1dc4190-3fad-4aae-9e54-2928eaca90dd.png">

### New

<img width="540" alt="Screenshot 2022-03-10 at 09 35 29" src="https://user-images.githubusercontent.com/510498/157655076-554818cb-d128-4ce1-a1d3-cc0f8e544746.png">
<img width="1203" alt="Screenshot 2022-03-10 at 09 59 57" src="https://user-images.githubusercontent.com/510498/157655083-d7ad9e51-4963-4e66-9ca8-1fc8703d0ede.png">