### PR TITLE
Include journey numbers in events

### DIFF
--- a/common/lib/api-client/models/journey.js
+++ b/common/lib/api-client/models/journey.js
@@ -5,6 +5,7 @@ module.exports = {
     vehicle: '',
     timestamp: '',
     date: '',
+    number: '',
     from_location: {
       jsonApi: 'hasOne',
       type: 'locations',

--- a/locales/en/events.json
+++ b/locales/en/events.json
@@ -46,7 +46,7 @@
     "description": "Vehicle {{vehicle_reg}} arrived at outer gate of {{location.title}}"
   },
   "JourneyCancel": {
-    "heading": "Journey cancelled",
+    "heading": "Journey {{journey.number}} cancelled",
     "description": "Journey from {{journey.from_location.title}} to {{journey.to_location.title}} cancelled"
   },
   "JourneyChangeVehicle": {
@@ -54,11 +54,11 @@
     "description": "$t(events::person) moved from {{previous_vehicle_reg}} to {{vehicle_reg}}"
   },
   "JourneyComplete": {
-    "heading": "Journey completed",
+    "heading": "Journey {{journey.number}} completed",
     "description": "Journey from {{journey.from_location.title}} to {{journey.to_location.title}} completed"
   },
   "JourneyCreate": {
-    "heading": "Journey created",
+    "heading": "Journey {{journey.number}} created",
     "description": "Journey from {{journey.from_location.title}} to {{journey.to_location.title}} created by {{supplier.name}}"
   },
   "JourneyExitThroughOuterGate": {
@@ -86,23 +86,23 @@
     "description": "Escort vehicle {{vehicle_reg}} boarding complete, ready to exit from {{journey.from_location.title}}"
   },
   "JourneyReject": {
-    "heading": "Journey rejected",
+    "heading": "Journey {{journey.number}} rejected",
     "description": "Journey from {{journey.from_location.title}} to {{journey.to_location.title}} rejected by {{move.supplier.name}}"
   },
   "JourneyStart": {
-    "heading": "Journey started",
+    "heading": "Journey {{journey.number}} started",
     "description": "Journey from {{journey.from_location.title}} to {{journey.to_location.title}} started by {{move.supplier.name}}"
   },
   "JourneyUpdate": {
-    "heading": "Journey updated by {{supplier.name}}",
+    "heading": "Journey {{journey.number}} updated by {{supplier.name}}",
     "description": ""
   },
   "JourneyUncancel": {
-    "heading": "Journey uncancelled",
+    "heading": "Journey {{journey.number}} uncancelled",
     "description": "Cancelled Journey from {{journey.from_location.title}} to {{journey.to_location.title}} revoked by {{move.supplier.name}}"
   },
   "JourneyUncomplete": {
-    "heading": "Journey uncompleted",
+    "heading": "Journey {{journey.number}} uncompleted",
     "description": "Completed Journey from {{journey.from_location.title}} to {{journey.to_location.title}} revoked by {{move.supplier.name}}"
   },
   "MoveDateChanged": {


### PR DESCRIPTION
This is to make it clearer which journey events are associated with which journeys.

Depends on https://github.com/ministryofjustice/hmpps-book-secure-move-api/pull/1787.

[Jira Ticket](https://dsdmoj.atlassian.net/browse/P4-3345)

## Screenshots

### Old

![Screenshot 2022-03-17 at 10 55 43](https://user-images.githubusercontent.com/510498/158794772-06a4374f-2174-4941-a430-081be09f36f0.png)

### New

![Screenshot 2022-03-17 at 10 55 38](https://user-images.githubusercontent.com/510498/158794761-80b45ca9-a9d6-4d53-b256-945a6fa2dbe1.png)