### PR TITLE
Add dependabot auto merge action

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,4 +1,4 @@
-name: dependabot auto-merge
+name: Dependabot Auto Merge PR
 
 on:
   pull_request:

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -10,5 +10,5 @@ jobs:
       - uses: actions/checkout@v2
       - uses: ahmadnassri/action-dependabot-auto-merge@v2
         with:
-          target: minor
-          github-token: ${{github.token}}
+          target: minor # includes patch updates as well!
+          github-token: ${{ github.token }}

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,14 @@
+name: dependabot auto-merge
+
+on:
+  pull_request:
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ahmadnassri/action-dependabot-auto-merge@v2
+        with:
+          target: minor
+          github-token: ${{github.token}}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

We have now added a new GitHub action to auto merge any dependabot PR's which are upgrading to either a new `minor` or `patch` version

**Note: This marketplace action does a check to see if the author is dependabot. So this will always pass on non dependabot PRs**

[Link to marketplace action](https://github.com/marketplace/actions/dependabot-auto-merge) 
### Why did it change

This will reduce the overhead needed to constantly attend to dependabot PRs each day

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

- [P4-3721](https://dsdmoj.atlassian.net/browse/P4-3721)
