### PR TITLE
fix: Add framework v2.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -135,6 +135,7 @@
     "@hmpps-book-secure-move-frameworks/2.3.0": "git+https://github.com/ministryofjustice/hmpps-book-secure-move-frameworks.git#v2.3.0",
     "@hmpps-book-secure-move-frameworks/2.3.1": "git+https://github.com/ministryofjustice/hmpps-book-secure-move-frameworks.git#v2.3.1",
     "@hmpps-book-secure-move-frameworks/2.4.0": "git+https://github.com/ministryofjustice/hmpps-book-secure-move-frameworks.git#v2.4.0",
+    "@hmpps-book-secure-move-frameworks/2.4.1": "git+https://github.com/ministryofjustice/hmpps-book-secure-move-frameworks.git#v2.4.1",
     "@hmpps-book-secure-move-frameworks/2.4.2": "git+https://github.com/ministryofjustice/hmpps-book-secure-move-frameworks.git#v2.4.2",
     "@hmpps-book-secure-move-frameworks/2.5.0": "git+https://github.com/ministryofjustice/hmpps-book-secure-move-frameworks.git#v2.5.0",
     "@ministryofjustice/frontend": "1.6.4",


### PR DESCRIPTION
It was missing and we're not sure why but a move was created with this version and it now can't be displayed.

(hotfix)