### PR TITLE
chore: Convert testcafe reports to relative path

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -269,6 +269,9 @@ jobs:
             NODE_OPTIONS: --max-old-space-size=12288
           command: |
             npm run test-e2e -- --test $(circleci tests glob "test/e2e/**/*.test.js" | circleci tests split --split-by=timings)
+      - run:
+          name: Convert testcafe reports to relative path
+          command: sed -i 's/\/home\/circleci\/project\///g' reports/testcafe/*.xml
       - store_test_results:
           path: reports/testcafe
       - store_artifacts:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Added a step to convert testcafe reports to relative paths.
<!--- Describe the changes in detail - the "what"-->

### Why did it change

This needs to happen so that circleci can balance our tests for us (shorter run times)

<!--- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

- P4-3545
