### PR TITLE
Reduce default field length

### DIFF
--- a/common/services/frameworks.js
+++ b/common/services/frameworks.js
@@ -134,7 +134,9 @@ const frameworksService = {
       component,
       itemName,
       rows: display.rows,
-      classes: inputWidthClasses[display.character_width] || '',
+      classes:
+        inputWidthClasses[display.character_width] ||
+        (type === 'text' ? 'govuk-input--width-20' : ''),
       descendants: questions,
       id: key,
       name: key,

--- a/common/services/frameworks.test.js
+++ b/common/services/frameworks.test.js
@@ -610,7 +610,7 @@ describe('Services', function () {
                 classes: 'govuk-label--s',
               },
               validate: [],
-              classes: '',
+              classes: 'govuk-input--width-20',
               rows: undefined,
               descendants: undefined,
               itemName: undefined,


### PR DESCRIPTION
For single line top level text fields the length ends up being the full length of the page. This looks a little odd, and it's inconsistent with the text area fields. We'd like to change the default so it looks better.

## Screenshots

### Old

![Screenshot 2022-04-11 at 14 45 24](https://user-images.githubusercontent.com/510498/162753842-2f8b70c5-8554-4b96-adb9-9a9d83ee1bc6.png)

### New

![Screenshot 2022-04-11 at 14 47 23](https://user-images.githubusercontent.com/510498/162753856-62b81ea2-3579-41da-bcf6-9f5af97166dd.png)