### PR TITLE
Ensure important events is an array

### DIFF
--- a/app/move/app/view/middleware/locals.move-details.js
+++ b/app/move/app/view/middleware/locals.move-details.js
@@ -9,7 +9,7 @@ function localsMoveDetails(req, res, next) {
   res.locals.moveIsLockout = move.is_lockout
   res.locals.moveId = move.id
 
-  const importantEvents = move.important_events || {}
+  const importantEvents = move.important_events || []
 
   res.locals.moveLodgingStarted = importantEvents.some(
     ({ event_type: eventType }) => eventType === 'MoveLodgingStart'


### PR DESCRIPTION
The `some` method only exists for arrays.

[Sentry issue](https://sentry.io/organizations/ministryofjustice/issues/3235426684/)