### PR TITLE
Restart deployment after branch based apply

### DIFF
--- a/.github/workflows/branch-deploy.yml
+++ b/.github/workflows/branch-deploy.yml
@@ -129,7 +129,7 @@ jobs:
 
           docker tag app $DOCKER_IMAGE_URL
           docker push $DOCKER_IMAGE_URL
-      
+
       - name: Upload kube configs
         env:
           PR_NUMBER: ${{ github.event.number }}
@@ -145,6 +145,8 @@ jobs:
           kubectl apply -f .github/branch-deploy/service.yml
           kubectl apply -f .github/branch-deploy/deployment.yml
           kubectl apply -f .github/branch-deploy/ingress.yml
+
+          kubectl rollout restart deployment "hmpps-book-secure-move-frontend-deployment-pr-${PR_NUMBER}"
 
       - name: Update deployment
         uses: actions/github-script@v6


### PR DESCRIPTION
This ensures that the pods are restarted with the latest Docker image, as currently the pods aren't updated with a new image if a branch gets changed after the first deployment.