### PR TITLE
[MAP-499] Use standardised approach for checking if PER can be edited

### DIFF
--- a/.github/workflows/branch-deploy.yml
+++ b/.github/workflows/branch-deploy.yml
@@ -110,7 +110,7 @@ jobs:
       - name: Set up NodeJS
         uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 18.18.2
 
       - name: Compile typescript
         run: |

--- a/common/controllers/framework/framework-section.js
+++ b/common/controllers/framework/framework-section.js
@@ -1,6 +1,8 @@
 const { filter, snakeCase } = require('lodash')
 
 const i18n = require('../../../config/i18n').default
+const canEditAssessment =
+  require('../../helpers/move/can-edit-assessment').canEditAssessment
 const setPreviousNextFrameworkSection = require('../../middleware/framework/set-previous-next-framework-section')
 const setMoveSummary = require('../../middleware/set-move-summary')
 const presenters = require('../../presenters')
@@ -61,10 +63,9 @@ class FrameworkSectionController extends FormWizardController {
   }
 
   setEditableStatus(req, res, next) {
-    const { editable, framework } = req.assessment
-
     res.locals.isEditable =
-      editable && req.canAccess(`${snakeCase(framework.name)}:update`)
+      canEditAssessment(req.move, req.canAccess) &&
+      ['requested', 'booked'].includes(req.move.status)
 
     next()
   }

--- a/common/controllers/framework/framework-section.test.js
+++ b/common/controllers/framework/framework-section.test.js
@@ -292,6 +292,12 @@ describe('Framework controllers', function () {
             },
           },
           canAccess: sinon.stub().returns(true),
+          move: {
+            profile: {
+              person_escort_record: {},
+            },
+            status: 'requested',
+          },
         }
         mockRes = {
           locals: {},
@@ -300,8 +306,7 @@ describe('Framework controllers', function () {
 
       context('when Person Escort Record is not editable', function () {
         beforeEach(function () {
-          mockReq.assessment.editable = false
-
+          mockReq.move.status = 'cancelled'
           controller.setEditableStatus(mockReq, mockRes, nextSpy)
         })
 
@@ -316,6 +321,7 @@ describe('Framework controllers', function () {
 
       context('when Person Escort Record is editable', function () {
         beforeEach(function () {
+          mockReq.move.status = 'requested'
           controller.setEditableStatus(mockReq, mockRes, nextSpy)
         })
 

--- a/common/controllers/framework/framework-step.js
+++ b/common/controllers/framework/framework-step.js
@@ -2,6 +2,8 @@ const { isEmpty, fromPairs, snakeCase } = require('lodash')
 
 const fieldHelpers = require('../../helpers/field')
 const frameworksHelpers = require('../../helpers/frameworks')
+const canEditAssessment =
+  require('../../helpers/move/can-edit-assessment').canEditAssessment
 const setMoveSummary = require('../../middleware/set-move-summary')
 const FormWizardController = require('../form-wizard')
 
@@ -12,9 +14,10 @@ class FrameworkStepController extends FormWizardController {
   }
 
   checkEditable(req, res, next) {
-    const { editable, framework } = req.assessment
-
-    if (!editable || !req.canAccess(`${snakeCase(framework.name)}:update`)) {
+    if (
+      !canEditAssessment(req.move, req.canAccess) ||
+      !['requested', 'booked'].includes(req.move.status)
+    ) {
       return res.redirect(req.baseUrl)
     }
 

--- a/common/controllers/framework/framework-step.test.js
+++ b/common/controllers/framework/framework-step.test.js
@@ -239,6 +239,12 @@ describe('Framework controllers', function () {
           },
           baseUrl: '/base-url',
           canAccess: sinon.stub().returns(true),
+          move: {
+            profile: {
+              person_escort_record: {},
+            },
+            status: 'requested',
+          },
         }
         mockRes = {
           redirect: sinon.spy(),
@@ -247,7 +253,7 @@ describe('Framework controllers', function () {
 
       context('when Person Escort Record is not editable', function () {
         beforeEach(function () {
-          mockReq.assessment.editable = false
+          mockReq.move.status = 'cancelled'
 
           controller.checkEditable(mockReq, mockRes, nextSpy)
         })


### PR DESCRIPTION
## Proposed changes

### What changed

Use standardised approach for checking if PER can be edited.

### Why did it change

Sometimes we allow people to edit the PER but then when they click on the individual sections it prevents them from editing them, as it was using different logic whcih was relying on the `.editable` field of the PER. We are looking into what causes the situation where this field does not have the expected value, but for now this should prevent any more issues for users.

### Issue tracking

- MAP-499

## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome

