### PR TITLE
Remove the WHATS_NEW_BANNER feature flag

### DIFF
--- a/common/templates/layouts/base.njk
+++ b/common/templates/layouts/base.njk
@@ -149,7 +149,7 @@
     </div>
   {% endif %}
 
-  {% if FEATURE_FLAGS.WHATS_NEW_BANNER and REQUEST_PATH === '/' and whatsNewContent and whatsNewContent.bannerContent %}
+  {% if REQUEST_PATH === '/' and whatsNewContent and whatsNewContent.bannerContent %}
     {{ appWhatsNewBanner(whatsNewContent.bannerContent) }}
   {% endif %}
 {% endblock %}

--- a/config/index.js
+++ b/config/index.js
@@ -292,7 +292,6 @@ module.exports = {
   },
   FEATURE_FLAGS: {
     GOT: /true/i.test(process.env.FEATURE_FLAG_GOT),
-    WHATS_NEW_BANNER: /true/i.test(process.env.FEATURE_FLAG_WHATS_NEW_BANNER),
   },
   FRAMEWORKS: {
     CURRENT_VERSION: process.env.FRAMEWORKS_VERSION || LATEST_FRAMEWORKS_BUILD,


### PR DESCRIPTION
Remove the WHATS_NEW_BANNER feature flag, as we now don't need to hide the banner in production