### PR TITLE
Update side panel at relevant points in the move

### DIFF
--- a/app/move/app/view/middleware/locals.move-details.js
+++ b/app/move/app/view/middleware/locals.move-details.js
@@ -1,9 +1,9 @@
 const presenters = require('../../../../../common/presenters')
 
 function localsMoveDetails(req, res, next) {
-  const { move } = req
+  const { journeys, move } = req
 
-  const moveDetails = presenters.moveToMetaListComponent(move)
+  const moveDetails = presenters.moveToMetaListComponent(move, journeys)
 
   res.locals.moveDetails = moveDetails
   res.locals.moveIsLockout = move.is_lockout

--- a/app/move/app/view/middleware/locals.move-details.test.js
+++ b/app/move/app/view/middleware/locals.move-details.test.js
@@ -15,6 +15,7 @@ describe('Move view app', function () {
             foo: 'bar',
             is_lockout: false,
           },
+          journeys: [],
         }
         res = {
           locals: {},
@@ -28,7 +29,8 @@ describe('Move view app', function () {
 
       it('should call presenter', function () {
         expect(presenters.moveToMetaListComponent).to.be.calledOnceWithExactly(
-          req.move
+          req.move,
+          req.journeys
         )
       })
 

--- a/common/components/add-another/add-another.js
+++ b/common/components/add-another/add-another.js
@@ -17,7 +17,7 @@ MOJFrontend.AddAnother.prototype.onRemoveButtonClick = function (e) {
 
 MOJFrontend.AddAnother.prototype.updateAttributes = function (index, item) {
   item.find('[data-name]').each(function (i, el) {
-    var originalId = el.id
+    const originalId = el.id
 
     const $el = $(el)
     el.name = $el.attr('data-name').replace(/%index%/, index)

--- a/common/helpers/move/get-move-summary.js
+++ b/common/helpers/move/get-move-summary.js
@@ -6,7 +6,7 @@ function getMoveSummary(move, opts) {
     return {}
   }
 
-  const moveSummary = moveToMetaListComponent(move, opts)
+  const moveSummary = moveToMetaListComponent(move, [], opts)
   // `move.person` caters for sessionData within form wizard journeys
   const person = move.person || move?.profile?.person
   const personMetaList = personToMetaListComponent(person)

--- a/common/helpers/move/get-move-summary.test.js
+++ b/common/helpers/move/get-move-summary.test.js
@@ -36,6 +36,7 @@ describe('Move helpers', function () {
         it('should get the move summary', function () {
           expect(moveToMetaListComponent).to.be.calledOnceWithExactly(
             mockMove,
+            [],
             { foo: 'bar' }
           )
         })
@@ -77,6 +78,7 @@ describe('Move helpers', function () {
         it('should get the move summary', function () {
           expect(moveToMetaListComponent).to.be.calledOnceWithExactly(
             mockMove,
+            [],
             { foo: 'bar' }
           )
         })
@@ -111,6 +113,7 @@ describe('Move helpers', function () {
         it('should get the move summary', function () {
           expect(moveToMetaListComponent).to.be.calledOnceWithExactly(
             mockMove,
+            [],
             { foo: 'bar' }
           )
         })

--- a/common/presenters/move-to-meta-list-component.js
+++ b/common/presenters/move-to-meta-list-component.js
@@ -1,4 +1,4 @@
-const { get, isNil } = require('lodash')
+const { isNil } = require('lodash')
 
 const moveAgreedField = require('../../app/move/app/new/fields/move-agreed')
 const componentService = require('../../common/services/component')
@@ -6,26 +6,24 @@ const i18n = require('../../config/i18n')
 const filters = require('../../config/nunjucks/filters')
 const mapUpdateLink = require('../helpers/move/map-update-link')
 
+const moveToJourneysSummary = require('./move-to-journeys-summary')
+
 /**
  * Convert a move into the structure required to render
  * as a `appMetaList` component
  *
  * @param {Object} move - the move to format
- *
+ * @param {Object} journeys - the move's journeys
+
  * @param {Object} [options] - config options for the presenter
  * @param {Object} [options.updateUrls={}] - object containing URLs for each edit step
  *
  * @returns {Object} - a move formatted as a `appMetaList` component
  */
-function moveToMetaListComponent(move, { updateUrls = {} } = {}) {
+function moveToMetaListComponent(move, journeys, { updateUrls = {} } = {}) {
   const {
     _vehicleRegistration,
-    date,
-    date_from: dateFrom,
-    date_to: dateTo,
     move_type: moveType,
-    from_location: fromLocation,
-    to_location: toLocation,
     additional_information: additionalInfo,
     prison_transfer_reason: prisonTransferReason,
     move_agreed: moveAgreed,
@@ -33,15 +31,6 @@ function moveToMetaListComponent(move, { updateUrls = {} } = {}) {
     reference,
     status,
   } = move || {}
-  const destinationTitle = get(toLocation, 'title', 'Unknown')
-  const destinationId = get(toLocation, 'id')
-  const useLabel = ['prison_recall', 'video_remand']
-  const destinationLabel = useLabel.includes(moveType)
-    ? `${i18n.t(`fields::move_type.items.${moveType}.label`, {
-        context: destinationId ? 'with_location' : '',
-        location: destinationTitle,
-      })}`
-    : destinationTitle
   const destinationSuffix =
     additionalInfo && moveType === 'prison_recall' ? ` — ${additionalInfo}` : ''
   const prisonTransferReasonTitle = prisonTransferReason
@@ -66,6 +55,17 @@ function moveToMetaListComponent(move, { updateUrls = {} } = {}) {
     text: i18n.t(`statuses::${status}`),
   })
 
+  if (!move || !journeys) {
+    return {
+      classes: 'govuk-!-font-size-16',
+      items: [],
+    }
+  }
+
+  const journeysSummary = moveToJourneysSummary(move, journeys, {
+    formatDate: filters.formatDateWithRelativeDay,
+  })
+
   const items = [
     {
       key: {
@@ -88,7 +88,7 @@ function moveToMetaListComponent(move, { updateUrls = {} } = {}) {
         text: i18n.t('fields::from_location.short_label'),
       },
       value: {
-        text: get(fromLocation, 'title'),
+        text: journeysSummary[0].fromLocation,
       },
     },
     {
@@ -96,7 +96,9 @@ function moveToMetaListComponent(move, { updateUrls = {} } = {}) {
         text: i18n.t('fields::move_type.short_label'),
       },
       value: {
-        text: moveType ? destinationLabel + destinationSuffix : undefined,
+        text:
+          journeysSummary.map(({ toLocation }) => toLocation).join(' and ') +
+          destinationSuffix,
       },
       action: 'move',
     },
@@ -105,25 +107,9 @@ function moveToMetaListComponent(move, { updateUrls = {} } = {}) {
         text: i18n.t('fields::date_type.label'),
       },
       value: {
-        text: filters.formatDateWithRelativeDay(date),
+        text: journeysSummary.map(({ date }) => date).join(' to '),
       },
       action: 'date',
-    },
-    {
-      key: {
-        text: i18n.t('fields::date_from.label'),
-      },
-      value: {
-        text: date ? undefined : filters.formatDateWithRelativeDay(dateFrom),
-      },
-    },
-    {
-      key: {
-        text: i18n.t('fields::date_to.label'),
-      },
-      value: {
-        text: date ? undefined : filters.formatDateWithRelativeDay(dateTo),
-      },
     },
     {
       key: {

--- a/common/presenters/move-to-meta-list-component.js
+++ b/common/presenters/move-to-meta-list-component.js
@@ -1,4 +1,4 @@
-const { isNil } = require('lodash')
+const { get, isNil } = require('lodash')
 
 const moveAgreedField = require('../../app/move/app/new/fields/move-agreed')
 const componentService = require('../../common/services/component')
@@ -23,7 +23,11 @@ const moveToJourneysSummary = require('./move-to-journeys-summary')
 function moveToMetaListComponent(move, journeys, { updateUrls = {} } = {}) {
   const {
     _vehicleRegistration,
+    date,
+    date_from: dateFrom,
+    date_to: dateTo,
     move_type: moveType,
+    to_location: toLocation,
     additional_information: additionalInfo,
     prison_transfer_reason: prisonTransferReason,
     move_agreed: moveAgreed,
@@ -31,6 +35,8 @@ function moveToMetaListComponent(move, journeys, { updateUrls = {} } = {}) {
     reference,
     status,
   } = move || {}
+  const destinationTitle = get(toLocation, 'title', 'Unknown')
+  const destinationId = get(toLocation, 'id')
   const useLabel = ['prison_recall', 'video_remand']
   const destinationSuffix =
     additionalInfo && moveType === 'prison_recall' ? ` — ${additionalInfo}` : ''
@@ -68,10 +74,8 @@ function moveToMetaListComponent(move, journeys, { updateUrls = {} } = {}) {
 
   const destinationLabel = useLabel.includes(moveType)
     ? `${i18n.t(`fields::move_type.items.${moveType}.label`, {
-        context: 'with_location',
-        location: journeysSummary
-          .map(({ toLocation }) => toLocation)
-          .join(' and '),
+        context: destinationId ? 'with_location' : '',
+        location: destinationTitle,
       })}`
     : journeysSummary.map(({ toLocation }) => toLocation).join(' and ')
 
@@ -117,6 +121,22 @@ function moveToMetaListComponent(move, journeys, { updateUrls = {} } = {}) {
         text: journeysSummary.map(({ date }) => date).join(' to '),
       },
       action: 'date',
+    },
+    {
+      key: {
+        text: i18n.t('fields::date_from.label'),
+      },
+      value: {
+        text: date ? undefined : filters.formatDateWithRelativeDay(dateFrom),
+      },
+    },
+    {
+      key: {
+        text: i18n.t('fields::date_to.label'),
+      },
+      value: {
+        text: date ? undefined : filters.formatDateWithRelativeDay(dateTo),
+      },
     },
     {
       key: {

--- a/common/presenters/move-to-meta-list-component.js
+++ b/common/presenters/move-to-meta-list-component.js
@@ -31,6 +31,7 @@ function moveToMetaListComponent(move, journeys, { updateUrls = {} } = {}) {
     reference,
     status,
   } = move || {}
+  const useLabel = ['prison_recall', 'video_remand']
   const destinationSuffix =
     additionalInfo && moveType === 'prison_recall' ? ` — ${additionalInfo}` : ''
   const prisonTransferReasonTitle = prisonTransferReason
@@ -55,9 +56,8 @@ function moveToMetaListComponent(move, journeys, { updateUrls = {} } = {}) {
     text: i18n.t(`statuses::${status}`),
   })
 
-  if (!move || !journeys) {
+  if (!move) {
     return {
-      classes: 'govuk-!-font-size-16',
       items: [],
     }
   }
@@ -65,6 +65,15 @@ function moveToMetaListComponent(move, journeys, { updateUrls = {} } = {}) {
   const journeysSummary = moveToJourneysSummary(move, journeys, {
     formatDate: filters.formatDateWithRelativeDay,
   })
+
+  const destinationLabel = useLabel.includes(moveType)
+    ? `${i18n.t(`fields::move_type.items.${moveType}.label`, {
+        context: 'with_location',
+        location: journeysSummary
+          .map(({ toLocation }) => toLocation)
+          .join(' and '),
+      })}`
+    : journeysSummary.map(({ toLocation }) => toLocation).join(' and ')
 
   const items = [
     {
@@ -96,9 +105,7 @@ function moveToMetaListComponent(move, journeys, { updateUrls = {} } = {}) {
         text: i18n.t('fields::move_type.short_label'),
       },
       value: {
-        text:
-          journeysSummary.map(({ toLocation }) => toLocation).join(' and ') +
-          destinationSuffix,
+        text: moveType ? destinationLabel + destinationSuffix : undefined,
       },
       action: 'move',
     },

--- a/common/presenters/move-to-meta-list-component.test.js
+++ b/common/presenters/move-to-meta-list-component.test.js
@@ -125,7 +125,7 @@ describe('Presenters', function () {
         })
 
         it('should translate correct number of times', function () {
-          expect(i18n.t).to.be.callCount(11)
+          expect(i18n.t).to.be.callCount(13)
         })
       })
 
@@ -172,6 +172,140 @@ describe('Presenters', function () {
         })
       })
     })
+
+    context('with only `date from`', function () {
+      const mockMove = {
+        date_from: '2020-05-01',
+      }
+      let transformedResponse
+
+      beforeEach(function () {
+        transformedResponse = moveToMetaListComponent(mockMove, [])
+      })
+
+      describe('response', function () {
+        it('should contain correct key ordering', function () {
+          const keys = transformedResponse.items.map(
+            item => item.key.text || item.key.html
+          )
+          expect(keys).deep.equal(['fields::date_from.label'])
+        })
+
+        it('should contain date_from date', function () {
+          const values = transformedResponse.items.map(
+            item => item.value.text || item.value.html
+          )
+          expect(values).deep.equal(['2020-05-01'])
+        })
+      })
+    })
+
+    context('with both `date from` and `date to`', function () {
+      const mockMove = {
+        date_from: '2020-05-01',
+        date_to: '2020-05-10',
+      }
+      let transformedResponse
+
+      beforeEach(function () {
+        transformedResponse = moveToMetaListComponent(mockMove, [])
+      })
+
+      describe('response', function () {
+        it('should contain correct key ordering', function () {
+          const keys = transformedResponse.items.map(
+            item => item.key.text || item.key.html
+          )
+          expect(keys).deep.equal([
+            'fields::date_from.label',
+            'fields::date_to.label',
+          ])
+        })
+
+        it('should contain both dates', function () {
+          const values = transformedResponse.items.map(
+            item => item.value.text || item.value.html
+          )
+          expect(values).deep.equal(['2020-05-01', '2020-05-10'])
+        })
+      })
+    })
+
+    context('with all dates', function () {
+      const mockMove = {
+        date_from: '2020-05-01',
+        date_to: '2020-05-10',
+        date: '2020-06-01',
+      }
+      let transformedResponse
+
+      beforeEach(function () {
+        transformedResponse = moveToMetaListComponent(mockMove, [])
+      })
+
+      describe('response', function () {
+        it('should contain correct key ordering', function () {
+          const keys = transformedResponse.items.map(
+            item => item.key.text || item.key.html
+          )
+          expect(keys).deep.equal(['fields::date_type.label'])
+        })
+
+        it('should only contain move date', function () {
+          const values = transformedResponse.items.map(
+            item => item.value.text || item.value.html
+          )
+          expect(values).deep.equal(['2020-06-01'])
+        })
+      })
+    })
+
+    context(
+      'with prison recall move type and without to_location',
+      function () {
+        const mockAdditionalInformation =
+          'Some additional information about this move'
+        let transformedResponse
+
+        beforeEach(function () {
+          transformedResponse = moveToMetaListComponent(
+            {
+              ...mockMove,
+              to_location: null,
+              move_type: 'prison_recall',
+              additional_information: mockAdditionalInformation,
+            },
+            []
+          )
+        })
+
+        it('should contain correct key', function () {
+          const keys = transformedResponse.items.map(
+            item => item.key.text || item.key.html
+          )
+          expect(keys).to.include('fields::move_type.short_label')
+        })
+
+        it('should contain correct value', function () {
+          const values = transformedResponse.items.map(
+            item => item.value.text || item.value.html
+          )
+          expect(values).to.include(
+            'fields::move_type.items.prison_recall.label — Some additional information about this move'
+          )
+        })
+
+        it('should call translation correctly', function () {
+          expect(i18n.t).to.be.calledWithExactly(
+            'fields::move_type.items.prison_recall.label',
+            {
+              context: '',
+              location: 'Unknown',
+            }
+          )
+        })
+      }
+    )
 
     context('when provided with updateUrls', function () {
       let transformedResponse

--- a/common/presenters/move-to-meta-list-component.test.js
+++ b/common/presenters/move-to-meta-list-component.test.js
@@ -262,7 +262,17 @@ describe('Presenters', function () {
             item => item.value.text || item.value.html
           )
           expect(values).to.include(
-            'Barrow in Furness County Court — Some additional information about this move'
+            'fields::move_type.items.prison_recall.label — Some additional information about this move'
+          )
+        })
+
+        it('should call translation correctly', function () {
+          expect(i18n.t).to.be.calledWithExactly(
+            'fields::move_type.items.prison_recall.label',
+            {
+              context: 'with_location',
+              location: 'Barrow in Furness County Court',
+            }
           )
         })
       })
@@ -292,6 +302,9 @@ describe('Presenters', function () {
           )
           expect(values).to.not.include(
             'fields::move_type.items.video_remand.label — Some additional information about this move'
+          )
+          expect(values).to.include(
+            'fields::move_type.items.video_remand.label'
           )
         })
       })

--- a/common/presenters/move-to-meta-list-component.test.js
+++ b/common/presenters/move-to-meta-list-component.test.js
@@ -260,53 +260,6 @@ describe('Presenters', function () {
       })
     })
 
-    context(
-      'with prison recall move type and without to_location',
-      function () {
-        const mockAdditionalInformation =
-          'Some additional information about this move'
-        let transformedResponse
-
-        beforeEach(function () {
-          transformedResponse = moveToMetaListComponent(
-            {
-              ...mockMove,
-              to_location: null,
-              move_type: 'prison_recall',
-              additional_information: mockAdditionalInformation,
-            },
-            []
-          )
-        })
-
-        it('should contain correct key', function () {
-          const keys = transformedResponse.items.map(
-            item => item.key.text || item.key.html
-          )
-          expect(keys).to.include('fields::move_type.short_label')
-        })
-
-        it('should contain correct value', function () {
-          const values = transformedResponse.items.map(
-            item => item.value.text || item.value.html
-          )
-          expect(values).to.include(
-            'fields::move_type.items.prison_recall.label — Some additional information about this move'
-          )
-        })
-
-        it('should call translation correctly', function () {
-          expect(i18n.t).to.be.calledWithExactly(
-            'fields::move_type.items.prison_recall.label',
-            {
-              context: '',
-              location: 'Unknown',
-            }
-          )
-        })
-      }
-    )
-
     context('when provided with updateUrls', function () {
       let transformedResponse
       let mockUpdateUrls
@@ -410,6 +363,49 @@ describe('Presenters', function () {
           )
         })
       })
+
+      context(
+        'with prison recall move type and without to_location',
+        function () {
+          beforeEach(function () {
+            transformedResponse = moveToMetaListComponent(
+              {
+                ...mockMove,
+                to_location: null,
+                move_type: 'prison_recall',
+                additional_information: mockAdditionalInformation,
+              },
+              []
+            )
+          })
+
+          it('should contain correct key', function () {
+            const keys = transformedResponse.items.map(
+              item => item.key.text || item.key.html
+            )
+            expect(keys).to.include('fields::move_type.short_label')
+          })
+
+          it('should contain correct value', function () {
+            const values = transformedResponse.items.map(
+              item => item.value.text || item.value.html
+            )
+            expect(values).to.include(
+              'fields::move_type.items.prison_recall.label — Some additional information about this move'
+            )
+          })
+
+          it('should call translation correctly', function () {
+            expect(i18n.t).to.be.calledWithExactly(
+              'fields::move_type.items.prison_recall.label',
+              {
+                context: '',
+                location: 'Unknown',
+              }
+            )
+          })
+        }
+      )
 
       context('with video remand move type', function () {
         beforeEach(function () {
@@ -516,7 +512,6 @@ describe('Presenters', function () {
             transformedResponse = moveToMetaListComponent(
               {
                 ...mockMove,
-                ...mockJourneys,
                 move_agreed: true,
               },
               mockJourneys
@@ -595,7 +590,6 @@ describe('Presenters', function () {
           transformedResponse = moveToMetaListComponent(
             {
               ...mockMove,
-              ...mockJourneys,
               move_agreed: false,
               move_agreed_by: 'Jon Doe',
             },
@@ -635,7 +629,6 @@ describe('Presenters', function () {
           transformedResponse = moveToMetaListComponent(
             {
               ...mockMove,
-              ...mockJourneys,
               move_agreed: 'true',
               move_agreed_by: 'Jon Doe',
             },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

We now add information to the side panel to inform users where and when a move is stopping overnight for a lockout 

### Why did it change

So that as user knows the whereabouts of the detainee throughout the move

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

- [P4-3343](https://dsdmoj.atlassian.net/browse/P4-3343)

## Screenshots
<!--- (Optional) Include screenshots if changes update interfaces or components -->
<!--- Delete/copy as appropriate --->

<img width="306" alt="Screenshot 2022-04-06 at 11 05 24" src="https://user-images.githubusercontent.com/40758489/161951544-343c9efc-4b7e-4824-8000-16a864a5eefb.png">
