### PR TITLE
MAP-923 changes to accessibility statement following review by Design

### DIFF
--- a/app/help/accessibility-statement.njk
+++ b/app/help/accessibility-statement.njk
@@ -44,11 +44,10 @@
 
 
     ## Feedback and contact information
-    We are always looking to improve our service, including its accessibility. If you find any problems that are not listed on this page or think 
-    we are not meeting accessibility requirements you can contact us by:
+    We are always looking to improve our service, including its accessibility.
 
-    - completing the Book a secure move [feedback survey]({{FEEDBACK_URL}})
-    - emailing [bookasecuremove@digital.justice.gov.uk](mailto:bookasecuremove@digital.justice.gov.uk)
+    If you find any problems that are not listed on this page or think we are not meeting accessibility 
+    requirements you email [bookasecuremove@digital.justice.gov.uk](mailto:bookasecuremove@digital.justice.gov.uk)
 
     ## Enforcement procedure
     The Equality and Human Rights Commission (EHRC) is responsible for enforcing the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018 (the 'accessibility regulations').


### PR DESCRIPTION
further changes as per this

Add a paragraph break after "We are always looking to improve our service, including its accessibility."

Remove the bullet point 'completing the Book a secure move [feedback survey](https://hmpps-book-secure-move-frontend-staging.apps.cloud-platform.service.justice.gov.uk/help/accessibility-statement#)' 

Remove second bullet and instead change preceding sentence to: "If you find any problems that are not listed on this page or think we are not meeting accessibility requirements you email [bookasecuremove@digital.justice.gov.uk](mailto:bookasecuremove@digital.justice.gov.uk)