### PR TITLE
Improve content for the handover event

### DIFF
--- a/locales/en/events.json
+++ b/locales/en/events.json
@@ -153,7 +153,7 @@
   },
   "MoveLodgingStart": {
     "heading": "Lodging started",
-    "description": "$t(events::person)  temporarily lodged at {{location.title}} $t(events::MoveLodgingStart.select_reason) $t(events::select_authorised_by)",
+    "description": "$t(events::person) temporarily lodged at {{location.title}} $t(events::MoveLodgingStart.select_reason) $t(events::select_authorised_by)",
     "select_reason": "$t(events::MoveLodgingStart.reason, {\"context\": \"{{reason}}\"})",
     "reason": "",
     "reason_overnight_lodging": "due to an overnight lodging",
@@ -456,11 +456,13 @@
     "description": "All information in this Person Escort Record was confirmed"
   },
   "PerHandover": {
-    "heading": "Person handed over",
-    "description": "This person was handed over $t(events::PerHandover.receiving, {\"context\": \"{{receiving_officer, exists}}\"}) $t(events::PerHandover.dispatching, {\"context\": \"{{dispatching_officer, exists}}\"})",
-    "receiving_true": "to <strong>{{receiving_officer}} ({{receiving_officer_id}}), {{receiving_organisation}}</strong>",
+    "heading": "Handover recorded",
+    "description": "$t(events::person) was handed over $t(events::PerHandover.location, {\"context\": \"{{location, exists}}\"}) $t(events::PerHandover.dispatching, {\"context\": \"{{dispatching_officer, exists}}\"}) $t(events::PerHandover.receiving, {\"context\": \"{{receiving_officer, exists}}\"})",
+    "location_true": "at {{location.title}}",
+    "location_false": "",
+    "receiving_true": "to {{receiving_officer}} ({{receiving_officer_id}}) of {{receiving_organisation}}",
     "receiving_false": "",
-    "dispatching_true": "by <strong>{{dispatching_officer}} ({{dispatching_officer_id}})</strong>",
+    "dispatching_true": "by {{dispatching_officer}} ({{dispatching_officer_id}})",
     "dispatching_false": ""
   }
 }


### PR DESCRIPTION
This improves the textual content for the handover event as per content designer request. The main difference is that the location of where the handover occurred is now included, as this supports lockouts where there can be more than one handover event.

[Jira Ticket](https://dsdmoj.atlassian.net/browse/P4-3662)

## Screenshots

### Old

![Screenshot 2022-05-11 at 15 21 32](https://user-images.githubusercontent.com/510498/167872602-ef7379af-8a35-41b9-82c4-2c6bc7561adb.png)

### New

![Screenshot 2022-05-11 at 15 17 44](https://user-images.githubusercontent.com/510498/167872527-fbd1efaa-dd20-4006-a7db-2ca55d085914.png)