### PR TITLE
chore: Swap branch based deploys to use PAT

### DIFF
--- a/.github/workflows/branch-deploy-cleanup.yml
+++ b/.github/workflows/branch-deploy-cleanup.yml
@@ -45,7 +45,7 @@ jobs:
           PR_NUMBER: ${{ github.event.number }}
         run: |
           aws ecr batch-delete-image --repository-name "${GITHUB_TEAM_NAME_SLUG}/${{ github.event.repository.name }}" --image-ids imageTag="pr-${PR_NUMBER}.latest"
-      
+
       - name: Delete kube configs
         env:
           PR_NUMBER: ${{ github.event.number }}
@@ -58,7 +58,7 @@ jobs:
       - name: Delete deployments
         uses: actions/github-script@v6
         with:
-          github-token: ${{github.token}}
+          github-token: ${{ secrets.BRANCH_BASED_DEPLOY_TOKEN }}
           script: |
             let deployments = (
               await github.rest.repos.listDeployments({

--- a/.github/workflows/branch-deploy.yml
+++ b/.github/workflows/branch-deploy.yml
@@ -30,7 +30,7 @@ jobs:
         name: Create deployment
         uses: actions/github-script@v6
         with:
-          github-token: ${{github.token}}
+          github-token: ${{ secrets.BRANCH_BASED_DEPLOY_TOKEN }}
           script: |
             try {
               return (await github.rest.repos.createDeployment({
@@ -48,7 +48,7 @@ jobs:
       - name: Update deployment
         uses: actions/github-script@v6
         with:
-          github-token: ${{github.token}}
+          github-token: ${{ secrets.BRANCH_BASED_DEPLOY_TOKEN }}
           script: |
             try {
               github.rest.repos.createDeploymentStatus({
@@ -64,7 +64,7 @@ jobs:
       - name: Delete deployments
         uses: actions/github-script@v6
         with:
-          github-token: ${{github.token}}
+          github-token: ${{ secrets.BRANCH_BASED_DEPLOY_TOKEN }}
           script: |
             try {
               let deployments = (
@@ -170,7 +170,7 @@ jobs:
       - name: Update deployment
         uses: actions/github-script@v6
         with:
-          github-token: ${{github.token}}
+          github-token: ${{ secrets.BRANCH_BASED_DEPLOY_TOKEN }}
           script: |
             try {
               github.rest.repos.createDeploymentStatus({


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

<!--- Describe the changes in detail - the "what"-->

Branch based deploys have been changed to use Personal Access Token to create the deployments.

### Why did it change

<!--- Describe the reason these changes were made - the "why" -->

This changed because dependabot opened/closed PRs weren't able perform any deploy actions.
