### PR TITLE
fix: "Review single request" button no longer spans multiple lines

### DIFF
--- a/locales/en/moves.json
+++ b/locales/en/moves.json
@@ -111,7 +111,7 @@
     "page_heading": "{{-name}} ({{-reference}})",
     "page_heading_summary": "From <strong>{{ fromLocation }}</strong> to <strong>{{ toLocation }}</strong> on <strong>{{ date }}</strong>",
     "page_heading_summary_and": "and from <strong>{{ fromLocation }}</strong> to <strong>{{ toLocation }}</strong> on <strong>{{ date }}</strong>",
-    "page_heading_summary_proposed": "From <strong>{{ fromLocation }}</strong> to <strong>{{ toLocation }}",
+    "page_heading_summary_proposed": "From <strong>{{ fromLocation }}</strong> to <strong>{{ toLocation }}</strong>",
     "page_title": "Move for {{-name}}",
     "court_hearings": {
       "heading": "Court hearing",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

<!--- Describe the changes in detail - the "what"-->

The "Review single request" button no longer spans multiple lines.


### Why did it change

<!--- Describe the reason these changes were made - the "why" -->

Because it didn't fit the style of the rest of the buttons on the website.

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

- P4-3840

## Screenshots
<!--- (Optional) Include screenshots if changes update interfaces or components -->
<!--- Delete/copy as appropriate --->


| Before | After |
| ------ | ----- |
| <kbd><img src="https://user-images.githubusercontent.com/4104309/194837740-11d271bf-7a44-4784-a39f-6afc1824ef98.png"></kbd> | <kbd><img src="https://user-images.githubusercontent.com/4104309/194838432-9d36a295-d168-419c-840e-dabc4bc93168.png"></kbd> |

## Checklists

### Testing

#### Automated testing

- [ ] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [ ] Chrome
- [x] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed
