### PR TITLE
[P4-4134] feat: Add link on view allocation page to edit details

### DIFF
--- a/app/allocation/controllers/view.js
+++ b/app/allocation/controllers/view.js
@@ -1,11 +1,27 @@
 const { sortBy } = require('lodash')
 
 const {
+  canEditAllocation,
+} = require('../../../common/helpers/allocation/can-edit-allocation')
+const {
   canEditAssessment,
 } = require('../../../common/helpers/move/can-edit-assessment')
 const canEditMove = require('../../../common/helpers/move/can-edit-move')
 const { isPerLocked } = require('../../../common/helpers/move/is-per-locked')
 const presenters = require('../../../common/presenters')
+
+function getActions(allocation, canAccess) {
+  if (!canEditAllocation(allocation, canAccess)) {
+    return []
+  }
+
+  return [
+    {
+      text: 'Change date of allocation',
+      url: `/allocation/${allocation.id}/edit/allocation-details`,
+    },
+  ]
+}
 
 function viewAllocation(req, res) {
   const { allocation, canAccess } = req
@@ -31,6 +47,7 @@ function viewAllocation(req, res) {
   }
 
   const locals = {
+    actions: getActions(allocation, canAccess),
     allocation,
     // TODO: Find way to store the actual URL they came from: See similar solution within moves app
     dashboardUrl: '/allocations',

--- a/app/allocation/controllers/view.test.js
+++ b/app/allocation/controllers/view.test.js
@@ -185,8 +185,12 @@ describe('Allocation controllers', function () {
           expect(locals.allocation).to.deep.equal(allocationExample)
         })
 
+        it('should include actions', function () {
+          expect(locals.actions).to.deep.equal([])
+        })
+
         it('should contain correct number of locals', function () {
-          expect(Object.keys(locals)).to.have.length(10)
+          expect(Object.keys(locals)).to.have.length(11)
         })
       })
 
@@ -290,6 +294,13 @@ describe('Allocation controllers', function () {
             },
           },
         ])
+      })
+
+      it('should include the edit allocation details action', function () {
+        expect(locals.actions[0]).to.deep.equal({
+          text: 'Change date of allocation',
+          url: `/allocation/${allocationExample.id}/edit/allocation-details`,
+        })
       })
     })
   })

--- a/app/allocation/views/view.njk
+++ b/app/allocation/views/view.njk
@@ -169,6 +169,20 @@
       </h3>
 
       {{ appMetaList(summary) }}
+
+      {% if actions | length %}
+        <section class="govuk-!-padding-top-3 govuk-!-margin-bottom-7">
+          <ul class="govuk-list govuk-!-margin-0 govuk-!-font-size-16">
+            {% for action in actions %}
+              <li class="{{ action.itemClasses }}">
+                <a href="{{ action.url }}" class="{{ action.classes }}">
+                  {{ t(action.text) }}
+                </a>
+              </li>
+            {% endfor %}
+          </ul>
+        </section>
+      {% endif %}
     </div>
   </div>
 {% endblock %}

--- a/app/move/app/view/middleware/locals.move-details.test.ts
+++ b/app/move/app/view/middleware/locals.move-details.test.ts
@@ -19,7 +19,7 @@ describe('Move view app', function () {
             id: '12345',
             is_lockout: false,
             profile: { id: 'profile', person: {} },
-            status: 'in-transit',
+            status: 'in_transit',
             from_location: {
               key: 'key',
               title: 'Title',
@@ -71,7 +71,7 @@ describe('Move view app', function () {
             id: '12345',
             is_lockout: false,
             profile: { id: 'profile', person: {} },
-            status: 'in-transit',
+            status: 'in_transit',
             from_location: {
               key: 'key',
               title: 'Title',

--- a/common/helpers/allocation/can-edit-allocation.test.ts
+++ b/common/helpers/allocation/can-edit-allocation.test.ts
@@ -1,0 +1,71 @@
+import { expect } from 'chai'
+
+import allocationFactory from '../../../factories/allocation'
+import moveFactory from '../../../factories/move'
+
+import { canEditAllocation } from './can-edit-allocation'
+
+describe('#canEditAllocation', function () {
+  let allocation = allocationFactory.build()
+  let permissions: string[]
+
+  function canAccessFunction(permissions: string[]) {
+    return (permission: string) => permissions.includes(permission)
+  }
+
+  beforeEach(function () {
+    permissions = [
+      'allocation:update',
+      'move:update',
+      'move:update:prison_transfer',
+    ]
+  })
+
+  context('when it can be edited', function () {
+    it('returns true', function () {
+      expect(
+        canEditAllocation(allocation, canAccessFunction(permissions))
+      ).to.be.true
+    })
+  })
+
+  context('when the user does not have permission', function () {
+    beforeEach(function () {
+      permissions = []
+    })
+
+    it('returns false', function () {
+      expect(
+        canEditAllocation(allocation, canAccessFunction(permissions))
+      ).to.be.false
+    })
+  })
+
+  context('when the allocation is cancelled', function () {
+    beforeEach(function () {
+      allocation = allocationFactory.build({ status: 'cancelled' })
+    })
+
+    it('returns false', function () {
+      expect(
+        canEditAllocation(allocation, canAccessFunction(permissions))
+      ).to.be.false
+    })
+  })
+
+  context('when an associated move cannot be edited', function () {
+    beforeEach(function () {
+      const moves = [
+        moveFactory.build(),
+        moveFactory.build({ status: 'in_transit' }),
+      ]
+      allocation = allocationFactory.build({ moves })
+    })
+
+    it('returns false', function () {
+      expect(
+        canEditAllocation(allocation, canAccessFunction(permissions))
+      ).to.be.false
+    })
+  })
+})

--- a/common/helpers/allocation/can-edit-allocation.ts
+++ b/common/helpers/allocation/can-edit-allocation.ts
@@ -1,0 +1,19 @@
+import { Allocation } from "../../types/allocation"
+
+const canEditMove = require('../../../common/helpers/move/can-edit-move')
+
+export function canEditAllocation(allocation: Allocation, canAccess: (permission: string) => boolean): boolean {
+  if (!canAccess('allocation:update')) {
+    return false
+  }
+
+  if (allocation.status === 'cancelled') {
+    return false
+  }
+
+  if (allocation.moves.some(move => !canEditMove(move, canAccess))) {
+    return false
+  }
+
+  return true
+}

--- a/common/types/allocation.ts
+++ b/common/types/allocation.ts
@@ -15,7 +15,10 @@ export interface Allocation {
   complete_in_full?: boolean
   requested_by?: string
   other_criteria?: string
-  status?: string
+  status?:
+    | 'cancelled'
+    | 'filled'
+    | 'unfilled'
   cancellation_reason?: string
   cancellation_reason_comment?: string
   created_at?: string

--- a/common/types/move.ts
+++ b/common/types/move.ts
@@ -8,7 +8,7 @@ export interface Move {
     | 'proposed'
     | 'requested'
     | 'booked'
-    | 'in-transit'
+    | 'in_transit'
     | 'completed'
     | 'cancelled'
   from_location: Location

--- a/factories/allocation.ts
+++ b/factories/allocation.ts
@@ -1,0 +1,16 @@
+import { Factory } from 'fishery'
+import { Allocation } from '../common/types/allocation'
+import locationFactory from './location'
+import moveFactory from './move'
+
+const allocationFactory = Factory.define<Allocation>(() => ({
+  id: '1c5b9f9a-2d70-4b4e-b5a3-6736b83c8bd9',
+  date: '2023-04-01',
+  from_location: locationFactory.build(),
+  moves_count: 2,
+  moves: moveFactory.buildList(2),
+  status: 'filled',
+  to_location: locationFactory.build()
+}))
+
+export default allocationFactory

--- a/factories/location.ts
+++ b/factories/location.ts
@@ -1,0 +1,12 @@
+import { Factory } from 'fishery'
+import { Location } from '../common/types/location'
+
+const locationFactory = Factory.define<Location>(() => ({
+  id: 'a15957ec-c983-4d29-98e4-334060b16dca',
+  key: 'AAA',
+  location_type: 'prison',
+  title: 'HMP Adelaide',
+  type: 'locations',
+}))
+
+export default locationFactory

--- a/factories/move.ts
+++ b/factories/move.ts
@@ -1,0 +1,20 @@
+import { Factory } from 'fishery'
+import { moveTransformer } from '../common/lib/api-client/transformers'
+import { Move } from '../common/types/move'
+import locationFactory from './location'
+
+const moveFactory = Factory.define<Move>(({ afterBuild }) => {
+  afterBuild(move => {
+    moveTransformer(move)
+  })
+
+  return {
+    from_location: locationFactory.build(),
+    id: '35957119-7e39-4c1f-9e0b-62f465ad007d',
+    move_type: 'prison_transfer',
+    profile: undefined,
+    status: 'requested',
+  }
+})
+
+export default moveFactory

--- a/package-lock.json
+++ b/package-lock.json
@@ -60,6 +60,7 @@
         "express-session": "1.17.3",
         "faker": "5.5.3",
         "filesize": "10.0.6",
+        "fishery": "2.2.2",
         "form-data": "4.0.0",
         "got": "11.8.6",
         "govuk-frontend": "4.5.0",
@@ -13151,6 +13152,14 @@
         "node": ">= 10.0.0"
       }
     },
+    "node_modules/fishery": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/fishery/-/fishery-2.2.2.tgz",
+      "integrity": "sha512-jeU0nDhPHJkupmjX+r9niKgVMTBDB8X+U/pktoGHAiWOSyNlMd0HhmqnjrpjUOCDPJYaSSu4Ze16h6dZOKSp2w==",
+      "dependencies": {
+        "lodash.mergewith": "^4.6.2"
+      }
+    },
     "node_modules/flat": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
@@ -17568,8 +17577,7 @@
     "node_modules/lodash.mergewith": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
-      "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==",
-      "dev": true
+      "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ=="
     },
     "node_modules/lodash.omit": {
       "version": "4.5.0",

--- a/package.json
+++ b/package.json
@@ -169,6 +169,7 @@
     "express-session": "1.17.3",
     "faker": "5.5.3",
     "filesize": "10.0.6",
+    "fishery": "2.2.2",
     "form-data": "4.0.0",
     "got": "11.8.6",
     "govuk-frontend": "4.5.0",

--- a/test/e2e/allocation/update.test.js
+++ b/test/e2e/allocation/update.test.js
@@ -1,0 +1,23 @@
+import { pmuUser } from '../_roles'
+import { allocation, newAllocation } from '../_routes'
+import { allocationJourney, page } from '../pages'
+
+fixture('Update an allocation').beforeEach(async t => {
+  await t.useRole(pmuUser).navigateTo(newAllocation)
+
+  t.ctx.allocation = await allocationJourney.createAllocation()
+
+  await t.navigateTo(allocation(t.ctx.allocation.id))
+})
+
+test('Change allocation date', async t => {
+  await t.click(allocationJourney.allocationViewPage.nodes.editDetailsLink)
+
+  const details = await allocationJourney.allocationDetailsEditPage.fill()
+  await page.submitForm()
+
+  await allocationJourney.allocationViewPage.checkSummary({
+    ...t.ctx.allocation,
+    ...details,
+  })
+})

--- a/test/e2e/pages/allocation-details-edit.js
+++ b/test/e2e/pages/allocation-details-edit.js
@@ -1,0 +1,37 @@
+import { format, startOfTomorrow } from 'date-fns'
+import faker from 'faker'
+import { Selector, t } from 'testcafe'
+
+import { fillInForm } from '../_helpers'
+
+import Page from './page'
+
+class AllocationDetailsEditPage extends Page {
+  constructor() {
+    super()
+    this.fields = {
+      date: Selector('#date'),
+    }
+    this.errorList = [
+      this.nodes.errorSummary.find('a').withAttribute('href', '#date'),
+    ]
+  }
+
+  async fill() {
+    await t
+      .expect(this.getCurrentUrl())
+      .match(
+        /\/allocation\/[\w]{8}(-[\w]{4}){3}-[\w]{12}\/edit\/allocation-details$/
+      )
+
+    const fieldsToFill = {
+      date: {
+        selector: this.fields.date,
+        value: format(faker.date.future(1, startOfTomorrow()), 'yyyy-MM-dd'),
+      },
+    }
+
+    return fillInForm(fieldsToFill)
+  }
+}
+export default AllocationDetailsEditPage

--- a/test/e2e/pages/allocation-journey.js
+++ b/test/e2e/pages/allocation-journey.js
@@ -3,6 +3,7 @@ import { t } from 'testcafe'
 import AllocationCancelPage from './allocation-cancel'
 import AllocationCriteriaPage from './allocation-criteria'
 import AllocationDetailsPage from './allocation-details'
+import AllocationDetailsEditPage from './allocation-details-edit'
 import AllocationViewPage from './allocation-view'
 import Page from './page'
 
@@ -12,12 +13,14 @@ const allocationDetailsPage = new AllocationDetailsPage()
 const allocationCriteriaPage = new AllocationCriteriaPage()
 const allocationCancelPage = new AllocationCancelPage()
 const allocationViewPage = new AllocationViewPage()
+const allocationDetailsEditPage = new AllocationDetailsEditPage()
 
 class AllocationJourney extends Page {
   constructor() {
     super()
     this.allocationCancelPage = allocationCancelPage
     this.allocationCriteriaPage = allocationCriteriaPage
+    this.allocationDetailsEditPage = allocationDetailsEditPage
     this.allocationDetailsPage = allocationDetailsPage
     this.allocationViewPage = allocationViewPage
   }

--- a/test/e2e/pages/allocation-view.js
+++ b/test/e2e/pages/allocation-view.js
@@ -34,6 +34,7 @@ class AllocationViewPage extends Page {
         'Remove from allocation'
       ),
       confirmationLink: count => Selector('a').withExactText(`${count} people`),
+      editDetailsLink: Selector('a').withText('Change date of allocation'),
     }
   }
 


### PR DESCRIPTION
## Proposed changes

### What changed

Added a link to the view allocation page which takes you to the edit allocation details page. This allows the allocation date to be changed by a user with the correct permissions (namely PMU).

### Why did it change

Feature request by PMU. Late last year we allowed moves that were part of an allocation to have their date changed individually as a temporary solution. Now, instead of that, PMU will be able to change the date of an allocation and all of its moves via a single action. Once this feature has been released we will be able to block direct editing of allocation move dates again.

### Issue tracking

- [P4-4134](https://dsdmoj.atlassian.net/browse/P4-4134)

## Screenshots

| Before | After |
| ------ | ----- |
| <kbd>![Screenshot 2023-04-19 at 13 13 56](https://user-images.githubusercontent.com/40831617/233071549-25f8014b-7fa6-4d68-bda5-798948bfdab9.png)</kbd> | <kbd>![Screenshot 2023-04-19 at 13 13 17](https://user-images.githubusercontent.com/40831617/233071564-ec835865-238b-4164-95cb-28e7b5ffa892.png)</kbd> |



## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [x] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

- [x] No environment variables were added or changed

### Other considerations

- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
- [ ] Update [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/main/README.md) with any new instructions or tasks


[P4-4134]: https://dsdmoj.atlassian.net/browse/P4-4134?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ