### PR TITLE
Make Contentful optional for development

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -15,9 +15,6 @@ if (!API_VERSION) {
   throw new Error('The API_VERSION environment variable must be set')
 }
 
-const CONTENTFUL_SPACE_ID = process.env.CONTENTFUL_SPACE_ID
-const CONTENTFUL_ACCESS_TOKEN = process.env.CONTENTFUL_ACCESS_TOKEN
-const CONTENTFUL_HOST = process.env.CONTENTFUL_HOST
 const IS_DEV = process.env.NODE_ENV !== 'production'
 const IS_PRODUCTION = process.env.NODE_ENV === 'production'
 const SUPPORT_URL = IS_PRODUCTION
@@ -68,9 +65,6 @@ function _authUrl(path) {
 }
 
 module.exports = {
-  CONTENTFUL_HOST,
-  CONTENTFUL_SPACE_ID,
-  CONTENTFUL_ACCESS_TOKEN,
   AUTH_BASE_URL,
   IS_DEV,
   IS_PRODUCTION,
@@ -180,6 +174,12 @@ module.exports = {
     user_caseloads_url: `${NOMIS_ELITE2_API_BASE_URL}/api/users/me/caseLoads`,
     healthcheck_url: `${NOMIS_ELITE2_API_BASE_URL}${NOMIS_ELITE2_API_HEALTHCHECK_PATH}`,
   },
+  CONTENTFUL_SPACE_ID:
+    process.env.CONTENTFUL_SPACE_ID || (IS_PRODUCTION ? null : 'space'),
+  CONTENTFUL_ACCESS_TOKEN:
+    process.env.CONTENTFUL_ACCESS_TOKEN ||
+    (IS_PRODUCTION ? null : 'access-token'),
+  CONTENTFUL_HOST: process.env.CONTENTFUL_HOST || 'cdn.contentful.com',
   ANALYTICS: {
     GA_ID: process.env.GOOGLE_ANALYTICS_ID,
   },


### PR DESCRIPTION
This changes how the Contentful configuration variables are determined to ensure in a development environment they're not required. Currently, the `.env.example` has them as empty values, but if a user were to follow this, the app wouldn't start.