### PR TITLE
fix: Allow optional string responses to go to API

### DIFF
--- a/common/helpers/frameworks/responses-to-save-reducer.js
+++ b/common/helpers/frameworks/responses-to-save-reducer.js
@@ -55,7 +55,7 @@ function responsesToSaveReducer(values = {}) {
       responseValue = value
     }
 
-    if (responseValue) {
+    if (responseValue || !hasValidation) {
       accumulator.push(
         pickBy({
           id,

--- a/common/helpers/frameworks/responses-to-save-reducer.test.js
+++ b/common/helpers/frameworks/responses-to-save-reducer.test.js
@@ -357,7 +357,7 @@ describe('Helpers', function () {
             expectedValue: [],
           },
           {
-            testName: 'with empty but optional field',
+            testName: 'with empty but optional radio field',
             formValues: {
               question: null,
             },
@@ -377,6 +377,29 @@ describe('Helpers', function () {
               {
                 id: '1',
                 value: {},
+              },
+            ],
+          },
+          {
+            testName: 'with empty but optional string field',
+            formValues: {
+              question: '',
+            },
+            responses: [
+              {
+                id: '1',
+                question: {
+                  key: 'question',
+                  response_type: 'string',
+                },
+                _question: {
+                  validate: [],
+                },
+              },
+            ],
+            expectedValue: [
+              {
+                id: '1',
               },
             ],
           },


### PR DESCRIPTION
This is to handle the situation where a text field has no validation on it, and therefore an empty value is a valid response, and we want it to be sent to the API.

This follows up 4190811408528391749a303f1ece4c6f67397d0c to improve on the logic.

Related to https://github.com/ministryofjustice/hmpps-book-secure-move-frameworks/pull/64.