### PR TITLE
chore: Update content of existing handover form

### DIFF
--- a/app/person-escort-record/app/confirm/fields.js
+++ b/app/person-escort-record/app/confirm/fields.js
@@ -84,6 +84,7 @@ const handoverReceivingOfficerContact = {
 }
 const handoverReceivingOrganisation = {
   name: 'handover_receiving_organisation',
+  id: 'handover_receiving_organisation',
   component: 'govukRadios',
   fieldset: {
     legend: {
@@ -119,6 +120,7 @@ const handoverOtherOganisation = {
 const handoverTime = {
   validate: 'required',
   name: 'handover_occurred_at',
+  id: 'handover_occurred_at',
   component: 'govukRadios',
   fieldset: {
     legend: {

--- a/locales/en/assessment.json
+++ b/locales/en/assessment.json
@@ -67,15 +67,15 @@
   },
   "prefilled_message": "This answer needs to be reviewed",
   "handover": {
-    "heading": "Handover",
+    "heading": "Record handover",
     "before_handover": {
       "heading": "Before you handover",
-      "content": "Check that you have:\n\n- <a href=\"{{ per_href }}\">reviewed the Person Escort Record</a> and the information is up to date\n- confirmed the correct person is being moved\n- completed the correct level of search\n- communicated risk and health information with receiving officer"
+      "content": "Check that you have:\n\n- <a href=\"{{ per_href }}\">reviewed the Person Escort Record</a> and the information is up to date\n- confirmed the correct person is being moved\n- completed the correct level of search\n- communicated risk and health information with the receiving officer"
     },
     "not_fit_to_travel": "If this person is not fit to travel you must <a href=\"{{cancel_href}}\" class=\"app-link--destructive\">cancel this move</a>",
     "dispatching_officer": "Dispatching officer",
     "receiving_officer": "Receiving officer",
-    "warning_text": "Once you handover this person, you will no longer be able to update their Person Escort Record"
+    "warning_text": "Once you've confirmed handover for this person, you will no longer be able to update their Person Escort Record."
   },
   "handover_status": {
     "heading": "Handover status",

--- a/locales/en/fields.json
+++ b/locales/en/fields.json
@@ -469,7 +469,7 @@
   },
   "confirm_handover": {
     "label": "Check this box to confirm that all the above tasks have been completed",
-    "error_message": "You must provide confirmation"
+    "error_message": "You must provide confirmation that all handover tasks have been completed"
   },
   "confirm_youth_risk_assessment": {
     "label": "Check this box to confirm that, to the best your knowledge, all information provided in the assessment is correct",
@@ -500,25 +500,30 @@
     "label": "Usable capacity"
   },
   "handover_dispatching_officer": {
-    "label": "Full name of dispatching officer"
+    "label": "Full name of the dispatching officer",
+    "error_message": "Enter full name of the dispatching officer"
   },
   "handover_dispatching_officer_id": {
-    "label": "ID of dispatching officer"
+    "label": "ID of the dispatching officer"
   },
   "handover_dispatching_officer_contact": {
-    "label": "Contact number of dispatching officer"
+    "label": "Contact number of the dispatching officer",
+    "error_message": "Enter the contact number of the dispatching officer"
   },
   "handover_receiving_officer": {
-    "label": "Full name of receiving officer"
+    "label": "Full name of the receiving officer",
+    "error_message": "Enter the full name of the receiving officer"
   },
   "handover_receiving_officer_id": {
-    "label": "ID of receiving officer"
+    "label": "ID of the receiving officer"
   },
   "handover_receiving_officer_contact": {
-    "label": "Contact number of receiving officer"
+    "label": "Contact number of the receiving officer",
+    "error_message": "Enter the contact number of the receiving officer"
   },
   "handover_receiving_organisation": {
-    "label": "Organisation of receiving officer",
+    "label": "Organisation of the receiving officer",
+    "error_message": "Enter the organisation of the receiving officer",
     "items": {
       "supplier": {
         "label": "Supplier"
@@ -533,6 +538,7 @@
   },
   "handover_occurred_at": {
     "label": "Handover time",
+    "error_message": "Enter the time handover happened",
     "items": {
       "now": {
         "label": "Now"

--- a/locales/en/validation.json
+++ b/locales/en/validation.json
@@ -4,7 +4,7 @@
     "heading": "There is a problem with this page"
   },
   "required": "cannot be blank",
-  "required_with_label": "Enter {{label}}",
+  "required_with_label": "Enter the {{label}}",
   "numeric": "can only contain numbers",
   "numeric_with_label": "{{label}} can only contain numbers",
   "equal": "must be a valid option",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

This is part **one** of the attached ticket, which is to fix the current handover form issues around the errors and update the content.

- Change the H1 on the existing form from just “Handover” to “Record handover” so it is a more action-based heading. This heading will also apply on the new lockouts handover form.
- Add the word “the” into bullet 4 so it says “communicated risk and health information with the receiving officer”
- Change the copy in the warning text slightly, so that it says this: Once you've confirmed handover for this person, you will no longer be able to update their Person Escort Record.
- Update the last two error links to allow the user to click to the error
- Update the content of the errors and error links

### Why did it change

So we can provide better error help to the user, and update the content to make it easier to understand.

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

- [P4-3396](https://dsdmoj.atlassian.net/browse/P4-3396)

## Screenshots
<!--- (Optional) Include screenshots if changes update interfaces or components -->
<!--- Delete/copy as appropriate --->

## BEFORE:
![image (13)](https://user-images.githubusercontent.com/40758489/165943148-983b1894-3a2f-461a-85d7-438e7408fa1d.png)

## AFTER
<img width="473" alt="Screenshot 2022-04-29 at 13 18 48" src="https://user-images.githubusercontent.com/40758489/165943264-0cb030b0-c9f3-45a6-8702-f7fa1e15ea0d.png">

