### PR TITLE
Migrating project to use groups in allowlist

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 orbs:
   browser-tools: circleci/browser-tools@1.4.6
-  hmpps: ministryofjustice/hmpps@7.4.1
+  hmpps: ministryofjustice/hmpps@7
 
 aliases:
   # Shared containers
@@ -116,7 +116,7 @@ jobs:
       - checkout
       - attach_workspace:
           at: .
-      - browser-tools/install-browser-tools :
+      - browser-tools/install-browser-tools:
           chrome-version: 114.0.5735.198
       - run:
           name: Compile typescript, build assets and frameworks

--- a/helm_deploy/hmpps-book-secure-move-frontend/Chart.yaml
+++ b/helm_deploy/hmpps-book-secure-move-frontend/Chart.yaml
@@ -5,5 +5,5 @@ name: hmpps-book-secure-move-frontend
 version: 0.2.0
 dependencies:
   - name: generic-service
-    version: 2.6.5
+    version: "2.8"
     repository: https://ministryofjustice.github.io/hmpps-helm-charts


### PR DESCRIPTION
This PR migrates the project to use groups of IPs in their allowlist.

By referring to groups to IP addresses, we can centralize the definition of groups of ip addresses.
If these lists require changing in the future, we can change the definition once and future deploys across all services will automatically include these new IPs.

0 allowlist(s) have been detected that can be migrated.


