### PR TITLE
[P4-4138] fix: Show correct allocation moves count on move details page

### DIFF
--- a/app/move/app/view/views/details.njk
+++ b/app/move/app/view/views/details.njk
@@ -51,11 +51,10 @@
 
 {% block tabContent %}
   {% if (isAllocationMove) %}
-    {# TODO: Get moves returned as part of an allocation so that we can determine the number #}
     {{ govukInsetText({
       html: t("messages::cancel_allocation_move.content", {
         context: "with_link" if canAccess("allocations:view"),
-        count: allocation.moves.length or allocation.moves_count,
+        count: allocation.moves_count,
         href: "/allocation/" + allocation.id
       }),
       classes: "govuk-!-margin-bottom-0"


### PR DESCRIPTION
## Proposed changes

### What changed

It was always showing "1 person" when viewing the details of a move that is part of an allocation. Now it shows the correct number.

### Why did it change

It was a bug.

### Issue tracking

- [P4-4138](https://dsdmoj.atlassian.net/browse/P4-4138)

## Screenshots

| Before | After |
| ------ | ----- |
| <kbd><img width="789" alt="Screenshot 2023-04-17 at 11 58 13" src="https://user-images.githubusercontent.com/40831617/232465429-1f170260-5375-46a0-979f-d746406a62ae.png"></kbd> | <kbd><img width="796" alt="Screenshot 2023-04-17 at 11 58 22" src="https://user-images.githubusercontent.com/40831617/232465471-2b076387-e09c-4dfb-a298-87f4d75dac2b.png"></kbd> |

## Checklists

### Testing

#### Automated testing

- [ ] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

- [x] No environment variables were added or changed

### Other considerations

Commit messages with a `fix` or `feat` type are automatically used to generate the [changelog](ministryofjustice/hmpps-book-secure-move-frontend/blob/main/CHANGELOG.md) and
[GitHub release notes](https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/releases) during the release task. Please make sure they will read well on their own in a
summary of changes and that the commit body gives a more detailed description of those changes if necessary.

- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
- [ ] Update [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/main/README.md) with any new instructions or tasks


[P4-4138]: https://dsdmoj.atlassian.net/browse/P4-4138?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ