### PR TITLE
Allow handover form to be used for lockouts

### DIFF
--- a/app/move/app/view/middleware/locals.move-details.js
+++ b/app/move/app/view/middleware/locals.move-details.js
@@ -18,6 +18,12 @@ function localsMoveDetails(req, res, next) {
     ({ event_type: eventType }) => eventType === 'MoveLodgingEnd'
   )
 
+  const handovers = presenters.moveToHandoversSummary(move, journeys)
+
+  if (move.is_lockout && handovers.length >= 2) {
+    res.locals.moveLockoutHandover = handovers[handovers.length - 1]
+  }
+
   next()
 }
 

--- a/app/move/app/view/views/_layout.njk
+++ b/app/move/app/view/views/_layout.njk
@@ -41,7 +41,7 @@
 
           <div class="govuk-grid-column-one-half govuk-!-text-align-right">
             {% if moveLodgingStarted %}
-              {% if not moveLodgingEnded %}
+              {% if not moveLodgingEnded and (not moveLockoutHandover or not moveLockoutHandover.recorded) %}
                 <a href="/move/{{moveId}}/police-custody-form" class="govuk-button">Add events</a>
               {% endif %}
 

--- a/app/move/app/view/views/_layout.njk
+++ b/app/move/app/view/views/_layout.njk
@@ -32,16 +32,23 @@
     <div class="govuk-!-margin-bottom-6 prison-lockout-banner">
       <div class="govuk-width-container prison-lockout-banner-content">
         <div class="govuk-grid-row">
-          <div class="govuk-grid-column-two-thirds">
+          <div class="govuk-grid-column-one-half">
             {{ govukWarningText({
               text: t("moves::is_lockout"),
               iconFallbackText: "Warning"
             }) }}
           </div>
-          <div class="govuk-grid-column-one-third">
-            {% if moveLodgingStarted and not moveLodgingEnded %}
-              <a href="/move/{{moveId}}/police-custody-form" class="govuk-button prison-lockout-banner-button">Add events</a>
-            {% endif %}   
+
+          <div class="govuk-grid-column-one-half govuk-!-text-align-right">
+            {% if moveLodgingStarted %}
+              {% if not moveLodgingEnded %}
+                <a href="/move/{{moveId}}/police-custody-form" class="govuk-button">Add events</a>
+              {% endif %}
+
+              {% if moveLockoutHandover and not moveLockoutHandover.recorded %}
+                <a href="/move/{{moveId}}/person-escort-record/confirm" class="govuk-button">Record handover</a>
+              {% endif %}
+            {% endif %}
           </div>
         </div>
       </div>

--- a/app/person-escort-record/app/confirm/controllers.js
+++ b/app/person-escort-record/app/confirm/controllers.js
@@ -119,6 +119,8 @@ class HandoverController extends ConfirmAssessmentController {
         handover_receiving_organisation: receivingOrganisation,
       } = values
 
+      const locationId = req.session?.currentLocation?.id
+
       await req.services.personEscortRecord.confirm(req.assessment.id, {
         handoverOccurredAt,
         dispatchingOfficer,
@@ -128,6 +130,7 @@ class HandoverController extends ConfirmAssessmentController {
         receivingOfficerId,
         receivingOfficerContact,
         receivingOrganisation,
+        locationId,
       })
 
       next()

--- a/app/person-escort-record/app/confirm/controllers.js
+++ b/app/person-escort-record/app/confirm/controllers.js
@@ -10,12 +10,13 @@ class HandoverController extends ConfirmAssessmentController {
 
   middlewareLocals() {
     super.middlewareLocals()
-    this.use(this.setMoveId)
+    this.use(this.setMoveDetails)
     this.use(this.setBreadcrumb)
   }
 
-  setMoveId(req, res, next) {
+  setMoveDetails(req, res, next) {
     res.locals.moveId = req.move.id
+    res.locals.moveIsLockout = req.move.is_lockout
     next()
   }
 

--- a/app/person-escort-record/app/confirm/controllers.test.js
+++ b/app/person-escort-record/app/confirm/controllers.test.js
@@ -436,6 +436,9 @@ describe('Person Escort Record controllers', function () {
               confirm: sinon.stub().resolves({}),
             },
           },
+          session: {
+            currentLocation: { id: 'abc' },
+          },
         }
       })
 
@@ -461,6 +464,7 @@ describe('Person Escort Record controllers', function () {
             receivingOfficerId: '456',
             receivingOfficerContact: '088888',
             receivingOrganisation: 'Serco',
+            locationId: 'abc',
           })
         })
 

--- a/app/person-escort-record/app/confirm/controllers.test.js
+++ b/app/person-escort-record/app/confirm/controllers.test.js
@@ -38,7 +38,7 @@ describe('Person Escort Record controllers', function () {
         sinon.stub(ConfirmAssessmentController.prototype, 'middlewareLocals')
         sinon.stub(controller, 'use')
         sinon.stub(controller, 'setBreadcrumb')
-        sinon.stub(controller, 'setMoveId')
+        sinon.stub(controller, 'setMoveDetails')
 
         controller.middlewareLocals()
       })
@@ -54,9 +54,9 @@ describe('Person Escort Record controllers', function () {
         )
       })
 
-      it('should call set move ID', function () {
+      it('should call set move details', function () {
         expect(controller.use).to.have.been.calledWithExactly(
-          controller.setMoveId
+          controller.setMoveDetails
         )
       })
 
@@ -184,12 +184,17 @@ describe('Person Escort Record controllers', function () {
         mockRes = {
           locals: {},
         }
-        controller.setMoveId(mockReq, mockRes, nextSpy)
+        controller.setMoveDetails(mockReq, mockRes, nextSpy)
       })
 
       it('should set move ID', function () {
         expect(mockRes.locals).to.have.property('moveId')
         expect(mockRes.locals.moveId).to.equal('12345')
+      })
+
+      it('should set move is lockout', function () {
+        expect(mockRes.locals).to.have.property('moveIsLockout')
+        expect(mockRes.locals.moveIsLockout).to.equal(undefined)
       })
 
       it('should call next without error', function () {

--- a/app/person-escort-record/app/confirm/handover-details.njk
+++ b/app/person-escort-record/app/confirm/handover-details.njk
@@ -10,7 +10,13 @@
   </h2>
 
   <div class="markdown govuk-!-margin-bottom-6">
-    {% markdown %}{{ t("assessment::handover.before_handover.content", { per_href: "/move/" + moveId + "/person-escort-record" }) | safe }}{% endmarkdown %}
+    {% markdown %}
+      {% if moveIsLockout %}
+        {{ t("assessment::handover.before_handover.content", { context: 'lockout', per_href: "/move/" + moveId + "/police-custody-form" }) | safe }}
+      {% else %}
+        {{ t("assessment::handover.before_handover.content", { per_href: "/move/" + moveId + "/person-escort-record" }) | safe }}
+      {% endif %}
+    {% endmarkdown %}
   </div>
 
   {{ callAsMacro(options.fields.confirm_handover.component)(options.fields.confirm_handover) }}
@@ -44,10 +50,17 @@
 
   {{ renderField("handover_occurred_at") }}
 
-  {{ govukWarningText({
-    text: t("assessment::handover.warning_text"),
-    iconFallbackText: "Warning"
-  }) }}
+  {% if moveIsLockout %}
+    {{ govukWarningText({
+      text: t("assessment::handover.warning_text", { context: 'lockout' }),
+      iconFallbackText: "Warning"
+    }) }}
+  {% else %}
+    {{ govukWarningText({
+      text: t("assessment::handover.warning_text"),
+      iconFallbackText: "Warning"
+    }) }}
+  {% endif %}
 {% endblock %}
 
 {% block contentSidebar %}

--- a/common/assets/scss/components/_lockout-banner.scss
+++ b/common/assets/scss/components/_lockout-banner.scss
@@ -9,7 +9,3 @@
   margin-left: 40%;
   padding-top: 18px;
 }
-
-.prison-lockout-banner-button {
-  margin-left: 17.6%;
-}

--- a/common/controllers/framework/confirm-assessment.js
+++ b/common/controllers/framework/confirm-assessment.js
@@ -16,10 +16,11 @@ class ConfirmAssessmentController extends FormWizardController {
 
   checkStatus(req, res, next) {
     const moveId = req.move?.id
+
     const isAllowed =
       req?.assessment?.status === 'completed' ||
-      (req?.assessment?.status === 'confirmed' &&
-        !req.assessment.handover_occurred_at)
+      (req?.assessment?.framework?.name === 'person-escort-record' &&
+        req?.assessment?.status === 'confirmed')
 
     if (isAllowed) {
       return next()

--- a/common/controllers/framework/confirm-assessment.test.js
+++ b/common/controllers/framework/confirm-assessment.test.js
@@ -106,8 +106,9 @@ describe('Framework controllers', function () {
         })
       })
 
-      context('with confirmed status', function () {
+      context('with confirmed status and is a PER', function () {
         beforeEach(function () {
+          mockReq.assessment.framework = { name: 'person-escort-record' }
           mockReq.assessment.status = 'confirmed'
           controller.checkStatus(mockReq, mockRes, nextSpy)
         })
@@ -121,24 +122,20 @@ describe('Framework controllers', function () {
         })
       })
 
-      context(
-        'with confirmed status and handover_occurred_at set',
-        function () {
-          beforeEach(function () {
-            mockReq.assessment.status = 'confirmed'
-            mockReq.assessment.handover_occurred_at = '123'
-            controller.checkStatus(mockReq, mockRes, nextSpy)
-          })
+      context('with confirmed status and is not a PER', function () {
+        beforeEach(function () {
+          mockReq.assessment.status = 'confirmed'
+          controller.checkStatus(mockReq, mockRes, nextSpy)
+        })
 
-          it('should redirect to move', function () {
-            expect(mockRes.redirect).to.be.calledOnceWithExactly('/move/12345')
-          })
+        it('should redirect to move', function () {
+          expect(mockRes.redirect).to.be.calledOnceWithExactly('/move/12345')
+        })
 
-          it('should not call next', function () {
-            expect(nextSpy).not.to.be.called
-          })
-        }
-      )
+        it('should not call next', function () {
+          expect(nextSpy).not.to.be.called
+        })
+      })
     })
 
     describe('#saveValues', function () {

--- a/common/lib/api-client/transformers/move.transformer.js
+++ b/common/lib/api-client/transformers/move.transformer.js
@@ -45,6 +45,8 @@ const addImportantEvents = data => {
       ({ event_type: eventType, classification }) =>
         eventType === 'PerPropertyChange' ||
         eventType === 'PerHandover' ||
+        eventType === 'MoveLodgingStart' ||
+        eventType === 'MoveLodgingEnd' ||
         (classification && classification !== 'default')
     )
   }

--- a/common/presenters/index.js
+++ b/common/presenters/index.js
@@ -20,6 +20,7 @@ const frameworkToTaskListComponent = require('./framework-to-task-list-component
 const moveToMessageBannerComponent = require('./message-banner/move-to-message-banner-component')
 const moveToAdditionalInfoListComponent = require('./move-to-additional-info-list-component')
 const moveToCardComponent = require('./move-to-card-component')
+const moveToHandoversSummary = require('./move-to-handovers-summary')
 const moveToIdentityBarActions = require('./move-to-identity-bar-actions')
 const moveToImportantEventsTagListComponent = require('./move-to-important-events-tag-list-component')
 const moveToInTransitEventsPanelList = require('./move-to-in-transit-events-panel-list')
@@ -65,6 +66,7 @@ module.exports = {
   movesToTableComponent,
   moveToAdditionalInfoListComponent,
   moveToCardComponent,
+  moveToHandoversSummary,
   moveToIdentityBarActions,
   moveToImportantEventsTagListComponent,
   moveToInTransitEventsPanelList,

--- a/common/services/person-escort-record.js
+++ b/common/services/person-escort-record.js
@@ -29,6 +29,7 @@ class PersonEscortRecordService extends BaseService {
       receivingOfficerId,
       receivingOfficerContact,
       receivingOrganisation,
+      locationId,
     } = {}
   ) {
     if (!id) {
@@ -43,6 +44,7 @@ class PersonEscortRecordService extends BaseService {
       receiving_officer_id: receivingOfficerId,
       receiving_officer_contact: receivingOfficerContact,
       receiving_organisation: receivingOrganisation,
+      location_id: locationId,
     })
 
     return this.apiClient

--- a/locales/en/assessment.json
+++ b/locales/en/assessment.json
@@ -70,12 +70,14 @@
     "heading": "Record handover",
     "before_handover": {
       "heading": "Before you handover",
-      "content": "Check that you have:\n\n- <a href=\"{{ per_href }}\">reviewed the Person Escort Record</a> and the information is up to date\n- confirmed the correct person is being moved\n- completed the correct level of search\n- communicated risk and health information with the receiving officer"
+      "content": "Check that you have:\n\n- <a href=\"{{ per_href }}\">reviewed the Person Escort Record</a> and the information is up to date\n- confirmed the correct person is being moved\n- completed the correct level of search\n- communicated risk and health information with the receiving officer",
+      "content_lockout": "Check that you have:\n\n- <a href=\"{{ per_href }}\">added all lockout events</a> and the information is up to date\n- confirmed the correct person is being moved\n- completed the correct level of search\n- communicated risk and health information with the receiving officer"
     },
     "not_fit_to_travel": "If this person is not fit to travel you must <a href=\"{{cancel_href}}\" class=\"app-link--destructive\">cancel this move</a>.",
     "dispatching_officer": "Dispatching officer",
     "receiving_officer": "Receiving officer",
-    "warning_text": "Once you’ve confirmed handover for this person, you will no longer be able to update their Person Escort Record."
+    "warning_text": "Once you’ve confirmed handover for this person, you will no longer be able to update their Person Escort Record.",
+    "warning_text_lockout": "Once you’ve confirmed handover for this person, you will no longer be able to add any new lockout events."
   },
   "handover_status": {
     "heading": "Handover status",

--- a/locales/en/assessment.json
+++ b/locales/en/assessment.json
@@ -72,10 +72,10 @@
       "heading": "Before you handover",
       "content": "Check that you have:\n\n- <a href=\"{{ per_href }}\">reviewed the Person Escort Record</a> and the information is up to date\n- confirmed the correct person is being moved\n- completed the correct level of search\n- communicated risk and health information with the receiving officer"
     },
-    "not_fit_to_travel": "If this person is not fit to travel you must <a href=\"{{cancel_href}}\" class=\"app-link--destructive\">cancel this move</a>",
+    "not_fit_to_travel": "If this person is not fit to travel you must <a href=\"{{cancel_href}}\" class=\"app-link--destructive\">cancel this move</a>.",
     "dispatching_officer": "Dispatching officer",
     "receiving_officer": "Receiving officer",
-    "warning_text": "Once you've confirmed handover for this person, you will no longer be able to update their Person Escort Record."
+    "warning_text": "Once you’ve confirmed handover for this person, you will no longer be able to update their Person Escort Record."
   },
   "handover_status": {
     "heading": "Handover status",


### PR DESCRIPTION
This updates the record handover form to be used for lockouts. See commits for individual details, but this changes some content on the form when during a lockout, includes the location when recording the handover and shows the record handover button.

[Jira Ticket](https://dsdmoj.atlassian.net/browse/P4-3396)

## Screenshots

![Screenshot 2022-05-11 at 14 11 02](https://user-images.githubusercontent.com/510498/167866837-578e5ba6-e82d-46d5-ba03-178943bb86cf.png)

![Screenshot 2022-05-11 at 14 10 54](https://user-images.githubusercontent.com/510498/167866844-79cc0b13-823d-4343-b86a-0d4a50dcaff7.png)

![Screenshot 2022-05-11 at 14 10 50](https://user-images.githubusercontent.com/510498/167866847-173298b8-7998-4e4c-a6ba-22bf51be3cb7.png)
