### PR TITLE
Redirect users to move page after filling in police form

### DIFF
--- a/app/police-custody-form/controllers.js
+++ b/app/police-custody-form/controllers.js
@@ -31,7 +31,7 @@ exports.addEvents = async function (req, res) {
     content: req.t('messages::events_added.content', { fullName }),
   })
 
-  return res.redirect(`/move/${moveId}/timeline`)
+  return res.redirect(`/move/${moveId}`)
 }
 
 function mapErrorMessages(errors) {

--- a/app/police-custody-form/controllers.test.js
+++ b/app/police-custody-form/controllers.test.js
@@ -41,7 +41,7 @@ describe('Police Custody Form controllers', function () {
 
       it('should redirect to the timeline/events page for that move', function () {
         expect(mockRes.redirect).to.be.calledOnceWithExactly(
-          '/move/12232552242/timeline'
+          '/move/12232552242'
         )
       })
 


### PR DESCRIPTION
Currently users are taken to the timeline, but we'd like users to end up on the main move page (which ends up on the warnings tab).