### PR TITLE
Change flag colour of 'DEATH IN CUSTODY' from red to grey

### DIFF
--- a/common/helpers/events/get-event-classification.js
+++ b/common/helpers/events/get-event-classification.js
@@ -5,6 +5,10 @@ const getEventClassification = event => {
     return classification
   }
 
+  if (eventType === 'PersonMoveDeathInCustody') {
+    return 'default'
+  }
+
   return classification && classification !== 'default'
     ? classification
     : undefined

--- a/common/helpers/events/get-event-classification.test.js
+++ b/common/helpers/events/get-event-classification.test.js
@@ -24,6 +24,11 @@ describe('Helpers', function () {
       event_type: 'PerPropertyChange',
       classification: 'default',
     }
+    const mockEventWithMoveDeathInCustodyEventType = {
+      id: 'eventId',
+      details: 'details',
+      event_type: 'PersonMoveDeathInCustody',
+    }
 
     describe('#getEventClassification', function () {
       let classification
@@ -83,6 +88,19 @@ describe('Helpers', function () {
         })
 
         it('should return expected classification', function () {
+          classification
+          expect(classification).to.deep.equal('default')
+        })
+      })
+
+      context('when event_type is PersonMoveDeathInCustody', function () {
+        beforeEach(function () {
+          classification = getEventClassification(
+            mockEventWithMoveDeathInCustodyEventType
+          )
+        })
+
+        it('should return default classification', function () {
           classification
           expect(classification).to.deep.equal('default')
         })

--- a/locales/en/events.json
+++ b/locales/en/events.json
@@ -362,7 +362,7 @@
     "description": ""
   },
   "PersonMoveDeathInCustody": {
-    "flag": "red",
+    "flag": "grey",
     "heading": "Death in custody",
     "description": "{{supplier_personnel_numbers, oxfordJoin}} reported a death in custody at {{reported_at, formatTime}} at {{location.title}}<br>$t(events::select_fault_classification)<br>$t(events::select_incident_vehicle)"
   },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

When an `event_type` is `PersonMoveDeathInCustody` we use the `app-tag--inactive` class instead of the `app-tag--destructive` class

### Why did it change

The purpose of this to change the colour of the flag ‘DEATH IN CUSTODY’ from red to grey. This is because it is **NOT** a risk, but rather ‘general information’.


### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

- [P4-3520](https://dsdmoj.atlassian.net/browse/P4-3520)

## Screenshots
<!--- (Optional) Include screenshots if changes update interfaces or components -->
<!--- Delete/copy as appropriate --->

<img width="1192" alt="Screenshot 2022-03-29 at 11 46 57" src="https://user-images.githubusercontent.com/40758489/160597124-6e7a04c8-8aca-4e5d-b416-31b2ab9866c1.png">
<img width="1153" alt="Screenshot 2022-03-29 at 11 47 23" src="https://user-images.githubusercontent.com/40758489/160597133-c3fecd4d-2314-4151-85bb-a5bda7c86389.png">

