### PR TITLE
Map 923 basm UI update accessibility statement

### DIFF
--- a/app/help/accessibility-statement.njk
+++ b/app/help/accessibility-statement.njk
@@ -15,73 +15,94 @@
 
   <div class="app-reading-width markdown">
     {% markdown %}
-    This accessibility statement applies to [bookasecuremove.service.justice.gov.uk](https://bookasecuremove.service.justice.gov.uk).
+    This accessibility statement applies to the Book a secure move service, available at 
+    [bookasecuremove.service.justice.gov.uk](https://bookasecuremove.service.justice.gov.uk).
 
     This website is run by HMPPS. We want as many people as possible to be able to use this website. For example, that means you should be able to:
 
     - change colours, contrast levels and fonts
-    - zoom in up to 300% without the text spilling off the screen
+    - zoom in up to 200% without problems
     - navigate the website using just a keyboard
 
-    We’ve also made the website text as simple as possible to understand.
+    We have also made the text in the service as simple as possible to understand.
 
-    [AbilityNet](https://mcmw.abilitynet.org.uk/) has advice on making your device easier to use if you have a disability.
+    [AbilityNet](https://mcmw.abilitynet.org.uk/) has advice on making your device (laptop, phone) easier to use if you have a disability.
 
     ## How accessible this website is
 
-    We know some parts of this website are not fully accessible:
+    We know some parts of this website are not fully accessible, for example:
     - there is no timeout warning when the user’s session is about to expire
     - there is only one way to navigate the site, for example there is no sitemap
+    - some pages have layouts that do not display correctly when magnified or resized
+    - some links don’t make it clear about where they will take the user to
+    - some pages contain forms with incorrectly labelled fields, legends or inputs
+    - some pages have content that is incorrectly structured and make it difficult for screen readers to navigate
+    - the colour of text against background colours does not always meet minimum contrast requirements 
+    - some error text does not make clear what the error is and does not link the user to the correct part of the page
+    - some pages contain an illogical focus order which makes it difficult for a user to navigate the service with a keyboard
+    - some pages have the same page title which makes navigation difficult
+
 
     ## Feedback and contact information
+    We are always looking to improve our service, including its accessibility. If you find any problems that are not listed on this page or think 
+    we are not meeting accessibility requirements you can contact us by:
 
-    Any feedback for the service should be provided initially through:
-    - general feedback via Book a secure move [feedback survey]({{FEEDBACK_URL}})
-    - faults via CGI Helpdesk on 0800 917 5148
-
-    ## Reporting accessibility problems with this website
-
-    We’re always looking to improve the accessibility of this website. If you find any problems not listed on this page or think we’re not meeting accessibility requirements contact Laura Roberts, Book a secure move product manager, on [laura.roberts@digital.justice.gov.uk](mailto:laura.roberts@digital.justice.gov.uk).
+    - completing the Book a secure move [feedback survey]({{FEEDBACK_URL}})
+    - emailing [bookasecuremove@digital.justice.gov.uk](mailto:bookasecuremove@digital.justice.gov.uk)
 
     ## Enforcement procedure
+    The Equality and Human Rights Commission (EHRC) is responsible for enforcing the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018 (the 'accessibility regulations').
+    
+    If you are not happy with how we respond to your complaint, contact the [Equality Advisory and Support Service (EASS)](https://www.equalityadvisoryservice.com/).
 
-    The Equality and Human Rights Commission (EHRC) is responsible for enforcing the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018 (the ‘accessibility regulations’). If you’re not happy with how we respond to your complaint, [contact the Equality Advisory and Support Service (EASS)](https://www.equalityadvisoryservice.com/).
-
-    ## Technical information about this website’s accessibility
-
+    ## Technical information about accessibility in this service
     HMPPS is committed to making its website accessible, in accordance with the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018.
 
     ### Compliance status
+    This service is partially compliant with the [Web Content Accessibility Guidelines version 2.1 AA standard](https://www.w3.org/TR/WCAG21/), due to the non-compliances listed below.
 
-    This website is partially compliant with the Web Content Accessibility Guidelines version 2.1 AA standard, due to ‘the non-compliances’ listed below.
+    ### Non-accessible content
+    The content listed below is non-accessible for the following reasons. We plan to address these issues as part of our ongoing work to 
+    improve the service.
 
-    ### Disproportionate burden
+    - Some pages have lists of information that are not structured properly. 
+      This does not meet [WCAG 1.3.1 Info and Relationships](https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships.html). We plan to fix this by October 2024.
+    - Some visual headings are not coded correctly and as a result do not provide the same structure to screen reader users. 
+      This does not meet [WCAG 1.3.1 Info and Relationships](https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships.html). We plan to fix this by October 2024.
+    - Some pages have a heading structure using levels which create an illogical relation between headings and the related content they introduce. 
+      This does not meet [WCAG 1.3.1 Info and Relationships](https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships.html). We plan to fix this by October 2024.
+    - Users can be timed out of the service without any prior warning or indication. 
+      This does not meet [WCAG 2.2.1 Timing Adjustable](https://www.w3.org/WAI/WCAG21/Understanding/timing-adjustable.html). We plan to fix this by October 2024.
+    - Some pages contain fields that are required inputs and others that are optional but do not indicate which is which. 
+      This does not meet [WCAG 3.3.2 Understanding Labels or Instructions](https://www.w3.org/WAI/WCAG21/Understanding/labels-or-instructions.html). We plan to fix this by October 2024. 
+    - Some pages have links with the same link text but direct users to different pages. 
+      This does not meet [2.4.4 Link Purpose (In Context)](https://www.w3.org/WAI/WCAG21/Understanding/link-purpose-in-context.html) and [2.4.9 Link Purpose (Link Only)](https://www.w3.org/WAI/WCAG21/Understanding/link-purpose-link-only.html). We plan to fix this by October 2024.
+    - Some pages have the same page title which creates an unclear navigation for users. 
+      This does not meet [WCAG 2.4.2 Page Titled](https://www.w3.org/WAI/WCAG21/Understanding/page-titled.html). We plan to fix this by October 2024.
+    - Some pages contain an illogical focus order which makes it difficult for users navigating the page with a keyboard. 
+      This does not meet [WCAG 2.4.3 Focus Order](https://www.w3.org/WAI/WCAG21/Understanding/focus-order.html). We plan to fix this by October 2024.
+    - Some text does not meet the required contrast against background colours. 
+      This does not meet [WCAG 1.4.3 Contrast (Minimum)](https://www.w3.org/WAI/WCAG21/Understanding/contrast-minimum.html). We plan to fix this by March 2025.
+    - Some error text does not make clear how to correct the error. 
+      This does not meet [WCAG 3.3.3 Error Suggestion](https://www.w3.org/WAI/WCAG21/Understanding/error-suggestion.html). We plan to fix this by March 2025.
+    - Some legends are not descriptive enough and do not provide a clear question for a user to understand. 
+      This does not meet [WCAG 2.4.6 Headings and Labels](https://www.w3.org/WAI/WCAG21/Understanding/headings-and-labels.html). We plan to fix this by March 2025.
+    - Some pages have layouts that do not display correctly when resized or magnified. 
+      This does not meet [WCAG 1.4.10 Reflow](https://www.w3.org/WAI/WCAG21/Understanding/reflow.html). We plan to fix this by March 2025.
+    - The focus indicator does not meet the required contrast for non-text elements. 
+      This does not meet [WCAG 1.4.11 Non-text Contrast](https://www.w3.org/WAI/WCAG21/Understanding/non-text-contrast.html). We plan to fix this by March 2025.
+    - Some pages contain forms that include fields that have duplicate labelling which make them difficult for screen reader users to navigate. 
+      This does not meet [WCAG 2.4.6 Headings and Labels](https://www.w3.org/WAI/WCAG21/Understanding/headings-and-labels.html). We plan to fix this by March 2025.
 
-    #### Navigation and accessing information
+   ## What we’re doing to improve accessibility
+   We will continue to do internal audits to check the accessibility of this service, as well as taking feedback from users.
 
-    There is no timeout warning that would let the users know their session is about to expire.
+   Any changes required will be planned into our ongoing work on this service.
 
-    There is no sitemap.
+   ## Preparation of this accessibility statement
+   This statement was prepared on 18 February 2021. It was last reviewed on 11 April 2024.
 
-    We’ve assessed the cost of fixing the issues with navigation and accessing information, and with interactive tools and transactions. We believe that doing so now would be a [disproportionate burden](http://www.legislation.gov.uk/uksi/2018/952/regulation/7/made) within the meaning of the accessibility regulations. We will make another assessment by December 30th 2021.
-
-    ## Content that’s not within the scope of the accessibility regulations
-
-    None
-
-    ## What we’re doing to improve accessibility
-
-    In addition to internal reviews already completed, we are completing an external accessibility review which will include an evaluation of assistive technologies (e.g. screen readers, screen enlargement applications, voice recognition programs) by December 30th 2021. Any actions identified will be reviewed and prioritised by the Book a secure move team.
-
-    ## Preparation of this accessibility statement
-
-    This statement was prepared on 18th February 2021. It was last reviewed on 18th February 2021.
-
-    This website was last tested in November 2020. The test was carried out by the team responsible for the site.
-
-    We used this approach to deciding on a sample of pages to test:
-    - high value pages
-    - all pages which have a unique layout
-    {% endmarkdown %}
+   This website was last tested on 6 January 2022. The test was carried out by the Digital Accessibility Centre who tested all pages on the service.
+  {% endmarkdown %}
   </div>
 {% endblock %}

--- a/app/help/accessibility-statement.njk
+++ b/app/help/accessibility-statement.njk
@@ -44,11 +44,10 @@
 
 
     ## Feedback and contact information
-    We are always looking to improve our service, including its accessibility. If you find any problems that are not listed on this page or think 
-    we are not meeting accessibility requirements you can contact us by:
+    We are always looking to improve our service, including its accessibility.
 
-    - completing the Book a secure move [feedback survey]({{FEEDBACK_URL}})
-    - emailing [bookasecuremove@digital.justice.gov.uk](mailto:bookasecuremove@digital.justice.gov.uk)
+    If you find any problems that are not listed on this page or think we are not meeting accessibility 
+    requirements you email [bookasecuremove@digital.justice.gov.uk](mailto:bookasecuremove@digital.justice.gov.uk)
 
     ## Enforcement procedure
     The Equality and Human Rights Commission (EHRC) is responsible for enforcing the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018 (the 'accessibility regulations').


### PR DESCRIPTION

further changes requested by design team

Add a paragraph break after "We are always looking to improve our service, including its accessibility."

Remove the bullet point 'completing the Book a secure move [feedback survey](https://hmpps-book-secure-move-frontend-staging.apps.cloud-platform.service.justice.gov.uk/help/accessibility-statement#)' 

Remove second bullet and instead change preceding sentence to: "If you find any problems that are not listed on this page or think we are not meeting accessibility requirements you email [bookasecuremove@digital.justice.gov.uk](mailto:bookasecuremove@digital.justice.gov.uk)