### PR TITLE
Ensure only active journeys are considered

### DIFF
--- a/common/presenters/move-to-journeys-summary.js
+++ b/common/presenters/move-to-journeys-summary.js
@@ -21,11 +21,17 @@ const presentLockout = (move, formatDate) => [
 ]
 
 module.exports = (move, journeys, { formatDate = filters.formatDate } = {}) => {
+  const filteredJourneys = journeys.filter(
+    ({ state }) => state !== 'rejected' && state !== 'cancelled'
+  )
+
   const hasJourneysOnDifferentDay =
-    journeys.filter(({ date }) => date !== move.date).length !== 0
+    filteredJourneys.filter(({ date }) => date !== move.date).length !== 0
 
   if (hasJourneysOnDifferentDay) {
-    return journeys.map(journey => presentMoveOrJourney(journey, formatDate))
+    return filteredJourneys.map(journey =>
+      presentMoveOrJourney(journey, formatDate)
+    )
   } else if (move.is_lockout) {
     return presentLockout(move, formatDate)
   } else {

--- a/common/presenters/move-to-journeys-summary.test.js
+++ b/common/presenters/move-to-journeys-summary.test.js
@@ -42,6 +42,46 @@ describe('Presenters', function () {
     )
 
     context(
+      "when the move is not locked out and there is a journey on a different date but it's cancelled",
+      function () {
+        it('will present the journeys correctly', function () {
+          const move = {
+            date: '2020-10-07',
+            is_lockout: false,
+            from_location: {
+              title: 'Guildford Custody Suite',
+            },
+            to_location: {
+              title: 'HMP Brixton',
+            },
+          }
+
+          const journeys = [
+            {
+              date: '2021-01-13',
+              state: 'cancelled',
+              from_location: {
+                title: 'WETHERBY (HMPYOI)',
+              },
+              to_location: {
+                title: 'Exeter Probation Office',
+              },
+            },
+          ]
+
+          expect(moveToJourneysSummary(move, journeys)).to.deep.equal([
+            {
+              context: undefined,
+              date: '7 Oct 2020',
+              fromLocation: 'Guildford Custody Suite',
+              toLocation: 'HMP Brixton',
+            },
+          ])
+        })
+      }
+    )
+
+    context(
       'when the move is locked out and there is one journey',
       function () {
         it('will present the journeys correctly', function () {


### PR DESCRIPTION
This removes any journeys which are cancelled or rejected and doesn't include them when displaying journeys in the identity bar and move details tab.

This was missed in #2375.