### PR TITLE
Use Universal Google Analytics Format

### DIFF
--- a/common/templates/layouts/base.njk
+++ b/common/templates/layouts/base.njk
@@ -67,8 +67,9 @@
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
       {% block customGtagConfig %}{% endblock %}
-      gtag('config', '{{ GA_ID }}')
-      gtag('set', {'user_id': '{{ USER.userId }}'}); // Set the user ID using signed-in user_id.
+      gtag('config', '{{ GA_ID }}', {
+        'user_id': '{{ USER.userId }}'
+      });
     </script>
   {% endif %}
 {% endblock %}


### PR DESCRIPTION
Follow this format for supplying a user_id for universal GA: https://developers.google.com/analytics/devguides/collection/gtagjs/cookies-user-id#set_user_id