### PR TITLE
chore: Fix dependabot PRs not being able to BDD

### DIFF
--- a/.github/workflows/branch-deploy-cleanup.yml
+++ b/.github/workflows/branch-deploy-cleanup.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Delete deployments
         uses: actions/github-script@v6
         with:
-          github-token: ${{secrets.GH_TOKEN}}
+          github-token: ${{github.token}}
           script: |
             let deployments = (
               await github.rest.repos.listDeployments({

--- a/.github/workflows/branch-deploy.yml
+++ b/.github/workflows/branch-deploy.yml
@@ -23,14 +23,12 @@ jobs:
   setup-build-publish-deploy:
     name: Setup, Build, Publish, and Deploy
     runs-on: ubuntu-latest
-    permissions:
-      actions: write
     steps:
       - id: create_deployment
         name: Create deployment
         uses: actions/github-script@v6
         with:
-          github-token: ${{secrets.GH_TOKEN}}
+          github-token: ${{github.token}}
           script: |
             return (await github.rest.repos.createDeployment({
               owner: context.repo.owner,
@@ -44,7 +42,7 @@ jobs:
       - name: Update deployment
         uses: actions/github-script@v6
         with:
-          github-token: ${{secrets.GH_TOKEN}}
+          github-token: ${{github.token}}
           script: |
             github.rest.repos.createDeploymentStatus({
               owner: context.repo.owner,
@@ -56,7 +54,7 @@ jobs:
       - name: Delete deployments
         uses: actions/github-script@v6
         with:
-          github-token: ${{secrets.GH_TOKEN}}
+          github-token: ${{github.token}}
           script: |
             let deployments = (
               await github.rest.repos.listDeployments({
@@ -153,7 +151,7 @@ jobs:
       - name: Update deployment
         uses: actions/github-script@v6
         with:
-          github-token: ${{secrets.GH_TOKEN}}
+          github-token: ${{github.token}}
           script: |
             github.rest.repos.createDeploymentStatus({
               owner: context.repo.owner,


### PR DESCRIPTION
This should hopefully fix the issue where the dependabot PRs branch-based deployment action was failing.