### PR TITLE
fix: [MAP-1157] Changed heading for PerGeneric

### DIFF
--- a/locales/en/events.json
+++ b/locales/en/events.json
@@ -396,7 +396,7 @@
     "description": "{{notes}}, completed by {{supplier_personnel_number}}"
   },
   "PerGeneric": {
-    "heading": "{{move.supplier.name}} has logged a generic event note",
+    "heading": "{{created_by}} has logged a generic event note",
     "heading_without_supplier": "Generic lockout event added",
     "description": "{{notes}}"
   },


### PR DESCRIPTION
## Proposed changes

### What changed

Changed heading for PerGeneric such that the supplier is shown and matches in the byline.

### Why did it change

Issue was raised showing conflicting information.

### Issue tracking

- MAP-1157

## Screenshots
<!--- (Optional) Include screenshots if changes update interfaces or components -->
<!--- Delete/copy as appropriate --->

| Before | After |
| ------ | ----- |
| 
![Screenshot 2024-06-07 at 18 01 12](https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/assets/165799926/0d961600-937e-4804-ae9c-ad620434f146) | 
![Screenshot 2024-06-07 at 18 01 55](https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/assets/165799926/757ecac7-d8b4-4603-a9c0-cdfad3dfc562) |

## Checklists

### Testing

#### Automated testing

- [ ] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed

### Other considerations

Commit messages with a `fix` or `feat` type are automatically used to generate the [changelog](ministryofjustice/hmpps-book-secure-move-frontend/blob/main/CHANGELOG.md) and
[GitHub release notes](https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/releases) during the release task. Please make sure they will read well on their own in a
summary of changes and that the commit body gives a more detailed description of those changes if necessary.

- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
- [ ] Update [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/main/README.md) with any new instructions or tasks
