### PR TITLE
feat: Change wording on handover form for lodgings

### DIFF
--- a/app/person-escort-record/app/confirm/handover-details.njk
+++ b/app/person-escort-record/app/confirm/handover-details.njk
@@ -13,6 +13,8 @@
     {% markdown %}
       {% if moveIsLockout %}
         {{ t("assessment::handover.before_handover.content", { context: 'lockout', per_href: "/move/" + moveId + "/police-custody-form" }) | safe }}
+      {% elif moveIsLodging %}
+        {{ t("assessment::handover.before_handover.content", { context: 'lodging', per_href: "/move/" + moveId + "/police-custody-form" }) | safe }}
       {% else %}
         {{ t("assessment::handover.before_handover.content", { per_href: "/move/" + moveId + "/person-escort-record" }) | safe }}
       {% endif %}

--- a/locales/en/assessment.json
+++ b/locales/en/assessment.json
@@ -77,7 +77,8 @@
     "before_handover": {
       "heading": "Before you handover",
       "content": "Check that you have:\n\n- <a href=\"{{ per_href }}\">reviewed the Person Escort Record</a> and the information is up to date\n- confirmed the correct person is being moved\n- completed the correct level of search\n- communicated risk and health information with the receiving officer",
-      "content_lockout": "Check that you have:\n\n- <a href=\"{{ per_href }}\">added all lockout events</a> and the information is up to date\n- confirmed the correct person is being moved\n- completed the correct level of search\n- communicated risk and health information with the receiving officer"
+      "content_lockout": "Check that you have:\n\n- <a href=\"{{ per_href }}\">added all lockout events</a> and the information is up to date\n- confirmed the correct person is being moved\n- completed the correct level of search\n- communicated risk and health information with the receiving officer",
+      "content_lodging": "Check that you have:\n\n- <a href=\"{{ per_href }}\">added all lodging events</a>\n- confirmed the correct person is being moved\n- completed the correct level of search\n- communicated risk and health information with the receiving officer"
     },
     "not_fit_to_travel": "If this person is not fit to travel you must <a href=\"{{cancel_href}}\" class=\"app-link--destructive\">cancel this move</a>.",
     "dispatching_officer": "Dispatching officer",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[MAP-XXXX] PR Title` -->

## Proposed changes

### What changed

<!--- Describe the changes in detail - the "what"-->
Changed the wording on the handover form.

### Why did it change

<!--- Describe the reason these changes were made - the "why" -->
This changed so that users see the right content for lodging moves during handover.

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

- MAP-87
