### PR TITLE
[P4-4171] Permit new Google Analytics subdomain in content security policy

### DIFF
--- a/server.js
+++ b/server.js
@@ -245,6 +245,7 @@ module.exports = async () => {
             'cdnjs.cloudflare.com',
             'www.googletagmanager.com',
             'www.google-analytics.com',
+            'region1.google-analytics.com',
             'cdn.jsdelivr.net',
           ],
           connectSrc: [
@@ -252,11 +253,13 @@ module.exports = async () => {
             "'unsafe-inline'",
             'www.googletagmanager.com',
             'www.google-analytics.com',
+            'region1.google-analytics.com',
             'api.os.uk',
           ],
           imgSrc: [
             "'self'",
             'www.google-analytics.com',
+            'region1.google-analytics.com',
             'api.os.uk',
             'data: blob:',
             'images.ctfassets.net',


### PR DESCRIPTION
## Proposed changes

### What changed

- Permit `unsafe-inline` for `region1.google-analytics.com` in content security policy

### Why did it change

- Because Google Analytics 4 

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

- [P4-4171](https://dsdmoj.atlassian.net/browse/P4-4171)

## Checklists

### Testing

#### Automated testing

- [ ] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed

### Other considerations

Commit messages with a `fix` or `feat` type are automatically used to generate the [changelog](ministryofjustice/hmpps-book-secure-move-frontend/blob/main/CHANGELOG.md) and
[GitHub release notes](https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/releases) during the release task. Please make sure they will read well on their own in a
summary of changes and that the commit body gives a more detailed description of those changes if necessary.

- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
- [ ] Update [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/main/README.md) with any new instructions or tasks
