### PR TITLE
Exclude certain events from tags list

### DIFF
--- a/common/presenters/move-to-important-events-tag-list-component.js
+++ b/common/presenters/move-to-important-events-tag-list-component.js
@@ -1,13 +1,16 @@
 const eventToTagComponent = require('./event-to-tag-component')
 
+const EXCLUDED_EVENTS = ['PerHandover', 'MoveLodgingStart', 'MoveLodgingEnd']
+
 const moveToImportantEventsTagListComponent = (
   move = {},
   linkToLocal = false
 ) => {
   const { important_events: importantEvents = [] } = move
-  return importantEvents.map(event =>
-    eventToTagComponent(event, move.id, linkToLocal)
-  )
+
+  return importantEvents
+    .filter(({ event_type: eventType }) => !EXCLUDED_EVENTS.includes(eventType))
+    .map(event => eventToTagComponent(event, move.id, linkToLocal))
 }
 
 module.exports = moveToImportantEventsTagListComponent


### PR DESCRIPTION
These were added accidentally when we started including these events in db2990edad77481b2e34e4274be7ebac6d40c42b and 5532e88971848e0d77ed60174c4624068d851d7a.

## Screenshots

### Old

<img width="644" alt="Screenshot 2022-05-13 at 11 03 39" src="https://user-images.githubusercontent.com/510498/168261346-8334fe5f-e3bb-492c-847b-8b85947aea55.png">

### New

<img width="290" alt="Screenshot 2022-05-13 at 11 03 43" src="https://user-images.githubusercontent.com/510498/168261381-72243249-ec9b-4964-811a-31eba34e55ca.png">