### PR TITLE
[P4-4140] Do not allow date change for allocation moves

### DIFF
--- a/app/move/app/view/controllers/render-details.test.js
+++ b/app/move/app/view/controllers/render-details.test.js
@@ -339,7 +339,6 @@ describe('Move view app', function () {
             const locals = res.render.args[0][1]
             expect(locals.updateLinks).to.deep.equal({
               move: '/move-url',
-              date: '/date-url',
             })
           })
         })

--- a/common/helpers/allocation/can-edit-allocation.ts
+++ b/common/helpers/allocation/can-edit-allocation.ts
@@ -18,5 +18,5 @@ export function canEditAllocation(
     return false
   }
 
-  return !allocation.moves.some(move => !canEditMoveDate(move, canAccess))
+  return !allocation.moves.some(move => !canEditMoveDate(move, canAccess, 'update_allocation'))
 }

--- a/common/helpers/move/can-edit-move-date.test.ts
+++ b/common/helpers/move/can-edit-move-date.test.ts
@@ -1,0 +1,85 @@
+import { expect } from 'chai'
+import sinon from 'sinon'
+
+import allocationFactory from '../../../factories/allocation'
+import moveFactory from '../../../factories/move'
+import { Move } from '../../types/move'
+
+import { canEditMoveDate } from './can-edit-move-date'
+
+describe('Move date helper', function () {
+  describe('#canEditMoveDate', function () {
+    let canAccessStub: sinon.SinonStub<any[], any>
+    const mockMove: Move = moveFactory.build()
+
+    beforeEach(function () {
+      canAccessStub = sinon.stub().returns(true)
+      mockMove.is_lodging = false
+      mockMove.allocation = undefined
+    })
+
+    context('without access', function () {
+      beforeEach(function () {
+        canAccessStub.withArgs('move:update').returns(false)
+      })
+
+      it('should return false', function () {
+        expect(canEditMoveDate(mockMove, canAccessStub)).to.be.false
+      })
+    })
+
+    context('with access', function () {
+      beforeEach(function () {
+        canAccessStub.withArgs('move:update').returns(true)
+      })
+
+      context('without lodging', function () {
+        beforeEach(function () {
+          mockMove.is_lodging = false
+        })
+
+        it('should return true', function () {
+          expect(canEditMoveDate(mockMove, canAccessStub)).to.be.true
+        })
+      })
+
+      context('with a lodging', function () {
+        beforeEach(function () {
+          mockMove.is_lodging = true
+        })
+
+        it('should return false', function () {
+          expect(canEditMoveDate(mockMove, canAccessStub)).to.be.false
+        })
+      })
+
+      context('when part of an allocation', function () {
+        beforeEach(function () {
+          mockMove.allocation = allocationFactory.build()
+        })
+
+        it('should return false', function () {
+          expect(canEditMoveDate(mockMove, canAccessStub)).to.be.false
+        })
+
+        context('when updating via allocation', function () {
+          it('should return true', function () {
+            expect(
+              canEditMoveDate(mockMove, canAccessStub, 'update_allocation')
+            ).to.be.true
+          })
+        })
+      })
+
+      context('when not part of an allocation', function () {
+        beforeEach(function () {
+          mockMove.allocation = undefined
+        })
+
+        it('should return true', function () {
+          expect(canEditMoveDate(mockMove, canAccessStub)).to.be.true
+        })
+      })
+    })
+  })
+})

--- a/common/helpers/move/can-edit-move-date.ts
+++ b/common/helpers/move/can-edit-move-date.ts
@@ -4,9 +4,14 @@ import { canEditMove } from './can-edit-move'
 
 export function canEditMoveDate(
   move: Move,
-  canAccess: (permission: string) => boolean
+  canAccess: (permission: string) => boolean,
+  context: string = 'none'
 ) {
   if (move.is_lodging) {
+    return false
+  }
+
+  if (move.allocation && context !== 'update_allocation') {
     return false
   }
 

--- a/common/types/move.ts
+++ b/common/types/move.ts
@@ -1,3 +1,4 @@
+import { Allocation } from './allocation'
 import { Event } from './event'
 import { Location } from './location'
 import { Profile } from './profile'
@@ -42,4 +43,5 @@ export interface Move {
   _isPerLocked?: boolean
   supplier?: Supplier
   is_lodging?: boolean
+  allocation?: Allocation
 }

--- a/factories/allocation.ts
+++ b/factories/allocation.ts
@@ -3,14 +3,20 @@ import { Allocation } from '../common/types/allocation'
 import locationFactory from './location'
 import moveFactory from './move'
 
-const allocationFactory = Factory.define<Allocation>(() => ({
-  id: '1c5b9f9a-2d70-4b4e-b5a3-6736b83c8bd9',
-  date: '2023-04-01',
-  from_location: locationFactory.build(),
-  moves_count: 2,
-  moves: moveFactory.buildList(2),
-  status: 'filled',
-  to_location: locationFactory.build()
-}))
+const allocationFactory = Factory.define<Allocation>(({ afterBuild }) => {
+  afterBuild(allocation => {
+    allocation.moves.forEach((move) => { move.allocation = allocation })
+  })
+
+  return {
+    id: '1c5b9f9a-2d70-4b4e-b5a3-6736b83c8bd9',
+    date: '2023-04-01',
+    from_location: locationFactory.build(),
+    moves_count: 2,
+    moves: moveFactory.buildList(2),
+    status: 'filled',
+    to_location: locationFactory.build()
+  }
+})
 
 export default allocationFactory


### PR DESCRIPTION
## Proposed changes

### What changed

- Hide date change link for allocation moves

### Why did it change

- This has been disabled in the API as we now have a proper way of updating allocation dates. We need to hide the link because if someone tries to use it, it will error out.

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

- [P4-4140](https://dsdmoj.atlassian.net/browse/P4-4140)

## Screenshots
<!--- (Optional) Include screenshots if changes update interfaces or components -->
<!--- Delete/copy as appropriate --->

| Before | After |
| ----- | ----- |
| ![Screenshot 2023-05-26 at 12 00 09](https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/assets/40831617/30d4f166-a8e4-42c2-a1d1-919cd31d5978) | ![Screenshot 2023-05-26 at 12 01 08](https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/assets/40831617/94ddf7d0-daa2-4082-a666-a24a11f07a09) |

## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

- [x] No environment variables were added or changed

### Other considerations

Commit messages with a `fix` or `feat` type are automatically used to generate the [changelog](ministryofjustice/hmpps-book-secure-move-frontend/blob/main/CHANGELOG.md) and
[GitHub release notes](https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/releases) during the release task. Please make sure they will read well on their own in a
summary of changes and that the commit body gives a more detailed description of those changes if necessary.

- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
- [ ] Update [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/main/README.md) with any new instructions or tasks


[P4-4140]: https://dsdmoj.atlassian.net/browse/P4-4140?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ