### PR TITLE
Increase timeouts on e2e tests

### DIFF
--- a/.testcaferc.json
+++ b/.testcaferc.json
@@ -1,8 +1,8 @@
 {
-  "assertionTimeout": 2000,
-  "selectorTimeout": 5000,
-  "pageLoadTimeout": 12000,
-  "pageRequestTimeout": 9000,
+  "assertionTimeout": 20000,
+  "selectorTimeout": 50000,
+  "pageLoadTimeout": 120000,
+  "pageRequestTimeout": 90000,
   "retryTestPages": true,
   "hostname": "localhost",
   "quarantineMode": {


### PR DESCRIPTION
## Proposed changes

### What changed

- Increase timeouts on e2e tests

### Why did it change

- They keep failing and the only seem to pass with very large timeouts. We need to get the main branch building again so we will leave them this high for now, and try and work out what's slowing them down so much later.
