### PR TITLE
chore: Fix dependabot PRs not being able to BDD

### DIFF
--- a/.github/workflows/branch-deploy.yml
+++ b/.github/workflows/branch-deploy.yml
@@ -23,6 +23,8 @@ jobs:
   setup-build-publish-deploy:
     name: Setup, Build, Publish, and Deploy
     runs-on: ubuntu-latest
+    permissions:
+      actions: write
     steps:
       - id: create_deployment
         name: Create deployment


### PR DESCRIPTION
This should hopefully fix the issue where the dependabot PRs branch-based deployment action was failing.