### PR TITLE
Consider assessment status when showing framework responses

### DIFF
--- a/common/components/framework-response/framework-response.yaml
+++ b/common/components/framework-response/framework-response.yaml
@@ -19,6 +19,10 @@ params:
     type: string
     required: false
     description: Determines if the value shown has been prefilled. If true, will link to the question URL with review text
+  - name: assessmentStatus
+    type: string
+    required: false
+    description: Determines if the question should be modifyable.
 
 examples:
   - name: string

--- a/common/components/framework-response/template.njk
+++ b/common/components/framework-response/template.njk
@@ -1,4 +1,4 @@
-{% if params.responded %}
+{% if params.responded or params.assessmentStatus === 'completed' or params.assessmentStatus === 'confirmed' %}
   {% if params.value and params.valueType %}
     {% if params.valueType === 'object::followup_comment' %}
       <p class="govuk-!-font-size-16">

--- a/common/components/framework-response/template.test.js
+++ b/common/components/framework-response/template.test.js
@@ -270,6 +270,40 @@ describe('Framework Response component', function () {
     })
   })
 
+  context('with completed assessment', function () {
+    const example = examples['unanswered question']
+
+    beforeEach(function () {
+      sinon.stub(i18n, 't').returnsArg(0)
+
+      const $ = renderComponentHtmlToCheerio('framework-response', {
+        ...example,
+        assessmentStatus: 'completed',
+      })
+      $component = $('body')
+    })
+
+    it('should render a parent span', function () {
+      expect($component.children().first().get(0).tagName).to.equal('span')
+    })
+
+    it('should contain correct classes', function () {
+      expect($component.children().first().attr('class')).to.equal(
+        'app-secondary-text-colour'
+      )
+    })
+
+    it('should translate text', function () {
+      expect(i18n.t).to.be.calledOnceWithExactly('empty_response')
+    })
+
+    it('should contain correct text', function () {
+      expect($component.children().first().text().trim()).to.equal(
+        'empty_response'
+      )
+    })
+  })
+
   context('with prefilled answer', function () {
     const example = examples['prefilled question']
 

--- a/common/helpers/frameworks/responses-to-save-reducer.js
+++ b/common/helpers/frameworks/responses-to-save-reducer.js
@@ -1,12 +1,14 @@
 const { flatten, kebabCase, pickBy } = require('lodash')
 
 function responsesToSaveReducer(values = {}) {
-  return (accumulator, { id, question }) => {
+  return (accumulator, { id, question, _question: { validate } = {} }) => {
     const { key: fieldName, response_type: responseType } = question
     const value = values[fieldName]
     let responseValue
 
-    if (!value) {
+    const hasValidation = validate ? validate.length !== 0 : true
+
+    if (!value && hasValidation) {
       return accumulator
     }
 

--- a/common/helpers/frameworks/responses-to-save-reducer.test.js
+++ b/common/helpers/frameworks/responses-to-save-reducer.test.js
@@ -356,6 +356,30 @@ describe('Helpers', function () {
             ],
             expectedValue: [],
           },
+          {
+            testName: 'with empty but optional field',
+            formValues: {
+              question: null,
+            },
+            responses: [
+              {
+                id: '1',
+                question: {
+                  key: 'question',
+                  response_type: 'object::followup_comment',
+                },
+                _question: {
+                  validate: [],
+                },
+              },
+            ],
+            expectedValue: [
+              {
+                id: '1',
+                value: {},
+              },
+            ],
+          },
         ]
 
         testCases.forEach(test => {

--- a/common/presenters/framework-field-summary-list-row.js
+++ b/common/presenters/framework-field-summary-list-row.js
@@ -55,6 +55,7 @@ function frameworkFieldToSummaryListRow(stepUrl) {
       responded: response.responded === true,
       prefilled: response.prefilled === true,
       questionUrl: `${stepUrl}#${id}`,
+      assessmentStatus: response.assessment?.status,
     }
 
     if ((response.nomis_mappings || []).length > 0) {

--- a/common/presenters/framework-field-summary-list-row.test.js
+++ b/common/presenters/framework-field-summary-list-row.test.js
@@ -46,6 +46,7 @@ describe('Presenters', function () {
               responded: false,
               prefilled: false,
               questionUrl: `${mockStepUrl}#${mockField.id}`,
+              assessmentStatus: undefined,
             }
           )
         })
@@ -82,6 +83,7 @@ describe('Presenters', function () {
               responded: false,
               prefilled: false,
               questionUrl: `${mockStepUrl}#${mockField.id}`,
+              assessmentStatus: undefined,
             }
           )
         })
@@ -130,6 +132,7 @@ describe('Presenters', function () {
               responded: false,
               prefilled: false,
               questionUrl: `${mockStepUrl}#${mockField.id}`,
+              assessmentStatus: undefined,
               afterContent: {
                 html: 'NOMIS_HTML',
               },
@@ -149,6 +152,29 @@ describe('Presenters', function () {
               },
             },
           ])
+        })
+      })
+
+      context('with assessment', function () {
+        beforeEach(function () {
+          response = frameworkFieldToSummaryListRow(mockStepUrl)({
+            ...mockField,
+            response: { assessment: { status: 'completed' } },
+          })
+        })
+
+        it('should call component service', function () {
+          expect(componentService.getComponent).to.be.calledOnceWithExactly(
+            'appFrameworkResponse',
+            {
+              value: undefined,
+              valueType: undefined,
+              responded: false,
+              prefilled: false,
+              questionUrl: `${mockStepUrl}#${mockField.id}`,
+              assessmentStatus: 'completed',
+            }
+          )
         })
       })
     })
@@ -184,6 +210,7 @@ describe('Presenters', function () {
               responded: false,
               prefilled: false,
               questionUrl: `${mockStepUrl}#${mockField.id}`,
+              assessmentStatus: undefined,
             }
           )
         })
@@ -248,6 +275,7 @@ describe('Presenters', function () {
                 responded: false,
                 prefilled: false,
                 questionUrl: `${mockStepUrl}#${mockFieldWithFollowup.id}`,
+                assessmentStatus: undefined,
               }
             )
             expect(componentService.getComponent).to.be.calledWithExactly(
@@ -258,6 +286,7 @@ describe('Presenters', function () {
                 responded: false,
                 prefilled: false,
                 questionUrl: `${mockStepUrl}#${mockFieldWithFollowup.items[0].followup[0].id}`,
+                assessmentStatus: undefined,
               }
             )
           })
@@ -306,6 +335,7 @@ describe('Presenters', function () {
                 responded: false,
                 prefilled: false,
                 questionUrl: `${mockStepUrl}#${mockFieldWithFollowup.id}`,
+                assessmentStatus: undefined,
               }
             )
           })
@@ -384,6 +414,7 @@ describe('Presenters', function () {
                   responded: false,
                   prefilled: false,
                   questionUrl: `${mockStepUrl}#${mockField.id}`,
+                  assessmentStatus: undefined,
                 }
               )
             })
@@ -413,6 +444,7 @@ describe('Presenters', function () {
                   responded: false,
                   prefilled: false,
                   questionUrl: `${mockStepUrl}#${mockField.id}`,
+                  assessmentStatus: undefined,
                 }
               )
             })
@@ -445,6 +477,7 @@ describe('Presenters', function () {
               responded: true,
               prefilled: false,
               questionUrl: `${mockStepUrl}#${mockField.id}`,
+              assessmentStatus: undefined,
             }
           )
         })
@@ -476,6 +509,7 @@ describe('Presenters', function () {
               responded: false,
               prefilled: true,
               questionUrl: `${mockStepUrl}#${mockField.id}`,
+              assessmentStatus: undefined,
             }
           )
         })
@@ -615,6 +649,7 @@ describe('Presenters', function () {
                 responded: true,
                 prefilled: false,
                 questionUrl: `${mockStepUrl}#${test.id}`,
+                assessmentStatus: undefined,
               }
             )
           })
@@ -635,6 +670,7 @@ describe('Presenters', function () {
               responded: false,
               prefilled: false,
               questionUrl: `${mockStepUrl}#${mockField.id}`,
+              assessmentStatus: undefined,
             }
           )
         })


### PR DESCRIPTION
Currently we always show a link to amend a framework response if the value is not set, regardless of the assessment status. This causes a problem with optional top-level questions which may not have been responded to by the time the PER is complete. At that point we can't let the user modify the PER though, as the PER cannot be changed once complete.

Related to https://github.com/ministryofjustice/hmpps-book-secure-move-api/pull/1814

[Jira Ticket](https://dsdmoj.atlassian.net/browse/P4-2987)

## Screenshots

### Old

![image](https://user-images.githubusercontent.com/510498/162416285-ceb9dbcb-430c-4bad-9db4-b2af6fc918f6.png)

### New

<img width="812" alt="Screenshot 2022-04-08 at 11 16 37" src="https://user-images.githubusercontent.com/510498/162416228-abb28c9e-ce96-47dd-829f-c2f0b4ef391b.png">