### PR TITLE
chore: Add missing packages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -308,7 +308,7 @@ jobs:
       - run:
           name: Install NPM
           command: |
-            apk add --no-cache libgcc libstdc++ curl
+            apk add --no-cache libgcc libstdc++ curl libtool automake autoconf nasm
             curl -fLO https://github.com/oznu/alpine-node/releases/download/16.15.1/node-v16.15.1-linux-x86_64-alpine.tar.gz
             tar -xzf node-v16.15.1-linux-x86_64-alpine.tar.gz -C /usr --strip-components=1 --no-same-owner
             rm -rf node-v16.15.1-linux-x86_64-alpine.tar.gz


### PR DESCRIPTION
gifsicle's post-install was throwing an error because of missing packages