### PR TITLE
[P4-4041] hide Answer question links when user is read only

### DIFF
--- a/app/move/app/view/views/warnings.njk
+++ b/app/move/app/view/views/warnings.njk
@@ -27,14 +27,6 @@
           {% endfor %}
         {% endif %}
       {% endfor %}
-    {% elif not canEditPer %}
-      {{ govukInsetText({
-      classes: "govuk-!-font-size-16 govuk-!-margin-0",
-      text: t("assessment::section_incomplete", {
-        context: "locked" if isPerLocked,
-        section: assessment.name | replace(" information", "")
-      })
-      }) }}
     {% elif assessment.panels %}
       {% for panel in assessment.panels %}
         {{ appPanel(panel) }}

--- a/app/move/app/view/views/warnings.njk
+++ b/app/move/app/view/views/warnings.njk
@@ -27,6 +27,14 @@
           {% endfor %}
         {% endif %}
       {% endfor %}
+    {% elif not canEditPer %}
+      {{ govukInsetText({
+      classes: "govuk-!-font-size-16 govuk-!-margin-0",
+      text: t("assessment::section_incomplete", {
+        context: "locked" if isPerLocked,
+        section: assessment.name | replace(" information", "")
+      })
+      }) }}
     {% elif assessment.panels %}
       {% for panel in assessment.panels %}
         {{ appPanel(panel) }}

--- a/common/components/framework-response/framework-response.yaml
+++ b/common/components/framework-response/framework-response.yaml
@@ -23,6 +23,10 @@ params:
     type: string
     required: false
     description: Determines if the question should be modifyable.
+  - name: editable
+    type: boolean
+    required: false
+    description: Determines if the user is able to edit the response (given status of per and user role)
 
 examples:
   - name: string
@@ -30,12 +34,14 @@ examples:
       value: Example string response
       valueType: string
       responded: true
+      editable: true
   - name: object
     data:
       value:
         option: "Yes"
       valueType: object::followup_comment
       responded: true
+      editable: true
   - name: object with details
     data:
       value:
@@ -43,6 +49,7 @@ examples:
         details: Example further details for this response
       valueType: object::followup_comment
       responded: true
+      editable: true
   - name: array
     data:
       value:
@@ -51,6 +58,7 @@ examples:
         - Item three
       valueType: array
       responded: true
+      editable: true
   - name: collection
     data:
       value:
@@ -62,6 +70,7 @@ examples:
           option: Item three
       valueType: collection::followup_comment
       responded: true
+      editable: true
   - name: collection with details
     data:
       value:
@@ -76,25 +85,36 @@ examples:
           details: Further details for option three
       valueType: collection::followup_comment
       responded: true
+      editable: true
   - name: additional HTML
     data:
       value: Example string response
       valueType: string
       responded: true
+      editable: true
       afterContent:
         html: <p>Some example <strong>HTML</strong></p>
   - name: unanswered question
     data:
       responded: false
+      editable: true
       questionUrl: /step-url#question-id
   - name: prefilled question
     data:
       value: Example string response
       valueType: string
       responded: false
+      editable: true
       prefilled: true
       questionUrl: /step-url#question-id
   - name: empty answer
     data:
       responded: true
+      editable: true
+      questionUrl: /step-url#question-id
+  - name: uneditable no response
+    data:
+      responded: false
+      editable: false
+      prefilled: false
       questionUrl: /step-url#question-id

--- a/common/components/framework-response/template.njk
+++ b/common/components/framework-response/template.njk
@@ -37,7 +37,7 @@
     </span>
   {% endif %}
 {% else %}
-  {% if canEditPer %}
+  {% if params.editable %}
     {% if params.prefilled %}
       <a href="{{ params.questionUrl }}">
         {{ t("actions::review_answer") }}
@@ -47,5 +47,9 @@
         {{ t("actions::answer_question") }}
       </a>
     {% endif %}
-   {% endif %}
+  {% else %}
+    <span class="app-secondary-text-colour">
+          {{ t("awaiting_response") }}
+        </span>
+  {% endif %}
 {% endif %}

--- a/common/components/framework-response/template.njk
+++ b/common/components/framework-response/template.njk
@@ -37,13 +37,15 @@
     </span>
   {% endif %}
 {% else %}
-  {% if params.prefilled %}
-    <a href="{{ params.questionUrl }}">
-      {{ t("actions::review_answer") }}
-    </a>
-  {% else %}
-    <a href="{{ params.questionUrl }}">
-      {{ t("actions::answer_question") }}
-    </a>
-  {% endif %}
+  {% if canEditPer %}
+    {% if params.prefilled %}
+      <a href="{{ params.questionUrl }}">
+        {{ t("actions::review_answer") }}
+      </a>
+    {% else %}
+      <a href="{{ params.questionUrl }}">
+        {{ t("actions::answer_question") }}
+      </a>
+    {% endif %}
+   {% endif %}
 {% endif %}

--- a/common/components/framework-response/template.test.js
+++ b/common/components/framework-response/template.test.js
@@ -304,6 +304,39 @@ describe('Framework Response component', function () {
     })
   })
 
+  context('with read only role', function () {
+    const example = examples['uneditable no response']
+
+    beforeEach(function () {
+      sinon.stub(i18n, 't').returnsArg(0)
+
+      const $ = renderComponentHtmlToCheerio('framework-response', {
+        ...example,
+      })
+      $component = $('body')
+    })
+
+    it('should render a parent span', function () {
+      expect($component.children().first().get(0).tagName).to.equal('span')
+    })
+
+    it('should contain correct classes', function () {
+      expect($component.children().first().attr('class')).to.equal(
+        'app-secondary-text-colour'
+      )
+    })
+
+    it('should translate text', function () {
+      expect(i18n.t).to.be.calledOnceWithExactly('awaiting_response')
+    })
+
+    it('should contain correct text', function () {
+      expect($component.children().first().text().trim()).to.equal(
+        'awaiting_response'
+      )
+    })
+  })
+
   context('with prefilled answer', function () {
     const example = examples['prefilled question']
 

--- a/common/controllers/framework/framework-section.js
+++ b/common/controllers/framework/framework-section.js
@@ -82,7 +82,9 @@ class FrameworkSectionController extends FormWizardController {
       presenters.frameworkStepToSummary(
         form.options.allFields,
         assessment.responses,
-        `${baseUrl}/`
+        `${baseUrl}/`,
+        assessment.editable &&
+          req.canAccess(`${snakeCase(assessment.framework.name)}:update`)
       )
     )
     const sectionProgress = assessment.meta?.section_progress.filter(

--- a/common/controllers/framework/framework-section.test.js
+++ b/common/controllers/framework/framework-section.test.js
@@ -420,7 +420,8 @@ describe('Framework controllers', function () {
         expect(presenters.frameworkStepToSummary).to.be.calledOnceWithExactly(
           mockReq.form.options.allFields,
           mockReq.assessment.responses,
-          `${mockReq.baseUrl}/`
+          `${mockReq.baseUrl}/`,
+          undefined
         )
       })
 

--- a/common/presenters/framework-field-summary-list-row.js
+++ b/common/presenters/framework-field-summary-list-row.js
@@ -4,7 +4,7 @@ const i18n = require('../../config/i18n').default
 const frameworkNomisMappingsToPanel = require('../presenters/framework-nomis-mappings-to-panel')
 const componentService = require('../services/component')
 
-function frameworkFieldToSummaryListRow(stepUrl) {
+function frameworkFieldToSummaryListRow(stepUrl, editPermission = false) {
   return field => {
     const { description, id, response, question, descendants, itemName } = field
     const headerText = description || question
@@ -33,7 +33,7 @@ function frameworkFieldToSummaryListRow(stepUrl) {
               },
             }
           })
-          .map(frameworkFieldToSummaryListRow(stepUrl))
+          .map(frameworkFieldToSummaryListRow(stepUrl, editPermission))
 
         return [
           {
@@ -56,6 +56,7 @@ function frameworkFieldToSummaryListRow(stepUrl) {
       prefilled: response.prefilled === true,
       questionUrl: `${stepUrl}#${id}`,
       assessmentStatus: response.assessment?.status,
+      editable: response.assessment?.editable && editPermission,
     }
 
     if ((response.nomis_mappings || []).length > 0) {
@@ -89,7 +90,11 @@ function frameworkFieldToSummaryListRow(stepUrl) {
     const followupRows = field.items
       .filter(item => item.followup)
       .filter(item => item.value === field.response.value)
-      .map(item => item.followup.map(frameworkFieldToSummaryListRow(stepUrl)))
+      .map(item =>
+        item.followup.map(
+          frameworkFieldToSummaryListRow(stepUrl, editPermission)
+        )
+      )
 
     return filter(flattenDeep([row, ...followupRows]))
   }

--- a/common/presenters/framework-field-summary-list-row.test.js
+++ b/common/presenters/framework-field-summary-list-row.test.js
@@ -47,6 +47,7 @@ describe('Presenters', function () {
               prefilled: false,
               questionUrl: `${mockStepUrl}#${mockField.id}`,
               assessmentStatus: undefined,
+              editable: undefined,
             }
           )
         })
@@ -84,6 +85,7 @@ describe('Presenters', function () {
               prefilled: false,
               questionUrl: `${mockStepUrl}#${mockField.id}`,
               assessmentStatus: undefined,
+              editable: undefined,
             }
           )
         })
@@ -136,6 +138,7 @@ describe('Presenters', function () {
               afterContent: {
                 html: 'NOMIS_HTML',
               },
+              editable: undefined,
             }
           )
         })
@@ -173,6 +176,7 @@ describe('Presenters', function () {
               prefilled: false,
               questionUrl: `${mockStepUrl}#${mockField.id}`,
               assessmentStatus: 'completed',
+              editable: undefined,
             }
           )
         })
@@ -211,6 +215,7 @@ describe('Presenters', function () {
               prefilled: false,
               questionUrl: `${mockStepUrl}#${mockField.id}`,
               assessmentStatus: undefined,
+              editable: undefined,
             }
           )
         })
@@ -276,6 +281,7 @@ describe('Presenters', function () {
                 prefilled: false,
                 questionUrl: `${mockStepUrl}#${mockFieldWithFollowup.id}`,
                 assessmentStatus: undefined,
+                editable: undefined,
               }
             )
             expect(componentService.getComponent).to.be.calledWithExactly(
@@ -287,6 +293,7 @@ describe('Presenters', function () {
                 prefilled: false,
                 questionUrl: `${mockStepUrl}#${mockFieldWithFollowup.items[0].followup[0].id}`,
                 assessmentStatus: undefined,
+                editable: undefined,
               }
             )
           })
@@ -336,6 +343,7 @@ describe('Presenters', function () {
                 prefilled: false,
                 questionUrl: `${mockStepUrl}#${mockFieldWithFollowup.id}`,
                 assessmentStatus: undefined,
+                editable: undefined,
               }
             )
           })
@@ -415,6 +423,7 @@ describe('Presenters', function () {
                   prefilled: false,
                   questionUrl: `${mockStepUrl}#${mockField.id}`,
                   assessmentStatus: undefined,
+                  editable: undefined,
                 }
               )
             })
@@ -445,6 +454,7 @@ describe('Presenters', function () {
                   prefilled: false,
                   questionUrl: `${mockStepUrl}#${mockField.id}`,
                   assessmentStatus: undefined,
+                  editable: undefined,
                 }
               )
             })
@@ -478,6 +488,7 @@ describe('Presenters', function () {
               prefilled: false,
               questionUrl: `${mockStepUrl}#${mockField.id}`,
               assessmentStatus: undefined,
+              editable: undefined,
             }
           )
         })
@@ -510,6 +521,7 @@ describe('Presenters', function () {
               prefilled: true,
               questionUrl: `${mockStepUrl}#${mockField.id}`,
               assessmentStatus: undefined,
+              editable: undefined,
             }
           )
         })
@@ -650,6 +662,7 @@ describe('Presenters', function () {
                 prefilled: false,
                 questionUrl: `${mockStepUrl}#${test.id}`,
                 assessmentStatus: undefined,
+                editable: undefined,
               }
             )
           })
@@ -671,6 +684,7 @@ describe('Presenters', function () {
               prefilled: false,
               questionUrl: `${mockStepUrl}#${mockField.id}`,
               assessmentStatus: undefined,
+              editable: undefined,
             }
           )
         })

--- a/common/presenters/framework-step-to-summary.js
+++ b/common/presenters/framework-step-to-summary.js
@@ -4,7 +4,12 @@ const frameworksHelpers = require('../helpers/frameworks')
 
 const frameworkFieldToSummaryListRow = require('./framework-field-summary-list-row')
 
-function frameworkStepToSummary(allFields, responses, baseUrl = '') {
+function frameworkStepToSummary(
+  allFields,
+  responses,
+  baseUrl = '',
+  editPermission = false
+) {
   return ([key, step], i, allSteps = []) => {
     const allNextSteps = allSteps
       .map(([key, step]) => step.next)
@@ -27,7 +32,7 @@ function frameworkStepToSummary(allFields, responses, baseUrl = '') {
     const summaryListRows = stepFields
       .map(frameworksHelpers.mapFieldFromName(allFields))
       .map(frameworksHelpers.appendResponseToField(responses))
-      .map(frameworkFieldToSummaryListRow(stepUrl))
+      .map(frameworkFieldToSummaryListRow(stepUrl, editPermission))
 
     return [
       key,

--- a/common/presenters/framework-step-to-summary.test.js
+++ b/common/presenters/framework-step-to-summary.test.js
@@ -16,6 +16,7 @@ describe('Presenters', function () {
       slug: 'step-slug',
       fields: ['fieldOne'],
     }
+    const mockPermission = true
     let frameworkStepToSummary
     let response
 
@@ -48,7 +49,8 @@ describe('Presenters', function () {
         response = frameworkStepToSummary(
           mockFields,
           mockResponses,
-          mockBaseUrl
+          mockBaseUrl,
+          mockPermission
         )(['/step-one', mockStep])
       })
 
@@ -70,7 +72,8 @@ describe('Presenters', function () {
 
       it('should render summary list rows', function () {
         expect(frameworkFieldToSummaryListRowStub).to.be.calledWithExactly(
-          '/base-url/step-slug'
+          '/base-url/step-slug',
+          true
         )
       })
 
@@ -98,13 +101,16 @@ describe('Presenters', function () {
       beforeEach(function () {
         response = frameworkStepToSummary(
           mockFields,
-          mockResponses
+          mockResponses,
+          undefined,
+          mockPermission
         )(['/step-one', mockStep])
       })
 
       it('should render summary list rows', function () {
         expect(frameworkFieldToSummaryListRowStub).to.be.calledWithExactly(
-          'step-slug'
+          'step-slug',
+          true
         )
       })
 
@@ -125,7 +131,8 @@ describe('Presenters', function () {
         response = frameworkStepToSummary(
           {},
           mockResponses,
-          mockBaseUrl
+          mockBaseUrl,
+          mockPermission
         )([
           '/step-one',
           {
@@ -197,7 +204,8 @@ describe('Presenters', function () {
             frameworkStepToSummary(
               mockFields,
               mockResponsesWithCondition,
-              mockBaseUrl
+              mockBaseUrl,
+              mockPermission
             )
           )
         })

--- a/locales/en/default.json
+++ b/locales/en/default.json
@@ -47,6 +47,7 @@
   "sort_ascending": "Sort {{label}} ascending",
   "sort_descending": "Sort {{label}} descending",
   "empty_response": "No answer provided",
+  "awaiting_response": "Awaiting answer",
   "empty_details": "Details not provided",
   "attach_photo": "Attach photo here",
   "initial_option": "--- Choose {{label}} ---",


### PR DESCRIPTION

## Proposed changes

### What changed

Users with read-only roles are no longer show a link to edit incomplete sections of a PER 

### Why did it change

The links were not useful as clicking them redirected back to the current page, given the user is unable to complete PERs

### Issue tracking
- [P4-4041](https://dsdmoj.atlassian.net/browse/P4-4041)

## Screenshots
<!--- (Optional) Include screenshots if changes update interfaces or components -->
<!--- Delete/copy as appropriate --->

| Before | After |
| ------ | ----- |


| <kbd><img width="816" alt="image" src="https://user-images.githubusercontent.com/113102670/207918572-5a451094-6a5f-48c6-9d09-a4221a2bf85c.png"></kbd> | <kbd>
<img width="831" alt="image" src="https://user-images.githubusercontent.com/113102670/207918726-118548fd-b423-459b-9671-573b3f56833f.png">
</kbd> |

## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [ ] Chrome
- [x] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed


### Other considerations

Commit messages with a `fix` or `feat` type are automatically used to generate the [changelog](ministryofjustice/hmpps-book-secure-move-frontend/blob/main/CHANGELOG.md) and
[GitHub release notes](https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/releases) during the release task. Please make sure they will read well on their own in a
summary of changes and that the commit body gives a more detailed description of those changes if necessary.

- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
- [ ] Update [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/main/README.md) with any new instructions or tasks
