### PR TITLE
fix: Fix error thrown by content which doesn't have a date

### DIFF
--- a/common/services/contentful/contentful.ts
+++ b/common/services/contentful/contentful.ts
@@ -94,14 +94,18 @@ export class ContentfulContent {
     return {
       title: this.title,
       body: this.body,
-      date: formatDate(this.date),
+      date: isNaN(this.date as unknown as number)
+        ? undefined
+        : formatDate(this.date),
     }
   }
 
   getBannerData() {
     return {
       body: this.bannerText,
-      date: formatDate(this.date),
+      date: isNaN(this.date as unknown as number)
+        ? undefined
+        : formatDate(this.date),
     }
   }
 
@@ -181,18 +185,5 @@ export class ContentfulService {
     }
 
     return entries.map(entry => entry.getPostData())
-  }
-
-  async fetchEntryBySlugId(slugId: any) {
-    const entry = (await this.client.getEntries({
-      content_type: this.contentType,
-      'fields.slug[in]': slugId,
-    })) as contentful.EntryCollection<ContentfulFields>
-
-    if (!entry.items?.length) {
-      return undefined
-    }
-
-    return this.createContent(entry.items[0].fields).getPostData()
   }
 }

--- a/common/services/contentful/dedicated-content.ts
+++ b/common/services/contentful/dedicated-content.ts
@@ -1,9 +1,24 @@
-import { ContentfulService } from './contentful'
+import * as contentful from 'contentful'
+
+import { ContentfulFields, ContentfulService } from './contentful'
 
 export class DedicatedContentService extends ContentfulService {
   public constructor() {
     super()
 
     this.contentType = 'dedicatedContent'
+  }
+
+  async fetchEntryBySlugId(slugId: any) {
+    const entry = (await this.client.getEntries({
+      content_type: this.contentType,
+      'fields.slug[in]': slugId,
+    })) as contentful.EntryCollection<ContentfulFields>
+
+    if (!entry.items?.length) {
+      return undefined
+    }
+
+    return this.createContent(entry.items[0].fields).getPostData()
   }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Fixed an error that was thrown when contentful content didn't have a date set.

### Why did it change

This has changed because it was causing an error when trying to view dedicated content in production.

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

- P4-4082

## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [ ] Chrome
- [x] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [ ] No environment variables were added or changed

