### PR TITLE
fix: Change the wording for optional fields when not answer given

### DIFF
--- a/locales/en/default.json
+++ b/locales/en/default.json
@@ -46,7 +46,7 @@
   "awaiting_person": "Person to be added",
   "sort_ascending": "Sort {{label}} ascending",
   "sort_descending": "Sort {{label}} descending",
-  "empty_response": "Reviewed and nothing provided",
+  "empty_response": "No answer provided",
   "empty_details": "Details not provided",
   "attach_photo": "Attach photo here",
   "initial_option": "--- Choose {{label}} ---",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

Change wording that appears in Overview table when no answer is given.

### What changed

The empty field text displayed has has changed from 'Reviewed and nothing provided' to 'No answer provided'.

### Why did it change

It assumes the user has definitely seen the question and chosen not to answer.

### Issue tracking

- [P4-3605](https://dsdmoj.atlassian.net/browse/P4-3605)

### Before

![image](https://user-images.githubusercontent.com/60104344/170255734-866aa346-0b34-4df9-84f7-7c58a6f71aa5.png)

### After

![image](https://user-images.githubusercontent.com/60104344/170256159-9e65b588-1f5a-4a81-913a-9d28093bc81f.png)
