### PR TITLE
Include property change events in move overview

### DIFF
--- a/common/helpers/events/get-event-classification.js
+++ b/common/helpers/events/get-event-classification.js
@@ -1,5 +1,10 @@
 const getEventClassification = event => {
-  const { classification } = event
+  const { event_type: eventType, classification } = event
+
+  if (eventType === 'PerPropertyChange') {
+    return classification
+  }
+
   return classification && classification !== 'default'
     ? classification
     : undefined

--- a/common/helpers/events/get-event-classification.test.js
+++ b/common/helpers/events/get-event-classification.test.js
@@ -19,6 +19,11 @@ describe('Helpers', function () {
       ...mockEvent,
       classification: 'incident',
     }
+    const mockEventWithPropertyChangeEventType = {
+      ...mockEvent,
+      event_type: 'PerPropertyChange',
+      classification: 'default',
+    }
 
     describe('#getEventClassification', function () {
       let classification
@@ -67,6 +72,19 @@ describe('Helpers', function () {
 
         it('should return expected classification', function () {
           expect(classification).to.deep.equal('incident')
+        })
+      })
+
+      context('when event has property change event type', function () {
+        beforeEach(function () {
+          classification = getEventClassification(
+            mockEventWithPropertyChangeEventType
+          )
+        })
+
+        it('should return expected classification', function () {
+          classification
+          expect(classification).to.deep.equal('default')
         })
       })
     })

--- a/common/helpers/events/get-header-classes.js
+++ b/common/helpers/events/get-header-classes.js
@@ -11,6 +11,8 @@ const getHeaderClasses = event => {
 
   if (classification === 'incident') {
     headerClasses += ' app-tag--destructive'
+  } else if (classification === 'default') {
+    headerClasses += ' app-tag--inactive'
   }
 
   return headerClasses

--- a/common/helpers/events/get-header-classes.test.js
+++ b/common/helpers/events/get-header-classes.test.js
@@ -19,6 +19,11 @@ describe('Helpers', function () {
       ...mockEvent,
       classification: 'incident',
     }
+    const mockEventWithPropertyChangeEventType = {
+      ...mockEvent,
+      event_type: 'PerPropertyChange',
+      classification: 'default',
+    }
 
     describe('#getHeaderClasses', function () {
       let headerClasses
@@ -60,6 +65,16 @@ describe('Helpers', function () {
 
         it('should return expected classes', function () {
           expect(headerClasses).to.deep.equal('app-tag app-tag--destructive')
+        })
+      })
+
+      context('when event has property change event type', function () {
+        beforeEach(function () {
+          headerClasses = getHeaderClasses(mockEventWithPropertyChangeEventType)
+        })
+
+        it('should return expected classes', function () {
+          expect(headerClasses).to.deep.equal('app-tag app-tag--inactive')
         })
       })
     })

--- a/common/lib/api-client/transformers/move.transformer.js
+++ b/common/lib/api-client/transformers/move.transformer.js
@@ -42,7 +42,9 @@ const addImportantEvents = data => {
     get(data, 'timeline_events.length')
   ) {
     data.important_events = data.timeline_events.filter(
-      ({ classification }) => classification && classification !== 'default'
+      ({ event_type: eventType, classification }) =>
+        eventType === 'PerPropertyChange' ||
+        (classification && classification !== 'default')
     )
   }
 }

--- a/common/presenters/move-to-in-transit-events-panel-list.js
+++ b/common/presenters/move-to-in-transit-events-panel-list.js
@@ -15,8 +15,11 @@ function toPanelList(events, move) {
 
 module.exports = function (move = {}) {
   const { timeline_events: timelineEvents = [] } = move
+
   const importantEvents = timelineEvents.filter(
-    ({ classification }) => classification === 'incident'
+    ({ event_type: eventType, classification }) =>
+      eventType === 'PerPropertyChange' || classification === 'incident'
   )
+
   return toPanelList(importantEvents, move)
 }

--- a/locales/en/events.json
+++ b/locales/en/events.json
@@ -30,6 +30,7 @@
   "no_events": "No events",
   "person": "{{person._fullname}}",
   "classification": {
+    "default": "Incident",
     "incident": "Serious incident",
     "medical": "Medical incident"
   },

--- a/locales/en/events.json
+++ b/locales/en/events.json
@@ -348,6 +348,10 @@
     "subtype_additional_clothing": "additional clothing",
     "subtype_relevant_information_given": "relevant information"
   },
+  "PerPropertyChange": {
+    "heading": "Property change",
+    "description": "{{notes}}"
+  },
   "PersonMoveAssault": {
     "flag": "red",
     "heading": "Assault occurred",


### PR DESCRIPTION
We'd like to include these events as important events that happen during a move. Since these events are not classified as incidents, the code had to be changed slightly to support these.

The code is a little messy, as it doesn't actually rely on the important events field as its returned from the API, but I think refactoring this is for a different time.

[Jira Ticket](https://dsdmoj.atlassian.net/browse/P4-3519)

## Screenshots

![Screenshot 2022-03-18 at 11 01 23](https://user-images.githubusercontent.com/510498/158991567-5baff7a3-ed5c-497a-adea-fd3d15626bd2.png)

![Screenshot 2022-03-18 at 11 02 08](https://user-images.githubusercontent.com/510498/158991631-00a34cb0-1c5a-4773-bf44-bc0e74fc9d6d.png)