### PR TITLE
Hide what's new banner after 2 weeks 

### DIFF
--- a/common/services/whats-new-content.js
+++ b/common/services/whats-new-content.js
@@ -10,6 +10,8 @@ const {
 } = require('../../config')
 const { DATE_FORMATS } = require('../../config/index')
 
+const TWO_WEEKS = 2 * 7 * 24 * 60 * 60 * 1000
+
 const options = {
   renderMark: {
     [MARKS.BOLD]: text => `<strong>${text}</strong>`,
@@ -36,6 +38,7 @@ const options = {
       `<a class="govuk-link" href="${node.data.uri}">${next(node.content)}</a>`,
   },
 }
+
 const service = {
   client: contentful.createClient({
     host: CONTENTFUL_HOST,
@@ -55,10 +58,14 @@ const service = {
       date: service.formatDate(date),
     }))
 
-    const formattedBannerContent = {
-      title: entries[0].title,
-      body: entries[0].briefBannerText,
-      date: service.formatDate(entries[0].date),
+    let formattedBannerContent = null
+
+    if (new Date() - entries[0].date <= TWO_WEEKS) {
+      formattedBannerContent = {
+        title: entries[0].title,
+        body: entries[0].briefBannerText,
+        date: service.formatDate(entries[0].date),
+      }
     }
 
     return {

--- a/common/services/whats-new-content.js
+++ b/common/services/whats-new-content.js
@@ -43,39 +43,46 @@ const service = {
     accessToken: CONTENTFUL_ACCESS_TOKEN,
   }),
   fetch: async () => {
-    const entries = await service.client.getEntries()
+    const entries = await service.fetchEntries()
 
-    if (!entries.items?.length) {
+    if (entries.length === 0) {
       return null
     }
 
-    const formattedEntries = entries.items.map(
-      ({ fields: { title, body, date } }) => ({
-        title,
-        body: service.convertToHTMLFormat(body),
-        date: service.formatDate(date),
-      })
-    )
+    const formattedEntries = entries.map(({ title, body, date }) => ({
+      title,
+      body: service.convertToHTMLFormat(body),
+      date: service.formatDate(date),
+    }))
 
-    const latestContent = entries.items[0]
-    const latestContentTitle = latestContent.fields.title
-    const latestContentBannerText = latestContent.fields.briefBannerText
+    const formattedBannerContent = {
+      title: entries[0].title,
+      body: entries[0].briefBannerText,
+      date: service.formatDate(entries[0].date),
+    }
 
     return {
-      bannerContent: {
-        title: latestContentTitle,
-        body: latestContentBannerText,
-        date: service.formatDate(latestContent.fields.date),
-      },
+      bannerContent: formattedBannerContent,
       posts: formattedEntries,
     }
   },
-  convertToHTMLFormat: contentBody => {
-    return documentToHtmlString(contentBody, options)
+  fetchEntries: async () => {
+    const entries = await service.client.getEntries()
+
+    if (!entries.items?.length) {
+      return []
+    }
+
+    return entries.items.map(
+      ({ fields: { title, body, briefBannerText, date } }) => ({
+        title,
+        body,
+        briefBannerText,
+        date: new Date(date),
+      })
+    )
   },
-  formatDate: date => {
-    const newDate = new Date(date)
-    return format(newDate, DATE_FORMATS.WITH_MONTH)
-  },
+  convertToHTMLFormat: body => documentToHtmlString(body, options),
+  formatDate: date => format(date, DATE_FORMATS.WITH_MONTH),
 }
 module.exports = service

--- a/common/services/whats-new-content.test.js
+++ b/common/services/whats-new-content.test.js
@@ -1,6 +1,11 @@
+const { format } = require('date-fns')
 const sinon = require('sinon')
 
+const { DATE_FORMATS } = require('../../config')
+
 const whatsNewContentService = require('./whats-new-content')
+
+const todaysDate = new Date()
 
 const mockedResponse = {
   items: [
@@ -143,7 +148,7 @@ const mockedResponse = {
           ],
         },
         briefBannerText: 'Some text briefly explaining the changes.',
-        date: '2022-03-04T00:00+00:00',
+        date: todaysDate.toISOString(),
       },
     },
   ],
@@ -181,7 +186,9 @@ describe('whatsNewContentService Service', function () {
     })
     it('returns the formatted date', async function () {
       const formattedEntries = await whatsNewContentService.fetch()
-      expect(formattedEntries.posts[0].date).to.equal('4 March 2022')
+      expect(formattedEntries.posts[0].date).to.equal(
+        format(todaysDate, DATE_FORMATS.WITH_MONTH)
+      )
     })
   })
 

--- a/common/templates/layouts/base.njk
+++ b/common/templates/layouts/base.njk
@@ -149,7 +149,7 @@
     </div>
   {% endif %}
 
-  {% if FEATURE_FLAGS.WHATS_NEW_BANNER and REQUEST_PATH === '/' and whatsNewContent %}
+  {% if FEATURE_FLAGS.WHATS_NEW_BANNER and REQUEST_PATH === '/' and whatsNewContent and whatsNewContent.bannerContent %}
     {{ appWhatsNewBanner(whatsNewContent.bannerContent) }}
   {% endif %}
 {% endblock %}


### PR DESCRIPTION
This ensures the banner is hidden after 2 weeks even if the user doesn't dismiss it. I've also refactored the service a little.