### PR TITLE
fix: Fix empty allocation date change bug

### DIFF
--- a/app/allocation/controllers/edit/allocation-details.test.ts
+++ b/app/allocation/controllers/edit/allocation-details.test.ts
@@ -223,6 +223,55 @@ describe('#saveValues', function () {
     })
   })
 
+  context('when count is zero (all moves cancelled)', function () {
+    const emptyAllocation = {
+      ...allocation,
+      moves: [],
+      moves_count: 0,
+    }
+
+    beforeEach(async function () {
+      allocationService = {
+        update: sinon
+          .stub()
+          .resolves({ ...emptyAllocation, date: '2023-01-02' }),
+      }
+      sessionModel = {
+        toJSON: sinon.stub().returns(mockData),
+        set: sinon.stub(),
+      }
+      next = sinon.stub()
+      flash = sinon.stub()
+
+      await controller.saveValues(
+        {
+          ...req,
+          allocation: emptyAllocation,
+          flash,
+          form: {
+            options: formOptions,
+            values: {
+              date: '2023-01-02',
+            },
+          },
+          sessionModel,
+          services: {
+            allocation: allocationService,
+          },
+        },
+        res,
+        next
+      )
+    })
+
+    it('sets the flash without error', function () {
+      expect(flash).to.have.been.calledWithExactly('success', {
+        title: 'test',
+        content: 'test',
+      })
+    })
+  })
+
   context('unhappy path', function () {
     const error = new Error('bad!')
 

--- a/app/allocation/controllers/edit/allocation-details.ts
+++ b/app/allocation/controllers/edit/allocation-details.ts
@@ -1,6 +1,7 @@
 import UpdateBaseController from './base'
 import { BasmRequest } from '../../../../common/types/basm_request'
 import { BasmResponse } from '../../../../common/types/basm_response'
+import { Move } from '../../../../common/types/move'
 
 const filters = require('../../../../config/nunjucks/filters')
 
@@ -72,8 +73,8 @@ class AllocationDetailsController extends UpdateBaseController {
   }
 
   private setFlash(req: AllocationRequest) {
-    const firstMove = req.allocation.moves[0]
-    const supplier = firstMove.supplier?.name || req.t('supplier_fallback')
+    const firstMove = req.allocation.moves[0] as Move | undefined
+    const supplier = firstMove?.supplier?.name || req.t('supplier_fallback')
 
     req.flash('success', {
       title: req.t('allocations::update_flash.heading'),

--- a/common/helpers/allocation/can-edit-allocation.test.ts
+++ b/common/helpers/allocation/can-edit-allocation.test.ts
@@ -53,6 +53,21 @@ describe('#canEditAllocation', function () {
     })
   })
 
+  context('when the moves count is zero (all moves cancelled)', function () {
+    beforeEach(function () {
+      allocation = allocationFactory.build({
+        moves: moveFactory.buildList(2, { status: 'cancelled' }),
+        moves_count: 0,
+      })
+    })
+
+    it('returns false', function () {
+      expect(
+        canEditAllocation(allocation, canAccessFunction(permissions))
+      ).to.be.false
+    })
+  })
+
   context('when an associated move cannot be edited', function () {
     beforeEach(function () {
       const moves = [

--- a/common/helpers/allocation/can-edit-allocation.ts
+++ b/common/helpers/allocation/can-edit-allocation.ts
@@ -11,6 +11,10 @@ export function canEditAllocation(allocation: Allocation, canAccess: (permission
     return false
   }
 
+  if (allocation.moves_count === 0) {
+    return false
+  }
+
   if (allocation.moves.some(move => !canEditMove(move, canAccess))) {
     return false
   }


### PR DESCRIPTION

[P4-4172]

<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

* Don't show the link to update an allocation if it's empty (which means that all moves have been cancelled)
* If someone accesses the page and changes the date anyway, do so without error

### Why did it change

* Sentry alerted us to this bug when someone tried to change the date of an allocation with zero move count

### Issue tracking

- [P4-4172](https://dsdmoj.atlassian.net/browse/P4-4172)

## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

- [x] No environment variables were added or changed

### Other considerations

Commit messages with a `fix` or `feat` type are automatically used to generate the [changelog](ministryofjustice/hmpps-book-secure-move-frontend/blob/main/CHANGELOG.md) and
[GitHub release notes](https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/releases) during the release task. Please make sure they will read well on their own in a
summary of changes and that the commit body gives a more detailed description of those changes if necessary.

- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
- [ ] Update [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/main/README.md) with any new instructions or tasks


[P4-4172]: https://dsdmoj.atlassian.net/browse/P4-4172?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[P4-4172]: https://dsdmoj.atlassian.net/browse/P4-4172?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ