### PR TITLE
Update identity bar at relevant points in the move

### DIFF
--- a/app/move/app/view/index.js
+++ b/app/move/app/view/index.js
@@ -8,6 +8,7 @@ const {
   setMoveWithEvents,
   setPersonEscortRecord,
   setYouthRiskAssessment,
+  setJourneys,
 } = require('../../middleware')
 
 const {
@@ -17,6 +18,7 @@ const {
 } = require('./controllers')
 const {
   localsActions,
+  localsIdentityBarJourneys,
   localsIdentityBar,
   localsMessageBanner,
   localsMoveDetails,
@@ -39,10 +41,12 @@ router.use(/\/(timeline|warnings).*/, setMoveWithEvents)
 router.use(breadcrumbs.setHome())
 router.use(setPersonEscortRecord)
 router.use(setYouthRiskAssessment)
+router.use(setJourneys)
 router.use(setBreadcrumb)
 router.use(localsUrls)
 router.use(localsActions)
 router.use(localsIdentityBar)
+router.use(localsIdentityBarJourneys)
 router.use(localsMessageBanner)
 router.use(localsMoveDetails)
 router.use(localsPersonSummary)

--- a/app/move/app/view/middleware/index.js
+++ b/app/move/app/view/middleware/index.js
@@ -1,5 +1,6 @@
 const localsActions = require('./locals.actions')
 const localsIdentityBar = require('./locals.identity-bar')
+const localsIdentityBarJourneys = require('./locals.identity-bar-journeys')
 const localsMessageBanner = require('./locals.message-banner')
 const localsMoveDetails = require('./locals.move-details')
 const localsPersonSummary = require('./locals.person-summary')
@@ -11,6 +12,7 @@ const setBreadcrumb = require('./set-breadcrumb')
 module.exports = {
   localsActions,
   localsIdentityBar,
+  localsIdentityBarJourneys,
   localsMessageBanner,
   localsMoveDetails,
   localsPersonSummary,

--- a/app/move/app/view/middleware/locals.identity-bar-journeys.js
+++ b/app/move/app/view/middleware/locals.identity-bar-journeys.js
@@ -1,0 +1,45 @@
+const filters = require('../../../../../config/nunjucks/filters')
+const formatSummary = moveOrJourney => ({
+  context: moveOrJourney.status,
+  date: filters.formatDate(moveOrJourney.date),
+  fromLocation: moveOrJourney.from_location?.title,
+  toLocation: moveOrJourney.to_location?.title,
+})
+const formatMoveLockOutSummary = move => [
+  {
+    fromLocation: move.from_location?.title,
+    toLocation: '(awaiting destination)',
+    date: filters.formatDate(move.date),
+  },
+  {
+    fromLocation: '(awaiting location)',
+    toLocation: move.to_location?.title,
+    date: '(awaiting date)',
+  },
+]
+
+function identityBarJourneys(req, res, next) {
+  const { move, journeys } = req
+
+  if (!move || !journeys) {
+    return next()
+  }
+
+  const hasJourneysOnDifferentDay =
+    journeys.filter(({ date }) => date !== move.date).length !== 0
+
+  if (hasJourneysOnDifferentDay) {
+    res.locals.identityBar.journeys = journeys.map(journey =>
+      formatSummary(journey)
+    )
+  } else if (move.is_lockout) {
+    res.locals.identityBar.journeys = formatMoveLockOutSummary(move)
+  } else {
+    res.locals.identityBar.journeys = [formatSummary(move)]
+  }
+
+  delete res.locals.identityBar.summary
+  next()
+}
+
+module.exports = identityBarJourneys

--- a/app/move/app/view/middleware/locals.identity-bar-journeys.test.js
+++ b/app/move/app/view/middleware/locals.identity-bar-journeys.test.js
@@ -1,0 +1,307 @@
+const middleware = require('./locals.identity-bar-journeys')
+
+describe('Move view app', function () {
+  describe('Middleware', function () {
+    describe('#localsIdentityBarJourneys()', function () {
+      let req, res, nextSpy
+
+      beforeEach(function () {
+        req = {
+          t: sinon.stub().returnsArg(0),
+        }
+        res = {
+          locals: { identityBar: {} },
+        }
+        nextSpy = sinon.spy()
+      })
+
+      context(
+        'when there are journeys and the move is not locked out and the journey dates are not the same as the move date',
+        function () {
+          beforeEach(function () {
+            req.move = {
+              id: '12345',
+              reference: 'AB1234XY',
+              date: '2020-10-07',
+              status: 'requested',
+              is_lockout: false,
+              profile: {
+                person: {
+                  _fullname: 'DOE, JOHN',
+                },
+              },
+              from_location: {
+                title: 'Guildford Custody Suite',
+              },
+              to_location: {
+                title: 'HMP Brixton',
+              },
+              foo: 'bar',
+            }
+
+            req.journeys = [
+              {
+                id: '544328e8-677a-4318-a59f-6f7d421d2cc2',
+                type: 'journeys',
+                state: 'completed',
+                billable: true,
+                vehicle: { id: '8619', fake: true, registration: 'QRD-6' },
+                date: '2021-01-13',
+                number: 1,
+                timestamp: '2021-01-11T09:00:00+00:00',
+                from_location: {
+                  id: '54b75c66-61dd-440e-be3d-b3c58c90be1d',
+                  type: 'locations',
+                  key: 'wyi',
+                  title: 'WETHERBY (HMPYOI)',
+                  location_type: 'prison',
+                  nomis_agency_id: 'WYI',
+                  can_upload_documents: false,
+                  young_offender_institution: true,
+                  premise: 'IlHchsRIlHchsR',
+                  locality: null,
+                  city: 'Wetherby',
+                  country: 'England',
+                  postcode: 'UO11 5VE',
+                  latitude: 53.935249,
+                  longitude: -1.36782,
+                  disabled_at: null,
+                },
+                to_location: {
+                  id: '496795c5-a6ca-4c80-b2cd-908ccd922fd3',
+                  type: 'locations',
+                  key: 'dcp009',
+                  title: 'Exeter Probation Office',
+                  location_type: 'probation_office',
+                  nomis_agency_id: 'DCP009',
+                  can_upload_documents: false,
+                  young_offender_institution: false,
+                  premise: null,
+                  locality: null,
+                  city: null,
+                  country: null,
+                  postcode: 'EX1 1RD',
+                  latitude: 50.72293,
+                  longitude: -3.524391,
+                  disabled_at: null,
+                },
+              },
+            ]
+
+            middleware(req, res, nextSpy)
+          })
+
+          it('should call next', function () {
+            expect(nextSpy).to.be.calledOnceWithExactly()
+          })
+
+          it('will show the journeys,', function () {
+            expect(res.locals.identityBar.journeys).to.deep.equal([
+              {
+                context: undefined,
+                date: '13 Jan 2021',
+                fromLocation: 'WETHERBY (HMPYOI)',
+                toLocation: 'Exeter Probation Office',
+              },
+            ])
+          })
+        }
+      )
+
+      context(
+        'when there are journeys and the move is locked out',
+        function () {
+          beforeEach(function () {
+            req.move = {
+              id: '12345',
+              reference: 'AB1234XY',
+              date: '2020-10-07',
+              status: 'requested',
+              is_lockout: true,
+              profile: {
+                person: {
+                  _fullname: 'DOE, JOHN',
+                },
+              },
+              from_location: {
+                title: 'Guildford Custody Suite',
+              },
+              to_location: {
+                title: 'HMP Brixton',
+              },
+              foo: 'bar',
+            }
+
+            req.journeys = [
+              {
+                id: '544328e8-677a-4318-a59f-6f7d421d2cc2',
+                type: 'journeys',
+                state: 'completed',
+                billable: true,
+                vehicle: { id: '8619', fake: true, registration: 'QRD-6' },
+                date: '2020-10-07',
+                number: 1,
+                timestamp: '2021-01-11T09:00:00+00:00',
+                from_location: {
+                  id: '54b75c66-61dd-440e-be3d-b3c58c90be1d',
+                  type: 'locations',
+                  key: 'wyi',
+                  title: 'WETHERBY (HMPYOI)',
+                  location_type: 'prison',
+                  nomis_agency_id: 'WYI',
+                  can_upload_documents: false,
+                  young_offender_institution: true,
+                  premise: 'IlHchsRIlHchsR',
+                  locality: null,
+                  city: 'Wetherby',
+                  country: 'England',
+                  postcode: 'UO11 5VE',
+                  latitude: 53.935249,
+                  longitude: -1.36782,
+                  disabled_at: null,
+                },
+                to_location: {
+                  id: '496795c5-a6ca-4c80-b2cd-908ccd922fd3',
+                  type: 'locations',
+                  key: 'dcp009',
+                  title: 'Exeter Probation Office',
+                  location_type: 'probation_office',
+                  nomis_agency_id: 'DCP009',
+                  can_upload_documents: false,
+                  young_offender_institution: false,
+                  premise: null,
+                  locality: null,
+                  city: null,
+                  country: null,
+                  postcode: 'EX1 1RD',
+                  latitude: 50.72293,
+                  longitude: -3.524391,
+                  disabled_at: null,
+                },
+              },
+            ]
+
+            middleware(req, res, nextSpy)
+          })
+
+          it('will show the move from/to locations,', function () {
+            expect(res.locals.identityBar.journeys).to.deep.equal([
+              {
+                date: '7 Oct 2020',
+                fromLocation: 'Guildford Custody Suite',
+                toLocation: '(awaiting destination)',
+              },
+              {
+                date: '(awaiting date)',
+                fromLocation: '(awaiting location)',
+                toLocation: 'HMP Brixton',
+              },
+            ])
+          })
+        }
+      )
+
+      context(
+        'when there are journeys and the move is not locked out and the move date is the same as the journey dates',
+        function () {
+          beforeEach(function () {
+            req.move = {
+              id: '12345',
+              reference: 'AB1234XY',
+              date: '2020-10-07',
+              status: 'requested',
+              is_lockout: false,
+              profile: {
+                person: {
+                  _fullname: 'DOE, JOHN',
+                },
+              },
+              from_location: {
+                title: 'Guildford Custody Suite',
+              },
+              to_location: {
+                title: 'HMP Brixton',
+              },
+              foo: 'bar',
+            }
+
+            req.journeys = [
+              {
+                id: '544328e8-677a-4318-a59f-6f7d421d2cc2',
+                type: 'journeys',
+                state: 'completed',
+                billable: true,
+                vehicle: { id: '8619', fake: true, registration: 'QRD-6' },
+                date: '2020-10-07',
+                number: 1,
+                timestamp: '2021-01-11T09:00:00+00:00',
+                from_location: {
+                  id: '54b75c66-61dd-440e-be3d-b3c58c90be1d',
+                  type: 'locations',
+                  key: 'wyi',
+                  title: 'WETHERBY (HMPYOI)',
+                  location_type: 'prison',
+                  nomis_agency_id: 'WYI',
+                  can_upload_documents: false,
+                  young_offender_institution: true,
+                  premise: 'IlHchsRIlHchsR',
+                  locality: null,
+                  city: 'Wetherby',
+                  country: 'England',
+                  postcode: 'UO11 5VE',
+                  latitude: 53.935249,
+                  longitude: -1.36782,
+                  disabled_at: null,
+                },
+                to_location: {
+                  id: '496795c5-a6ca-4c80-b2cd-908ccd922fd3',
+                  type: 'locations',
+                  key: 'dcp009',
+                  title: 'Exeter Probation Office',
+                  location_type: 'probation_office',
+                  nomis_agency_id: 'DCP009',
+                  can_upload_documents: false,
+                  young_offender_institution: false,
+                  premise: null,
+                  locality: null,
+                  city: null,
+                  country: null,
+                  postcode: 'EX1 1RD',
+                  latitude: 50.72293,
+                  longitude: -3.524391,
+                  disabled_at: null,
+                },
+              },
+            ]
+
+            middleware(req, res, nextSpy)
+          })
+
+          it('will show the move from/to locations,', function () {
+            expect(res.locals.identityBar.journeys).to.deep.equal([
+              {
+                context: 'requested',
+                date: '7 Oct 2020',
+                fromLocation: 'Guildford Custody Suite',
+                toLocation: 'HMP Brixton',
+              },
+            ])
+          })
+        }
+      )
+
+      context('move and journey are empty', function () {
+        beforeEach(function () {
+          req.move = null
+          req.journeys = null
+
+          middleware(req, res, nextSpy)
+        })
+
+        it('should call next', function () {
+          expect(nextSpy).to.be.calledOnceWithExactly()
+        })
+      })
+    })
+  })
+})

--- a/app/move/app/view/middleware/locals.identity-bar.test.js
+++ b/app/move/app/view/middleware/locals.identity-bar.test.js
@@ -31,6 +31,7 @@ describe('Move view app', function () {
             reference: 'AB1234XY',
             date: '2020-10-07',
             status: 'requested',
+            is_lockout: false,
             profile: {
               person: {
                 _fullname: 'DOE, JOHN',

--- a/app/move/app/view/middleware/locals.move-details.js
+++ b/app/move/app/view/middleware/locals.move-details.js
@@ -6,6 +6,7 @@ function localsMoveDetails(req, res, next) {
   const moveDetails = presenters.moveToMetaListComponent(move)
 
   res.locals.moveDetails = moveDetails
+  res.locals.moveIsLockout = move.is_lockout
 
   next()
 }

--- a/app/move/app/view/middleware/locals.move-details.test.js
+++ b/app/move/app/view/middleware/locals.move-details.test.js
@@ -13,6 +13,7 @@ describe('Move view app', function () {
           move: {
             id: '12345',
             foo: 'bar',
+            is_lockout: false,
           },
         }
         res = {
@@ -36,7 +37,9 @@ describe('Move view app', function () {
           moveDetails: {
             id: '12345',
             foo: 'bar',
+            is_lockout: false,
           },
+          moveIsLockout: false,
         })
       })
 

--- a/app/move/app/view/views/_layout.njk
+++ b/app/move/app/view/views/_layout.njk
@@ -30,7 +30,7 @@
 
   {% if moveIsLockout %}
     <div class="govuk-!-margin-bottom-6 prison-lockout-banner">
-      <div class="govuk-!-padding-top-3 prison-lockout-banner-content">
+      <div class="prison-lockout-banner-content">
         {{ govukWarningText({
           text: t("moves::is_lockout"),
           iconFallbackText: "Warning"

--- a/app/move/app/view/views/_layout.njk
+++ b/app/move/app/view/views/_layout.njk
@@ -28,6 +28,17 @@
     {{ appIdentityBar(identityBar) }}
   {% endblock %}
 
+  {% if moveIsLockout %}
+    <div class="govuk-!-margin-bottom-6 prison-lockout-banner">
+      <div class="govuk-!-padding-top-3 prison-lockout-banner-content">
+        {{ govukWarningText({
+          text: t("moves::is_lockout"),
+          iconFallbackText: "Warning"
+        }) }}
+      </div>
+    </div>
+  {% endif %}
+
   {% block contentContainer %}
   <div class="govuk-grid-row">
 

--- a/common/assets/scss/components/_all.scss
+++ b/common/assets/scss/components/_all.scss
@@ -7,6 +7,7 @@
 @import "stack-trace";
 @import "sticky-sidebar";
 @import "whats-new-banner";
+@import "lockout-banner";
 
 // Load components from the shared components folder
 @import "add-another/add-another";

--- a/common/assets/scss/components/_lockout-banner.scss
+++ b/common/assets/scss/components/_lockout-banner.scss
@@ -1,10 +1,11 @@
 .prison-lockout-banner {
   background: #F8F8F8;
-  height:70px;
+  height: 80px;
   width: 500%;
   margin-left: -200%;
 }
 
 .prison-lockout-banner-content {
-  margin-left: 40%
+  margin-left: 40%;
+  padding-top: 18px;
 }

--- a/common/assets/scss/components/_lockout-banner.scss
+++ b/common/assets/scss/components/_lockout-banner.scss
@@ -1,0 +1,10 @@
+.prison-lockout-banner {
+  background: #F8F8F8;
+  height:70px;
+  width: 500%;
+  margin-left: -200%;
+}
+
+.prison-lockout-banner-content {
+  margin-left: 40%
+}

--- a/common/assets/scss/overrides/_all.scss
+++ b/common/assets/scss/overrides/_all.scss
@@ -3,3 +3,7 @@
 @import "moj-frontend";
 @import "positioning";
 @import "visibility";
+
+body {
+  overflow: hidden
+}

--- a/common/components/identity-bar/_identity-bar.scss
+++ b/common/components/identity-bar/_identity-bar.scss
@@ -1,5 +1,5 @@
 .app-identity-bar {
-  padding-bottom: govuk-spacing(9);
+  padding-bottom: govuk-spacing(6);
 
   &.is-sticky {
     top: 0 !important;

--- a/common/components/identity-bar/template.njk
+++ b/common/components/identity-bar/template.njk
@@ -12,6 +12,18 @@
           {{ params.heading.html | safe if params.heading.html else params.heading.text }}
         </h1>
 
+        {% if params.journeys | length %}
+          <p class="app-identity-bar__summary">
+            {% for journey in params.journeys %}
+              {% if loop.first %}
+                {{ t("moves::detail.page_heading_summary", journey) | safe }}
+              {% else %}
+                <br />{{ t("moves::detail.page_heading_summary_and", journey) | safe }}
+              {% endif %}
+            {% endfor %}
+          </p>
+        {% endif %}
+
         {% if params.summary.html or params.summary.text %}
           <p class="app-identity-bar__summary">
             {{ params.summary.html | safe if params.summary.html else params.summary.text }}

--- a/common/components/identity-bar/template.njk
+++ b/common/components/identity-bar/template.njk
@@ -18,7 +18,7 @@
               {% if loop.first %}
                 {{ t("moves::detail.page_heading_summary", journey) | safe }}
               {% else %}
-                <br />{{ t("moves::detail.page_heading_summary_and", journey) | safe }}
+                {{ t("moves::detail.page_heading_summary_and", journey) | safe }}
               {% endif %}
             {% endfor %}
           </p>

--- a/locales/en/moves.json
+++ b/locales/en/moves.json
@@ -110,6 +110,7 @@
     "page_caption": "Move for",
     "page_heading": "{{-name}} ({{-reference}})",
     "page_heading_summary": "From <strong>{{ fromLocation }}</strong> to <strong>{{ toLocation }}</strong> on <strong>{{ date }}</strong>",
+    "page_heading_summary_and": "and <strong>{{ fromLocation }}</strong> to <strong>{{ toLocation }}</strong> on <strong>{{ date }}</strong>",
     "page_heading_summary_proposed": "From <strong>{{ fromLocation }}</strong> to <strong>{{ toLocation }}",
     "page_title": "Move for {{-name}}",
     "court_hearings": {

--- a/locales/en/moves.json
+++ b/locales/en/moves.json
@@ -110,7 +110,7 @@
     "page_caption": "Move for",
     "page_heading": "{{-name}} ({{-reference}})",
     "page_heading_summary": "From <strong>{{ fromLocation }}</strong> to <strong>{{ toLocation }}</strong> on <strong>{{ date }}</strong>",
-    "page_heading_summary_and": "and <strong>{{ fromLocation }}</strong> to <strong>{{ toLocation }}</strong> on <strong>{{ date }}</strong>",
+    "page_heading_summary_and": "and from <strong>{{ fromLocation }}</strong> to <strong>{{ toLocation }}</strong> on <strong>{{ date }}</strong>",
     "page_heading_summary_proposed": "From <strong>{{ fromLocation }}</strong> to <strong>{{ toLocation }}",
     "page_title": "Move for {{-name}}",
     "court_hearings": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

When a move is locked out we show a prison lockout banner warning message, and we show all the journeys which are not cancelled or rejected to the user.

### Why did it change

As a user I want to know where and when a move is stopping overnight for a lockout so that I know the whereabouts of the detainee.

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

- [P4-3342](https://dsdmoj.atlassian.net/browse/P4-3342)

## Screenshots
<!--- (Optional) Include screenshots if changes update interfaces or components -->
<!--- Delete/copy as appropriate --->
<img width="1792" alt="Screenshot 2022-04-04 at 13 54 20" src="https://user-images.githubusercontent.com/40758489/161548094-b665983e-fd55-4390-a05e-0c23286f3fde.png">
<img width="1792" alt="Screenshot 2022-04-04 at 13 57 15" src="https://user-images.githubusercontent.com/40758489/161548876-5448ae40-57b5-49d3-9a56-916d47f18a43.png">

