### PR TITLE
[P4-3883] Exclude proposed journeys from the "Handover status" section of the move details tab

### DIFF
--- a/app/move/app/view/middleware/locals.move-details.js
+++ b/app/move/app/view/middleware/locals.move-details.js
@@ -18,7 +18,7 @@ function localsMoveDetails(req, res, next) {
     ({ event_type: eventType }) => eventType === 'MoveLodgingEnd'
   )
 
-  const handovers = presenters.moveToHandoversSummary(move, journeys)
+  const handovers = presenters.moveToHandoversSummary(move, journeys, true)
 
   if (move.is_lockout && handovers.length >= 2) {
     res.locals.moveLockoutHandover = handovers[handovers.length - 1]

--- a/common/presenters/move-to-handovers-summary.js
+++ b/common/presenters/move-to-handovers-summary.js
@@ -31,9 +31,12 @@ const findPerHandoverEvents = (move, journey, events) => {
   })
 }
 
-module.exports = (move, journeys) => {
+module.exports = (move, journeys, includeProposed) => {
   const filteredJourneys = journeys.filter(
-    ({ state }) => state !== 'rejected' && state !== 'cancelled'
+    ({ state }) =>
+      state !== 'rejected' &&
+      state !== 'cancelled' &&
+      (includeProposed || state !== 'proposed')
   )
 
   if (['proposed', 'requested', 'booked'].includes(move.status)) {

--- a/common/presenters/move-to-handovers-summary.js
+++ b/common/presenters/move-to-handovers-summary.js
@@ -42,13 +42,25 @@ module.exports = (move, journeys) => {
     )
   }
 
-  return filteredJourneys.flatMap(journey => {
-    const events = findPerHandoverEvents(move, journey, move.important_events)
+  const handovers = []
 
-    if (events.length) {
-      return events.map(event => formatRecordedHandover(journey, event))
+  filteredJourneys.reverse().forEach(journey => {
+    const handoverEvent = findPerHandoverEvents(
+      move,
+      journey,
+      move.important_events
+    )
+      .reverse()
+      .find(event => {
+        return !handovers.find(handover => handover.event === event.id)
+      })
+
+    if (handoverEvent) {
+      handovers.unshift(formatRecordedHandover(journey, handoverEvent))
     } else {
-      return [formatAwaitingHandover(journey.from_location)]
+      handovers.unshift(formatAwaitingHandover(journey.from_location))
     }
   })
+
+  return handovers
 }

--- a/common/presenters/move-to-handovers-summary.test.js
+++ b/common/presenters/move-to-handovers-summary.test.js
@@ -17,7 +17,9 @@ describe('Presenters', function () {
             important_events: [],
           }
 
-          expect(moveToHandoversSummary(thisMove, journeys)).to.deep.equal([])
+          expect(
+            moveToHandoversSummary(thisMove, journeys, false)
+          ).to.deep.equal([])
         })
       })
 
@@ -34,7 +36,9 @@ describe('Presenters', function () {
             ],
           }
 
-          expect(moveToHandoversSummary(thisMove, journeys)).to.deep.equal([
+          expect(
+            moveToHandoversSummary(thisMove, journeys, false)
+          ).to.deep.equal([
             {
               recorded: true,
               event: 'abc',
@@ -64,7 +68,9 @@ describe('Presenters', function () {
             important_events: [],
           }
 
-          expect(moveToHandoversSummary(thisMove, journeys)).to.deep.equal([
+          expect(
+            moveToHandoversSummary(thisMove, journeys, false)
+          ).to.deep.equal([
             {
               recorded: false,
               location: 'Location',
@@ -86,7 +92,9 @@ describe('Presenters', function () {
             ],
           }
 
-          expect(moveToHandoversSummary(thisMove, journeys)).to.deep.equal([
+          expect(
+            moveToHandoversSummary(thisMove, journeys, false)
+          ).to.deep.equal([
             {
               recorded: true,
               event: 'abc',
@@ -132,7 +140,9 @@ describe('Presenters', function () {
             ],
           }
 
-          expect(moveToHandoversSummary(thisMove, thisJourneys)).to.deep.equal([
+          expect(
+            moveToHandoversSummary(thisMove, thisJourneys, false)
+          ).to.deep.equal([
             {
               recorded: true,
               event: 'abc',
@@ -177,7 +187,9 @@ describe('Presenters', function () {
             ],
           }
 
-          expect(moveToHandoversSummary(thisMove, thisJourneys)).to.deep.equal([
+          expect(
+            moveToHandoversSummary(thisMove, thisJourneys, false)
+          ).to.deep.equal([
             {
               recorded: true,
               event: 'abc',

--- a/common/presenters/move-to-summary-list-component.js
+++ b/common/presenters/move-to-summary-list-component.js
@@ -95,7 +95,7 @@ function moveToSummaryListComponent(
     })
   }
 
-  const handoversSummary = moveToHandoversSummary(move, journeys)
+  const handoversSummary = moveToHandoversSummary(move, journeys, false)
 
   if (handoversSummary.length) {
     const links = handoversSummary.map(({ recorded, event, location }) => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

<!--- Describe the changes in detail - the "what"-->

Changed it so that 1 PerHandover can only mark 1 Journey as handed over.
Excluded proposed journeys from the handover status section.

### Why did it change

<!--- Describe the reason these changes were made - the "why" -->

We've noticed that a move has been created with 2 journeys from the same location, 1 proposed, 1 complete, and it is showing 2 rows as `handed over` for the same location in the details tab.

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

- P4-3883
