### PR TITLE
test: Add regression test for allocations with cancelled moves

### DIFF
--- a/common/helpers/allocation/can-edit-allocation.test.ts
+++ b/common/helpers/allocation/can-edit-allocation.test.ts
@@ -68,4 +68,20 @@ describe('#canEditAllocation', function () {
       ).to.be.false
     })
   })
+
+  context('when an associated move is cancelled', function () {
+    beforeEach(function () {
+      const moves = [
+        moveFactory.build(),
+        moveFactory.build({ status: 'cancelled' }),
+      ]
+      allocation = allocationFactory.build({ moves })
+    })
+
+    it('returns true', function () {
+      expect(
+        canEditAllocation(allocation, canAccessFunction(permissions))
+      ).to.be.true
+    })
+  })
 })


### PR DESCRIPTION
## Proposed changes

### What changed

We still want to be able to edit the date of an allocation if it has cancelled moves associated with it. This already works, but the logic depends on the fact that cancelled moves are considered editable, so I'm adding a test in case that changes in future.

### Why did it change

We decided to double-check this functionality, so that it doesn't end up blocking PMU from changing the date of some allocations

### Issue tracking

- [P4-4137](https://dsdmoj.atlassian.net/browse/P4-4137)

## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

- [x] No environment variables were added or changed

### Other considerations

Commit messages with a `fix` or `feat` type are automatically used to generate the [changelog](ministryofjustice/hmpps-book-secure-move-frontend/blob/main/CHANGELOG.md) and
[GitHub release notes](https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/releases) during the release task. Please make sure they will read well on their own in a
summary of changes and that the commit body gives a more detailed description of those changes if necessary.

- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
- [ ] Update [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/main/README.md) with any new instructions or tasks


[P4-4137]: https://dsdmoj.atlassian.net/browse/P4-4137?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ