### PR TITLE
Add analytics to in-service communication banners and footer links

### DIFF
--- a/common/assets/javascripts/application.js
+++ b/common/assets/javascripts/application.js
@@ -24,6 +24,7 @@ const HcSticky = require('hc-sticky')
 const StickySidebar = require('sticky-sidebar/dist/sticky-sidebar')
 
 const AddAnother = require('../../components/add-another/add-another')
+const Footer = require('../../components/footer/footer')
 const Header = require('../../components/internal-header/internal-header')
 const Message = require('../../components/message/message')
 const Time = require('../../components/time/time')
@@ -105,4 +106,9 @@ const $multiFileUploads = document.querySelectorAll(
 )
 nodeListForEach($multiFileUploads, function ($multiFileUpload) {
   new MultiFileUpload($multiFileUpload).init()
+})
+
+const $footer = document.querySelectorAll('footer')
+nodeListForEach($footer, function ($module) {
+  new Footer($module).init()
 })

--- a/common/components/footer/footer.js
+++ b/common/components/footer/footer.js
@@ -1,0 +1,37 @@
+function Footer($module) {
+  this.cacheEls($module)
+}
+
+Footer.prototype = {
+  init: function () {
+    this.renderFooter(this.$module)
+  },
+
+  cacheEls: function ($module) {
+    this.$module = $module
+  },
+
+  renderFooter: function ($element) {
+    $element.getElementsByTagName('li').forEach(element => {
+      element.setAttribute(
+        'id',
+        `footer-link-${element.textContent
+          .trim()
+          .split(' ')
+          .join('-')
+          .toLowerCase()}`
+      )
+
+      element.onclick = e => {
+        if (window.gtag) {
+          window.gtag('event', `${element.id}-clicked`, {
+            event_category: 'footer-link-clicked',
+            event_label: `when the ${element.id} is clicked`,
+          })
+        }
+      }
+    })
+  },
+}
+
+module.exports = Footer

--- a/common/components/whats-new-banner/template.njk
+++ b/common/components/whats-new-banner/template.njk
@@ -4,7 +4,7 @@
       <div class="govuk-grid-column-two-thirds">
         <h1 class="govuk-heading-l">{{ params.title }}</h1>
         <p class="govuk-body">{{ params.date }}: {{ params.body }}.<p>
-        <a href="/whats-new" class="govuk-link">Read more about these changes.</a>
+        <a href="/whats-new" id="whats-new-page-link" class="govuk-link">Read more about these changes.</a>
       </div>
       <div class="govuk-grid-column-one-third">
         <a href="#" id="dismiss-banner-button" class="govuk-link dismiss-button">Dismiss</a>

--- a/common/components/whats-new-banner/whats-new-banner.js
+++ b/common/components/whats-new-banner/whats-new-banner.js
@@ -19,6 +19,7 @@ Banner.prototype = {
       this.removeElement($element)
     } else {
       this.dismissBanner(this.$module)
+      this.linkToWhatsNewPageClicked()
     }
   },
 
@@ -29,6 +30,23 @@ Banner.prototype = {
       e.preventDefault()
       this.removeElement($element)
       this.setBannerCookie($element)
+      this.sendEvent(
+        'dismiss-whats-new-banner',
+        'banner-dismissed',
+        'When a user has clicked the dimiss banner button'
+      )
+    }
+  },
+
+  linkToWhatsNewPageClicked: function () {
+    const link = document.getElementById('whats-new-page-link')
+
+    link.onclick = e => {
+      this.sendEvent(
+        'whats-new-banner-call-to-action-link-clicked',
+        'banner-call-to-action-clicked',
+        'When a user has clicked on the read more about these changes banner link'
+      )
     }
   },
 
@@ -66,6 +84,14 @@ Banner.prototype = {
   setBannerCookie: function () {
     const date = this.getContentDate(this.$module)
     document.cookie = 'banner-dismissed' + '=' + date + ';' + ';path=/'
+  },
+  sendEvent: function (eventName, eventCategory, eventLabel) {
+    if (window.gtag) {
+      window.gtag('event', eventName, {
+        event_category: eventCategory,
+        event_label: eventLabel,
+      })
+    }
   },
 }
 

--- a/common/components/whats-new-banner/whats-new-banner.test.js
+++ b/common/components/whats-new-banner/whats-new-banner.test.js
@@ -66,7 +66,7 @@ describe('Whats new banner component', function () {
 
     it('should render read more about these changes link', function () {
       expect($component.html()).to.contain(
-        '<a href="/whats-new" class="govuk-link">Read more about these changes.</a>'
+        '<a href="/whats-new" id="whats-new-page-link" class="govuk-link">Read more about these changes.</a>'
       )
     })
   })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

We have added GA to the banner and footer links to allow us to track user interaction

### Why did it change

To track user interaction

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

- [P4-3459](https://dsdmoj.atlassian.net/browse/P4-3459)