### PR TITLE
[MAP-212] Add feature flag for AP moves

### DIFF
--- a/app/move/app/new/controllers/move-details.js
+++ b/app/move/app/new/controllers/move-details.js
@@ -1,6 +1,8 @@
 const { get, map, omitBy, set } = require('lodash')
 
 const commonMiddleware = require('../../../../../common/middleware')
+const locationService = require('../../../../../common/services/location')
+const { FEATURE_FLAGS } = require('../../../../../config')
 
 const CreateBaseController = require('./base')
 
@@ -55,43 +57,78 @@ class MoveDetailsController extends CreateBaseController {
     )
   }
 
-  setMoveTypes(req, res, next) {
-    const permittedMoveTypes = get(req.session, 'user.permissions', [])
-      .filter(permission => permission.includes('move:create:'))
-      .map(permission => permission.replace('move:create:', ''))
-      .filter(
-        permission =>
-          !(
-            !this.isFromGivenLocationType(req, 'police') &&
-            permission === 'prison_recall'
+  async apMovesAllowed(req) {
+    if (!this.isFromGivenLocationType(req, 'prison')) {
+      return false
+    }
+
+    if (!FEATURE_FLAGS.AP_DISABLED_SUPPLIERS?.length) {
+      return true
+    }
+
+    const move = req.getMove()
+    const locationId = move.from_location?.id || move.from_location
+    const location = await locationService.findById(req, locationId, true)
+
+    if (
+      location.suppliers
+        .map(supplier => supplier.key)
+        .some(supplier =>
+          FEATURE_FLAGS.AP_DISABLED_SUPPLIERS.includes(supplier)
+        )
+    ) {
+      return false
+    }
+
+    return true
+  }
+
+  async setMoveTypes(req, res, next) {
+    try {
+      let permittedMoveTypes = get(req.session, 'user.permissions', [])
+        .filter(permission => permission.includes('move:create:'))
+        .map(permission => permission.replace('move:create:', ''))
+        .filter(
+          permission =>
+            !(
+              !this.isFromGivenLocationType(req, 'police') &&
+              permission === 'prison_recall'
+            )
+        )
+
+      if (
+        permittedMoveTypes.find(moveType => moveType === 'approved_premises')
+      ) {
+        const canApMove = await this.apMovesAllowed(req)
+
+        if (!canApMove) {
+          permittedMoveTypes = permittedMoveTypes.filter(
+            moveType => moveType !== 'approved_premises'
           )
+        }
+      }
+
+      const existingItems = req.form.options.fields.move_type.items
+      const permittedItems = existingItems.filter(item =>
+        permittedMoveTypes.includes(item.value)
       )
-      .filter(
-        permission =>
-          !(
-            !this.isFromGivenLocationType(req, 'prison') &&
-            permission === 'approved_premises'
-          )
+      const removedConditionals = map(
+        existingItems.filter(item => !permittedMoveTypes.includes(item.value)),
+        'conditional'
       )
 
-    const existingItems = req.form.options.fields.move_type.items
-    const permittedItems = existingItems.filter(item =>
-      permittedMoveTypes.includes(item.value)
-    )
-    const removedConditionals = map(
-      existingItems.filter(item => !permittedMoveTypes.includes(item.value)),
-      'conditional'
-    )
+      // update move_type with only permitted items
+      set(req, 'form.options.fields.move_type.items', permittedItems)
 
-    // update move_type with only permitted items
-    set(req, 'form.options.fields.move_type.items', permittedItems)
+      // remove any conditionals fields that are no longer needed
+      req.form.options.fields = omitBy(req.form.options.fields, (value, key) =>
+        removedConditionals.includes(key)
+      )
 
-    // remove any conditionals fields that are no longer needed
-    req.form.options.fields = omitBy(req.form.options.fields, (value, key) =>
-      removedConditionals.includes(key)
-    )
-
-    next()
+      next()
+    } catch (error) {
+      next(error)
+    }
   }
 
   process(req, res, next) {

--- a/config/index.ts
+++ b/config/index.ts
@@ -304,6 +304,12 @@ export const FEATURE_FLAGS = {
     process.env.FEATURE_FLAG_ADD_LODGE_BUTTON || ''
   ),
   DATE_OF_ARREST: /true/i.test(process.env.FEATURE_FLAG_DATE_OF_ARREST || ''),
+  AP_DISABLED_SUPPLIERS: (
+      (process.env.FEATURE_FLAG_AP_DISABLED_SUPPLIERS || '')
+          .split(',')
+          .filter(supplier => supplier != '')
+          .map(supplier => supplier.trim())
+  ),
 }
 export const FRAMEWORKS = {
   CURRENT_VERSION: process.env.FRAMEWORKS_VERSION || LATEST_FRAMEWORKS_BUILD,

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -71,9 +71,10 @@
 
 ## Feature Flags
 
-| Name                                    | Description                                                                  | Default |
-| :-------------------------------------- | :--------------------------------------------------------------------------- | :------ |
-| FEATURE_FLAG_GOT | This will enable Got as the request library for the API instead of axios. | false |
+| Name                               | Description                                                                               | Default |
+| :--------------------------------- | :---------------------------------------------------------------------------------------- | :------ |
+| FEATURE_FLAG_GOT                   | This will enable Got as the request library for the API instead of axios.                 | false   |
+| FEATURE_FLAG_AP_DISABLED_SUPPLIERS | Comma-separated list of keys of suppliers that cannot yet accept approved premises moves. |         |
 
 ## Development specific
 

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -14,13 +14,14 @@ generic-service:
   env:
     API_BASE_URL: "https://hmpps-book-secure-move-api-preprod.apps.cloud-platform.service.justice.gov.uk"
     AUTH_PROVIDER_URL: "https://sign-in-preprod.hmpps.service.justice.gov.uk"
+    FEATURE_FLAG_ADD_LODGE_BUTTON: "true"
+    FEATURE_FLAG_AP_DISABLED_SUPPLIERS: "serco"
     FEEDBACK_URL: "https://eu.surveymonkey.com/r/3CKYXSC"
     GOOGLE_ANALYTICS_ID: "G-3LCJP1TWQC"
     MOVE_DESIGN_FEEDBACK_URL: "https://eu.surveymonkey.com/r/BKZC8BV"
     NOMIS_ELITE2_API_URL: "https://api-preprod.prison.service.justice.gov.uk"
     SENTRY_ENVIRONMENT: "preproduction"
     SERVER_HOST: "hmpps-book-secure-move-frontend-preprod.apps.cloud-platform.service.justice.gov.uk"
-    FEATURE_FLAG_ADD_LODGE_BUTTON: "true"
 
 
   # Pre-existing kubernetes secrets to load as environment variables in the deployment.

--- a/helm_deploy/values-production.yaml
+++ b/helm_deploy/values-production.yaml
@@ -14,13 +14,14 @@ generic-service:
   env:
     API_BASE_URL: "https://hmpps-book-secure-move-api-production.apps.live-1.cloud-platform.service.justice.gov.uk"
     AUTH_PROVIDER_URL: "https://sign-in.hmpps.service.justice.gov.uk"
+    FEATURE_FLAG_ADD_LODGE_BUTTON: "false"
+    FEATURE_FLAG_AP_DISABLED_SUPPLIERS: "serco"
     FEEDBACK_URL: "https://eu.surveymonkey.com/r/3CKYXSC"
     GOOGLE_ANALYTICS_ID: "G-58WMNWR101"
     MOVE_DESIGN_FEEDBACK_URL: "https://eu.surveymonkey.com/r/BKZC8BV"
     NOMIS_ELITE2_API_URL: "https://api.prison.service.justice.gov.uk"
     SENTRY_ENVIRONMENT: "production"
     SERVER_HOST: "bookasecuremove.service.justice.gov.uk"
-    FEATURE_FLAG_ADD_LODGE_BUTTON: "false"
 
   # Pre-existing kubernetes secrets to load as environment variables in the deployment.
   # namespace_secrets:


### PR DESCRIPTION
## Proposed changes

### What changed

Added feature flag to disable AP moves for certain suppliers

### Why did it change

Added feature flag to disable AP moves for certain suppliers. The FEATURE_FLAG_AP_DISABLED_SUPPLIERS environment variable, if set, should be a comma-separated list of supplier keys, as they exist in the BaSM API DB. For example:

serco
geoamey
serco,geoamey

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

- MAP-212

## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO NOT include new environment variables -->
- [x] Documented in the [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/main/README.md)
- [ ] Added to [continuous integration](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-book-secure-move-frontend)
- [x] Added to Helm config

### Other considerations

Commit messages with a `fix` or `feat` type are automatically used to generate the [changelog](ministryofjustice/hmpps-book-secure-move-frontend/blob/main/CHANGELOG.md) and
[GitHub release notes](https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/releases) during the release task. Please make sure they will read well on their own in a
summary of changes and that the commit body gives a more detailed description of those changes if necessary.

- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
- [x] Update [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/main/README.md) with any new instructions or tasks
