### PR TITLE
Add breadcrumbs to moves dashboard

### DIFF
--- a/app/move/app/view/middleware/set-breadcrumb.js
+++ b/app/move/app/view/middleware/set-breadcrumb.js
@@ -1,6 +1,27 @@
+const i18n = require('../../../../../config/i18n')
+const movesApp = require('../../../../moves')
+
+function dashboardBreadcrumbTextContext(movesUrl) {
+  if (movesUrl.includes('/outgoing')) {
+    return 'outgoing_moves'
+  } else if (movesUrl.includes('/incoming')) {
+    return 'incoming_moves'
+  } else if (movesUrl.includes('/requested')) {
+    return 'single_requests'
+  }
+}
+
 function setBreadcrumb(req, res, next) {
   const { profile, reference } = req.move || {}
   const name = profile?.person?._fullname
+  const movesUrl = req.session?.movesUrl || movesApp.mountpath
+
+  res.breadcrumb({
+    text: i18n.t('collections::page_title', {
+      context: dashboardBreadcrumbTextContext(movesUrl),
+    }),
+    href: movesUrl,
+  })
 
   if (reference) {
     res.breadcrumb({

--- a/app/move/app/view/middleware/set-breadcrumb.test.js
+++ b/app/move/app/view/middleware/set-breadcrumb.test.js
@@ -12,6 +12,7 @@ describe('Move view app', function () {
             id: '12345',
             reference: 'ABCDEF',
           },
+          session: {},
         }
         res = {
           breadcrumb: sinon.spy(),
@@ -29,8 +30,15 @@ describe('Move view app', function () {
           middleware(req, res, nextSpy)
         })
 
-        it('should set breadcrumb', function () {
-          expect(res.breadcrumb).to.calledOnceWithExactly({
+        it('should set master breadcrumb', function () {
+          expect(res.breadcrumb).to.calledWithExactly({
+            text: 'Results',
+            href: '/moves',
+          })
+        })
+
+        it('should set detail breadcrumb', function () {
+          expect(res.breadcrumb).to.calledWithExactly({
             text: 'DOE, JOHN (ABCDEF)',
             href: '/base-url',
           })
@@ -47,8 +55,15 @@ describe('Move view app', function () {
           middleware(req, res, nextSpy)
         })
 
+        it('should set master breadcrumb', function () {
+          expect(res.breadcrumb).to.calledWithExactly({
+            text: 'Results',
+            href: '/moves',
+          })
+        })
+
         it('should set breadcrumb', function () {
-          expect(res.breadcrumb).to.calledOnceWithExactly({
+          expect(res.breadcrumb).to.calledWithExactly({
             text: 'ABCDEF',
             href: '/base-url',
           })
@@ -65,8 +80,65 @@ describe('Move view app', function () {
           middleware(req, res, nextSpy)
         })
 
-        it('should set breadcrumb', function () {
-          expect(res.breadcrumb).not.to.be.called
+        it('should set master breadcrumb', function () {
+          expect(res.breadcrumb).to.calledOnceWithExactly({
+            text: 'Results',
+            href: '/moves',
+          })
+        })
+
+        it('should call next', function () {
+          expect(nextSpy).to.be.calledOnceWithExactly()
+        })
+      })
+
+      context('with outgoing dashboard', function () {
+        beforeEach(function () {
+          req.session.movesUrl = '/moves/outgoing'
+          middleware(req, res, nextSpy)
+        })
+
+        it('should set master breadcrumb', function () {
+          expect(res.breadcrumb).to.calledWithExactly({
+            text: 'Outgoing moves',
+            href: '/moves/outgoing',
+          })
+        })
+
+        it('should call next', function () {
+          expect(nextSpy).to.be.calledOnceWithExactly()
+        })
+      })
+
+      context('with incoming dashboard', function () {
+        beforeEach(function () {
+          req.session.movesUrl = '/moves/incoming'
+          middleware(req, res, nextSpy)
+        })
+
+        it('should set master breadcrumb', function () {
+          expect(res.breadcrumb).to.calledWithExactly({
+            text: 'Incoming moves',
+            href: '/moves/incoming',
+          })
+        })
+
+        it('should call next', function () {
+          expect(nextSpy).to.be.calledOnceWithExactly()
+        })
+      })
+
+      context('with single requests dashboard', function () {
+        beforeEach(function () {
+          req.session.movesUrl = '/moves/requested'
+          middleware(req, res, nextSpy)
+        })
+
+        it('should set master breadcrumb', function () {
+          expect(res.breadcrumb).to.calledWithExactly({
+            text: 'Single requests',
+            href: '/moves/requested',
+          })
         })
 
         it('should call next', function () {

--- a/app/move/app/view/views/_layout.njk
+++ b/app/move/app/view/views/_layout.njk
@@ -17,16 +17,6 @@
   </section>
 {% endmacro %}
 
-{% block breadcrumbs %}
-  <div class="govuk-width-container">
-    {{ govukBackLink({
-      text: t("actions::back_to_dashboard"),
-      classes: "app-print--hide",
-      href: MOVES_URL
-    }) }}
-  </div>
-{% endblock %}
-
 {% block content %}
   {% if messageBanner %}
     <div class="govuk-!-margin-bottom-5">

--- a/common/templates/layouts/base.njk
+++ b/common/templates/layouts/base.njk
@@ -137,20 +137,18 @@
     {% endif %}
   {% endblock %}
 
-  {% block breadcrumbs %}
-    {% set breadcrumbs = getBreadcrumbs() %}
-    {% if breadcrumbs|length > 1 %}
-      <div class="govuk-width-container">
-        {{ govukBreadcrumbs({
-          items: breadcrumbs,
-          attributes: {
-            'data-auto-id': 'breadcrumbs'
-          }
-        }) }}
-      </div>
-    {% endif %}
-  {% endblock %}
-  
+  {% set breadcrumbs = getBreadcrumbs() %}
+  {% if breadcrumbs|length > 1 %}
+    <div class="govuk-width-container">
+      {{ govukBreadcrumbs({
+        items: breadcrumbs,
+        attributes: {
+          'data-auto-id': 'breadcrumbs'
+        }
+      }) }}
+    </div>
+  {% endif %}
+
   {% if FEATURE_FLAGS.WHATS_NEW_BANNER and REQUEST_PATH === '/' and whatsNewContent %}
     {{ appWhatsNewBanner(whatsNewContent.bannerContent) }}
   {% endif %}


### PR DESCRIPTION
This adds a breadcrumb item to allow the user to go back to the moves dashboard they were on before viewing the move. This replaces #2211.

## Screenshots

### Old

![Screenshot 2022-03-30 at 14 17 38](https://user-images.githubusercontent.com/510498/160843867-bcddceb0-f3a0-4d59-aea4-6caa18aece13.png)

### New

![Screenshot 2022-03-30 at 13 38 43](https://user-images.githubusercontent.com/510498/160843896-496c5f55-466b-4fc1-b5d6-d7a67f109f03.png)
![Screenshot 2022-03-30 at 13 39 31](https://user-images.githubusercontent.com/510498/160843900-9360c60c-fdd0-4bcc-bf4e-c05cb5b1bfac.png)
![Screenshot 2022-03-30 at 13 39 46](https://user-images.githubusercontent.com/510498/160843903-eab98528-4a63-41c8-9fc8-6407701f8ca7.png)
