### PR TITLE
Add lockout warning to listing

### DIFF
--- a/app/moves/middleware/set-results.moves.js
+++ b/app/moves/middleware/set-results.moves.js
@@ -14,6 +14,12 @@ function setResultsMoves(bodyKey, locationKey) {
       const args = omitBy(req.body[bodyKey], isUndefined)
       const activeMoves = await req.services.move.getActive(args)
 
+      for (let i = 0; i < activeMoves.length; i++) {
+        const move = activeMoves[i]
+        const eventsForMove = await req.services.move.getByIdWithEvents(move.id)
+        move.timeline_events = eventsForMove.timeline_events
+      }
+
       if (groupBy === 'vehicle') {
         req.resultsAsCards = presenters.movesByVehicle({
           moves: activeMoves,

--- a/app/moves/middleware/set-results.moves.test.js
+++ b/app/moves/middleware/set-results.moves.test.js
@@ -8,6 +8,8 @@ const mockActiveMoves = [
   { id: '3', foo: 'bar', status: 'completed' },
   { id: '4', fizz: 'buzz', status: 'completed' },
 ]
+
+const mockActiveEvents = []
 const mockBodyKey = 'outgoing'
 const mockLocationKey = 'from_location'
 const errorStub = new Error('Problem')
@@ -19,6 +21,7 @@ describe('Moves middleware', function () {
     beforeEach(function () {
       moveService = {
         getActive: sinon.stub(),
+        getByIdWithEvents: sinon.stub(),
       }
       moveToCardComponentMapStub = sinon.stub().returnsArg(0)
       sinon.stub(presenters, 'movesByVehicle').returnsArg(0)
@@ -49,6 +52,7 @@ describe('Moves middleware', function () {
     context('when API call returns successfully', function () {
       beforeEach(function () {
         moveService.getActive.resolves(mockActiveMoves)
+        moveService.getByIdWithEvents.resolves(mockActiveEvents)
       })
 
       context('without current location', function () {

--- a/common/components/card/_card.scss
+++ b/common/components/card/_card.scss
@@ -135,3 +135,7 @@ $_image-height: 100px;
     margin-top: govuk-spacing(1);
   }
 }
+
+.card-warning-text {
+  padding-top: 15px
+}

--- a/common/components/card/template.njk
+++ b/common/components/card/template.njk
@@ -1,6 +1,7 @@
 {% from "tag/macro.njk" import appTag %}
 {% from "moj/components/badge/macro.njk" import mojBadge %}
 {% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
+{% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
 
 {% set headingLevel = params.headingLevel if params.headingLevel else 2 %}
 
@@ -68,5 +69,15 @@
     {% if params.insetText %}
       {{ govukInsetText(params.insetText) }}
     {% endif %}
+
+    {% if params.isLockOut %}
+      <div class="card-warning-text">
+        {{ govukWarningText({
+          text: "Prison lockout",
+          iconFallbackText: "Warning"
+        }) }}
+      </div>
+    {% endif %}
+
   </div>
 </div>

--- a/common/presenters/move-to-card-component.js
+++ b/common/presenters/move-to-card-component.js
@@ -9,6 +9,7 @@ function moveToCardComponent({
   showMeta = true,
   showTags = true,
   showStatus = true,
+  showIsALockout = false,
   showToLocation = false,
   showFromLocation = false,
   hrefSuffix = '',
@@ -44,6 +45,17 @@ function moveToCardComponent({
       })
     }
 
+    if (move.timeline_events) {
+      for (let i = 0; i < move.timeline_events.length; i++) {
+        const eventType = move.timeline_events[i].event_type
+
+        if (eventType === 'MoveLockout') {
+          showIsALockout = true
+          break
+        }
+      }
+    }
+
     const showStatusBadge =
       showStatus && !excludedBadgeStatuses.includes(status) && !isCompact
     const statusBadge = showStatusBadge
@@ -73,6 +85,7 @@ function moveToCardComponent({
     return {
       ...personCardComponent,
       status: statusBadge,
+      isLockOut: showIsALockout,
       classes: isCompact
         ? `app-card--compact ${personCardComponent.classes || ''}`
         : personCardComponent.classes || '',

--- a/common/presenters/move-to-card-component.test.js
+++ b/common/presenters/move-to-card-component.test.js
@@ -78,6 +78,7 @@ describe('Presenters', function () {
               status: {
                 text: '__translated__',
               },
+              isLockOut: false,
               caption: undefined,
               tags: [{ items: 'moveToImportantEventsTagListComponent' }],
             })
@@ -270,6 +271,42 @@ describe('Presenters', function () {
           classes: 'app-card--compact ',
           status: undefined,
           caption: undefined,
+          isLockOut: false,
+        })
+      })
+    })
+
+    context('with lockout enabled', function () {
+      beforeEach(function () {
+        transformedResponse = moveToCardComponent({
+          showIsALockout: true,
+        })(mockMove)
+      })
+
+      it('should call profile to card component correctly', function () {
+        expect(profileToCardComponentItemStub).to.be.calledWithExactly({
+          profile: mockMove.profile,
+          href: '/move/12345',
+          reference: 'AB12FS45',
+        })
+        expect(profileToCardComponentStub).to.be.calledWithExactly({
+          locationType: undefined,
+          meta: [],
+          showImage: false,
+          showMeta: false,
+          showTags: false,
+        })
+      })
+      it('should contain correct output', function () {
+        expect(transformedResponse).to.deep.equal({
+          ...mockPersonCardComponent,
+          classes: '',
+          status: {
+            text: '__translated__',
+          },
+          tags: [{ items: 'moveToImportantEventsTagListComponent' }],
+          caption: undefined,
+          isLockOut: true,
         })
       })
     })
@@ -305,6 +342,7 @@ describe('Presenters', function () {
           classes: 'app-card--compact ',
           status: undefined,
           caption: undefined,
+          isLockOut: false,
         })
       })
     })
@@ -332,6 +370,7 @@ describe('Presenters', function () {
             classes: '',
             status: undefined,
             caption: undefined,
+            isLockOut: false,
             tags: [{ items: 'moveToImportantEventsTagListComponent' }],
           })
         })
@@ -367,6 +406,7 @@ describe('Presenters', function () {
             classes: `app-card--compact ${mockClasses}`,
             status: undefined,
             caption: undefined,
+            isLockOut: false,
           })
         })
       })
@@ -380,6 +420,7 @@ describe('Presenters', function () {
           expect(transformedResponse).to.deep.equal({
             ...mockPersonCardComponent,
             classes: mockClasses,
+            isLockOut: false,
             status: {
               text: '__translated__',
             },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

When the move has an event of `MoveLockout` present in its `timeline_events` we show a warning message.

### Why did it change

So we can show the user that a move is locked out

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

- [P4-3340](https://dsdmoj.atlassian.net/browse/P4-3340)

## Screenshots
<!--- (Optional) Include screenshots if changes update interfaces or components -->
<!--- Delete/copy as appropriate --->

<img width="1074" alt="Screenshot 2022-03-24 at 15 22 58" src="https://user-images.githubusercontent.com/40758489/159950631-88dda088-636a-4e0c-a05d-5195d30ab82b.png">

