### PR TITLE
fix: Add more GA URLs to connect-src and img-src CSP directives

### DIFF
--- a/server.js
+++ b/server.js
@@ -255,6 +255,8 @@ module.exports = async () => {
             'www.google-analytics.com',
             'region1.google-analytics.com',
             'api.os.uk',
+            'region1.analytics.google.com',
+            'stats.g.doubleclick.net',
           ],
           imgSrc: [
             "'self'",
@@ -263,6 +265,7 @@ module.exports = async () => {
             'api.os.uk',
             'data: blob:',
             'images.ctfassets.net',
+            'www.google.co.uk/ads/ga-audiences',
           ],
           fontSrc: ["'self'", 'fonts.googleapis.com'],
           styleSrc: ["'self'", "'unsafe-inline'", 'cdn.jsdelivr.net'],


### PR DESCRIPTION
## Proposed changes

### What changed

- Add more GA URLs to connect-src and img-src CSP directives

### Why did it change

- Browser console was complaining about these.

### Issue tracking

- [MAP-951]

### Other considerations

- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
