### PR TITLE
Update wording on handover banner

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -65,11 +65,11 @@
     "nomis":"This number was originally from NOMIS"
   },
   "assessment_confirmed": {
-    "heading":"$t({{context}}) confirmed",
-    "heading_person_escort_record":"Handover recorded successfully",
-    "content":"",
-    "content_youth_risk_assessment":"The $t({{context}}) for <strong>{{name}}</strong> has been successfully confirmed. You can now start the Person Escort Record.",
-    "content_person_escort_record":"The handover for <strong>{{name}}</strong> has been recorded. You can view the details recorded in the <a href=\"{{timelineUrl}}\">history of events</a>."
+    "heading": "$t({{context}}) confirmed",
+    "heading_person_escort_record": "Handover recorded successfully",
+    "content": "",
+    "content_youth_risk_assessment": "The $t({{context}}) for <strong>{{name}}</strong> has been successfully confirmed. You can now start the Person Escort Record.",
+    "content_person_escort_record": "The handover for <strong>{{name}}</strong> has been recorded. You can view the details in the <a href=\"{{timelineUrl}}\">history of events</a>."
   },
   "events_added": {
     "heading": "Lockout events added successfully",


### PR DESCRIPTION
As requested by the content designer, we've removed the word "recorded" from the text.

[Jira Ticket](https://dsdmoj.atlassian.net/browse/P4-3509)