### PR TITLE
Allow Population Managers to change move dates

### DIFF
--- a/common/lib/permissions.js
+++ b/common/lib/permissions.js
@@ -173,6 +173,7 @@ const pmuPermissions = [
   'moves:view:proposed',
   'move:review',
   'move:view',
+  'move:update',
   'person_escort_record:view',
   'person_escort_record:print',
   'youth_risk_assessment:view',

--- a/common/lib/permissions.js
+++ b/common/lib/permissions.js
@@ -174,6 +174,7 @@ const pmuPermissions = [
   'move:review',
   'move:view',
   'move:update',
+  'move:update:prison_transfer',
   'person_escort_record:view',
   'person_escort_record:print',
   'youth_risk_assessment:view',

--- a/common/lib/permissions.test.js
+++ b/common/lib/permissions.test.js
@@ -231,6 +231,7 @@ describe('Permissions', function () {
           'move:review',
           'move:view',
           'move:update',
+          'move:update:prison_transfer',
           'person_escort_record:view',
           'person_escort_record:print',
           'youth_risk_assessment:view',

--- a/common/lib/permissions.test.js
+++ b/common/lib/permissions.test.js
@@ -230,6 +230,7 @@ describe('Permissions', function () {
           'moves:view:proposed',
           'move:review',
           'move:view',
+          'move:update',
           'person_escort_record:view',
           'person_escort_record:print',
           'youth_risk_assessment:view',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Give PMU users the permission to update a move

### Why did it change

So we can allow PMU users to update a moves date

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

- [P4-3777](https://dsdmoj.atlassian.net/browse/P4-3777)