### PR TITLE
chore: Install NPM on build docker step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -305,6 +305,9 @@ jobs:
     steps:
       - checkout
       - *set_package_version
+      - run:
+          name: Install NPM
+          command: apt install npm
       - *install_dependencies
       - when:
           condition: <<parameters.production>>


### PR DESCRIPTION
Staging builds are failing because NPM isn't installed