### PR TITLE
Fix allocation edit page  p4 4133

### DIFF
--- a/app/allocation/controllers/edit/allocation-details.test.ts
+++ b/app/allocation/controllers/edit/allocation-details.test.ts
@@ -71,7 +71,12 @@ const req: AllocationRequest = {
       update: () => {},
     },
   },
+  session: {
+    save: () => undefined,
+  },
   sessionModel: {
+    reset: () => undefined,
+    set: () => undefined,
     toJSON: () => ({}),
   },
 }
@@ -153,10 +158,7 @@ describe('#saveValues', function () {
   context('happy path', function () {
     beforeEach(async function () {
       allocationService = {
-        update: sinon.stub().resolves({
-          id: 9,
-          allocationCreated: true,
-        }),
+        update: sinon.stub().resolves({ ...allocation, date: '2023-01-02' }),
       }
       sessionModel = {
         toJSON: sinon.stub().returns(mockData),
@@ -195,6 +197,13 @@ describe('#saveValues', function () {
 
     it('calls next', function () {
       expect(next).to.have.been.calledOnce
+    })
+
+    it('updates the sessionModel with the allocation', function () {
+      expect(sessionModel.set).to.have.been.calledWithExactly('allocation', {
+        ...allocation,
+        date: '2023-01-02',
+      })
     })
   })
 

--- a/app/allocation/controllers/edit/allocation-details.test.ts
+++ b/app/allocation/controllers/edit/allocation-details.test.ts
@@ -62,6 +62,8 @@ const formOptions = {
 
 const req: AllocationRequest = {
   allocation,
+  canAccess: _string => true,
+  flash: () => undefined,
   form: {
     options: formOptions,
     values: {},
@@ -79,6 +81,7 @@ const req: AllocationRequest = {
     set: () => undefined,
     toJSON: () => ({}),
   },
+  t: (_keys, _options) => 'test',
 }
 
 const res: BasmResponse = {
@@ -153,6 +156,7 @@ describe('#saveValues', function () {
   let allocationService: any
   let sessionModel: any
   let next: any
+  let flash: any
   const mockData = { 'csrf-secret': '123', errors: null }
 
   context('happy path', function () {
@@ -165,9 +169,12 @@ describe('#saveValues', function () {
         set: sinon.stub(),
       }
       next = sinon.stub()
+      flash = sinon.stub()
+
       await controller.saveValues(
         {
           ...req,
+          flash,
           form: {
             options: formOptions,
             values: {
@@ -203,6 +210,13 @@ describe('#saveValues', function () {
       expect(sessionModel.set).to.have.been.calledWithExactly('allocation', {
         ...allocation,
         date: '2023-01-02',
+      })
+    })
+
+    it('sets the flash', function () {
+      expect(flash).to.have.been.calledWithExactly('success', {
+        title: 'test',
+        content: 'test',
       })
     })
   })

--- a/app/allocation/controllers/edit/allocation-details.test.ts
+++ b/app/allocation/controllers/edit/allocation-details.test.ts
@@ -93,9 +93,9 @@ describe('#getValues', function () {
     controller.getValues(req, res, callback)
   })
 
-  it('calls back with the date from the allocation', function () {
+  it('calls back with the formatted date from the allocation', function () {
     expect(callback).to.have.been.calledWithExactly(null, {
-      date: '2023-01-01',
+      date: 'Sunday 1 Jan 2023',
     })
   })
 })

--- a/app/allocation/controllers/edit/allocation-details.ts
+++ b/app/allocation/controllers/edit/allocation-details.ts
@@ -5,7 +5,7 @@ import { BasmResponse } from '../../../../common/types/basm_response'
 const presenters = require('../../../../common/presenters')
 
 type FormValues = { date?: string }
-type AllocationRequest = Required<Pick<BasmRequest, 'allocation' | 'form' | 'services' | 'sessionModel'>>
+type AllocationRequest = Required<Pick<BasmRequest, 'allocation' | 'form' | 'services' | 'session' | 'sessionModel'>>
 
 class AllocationDetailsController extends UpdateBaseController {
 
@@ -45,12 +45,22 @@ class AllocationDetailsController extends UpdateBaseController {
       const id = req.allocation.id
       const date = req.form.values.date
 
-      await req.services.allocation.update({ id: id, date: date })
+      const allocation = await req.services.allocation.update({ id: id, date: date })
 
+      req.sessionModel.set('allocation', allocation)
       next()
     } catch (err) {
       next(err)
     }
+  }
+
+  render(req: AllocationRequest, res: BasmResponse, next: () => void) {
+    super.render(req, res, next)
+
+    // Discard the session model once we've rendered the error messages.
+    // We don't want the errors to hang around in the session after the user has been informed.
+    req.sessionModel.reset()
+    req.session.save()
   }
 }
 

--- a/app/allocation/controllers/edit/allocation-details.ts
+++ b/app/allocation/controllers/edit/allocation-details.ts
@@ -2,6 +2,8 @@ import UpdateBaseController from './base'
 import { BasmRequest } from '../../../../common/types/basm_request'
 import { BasmResponse } from '../../../../common/types/basm_response'
 
+const filters = require('../../../../config/nunjucks/filters')
+
 const presenters = require('../../../../common/presenters')
 
 type FormValues = { date?: string }
@@ -15,9 +17,13 @@ class AllocationDetailsController extends UpdateBaseController {
         return callback(err)
       }
 
-      if (!values.date) {
+      const { date } = req.allocation
+
+      if (!date) {
         values.date = req.allocation.date
       }
+
+      values.date = filters.formatDateAsRelativeDay(date)
 
       callback(null, values)
     })

--- a/common/types/basm_request.ts
+++ b/common/types/basm_request.ts
@@ -20,5 +20,8 @@ export interface BasmRequest extends Express.Request {
   services?: {
     allocation: Service
   }
+  session?: {
+    save: () => void
+  }
   sessionModel?: SessionModel
 }

--- a/common/types/basm_request.ts
+++ b/common/types/basm_request.ts
@@ -7,6 +7,7 @@ import { SessionModel } from './session_model'
 export interface BasmRequest extends Express.Request {
   allocation?: Allocation
   canAccess: (permission: string) => boolean
+  flash?: (yeah: any, nah: any) => void
   form?: {
     options: {
       fields: object
@@ -24,4 +25,5 @@ export interface BasmRequest extends Express.Request {
     save: () => void
   }
   sessionModel?: SessionModel
+  t?: (keys: string, options?: any) => string
 }

--- a/common/types/move.ts
+++ b/common/types/move.ts
@@ -1,6 +1,7 @@
 import { Event } from './event'
 import { Location } from './location'
 import { Profile } from './profile'
+import { Supplier } from './supplier'
 
 export interface Move {
   profile?: Profile
@@ -38,4 +39,5 @@ export interface Move {
   is_lockout?: boolean
   _canEdit?: boolean
   _isPerLocked?: boolean
+  supplier?: Supplier
 }

--- a/common/types/session_model.ts
+++ b/common/types/session_model.ts
@@ -1,3 +1,8 @@
+import { Allocation } from "./allocation"
+
 export interface SessionModel {
+  allocation?: Allocation
+  reset: () => void
+  set: (key: string, value: any) => any
   toJSON: () => any
 }

--- a/common/types/supplier.ts
+++ b/common/types/supplier.ts
@@ -1,0 +1,5 @@
+export interface Supplier {
+  id: string
+  name: string
+  key: string
+}

--- a/locales/en/allocations.json
+++ b/locales/en/allocations.json
@@ -13,5 +13,9 @@
   },
   "allocation_cancellation_reason": {
     "page_title": "Cancel this allocation"
+  },
+  "update_flash": {
+    "heading": "Allocation updated",
+    "message": "This move has been updated with {{ supplier }}"
   }
 }


### PR DESCRIPTION
## Proposed changes

### What changed

- Format the date nicely on the edit allocation details page
- Clear errors after displaying them so they don't show up again if you navigate away and come back
- Show success banner (just shows "the supplier" instead of the name of the supplier as we don't download the necessary details from the API)

### Why did it change

- Feedback after demo on Friday

### Issue tracking

- [P4-4133](https://dsdmoj.atlassian.net/browse/P4-4133)

## Screenshots

![Screenshot 2023-04-24 at 10 12 23](https://user-images.githubusercontent.com/40831617/233952983-5ae014dd-a3dc-41cc-8438-f37d6dd4e8c3.png)
---
![Screenshot 2023-04-24 at 10 13 04](https://user-images.githubusercontent.com/40831617/233952999-8a6dac95-3c90-436f-bd0f-cd3fef8b9b42.png)




## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed

### Other considerations

Commit messages with a `fix` or `feat` type are automatically used to generate the [changelog](ministryofjustice/hmpps-book-secure-move-frontend/blob/main/CHANGELOG.md) and
[GitHub release notes](https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/releases) during the release task. Please make sure they will read well on their own in a
summary of changes and that the commit body gives a more detailed description of those changes if necessary.

- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
- [ ] Update [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/main/README.md) with any new instructions or tasks


[P4-4133]: https://dsdmoj.atlassian.net/browse/P4-4133?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ