### PR TITLE
[MAP-886] Remove inactive locations list

### DIFF
--- a/app/locations/controllers.js
+++ b/app/locations/controllers.js
@@ -17,13 +17,9 @@ async function locations(req, res, next) {
   const activeLocations = userLocations.filter(
     location => location.disabled_at === null
   )
-  const inactiveLocations = userLocations.filter(
-    location => location.disabled_at !== null
-  )
 
   res.render('locations/views/locations.njk', {
     activeLocations,
-    inactiveLocations,
     regions,
   })
 }

--- a/app/locations/controllers.test.js
+++ b/app/locations/controllers.test.js
@@ -81,10 +81,6 @@ describe('Locations controllers', function () {
           expect(params.activeLocations).to.deep.equal(
             mockLocations.filter(l => l.disabled_at === null)
           )
-          expect(params).to.have.property('inactiveLocations')
-          expect(params.inactiveLocations).to.deep.equal(
-            mockLocations.filter(l => l.disabled_at !== null)
-          )
         })
       }
     )

--- a/app/locations/views/locations.njk
+++ b/app/locations/views/locations.njk
@@ -51,27 +51,6 @@
               </a>
             </li>
           {% endfor %}
-
-          {% if inactiveLocations | length %}
-            <br>
-
-            <details class="govuk-details" data-module="govuk-details">
-              <summary class="govuk-details__summary">
-                <span class="govuk-details__summary-text">
-                  {{ inactiveLocations | length }} inactive locations
-                </span>
-              </summary>
-              <div class="govuk-details__text">
-                {% for location in inactiveLocations %}
-                  <li>
-                    <a href="/locations/{{ location.id }}">
-                      {{ location.title }}
-                    </a>
-                  </li>
-                {% endfor %}
-              </div>
-            </details>
-          {% endif %}
         </ul>
       </div>
     </div>

--- a/test/e2e/pages/page.ts
+++ b/test/e2e/pages/page.ts
@@ -34,7 +34,6 @@ export class Page {
       ).withAttribute('href', /\/locations\/.+/),
       locationValue: Selector('.moj-organisation-nav__title'),
       dateSelectInput: '[name="date_select"]',
-      inactiveLocations: Selector('.govuk-details__summary-text'),
     }
 
   getCurrentUrl = ClientFunction(() => window.location.href)
@@ -60,10 +59,6 @@ export class Page {
       .contains('/locations')
       .expect((this.nodes.locationsList as Selector).count)
       .notEql(0, { timeout: 15000 })
-
-    if (await (this.nodes.inactiveLocations as Selector).exists) {
-      await t.click(this.nodes.inactiveLocations as Selector)
-    }
 
     if (isUndefined(position)) {
       const count = await (this.nodes.locationsList as Selector).count


### PR DESCRIPTION
## Proposed changes

### What changed

 Remove inactive locations list

### Why did it change

Because it violated accessibility standards and was an unused feature, so we decided to just delete it

### Issue tracking

- [MAP-886]

## Screenshots

| Before | After |
| ------ | ------ |
| <img width="622" alt="Screenshot 2024-06-06 at 16 14 14" src="https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/assets/40831617/f4a2bd0e-7b24-4cf1-9b3a-5f930539f53e"> | <img width="650" alt="Screenshot 2024-06-06 at 16 14 28" src="https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/assets/40831617/584db190-3ab1-4a73-a485-95e83e2ffe70"> |

## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [x] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed

### Other considerations

Commit messages with a `fix` or `feat` type are automatically used to generate the [changelog](ministryofjustice/hmpps-book-secure-move-frontend/blob/main/CHANGELOG.md) and
[GitHub release notes](https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/releases) during the release task. Please make sure they will read well on their own in a
summary of changes and that the commit body gives a more detailed description of those changes if necessary.

- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
- [ ] Update [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/main/README.md) with any new instructions or tasks


[MAP-886]: https://dsdmoj.atlassian.net/browse/MAP-886?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ