### PR TITLE
Reduce Sentry Transaction Sampling from 10% to 1% and ignore /healthcheck

### DIFF
--- a/server.js
+++ b/server.js
@@ -85,7 +85,11 @@ module.exports = async () => {
           samplingContext.transactionContext &&
           samplingContext.transactionContext.name
 
-        if (transactionName && transactionName.includes('ping') || transactionName.includes('/healthcheck')) {
+        if (
+          transactionName &&
+          transactionName.includes('ping') ||
+          transactionName.includes('/healthcheck')
+        ) {
           return 0
         } else {
           return 0.01

--- a/server.js
+++ b/server.js
@@ -86,8 +86,7 @@ module.exports = async () => {
           samplingContext.transactionContext.name
 
         if (
-          transactionName &&
-          transactionName.includes('ping') ||
+          (transactionName && transactionName.includes('ping')) ||
           transactionName.includes('/healthcheck')
         ) {
           return 0

--- a/server.js
+++ b/server.js
@@ -85,10 +85,10 @@ module.exports = async () => {
           samplingContext.transactionContext &&
           samplingContext.transactionContext.name
 
-        if (transactionName && transactionName.includes('ping')) {
+        if (transactionName && transactionName.includes('ping') || transactionName.includes('/healthcheck')) {
           return 0
         } else {
-          return 0.1
+          return 0.01
         }
       },
     })


### PR DESCRIPTION
## Proposed changes

Reduce Sentry Transaction Sampling from 10% to 1% and ignore /healthcheck

### What changed

<!--- Describe the changes in detail - the "what"-->

- Reduced Sentry Transaction Sampling rate from 10% to 1%
- Ignore `/healthcheck` endpoint when sampling Sentry transactions

### Why did it change

<!--- Describe the reason these changes were made - the "why" -->

- The project currently consumes ~1.8 million transactions, this change will reduce the consumption by ~90%

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

