### PR TITLE
Increase resource_class from a medium to a large for our end to end tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -237,7 +237,7 @@ jobs:
 
   end-to-end-test:
     <<: *circle_container
-    resource_class: medium
+    resource_class: large
     parallelism: 8
     steps:
       - checkout


### PR DESCRIPTION
Increase the resource class for our end to end tests.

We have gone from a **medium	2vcpu	4GB ram** to a  **large	4vcpu	8GB ram**

