### PR TITLE
[MAP-884] Mark overview as links not tabs for screen readers

### DIFF
--- a/common/components/filter/template.njk
+++ b/common/components/filter/template.njk
@@ -1,9 +1,9 @@
 <nav class="app-filter {{ params.classes if params.classes }}">
-  <ul class="app-filter__list" role="tablist">
+  <ul class="app-filter__list">
     {% for item in params.items %}
       <li
         class="app-filter__list-item {{ 'app-filter__list-item--active' if item.active }}"
-        role="tab"
+        role="link"
         aria-selected="{{ 'true' if item.active else 'false' }}"
         {% if item.active %}
         tabindex="0"

--- a/common/components/filter/template.test.js
+++ b/common/components/filter/template.test.js
@@ -24,10 +24,6 @@ describe('Filter component', function () {
       expect(component.find('ul').length).to.equal(1)
     })
 
-    it('should render role attribute on list', function () {
-      expect(component.find('ul').attr('role')).to.equal('tablist')
-    })
-
     describe('items', function () {
       let item1
       let item2
@@ -62,9 +58,9 @@ describe('Filter component', function () {
       })
 
       it('should render role attribute', function () {
-        expect(item1.attr('role')).to.equal('tab')
-        expect(item2.attr('role')).to.equal('tab')
-        expect(item3.attr('role')).to.equal('tab')
+        expect(item1.attr('role')).to.equal('link')
+        expect(item2.attr('role')).to.equal('link')
+        expect(item3.attr('role')).to.equal('link')
       })
 
       context('when not active', function () {


### PR DESCRIPTION
## Proposed changes

### What changed

- Mark overview as links not tabs for screen readers

### Why did it change

- Flagged by accessibility report

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

[MAP-884]


[MAP-884]: https://dsdmoj.atlassian.net/browse/MAP-884?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ