### PR TITLE
Show lockout events in their own section

### DIFF
--- a/app/move/app/view/views/warnings.njk
+++ b/app/move/app/view/views/warnings.njk
@@ -11,7 +11,20 @@
       text: t("assessment::section_incomplete")
     }) }}
   {% elif assessment.count > 0 %}
-    {% if assessment.panels %}
+    {% if assessment.groupedPanels %}
+      {% for groupedPanel in assessment.groupedPanels %}
+        {% if groupedPanel.heading %}
+          <h3 class="govuk-heading-s govuk-!-margin-bottom-2 govuk-!-margin-top-2">
+            {{ groupedPanel.heading }}
+          </h3>
+        {% endif %}
+        {% if groupedPanel.panels %}
+          {% for panel in groupedPanel.panels %}
+            {{ appPanel(panel) }}
+          {% endfor %}
+        {% endif %}
+      {% endfor %}
+    {% elif assessment.panels %}
       {% for panel in assessment.panels %}
         {{ appPanel(panel) }}
       {% endfor %}
@@ -72,7 +85,6 @@
     </div>
 
     {% if warnings.sections | length %}
-
       {% for section in warnings.sections %}
         <section class="app-!-position-relative govuk-!-margin-top-7">
           <h2 class="govuk-heading-m govuk-!-margin-bottom-2">
@@ -84,7 +96,6 @@
           {{ renderAssessmentComponent(section) }}
         </section>
       {% endfor %}
-
     {% endif %}
   {% else %}
     {{ govukInsetText({

--- a/common/presenters/move-to-in-transit-events-panel-list.test.js
+++ b/common/presenters/move-to-in-transit-events-panel-list.test.js
@@ -15,6 +15,7 @@ describe('Presenters', function () {
         {
           classification: 'incident',
           occurred_at: '2020-01-01',
+          supplier: 'ABC',
         },
         {
           classification: 'incident',
@@ -31,14 +32,22 @@ describe('Presenters', function () {
       panelList = moveToInTransitEventsPanelList(move)
     })
 
-    it('should return panels for incident events', function () {
+    it('should return panels for incident and lockout events', function () {
       expect(panelList).to.deep.equal({
         context: 'framework',
         count: 2,
         isCompleted: true,
         key: 'in-transit-events',
         name: 'In transit information',
-        panels: ['panel', 'panel'],
+        groupedPanels: [
+          {
+            panels: ['panel'],
+          },
+          {
+            heading: 'Lockout events',
+            panels: ['panel'],
+          },
+        ],
       })
     })
   })


### PR DESCRIPTION
This improves how events are shown in the warnings tab to move events that have occurred during a lockout to be shown in their own section. Lockout events are determined by whether the event was created by a supplier or not.

[Jira Ticket](https://dsdmoj.atlassian.net/browse/P4-3508)

## Screenshots

### Old

<img width="805" alt="Screenshot 2022-04-04 at 10 34 42" src="https://user-images.githubusercontent.com/510498/161516842-f3de0658-7410-4910-a67e-9f739dc7ae22.png">

### New

<img width="815" alt="Screenshot 2022-04-04 at 10 34 31" src="https://user-images.githubusercontent.com/510498/161516859-908dd1ea-48fc-45fa-a4fd-d02825ab8c17.png">