### PR TITLE
Ensure label is found when adding another

### DIFF
--- a/common/components/add-another/add-another.js
+++ b/common/components/add-another/add-another.js
@@ -17,12 +17,17 @@ MOJFrontend.AddAnother.prototype.onRemoveButtonClick = function (e) {
 
 MOJFrontend.AddAnother.prototype.updateAttributes = function (index, item) {
   item.find('[data-name]').each(function (i, el) {
+    var originalId = el.id
+
     const $el = $(el)
     el.name = $el.attr('data-name').replace(/%index%/, index)
     el.id = $el.attr('data-id').replace(/%index%/, index)
 
     // Book a secure move changes to this method from here
-    const label = $el.siblings('label')[0] || $el.parents('label')[0]
+    const label =
+      $el.siblings('label')[0] ||
+      $el.parents('label')[0] ||
+      item.find('[for="' + originalId + '"]')[0]
 
     if (label) {
       label.htmlFor = el.id


### PR DESCRIPTION
This copies the fix from MoJ Frontend (https://github.com/ministryofjustice/moj-frontend/pull/186) in to our own copy of the library, see details on that original PR for what the issue is and why this fixes it.

Ideally, we wouldn't have customised this component so much that upstream fixes are applied downstream, but for now at least this fixes the bug.

[Jira Ticket](https://dsdmoj.atlassian.net/browse/P4-3549)