### PR TITLE
[P4-4144] Ignore metrics path in Application Insights telemetry

### DIFF
--- a/common/lib/azure-appinsights.ts
+++ b/common/lib/azure-appinsights.ts
@@ -43,7 +43,7 @@ export const addUserDataToRequests = (envelope: EnvelopeTelemetry, contextObject
 }
 
 export const ignorePathsProcessor = (envelope: EnvelopeTelemetry) => {
-  const prefixesToIgnore = ['GET /healthcheck/ping']
+  const prefixesToIgnore = ['GET /healthcheck/ping', 'GET /metrics']
 
   const isRequest = envelope.data.baseType === Contracts.TelemetryTypeString.Request
   if (isRequest) {


### PR DESCRIPTION
## Proposed changes

### What changed

- Ignore metrics path in Application Insights telemetry

### Why did it change

- It's a very spammy endpoint and we don't need to track it

### Issue tracking

- [P4-4144](https://dsdmoj.atlassian.net/browse/P4-4144)

## Checklists

### Testing

#### Automated testing

- [ ] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed

### Other considerations

Commit messages with a `fix` or `feat` type are automatically used to generate the [changelog](ministryofjustice/hmpps-book-secure-move-frontend/blob/main/CHANGELOG.md) and
[GitHub release notes](https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/releases) during the release task. Please make sure they will read well on their own in a
summary of changes and that the commit body gives a more detailed description of those changes if necessary.

- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
- [ ] Update [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/main/README.md) with any new instructions or tasks
