### PR TITLE
feat: MAP-1501 Display the date a move is updated to

### DIFF
--- a/locales/en/events.json
+++ b/locales/en/events.json
@@ -157,7 +157,7 @@
   },
   "MoveDateChanged": {
     "heading": "Move date changed",
-    "description": "The move date has been updated"
+    "description": "The move date has been updated to {{date, formatDateWithDay}}"
   },
   "MoveLockout": {
     "contextKey": "reason",


### PR DESCRIPTION
Before: 
<img width="609" alt="image" src="https://github.com/user-attachments/assets/c96b7e36-23e6-46ab-840d-961e51ee40fb">


After:
<img width="718" alt="image" src="https://github.com/user-attachments/assets/50517015-4584-4df5-8a68-d32169d9c589">