### PR TITLE
[MAP-536] Get branch-based deploy working

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ aliases:
   - &node_container
     executor:
       name: hmpps/node
-      tag: 18.14-browsers
+      tag: 18.19-browsers
   # Common steps
   - &install_dependencies
     run:

--- a/.github/workflows/branch-deploy.yml
+++ b/.github/workflows/branch-deploy.yml
@@ -110,7 +110,7 @@ jobs:
       - name: Set up NodeJS
         uses: actions/setup-node@v3
         with:
-          node-version: 18.18.2
+          node-version: 18
 
       - name: Compile typescript
         run: |

--- a/.github/workflows/branch-deploy.yml
+++ b/.github/workflows/branch-deploy.yml
@@ -197,4 +197,3 @@ jobs:
             } catch (e) {
               core.setFailed(e)
             }
-

--- a/package-lock.json
+++ b/package-lock.json
@@ -187,7 +187,7 @@
       },
       "engines": {
         "node": "18",
-        "npm": "9"
+        "npm": "10"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -304,7 +304,7 @@
   },
   "engines": {
     "node": "18",
-    "npm": "9"
+    "npm": "10"
   },
   "files": [],
   "scripts": {


### PR DESCRIPTION
## Proposed changes

### What changed

Upgrade NPM to v10 to allow Node v18.19+ in build scripts

### Why did it change

So we don't have to pin Node to < v18.19
