### PR TITLE
Integrate images into Contentful content

### DIFF
--- a/common/services/whats-new-content.js
+++ b/common/services/whats-new-content.js
@@ -36,6 +36,8 @@ const options = {
       `<ol class="govuk-list govuk-list--number">${next(node.content)}</ol>`,
     [BLOCKS.PARAGRAPH]: (node, next) =>
       `<p class="govuk-body">${next(node.content)}</p>`,
+    [BLOCKS.EMBEDDED_ASSET]: node =>
+      `<img src="https:${node.data.target.fields.file.url}" height=${node.data.target.fields.file.details.image.height} width=${node.data.target.fields.file.details.image.width} alt=${node.data.target.fields.description} <img/>`,
     [INLINES.HYPERLINK]: (node, next) =>
       `<a class="govuk-link" href="${node.data.uri}">${next(node.content)}</a>`,
   },

--- a/common/services/whats-new-content.test.js
+++ b/common/services/whats-new-content.test.js
@@ -187,6 +187,30 @@ const mockedResponse = {
               ],
               data: {},
             },
+            {
+              nodeType: 'embedded-asset-block',
+              data: {
+                target: {
+                  metadata: [],
+                  sys: [],
+                  fields: {
+                    title: 'Test asset',
+                    description: 'asset-test',
+                    file: {
+                      url: '//images.ctfassets.net/m5k1kmk3zqwh/4W3q8OwEoyEQxjJtdtCkbg/51b7fc14e8d568d5f5314733e1b9aadb/image.png',
+                      details: {
+                        size: 497136,
+                        image: { width: 867, height: 479 },
+                      },
+                      fileName: 'image.png',
+                      contentType: 'image/png',
+                    },
+                  },
+                },
+              },
+
+              content: [],
+            },
           ],
         },
         briefBannerText: 'Some text briefly explaining the changes.',
@@ -209,7 +233,7 @@ describe('whatsNewContentService Service', function () {
     it('returns the formatted body', async function () {
       const formattedEntries = await whatsNewContentService.fetch()
       expect(formattedEntries.posts[0].body).to.equal(
-        '<h1 class="govuk-heading-l">The latest updates and improvements to Book a secure move.</h1><h2 class="govuk-heading-s govuk-!-margin-top-5">Test heading 2.</h2><h3 class="govuk-heading-m govuk-!-margin-top-4"><i>Test heading 3.</i></h3><h4 class="govuk-heading-m">Test heading 4.</h4><a class="govuk-link" href="https://google.com">Test Link</a><p class="govuk-body"><strong>Some random paragraph text.</strong></p><ul class="govuk-list govuk-list--bullet"><li><p class="govuk-body">TEST LINE 1</p></li><li><p class="govuk-body">TEST LINE 2</p></li></ul><ol class="govuk-list govuk-list--number"><li><p class="govuk-body">TEST LINE 1</p></li><li><p class="govuk-body">TEST LINE 2</p></li></ol>'
+        '<h1 class="govuk-heading-l">The latest updates and improvements to Book a secure move.</h1><h2 class="govuk-heading-s govuk-!-margin-top-5">Test heading 2.</h2><h3 class="govuk-heading-m govuk-!-margin-top-4"><i>Test heading 3.</i></h3><h4 class="govuk-heading-m">Test heading 4.</h4><a class="govuk-link" href="https://google.com">Test Link</a><p class="govuk-body"><strong>Some random paragraph text.</strong></p><ul class="govuk-list govuk-list--bullet"><li><p class="govuk-body">TEST LINE 1</p></li><li><p class="govuk-body">TEST LINE 2</p></li></ul><ol class="govuk-list govuk-list--number"><li><p class="govuk-body">TEST LINE 1</p></li><li><p class="govuk-body">TEST LINE 2</p></li></ol><img src="https://images.ctfassets.net/m5k1kmk3zqwh/4W3q8OwEoyEQxjJtdtCkbg/51b7fc14e8d568d5f5314733e1b9aadb/image.png" height=479 width=867 alt=asset-test <img/>'
       )
     })
     it('returns the content title', async function () {

--- a/server.js
+++ b/server.js
@@ -246,6 +246,7 @@ app.use(
           'www.google-analytics.com',
           'api.os.uk',
           'data: blob:',
+          'images.ctfassets.net',
         ],
         fontSrc: ["'self'", 'fonts.googleapis.com'],
         styleSrc: ["'self'", "'unsafe-inline'", 'cdn.jsdelivr.net'],


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

We now have the ability to integrate images into Contenful content via the use of assets

### Why did it change

This allows us to show changes via the use of images as well as text

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

- [P4-3522](https://dsdmoj.atlassian.net/browse/P4-3522)

## Screenshots
<!--- (Optional) Include screenshots if changes update interfaces or components -->
<!--- Delete/copy as appropriate --->
<img width="1788" alt="Screenshot 2022-05-05 at 12 07 35" src="https://user-images.githubusercontent.com/40758489/166920230-1157cfc7-e4be-4993-b388-708aa69dc17b.png">

