### PR TITLE
Fix remove property button from ghosting when adding new property element

### DIFF
--- a/common/components/add-another/_add-another.scss
+++ b/common/components/add-another/_add-another.scss
@@ -1,6 +1,6 @@
 @include govuk-media-query($from: tablet) {
   .moj-add-another__remove-button {
-    position: absolute;
-    right: 0;
+    float: right;
+    margin-bottom: 0px;
   }
 }

--- a/common/components/add-another/template.njk
+++ b/common/components/add-another/template.njk
@@ -42,7 +42,7 @@
     {% endif %}
   {% endfor %}
 
-  <div class="app-add-another__add-item {{ 'app-border-top-1 govuk-!-padding-top-5' if items.length > 0 }}">
+  <div class="app-add-another__add-item {{ 'app-border-top-1 govuk-!-padding-top-5 govuk-!-margin-top-4' if items.length > 0 }}">
     {{ govukButton({
       text: t("actions::add_item", {
         context: "with_items" if items.length > 0,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Updated the scss styles used on the Remove property button

Note: **This issue is around the `add-another` component, which actually affected all pages where you would add another element to a form**

### Why did it change

The old scss stylings caused the button to act in a way which wasn't what we wanted, not allowing the user to remove a property item due to it ghosting.

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

- [P4-3723](https://dsdmoj.atlassian.net/browse/P4-3723)
