### PR TITLE
chore: Reduce branch based deploy pod count to 1

### DIFF
--- a/.github/branch-deploy/deployment.yml
+++ b/.github/branch-deploy/deployment.yml
@@ -4,13 +4,13 @@ metadata:
   name: hmpps-book-secure-move-frontend-deployment-pr-{PR_NUMBER}
   namespace: hmpps-book-secure-move-frontend-staging
 spec:
-  replicas: 2
+  replicas: 1
   revisionHistoryLimit: 10
   strategy:
     type: RollingUpdate
     rollingUpdate:
       maxUnavailable: 0
-      maxSurge: 2
+      maxSurge: 1
   selector:
     matchLabels:
       app: hmpps-book-secure-move-frontend-web-pr-{PR_NUMBER}


### PR DESCRIPTION
It's a bit excessive to have 2 pods for branch based deploys