### PR TITLE
[MAP-293] Support incomplete_per cancellation reason

### DIFF
--- a/common/services/single-request.js
+++ b/common/services/single-request.js
@@ -54,7 +54,7 @@ class SingleRequestService extends BaseService {
           status: 'cancelled',
           // TODO: Find a better filter for this. Currently we will need to add any new reasons from the API here.
           cancellation_reason:
-            'made_in_error,supplier_declined_to_move,cancelled_by_pmu,other',
+            'made_in_error,supplier_declined_to_move,cancelled_by_pmu,incomplete_per,other',
         }
         break
       default:

--- a/common/services/single-request.test.js
+++ b/common/services/single-request.test.js
@@ -260,7 +260,7 @@ describe('Single request service', function () {
             expect(moveService.get.args[0][0].filter).to.deep.include({
               status: 'cancelled',
               cancellation_reason:
-                'made_in_error,supplier_declined_to_move,cancelled_by_pmu,other',
+                'made_in_error,supplier_declined_to_move,cancelled_by_pmu,incomplete_per,other',
             })
           })
         })

--- a/locales/en/fields.json
+++ b/locales/en/fields.json
@@ -337,6 +337,9 @@
       "database_correction": {
         "label": "Actual cancellation reason and time unknown due to missing supplier data"
       },
+      "incomplete_per": {
+        "label": "Cancelled due to incomplete PER"
+      },
       "other": {
         "label": "Another reason"
       }

--- a/locales/en/statuses.json
+++ b/locales/en/statuses.json
@@ -26,6 +26,7 @@
   "description_supplier_declined_to_move": "Reason — $t(fields::cancellation_reason.items.supplier_declined_to_move.label)",
   "description_cancelled_by_pmu": "Reason — $t(fields::cancellation_reason.items.cancelled_by_pmu.label) — {{comment}}",
   "description_database_correction": "Reason — $t(fields::cancellation_reason.items.database_correction.label)",
+  "description_incomplete_per": "Reason — $t(fields::cancellation_reason.items.incomplete_per.label)",
   "description_other": "Reason — {{comment}}",
   "description_rejected": "Comments — {{comment}}",
   "description_no_transport_available": "<p>Reason — $t(fields::rejection_reason.items.no_transport_available)</p> $t(statuses::description_cancelled_rejected)",


### PR DESCRIPTION
## Proposed changes

### What changed

- Support `incomplete_per` cancellation reason

### Why did it change

- This cancellation reason has been added to the API to enable suppliers to cancel moves when the PER is incomplete without being accused of unnecessary cancellations. We need to make sure that the frontend doesn't break and that it displays the reason correctly.

### Issue tracking

- MAP-293

## Screenshots
<!--- (Optional) Include screenshots if changes update interfaces or components -->
<!--- Delete/copy as appropriate --->

<img width="1199" alt="Screenshot 2023-11-10 at 11 17 59" src="https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/assets/40831617/dea6aa36-9929-4c2a-8305-81adae907c25">

## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed

### Other considerations

Commit messages with a `fix` or `feat` type are automatically used to generate the [changelog](ministryofjustice/hmpps-book-secure-move-frontend/blob/main/CHANGELOG.md) and
[GitHub release notes](https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/releases) during the release task. Please make sure they will read well on their own in a
summary of changes and that the commit body gives a more detailed description of those changes if necessary.

- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
- [ ] Update [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/main/README.md) with any new instructions or tasks
