### PR TITLE
feat: Fix headings used for styling

### DIFF
--- a/common/components/message/template.njk
+++ b/common/components/message/template.njk
@@ -12,9 +12,15 @@
   {% if params.title.html or params.title.text %}aria-labelledby="app-message__heading"{% endif %}
   >
   {% if params.title.html or params.title.text %}
-    <h2 class="app-message__heading" id="app-message__heading">
-      {{ params.title.html | safe if params.title.html else params.title.text }}
-    </h2>
+    {% if params.content.html or params.content.text %}
+      <h2 class="app-message__heading" id="app-message__heading">
+        {{ params.title.html | safe if params.title.html else params.title.text }}
+      </h2>
+    {% else %}
+      <span class="app-message__heading" id="app-message__heading">
+        {{ params.title.html | safe if params.title.html else params.title.text }}
+      </span>
+    {% endif %}
   {% endif %}
 
   {% if params.content.html or params.content.text %}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

<!--- Describe the changes in detail - the "what"-->

The `Message` component has been changed to only use a h2 title if there's content to be displayed under it.

### Why did it change

<!--- Describe the reason these changes were made - the "why" -->

This came up in the accessibility audit, the auditors stated: "This text has been marked up as a level 2 heading, and does not provide the purpose of a heading, and does not introduce any content or information. For users of screen reading assistive technologies, this can be misleading when not encountering any information after the heading."

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

- P4-3548

## Screenshots
<!--- (Optional) Include screenshots if changes update interfaces or components -->
<!--- Delete/copy as appropriate --->

No visible changes.

## Checklists

### Testing

#### Automated testing

- [ ] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [ ] Chrome
- [x] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed
