### PR TITLE
chore: Populate created_by for events created through the police custody form

### DIFF
--- a/app/auth/middleware.js
+++ b/app/auth/middleware.js
@@ -17,7 +17,7 @@ function processAuthResponse() {
       const decodedAccessToken = decodeAccessToken(accessToken)
       const previousSession = { ...req.session }
 
-      const user = await loadUser(accessToken)
+      const user = await loadUser(req, accessToken)
 
       req.session.regenerate(error => {
         if (error) {

--- a/app/moves/middleware/set-download-results.moves.js
+++ b/app/moves/middleware/set-download-results.moves.js
@@ -1,7 +1,7 @@
 function setDownloadResultsMoves(bodyKey) {
   return async function handleResults(req, res, next) {
     try {
-      req.results = await req.services.move.getDownload(req.body[bodyKey])
+      req.results = await req.services.move.getDownload(req, req.body[bodyKey])
       next()
     } catch (error) {
       next(error)

--- a/app/moves/middleware/set-download-results.moves.test.js
+++ b/app/moves/middleware/set-download-results.moves.test.js
@@ -40,6 +40,7 @@ describe('Moves middleware', function () {
 
         it('should call API with move date and location ID', function () {
           expect(moveService.getDownload).to.be.calledOnceWithExactly(
+            req,
             req.body[mockBodyKey]
           )
         })

--- a/app/moves/middleware/set-download-results.single-requests.js
+++ b/app/moves/middleware/set-download-results.single-requests.js
@@ -2,7 +2,10 @@ async function setDownloadResultsSingleRequests(req, res, next) {
   const singleRequestService = req.services.singleRequest
 
   try {
-    req.results = await singleRequestService.getDownload(req.body.requested)
+    req.results = await singleRequestService.getDownload(
+      req,
+      req.body.requested
+    )
     next()
   } catch (error) {
     next(error)

--- a/app/moves/middleware/set-download-results.single-requests.test.js
+++ b/app/moves/middleware/set-download-results.single-requests.test.js
@@ -43,7 +43,7 @@ describe('Moves middleware', function () {
       it('should call the data service with request body', function () {
         expect(
           singleRequestService.getDownload
-        ).to.have.been.calledOnceWithExactly({
+        ).to.have.been.calledOnceWithExactly(req, {
           status: 'proposed',
           createdAtDate: ['2019-01-01', '2019-01-07'],
           fromLocationId: '123',

--- a/app/police-custody-form/controllers.js
+++ b/app/police-custody-form/controllers.js
@@ -22,7 +22,7 @@ exports.addEvents = async function (req, res) {
     return res.render('police-custody-form/police-custody-form')
   }
 
-  await req.services.event.postEvents(lockoutEvents, move, journeys, user)
+  await req.services.event.postEvents(req, lockoutEvents, move, journeys, user)
 
   const fullName = move.profile.person._fullname
 

--- a/common/lib/api-client/rest-client.js
+++ b/common/lib/api-client/rest-client.js
@@ -7,9 +7,9 @@ const {
 const auth = require('./auth')()
 const getRequestHeaders = require('./request-headers')
 
-const restClient = async (url, args, options = {}) => {
+const restClient = async (req, url, args, options = {}) => {
   const authorizationHeader = await auth.getAuthorizationHeader()
-  const requestHeaders = getRequestHeaders(options.format)
+  const requestHeaders = getRequestHeaders(req, options.format)
   const headers = {
     ...authorizationHeader,
     ...requestHeaders,
@@ -30,7 +30,7 @@ const restClient = async (url, args, options = {}) => {
 
 restClient.get = restClient
 
-restClient.post = (url, data, options) =>
-  restClient(url, data, { ...options, method: 'post' })
+restClient.post = (req, url, data, options) =>
+  restClient(req, url, data, { ...options, method: 'post' })
 
 module.exports = restClient

--- a/common/lib/api-client/rest-client.test.js
+++ b/common/lib/api-client/rest-client.test.js
@@ -34,7 +34,7 @@ describe('API Client', function () {
       let data
 
       beforeEach(async function () {
-        data = await restClient('/foo')
+        data = await restClient({}, '/foo')
       })
 
       it('should get the authorization header', function () {
@@ -42,7 +42,7 @@ describe('API Client', function () {
       })
 
       it('should get the default client headers', function () {
-        expect(getRequestHeadersStub).to.be.calledOnceWithExactly(undefined)
+        expect(getRequestHeadersStub).to.be.calledOnceWithExactly({}, undefined)
       })
 
       it('should make the expected request', function () {
@@ -64,7 +64,7 @@ describe('API Client', function () {
 
     context('when calling the API with params', function () {
       beforeEach(async function () {
-        await restClient('/foo', { bar: 'baz' })
+        await restClient({}, '/foo', { bar: 'baz' })
       })
 
       it('should make the expected request', function () {
@@ -83,7 +83,7 @@ describe('API Client', function () {
 
     context('when calling the API as a post with no data', function () {
       beforeEach(async function () {
-        await restClient('/foo', null, { method: 'post' })
+        await restClient({}, '/foo', null, { method: 'post' })
       })
 
       it('should make the expected request', function () {
@@ -102,7 +102,7 @@ describe('API Client', function () {
 
     context('when calling the API as a post with data', function () {
       beforeEach(async function () {
-        await restClient('/foo', { bar: 'baz' }, { method: 'post' })
+        await restClient({}, '/foo', { bar: 'baz' }, { method: 'post' })
       })
 
       it('should make the expected request', function () {
@@ -122,11 +122,17 @@ describe('API Client', function () {
 
     context('when calling the API - format', function () {
       beforeEach(async function () {
-        await restClient('/foo', { bar: 'baz' }, { format: 'application/foo' })
+        await restClient(
+          {},
+          '/foo',
+          { bar: 'baz' },
+          { format: 'application/foo' }
+        )
       })
 
       it('should pass the expected format to the method that returns the default client headers', function () {
         expect(getRequestHeadersStub).to.be.calledOnceWithExactly(
+          {},
           'application/foo'
         )
       })
@@ -134,7 +140,7 @@ describe('API Client', function () {
 
     context('when using get method', function () {
       beforeEach(async function () {
-        await restClient.get('/foo', { bar: 'baz' })
+        await restClient.get({}, '/foo', { bar: 'baz' })
       })
 
       it('should make the expected request', function () {
@@ -153,7 +159,7 @@ describe('API Client', function () {
 
     context('when using post method', function () {
       beforeEach(async function () {
-        await restClient.post('/foo', { bar: 'baz' })
+        await restClient.post({}, '/foo', { bar: 'baz' })
       })
 
       it('should make the expected request', function () {

--- a/common/lib/user.js
+++ b/common/lib/user.js
@@ -15,7 +15,7 @@ const forenameToInitial = name => {
   return `${name.charAt()}. ${name.split(' ').pop()}`
 }
 
-async function loadUser(accessToken) {
+async function loadUser(req, accessToken) {
   const {
     user_id: userId,
     user_name: username,
@@ -31,7 +31,12 @@ async function loadUser(accessToken) {
 
   const permissions = rolesToPermissions(authorities)
 
-  const locations = await getLocations(accessToken, supplierId, permissions)
+  const locations = await getLocations(
+    req,
+    accessToken,
+    supplierId,
+    permissions
+  )
   locations.sort((a, b) => a.title.localeCompare(b.title))
 
   return {

--- a/common/lib/user.test.js
+++ b/common/lib/user.test.js
@@ -33,7 +33,7 @@ describe('User', function () {
         './permissions': permissionsLibStub,
       })
 
-      user = await loadUser(accessToken)
+      user = await loadUser({}, accessToken)
     })
 
     it('sets the userId', function () {

--- a/common/services/event.js
+++ b/common/services/event.js
@@ -19,7 +19,7 @@ const perEvents = [
 const personMoveEvents = ['PersonMoveUsedForce', 'PersonMoveDeathInCustody']
 
 class EventService extends BaseService {
-  postEvents(lockoutEvents, move, journeys, user) {
+  postEvents(req, lockoutEvents, move, journeys, user) {
     const todaysDate = new Date()
     const events = []
 
@@ -78,9 +78,7 @@ class EventService extends BaseService {
           },
         }
 
-        const response = await restClient.post('/events', payload)
-
-        return response
+        return await restClient.post(req, '/events', payload)
       })
     )
   }

--- a/common/services/event.test.js
+++ b/common/services/event.test.js
@@ -140,6 +140,7 @@ describe('Event Service', function () {
     context('with a PER_EVENTS lockout event', function () {
       beforeEach(async function () {
         await eventService.postEvents(
+          {},
           perMocklockoutEvents,
           move,
           journeys,
@@ -153,6 +154,7 @@ describe('Event Service', function () {
 
       it('will be called with the correct payload for a PER_EVENT', function () {
         expect(restClient.post).to.be.calledWithExactly(
+          {},
           '/events',
           mockedPERPayload
         )
@@ -162,6 +164,7 @@ describe('Event Service', function () {
     context('with a PERSON_MOVE_EVENTS lockout event', function () {
       beforeEach(async function () {
         await eventService.postEvents(
+          {},
           personMoveMocklockoutEvents,
           move,
           journeys,
@@ -171,6 +174,7 @@ describe('Event Service', function () {
 
       it('will be called with the correct payload for a PERSON_MOVE_EVENTS', function () {
         expect(restClient.post).to.be.calledWithExactly(
+          {},
           '/events',
           mockedPersonMovePayload
         )

--- a/common/services/move.js
+++ b/common/services/move.js
@@ -233,16 +233,19 @@ class MoveService extends BaseService {
     })
   }
 
-  async getDownload({
-    status = 'requested,accepted,booked,in_transit,completed,cancelled',
-    dateRange = [],
-    createdAtDate = [],
-    fromLocationId,
-    toLocationId,
-    supplierId = undefined,
-    dateOfBirthFrom,
-    dateOfBirthTo,
-  } = {}) {
+  async getDownload(
+    req,
+    {
+      status = 'requested,accepted,booked,in_transit,completed,cancelled',
+      dateRange = [],
+      createdAtDate = [],
+      fromLocationId,
+      toLocationId,
+      supplierId = undefined,
+      dateOfBirthFrom,
+      dateOfBirthTo,
+    } = {}
+  ) {
     const [startDate, endDate] = dateRange
     const [createdAtFrom, createdAtTo] = createdAtDate
     const filter = omitBy(
@@ -266,6 +269,7 @@ class MoveService extends BaseService {
     )
 
     const response = await restClient.post(
+      req,
       '/moves/csv',
       { filter },
       {

--- a/common/services/move.test.js
+++ b/common/services/move.test.js
@@ -948,11 +948,12 @@ describe('Move Service', function () {
 
     context('without arguments', function () {
       beforeEach(async function () {
-        moves = await moveService.getDownload()
+        moves = await moveService.getDownload({})
       })
 
       it('should call getAll with all statuses', function () {
         expect(restClient.post).to.be.calledOnceWithExactly(
+          {},
           '/moves/csv',
           {
             filter: {
@@ -976,16 +977,20 @@ describe('Move Service', function () {
       const mockToLocationId = 'b195d0f0-df8e-4b97-891e-92020d6820b9'
 
       beforeEach(async function () {
-        moves = await moveService.getDownload({
-          dateRange: mockDateRange,
-          createdAtDate: mockCreatedRange,
-          fromLocationId: mockFromLocationId,
-          toLocationId: mockToLocationId,
-        })
+        moves = await moveService.getDownload(
+          {},
+          {
+            dateRange: mockDateRange,
+            createdAtDate: mockCreatedRange,
+            fromLocationId: mockFromLocationId,
+            toLocationId: mockToLocationId,
+          }
+        )
       })
 
       it('should call getAll with all statuses', function () {
         expect(restClient.post).to.be.calledOnceWithExactly(
+          {},
           '/moves/csv',
           {
             filter: {

--- a/common/services/reference-data.js
+++ b/common/services/reference-data.js
@@ -89,10 +89,14 @@ class ReferenceDataService extends BaseService {
     })
   }
 
-  async getLocationsBySupplierId(supplierId) {
-    const { data } = await restClient(`/suppliers/${supplierId}/locations`, {
-      per_page: 2000,
-    })
+  async getLocationsBySupplierId(req, supplierId) {
+    const { data } = await restClient(
+      req,
+      `/suppliers/${supplierId}/locations`,
+      {
+        per_page: 2000,
+      }
+    )
     const locations = data.map(location => {
       const { attributes, relationships, ...values } = location
       return {

--- a/common/services/reference-data.test.js
+++ b/common/services/reference-data.test.js
@@ -681,11 +681,15 @@ describe('Reference Data Service', function () {
       const mockId = 'd335715f-c9d1-415c-a7c8-06e830158214'
 
       beforeEach(async function () {
-        locations = await referenceDataService.getLocationsBySupplierId(mockId)
+        locations = await referenceDataService.getLocationsBySupplierId(
+          {},
+          mockId
+        )
       })
 
       it('should call the supplier location endpoint', function () {
         expect(restClient).to.be.calledOnceWithExactly(
+          {},
           '/suppliers/d335715f-c9d1-415c-a7c8-06e830158214/locations',
           {
             per_page: 2000,

--- a/common/services/single-request.js
+++ b/common/services/single-request.js
@@ -92,8 +92,8 @@ class SingleRequestService extends BaseService {
     })
   }
 
-  getDownload(args) {
-    return this.moveService.getDownload(args)
+  getDownload(req, args) {
+    return this.moveService.getDownload(req, args)
   }
 
   approve(id, { date } = {}) {

--- a/common/services/single-request.test.js
+++ b/common/services/single-request.test.js
@@ -291,15 +291,21 @@ describe('Single request service', function () {
 
     context('with arguments', function () {
       beforeEach(async function () {
-        moves = await singleRequestService.getDownload({
-          foo: 'bar',
-        })
+        moves = await singleRequestService.getDownload(
+          {},
+          {
+            foo: 'bar',
+          }
+        )
       })
 
       it('should call getAll with existing args and include', function () {
-        expect(moveService.getDownload).to.be.calledOnceWithExactly({
-          foo: 'bar',
-        })
+        expect(moveService.getDownload).to.be.calledOnceWithExactly(
+          {},
+          {
+            foo: 'bar',
+          }
+        )
       })
 
       it('should return moves', function () {

--- a/common/services/user.js
+++ b/common/services/user.js
@@ -46,8 +46,12 @@ async function getFullName(token, username = 'me') {
   return fullNameCache[username]
 }
 
-async function getLocations(token, supplierId, permissions) {
-  const supplierLocations = await getSupplierLocations(supplierId, permissions)
+async function getLocations(req, token, supplierId, permissions) {
+  const supplierLocations = await getSupplierLocations(
+    req,
+    supplierId,
+    permissions
+  )
 
   if (supplierLocations) {
     return supplierLocations
@@ -125,16 +129,16 @@ function getNomisLocations(token) {
     )
 }
 
-async function getSupplierLocations(supplierId, permissions) {
+async function getSupplierLocations(req, supplierId, permissions) {
   if (supplierId) {
-    return await referenceDataService.getLocationsBySupplierId(supplierId)
+    return await referenceDataService.getLocationsBySupplierId(req, supplierId)
   }
 
   if (permissions.includes('locations:contract_delivery_manager')) {
     const suppliers = await referenceDataService.getSuppliers()
     const supplierLocations = await Promise.all(
       suppliers.map(supplier =>
-        referenceDataService.getLocationsBySupplierId(supplier.id)
+        referenceDataService.getLocationsBySupplierId(req, supplier.id)
       )
     )
 

--- a/common/services/user.test.js
+++ b/common/services/user.test.js
@@ -272,7 +272,7 @@ describe('User service', function () {
               .get('/')
               .reply(200, JSON.stringify(authGroups))
 
-            result = await getLocations(encodeToken(tokenData), null, [])
+            result = await getLocations({}, encodeToken(tokenData), null, [])
           })
 
           it('requests the user’s groups from HMPPS SSO', function () {
@@ -298,7 +298,7 @@ describe('User service', function () {
             .get('/')
             .reply(200, JSON.stringify(mockUserCaseloads))
 
-          result = await getLocations(token, null, [])
+          result = await getLocations({}, token, null, [])
         })
 
         it('requests the user’s caseloads from the NOMIS Elite 2 API', function () {
@@ -320,7 +320,7 @@ describe('User service', function () {
 
           token = encodeToken(tokenData)
 
-          result = await getLocations(token, null, [])
+          result = await getLocations({}, token, null, [])
         })
 
         it('defaults to an empty list of locations', function () {
@@ -341,20 +341,20 @@ describe('User service', function () {
 
     context('with a supplier ID', function () {
       beforeEach(async function () {
-        result = await getLocations(null, supplierStub.id, [])
+        result = await getLocations({}, null, supplierStub.id, [])
       })
 
       it('looks up locations for the supplier', function () {
         expect(
           referenceDataStub.getLocationsBySupplierId
-        ).to.be.calledWithExactly(supplierStub.id)
+        ).to.be.calledWithExactly({}, supplierStub.id)
         expect(result).to.deep.equal(locationsStub)
       })
     })
 
     context('with a contract delivery manager permission', function () {
       beforeEach(async function () {
-        result = await getLocations(null, null, [
+        result = await getLocations({}, null, null, [
           'locations:contract_delivery_manager',
         ])
       })
@@ -363,7 +363,7 @@ describe('User service', function () {
         expect(referenceDataStub.getSuppliers).to.be.calledOnce
         expect(
           referenceDataStub.getLocationsBySupplierId
-        ).to.be.calledWithExactly(supplierStub.id)
+        ).to.be.calledWithExactly({}, supplierStub.id)
         expect(result).to.deep.equal(locationsStub)
       })
     })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

<!--- Describe the changes in detail - the "what"-->
Multiple functions have been changed to pass `req` through to RestClient.

### Why did it change

When a function in RestClient was refactored previously, the instances of it weren't refactored to match, this means that headers weren't correctly being sent to the API, meaning that the created_by of the events aren't being populated.

<!--- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

- P4-3828
