### PR TITLE
Remove references to codeclimate

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -218,25 +218,9 @@ jobs:
           name: Lint the code
           command: npm run circle:lint
       - run:
-          name: Setup Code Climate test-reporter
-          # download test reporter as a static binary
-          command: |
-            curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-0.8.0-linux-amd64 > ./cc-test-reporter
-            chmod +x ./cc-test-reporter
-      - run:
-          name: Notify CodeClimate before build
-          command: |
-            ./cc-test-reporter before-build
-          when: always
-      - run:
           name: Run unit tests
           command: |
             npm run circle:coverage
-      - run:
-          name: Upload coverage to CodeClimate
-          command: |
-            ./cc-test-reporter after-build
-          when: always
       - store_test_results:
           path: reports
       - store_artifacts:

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,6 +1,0 @@
-exclude_patterns:
-- "**/node_modules/"
-- "**/*.test.js"
-- "**/test/"
-- "**/coverage/"
-- "./build/"

--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 [![CircleCI](https://circleci.com/gh/ministryofjustice/hmpps-book-secure-move-frontend.svg?style=svg)](https://circleci.com/gh/ministryofjustice/hmpps-book-secure-move-frontend)
 [![Coverage Status](https://coveralls.io/repos/github/ministryofjustice/hmpps-book-secure-move-frontend/badge.svg)](https://coveralls.io/github/ministryofjustice/hmpps-book-secure-move-frontend)
-[![Test Coverage](https://api.codeclimate.com/v1/badges/93a7ea86058dc9d2f2dc/test_coverage)](https://codeclimate.com/github/ministryofjustice/hmpps-book-secure-move-frontend/test_coverage)
-[![Maintainability](https://api.codeclimate.com/v1/badges/93a7ea86058dc9d2f2dc/maintainability)](https://codeclimate.com/github/ministryofjustice/hmpps-book-secure-move-frontend/maintainability)
 
 Book a secure move is part of the HMPPS Prisoner Escort and Custody
 Service (PECS) programme.


### PR DESCRIPTION
We removed codeclimate a while back, this PR is to remove the last references of it within our circle ci config file and readme.