### PR TITLE
fix: MAP-345 add download moves permission to CDM

### DIFF
--- a/common/lib/permissions.js
+++ b/common/lib/permissions.js
@@ -44,6 +44,7 @@ const contractDeliveryManagerPermissions = [
   'moves:view:proposed',
   'move:view',
   'move:view:journeys',
+  'moves:download',
   'person_escort_record:view',
   'person_escort_record:print',
   'youth_risk_assessment:view',

--- a/common/lib/permissions.test.js
+++ b/common/lib/permissions.test.js
@@ -324,6 +324,7 @@ describe('Permissions', function () {
           'allocations:view',
           'locations:contract_delivery_manager',
           'locations:all',
+          'moves:download',
           'moves:view:outgoing',
           'moves:view:incoming',
           'moves:view:proposed',


### PR DESCRIPTION
Allows PECS team to download hourly CSV