### PR TITLE
MAP-1565 Add Framework version 2.5.1

### DIFF
--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -16,13 +16,13 @@ generic-service:
     AUTH_PROVIDER_URL: "https://sign-in-preprod.hmpps.service.justice.gov.uk"
     FEATURE_FLAG_ADD_LODGE_BUTTON: "true"
     FEEDBACK_URL: "https://eu.surveymonkey.com/r/3CKYXSC"
+    FRAMEWORKS_VERSION: "2.5.0"
     GOOGLE_ANALYTICS_ID: "G-3LCJP1TWQC"
     MANAGE_USERS_API_URL: "https://manage-users-api-preprod.hmpps.service.justice.gov.uk"
     MOVE_DESIGN_FEEDBACK_URL: "https://eu.surveymonkey.com/r/BKZC8BV"
     NOMIS_ELITE2_API_URL: "https://prison-api-preprod.prison.service.justice.gov.uk"
     SENTRY_ENVIRONMENT: "preproduction"
     SERVER_HOST: "hmpps-book-secure-move-frontend-preprod.apps.cloud-platform.service.justice.gov.uk"
-    FRAMEWORKS_VERSION: "2.5.0"
 
 
   # Pre-existing kubernetes secrets to load as environment variables in the deployment.

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -22,6 +22,7 @@ generic-service:
     NOMIS_ELITE2_API_URL: "https://prison-api-preprod.prison.service.justice.gov.uk"
     SENTRY_ENVIRONMENT: "preproduction"
     SERVER_HOST: "hmpps-book-secure-move-frontend-preprod.apps.cloud-platform.service.justice.gov.uk"
+    FRAMEWORKS_VERSION: "2.5.0"
 
 
   # Pre-existing kubernetes secrets to load as environment variables in the deployment.

--- a/helm_deploy/values-production.yaml
+++ b/helm_deploy/values-production.yaml
@@ -16,13 +16,13 @@ generic-service:
     AUTH_PROVIDER_URL: "https://sign-in.hmpps.service.justice.gov.uk"
     FEATURE_FLAG_ADD_LODGE_BUTTON: "false"
     FEEDBACK_URL: "https://eu.surveymonkey.com/r/3CKYXSC"
+    FRAMEWORKS_VERSION: "2.5.0"
     GOOGLE_ANALYTICS_ID: "G-58WMNWR101"
     MANAGE_USERS_API_URL: "https://manage-users-api.hmpps.service.justice.gov.uk"
     MOVE_DESIGN_FEEDBACK_URL: "https://eu.surveymonkey.com/r/BKZC8BV"
     NOMIS_ELITE2_API_URL: "https://prison-api.prison.service.justice.gov.uk"
     SENTRY_ENVIRONMENT: "production"
     SERVER_HOST: "bookasecuremove.service.justice.gov.uk"
-    FRAMEWORKS_VERSION: "2.5.0"
 
   # Pre-existing kubernetes secrets to load as environment variables in the deployment.
   # namespace_secrets:

--- a/helm_deploy/values-production.yaml
+++ b/helm_deploy/values-production.yaml
@@ -22,6 +22,7 @@ generic-service:
     NOMIS_ELITE2_API_URL: "https://prison-api.prison.service.justice.gov.uk"
     SENTRY_ENVIRONMENT: "production"
     SERVER_HOST: "bookasecuremove.service.justice.gov.uk"
+    FRAMEWORKS_VERSION: "2.5.0"
 
   # Pre-existing kubernetes secrets to load as environment variables in the deployment.
   # namespace_secrets:

--- a/helm_deploy/values-uat.yaml
+++ b/helm_deploy/values-uat.yaml
@@ -19,6 +19,7 @@ generic-service:
     NOMIS_ELITE2_API_URL: "https://prison-api-dev.prison.service.justice.gov.uk"
     SENTRY_ENVIRONMENT: "uat"
     SERVER_HOST: "hmpps-book-secure-move-frontend-uat.apps.cloud-platform.service.justice.gov.uk"
+    FRAMEWORKS_VERSION: "2.5.0"
 
   # Pre-existing kubernetes secrets to load as environment variables in the deployment.
   # namespace_secrets:

--- a/helm_deploy/values-uat.yaml
+++ b/helm_deploy/values-uat.yaml
@@ -14,12 +14,12 @@ generic-service:
     API_BASE_URL: "https://hmpps-book-secure-move-api-uat.apps.cloud-platform.service.justice.gov.uk"
     AUTH_PROVIDER_URL: "https://sign-in-dev.hmpps.service.justice.gov.uk"
     CONTENTFUL_HOST: "preview.contentful.com"
+    FRAMEWORKS_VERSION: "2.5.0"
     GOOGLE_ANALYTICS_ID: "G-3G741W4FQ2"
     MANAGE_USERS_API_URL: "https://manage-users-api-dev.hmpps.service.justice.gov.uk"
     NOMIS_ELITE2_API_URL: "https://prison-api-dev.prison.service.justice.gov.uk"
     SENTRY_ENVIRONMENT: "uat"
     SERVER_HOST: "hmpps-book-secure-move-frontend-uat.apps.cloud-platform.service.justice.gov.uk"
-    FRAMEWORKS_VERSION: "2.5.0"
 
   # Pre-existing kubernetes secrets to load as environment variables in the deployment.
   # namespace_secrets:

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "@hmpps-book-secure-move-frameworks/2.4.1": "git+https://github.com/ministryofjustice/hmpps-book-secure-move-frameworks.git#v2.4.1",
         "@hmpps-book-secure-move-frameworks/2.4.2": "git+https://github.com/ministryofjustice/hmpps-book-secure-move-frameworks.git#v2.4.2",
         "@hmpps-book-secure-move-frameworks/2.5.0": "git+https://github.com/ministryofjustice/hmpps-book-secure-move-frameworks.git#v2.5.0",
+        "@hmpps-book-secure-move-frameworks/2.5.1": "git+https://github.com/ministryofjustice/hmpps-book-secure-move-frameworks.git#v2.5.1",
         "@ministryofjustice/frontend": "2.1.2",
         "@promster/express": "7.0.6",
         "@sentry/node": "7.36.0",
@@ -3367,6 +3368,11 @@
     "node_modules/@hmpps-book-secure-move-frameworks/2.5.0": {
       "version": "2.5.0",
       "resolved": "git+ssh://git@github.com/ministryofjustice/hmpps-book-secure-move-frameworks.git#7779a1d0e567b6c377e8f25d710ee6224f5c8da3",
+      "license": "MIT"
+    },
+    "node_modules/@hmpps-book-secure-move-frameworks/2.5.1": {
+      "version": "2.5.1",
+      "resolved": "git+ssh://git@github.com/ministryofjustice/hmpps-book-secure-move-frameworks.git#a3d765454de685e15831889b5ba26d33c21720d0",
       "license": "MIT"
     },
     "node_modules/@humanwhocodes/config-array": {

--- a/package.json
+++ b/package.json
@@ -146,6 +146,7 @@
     "@hmpps-book-secure-move-frameworks/2.4.1": "git+https://github.com/ministryofjustice/hmpps-book-secure-move-frameworks.git#v2.4.1",
     "@hmpps-book-secure-move-frameworks/2.4.2": "git+https://github.com/ministryofjustice/hmpps-book-secure-move-frameworks.git#v2.4.2",
     "@hmpps-book-secure-move-frameworks/2.5.0": "git+https://github.com/ministryofjustice/hmpps-book-secure-move-frameworks.git#v2.5.0",
+    "@hmpps-book-secure-move-frameworks/2.5.1": "git+https://github.com/ministryofjustice/hmpps-book-secure-move-frameworks.git#v2.5.1",
     "@ministryofjustice/frontend": "2.1.2",
     "@promster/express": "7.0.6",
     "@sentry/node": "7.36.0",


### PR DESCRIPTION
[MAP-1565](https://dsdmoj.atlassian.net/browse/MAP-1565)
## Proposed changes

Here we add support for Framework v2.5.1, adding a new question to the Personal Escort Record:
**Do not deploy until the API version has been deployed/migrated and suppliers have given us the go ahead**

### Risk Information form
![cd-1](https://github.com/user-attachments/assets/30160e58-27cb-4234-bcc9-bbaf2620a619)

### Warnings page
![cd-2](https://github.com/user-attachments/assets/0342e209-c17c-4785-914f-e7d215d25e5b)

### PER page
![cd-3](https://github.com/user-attachments/assets/1e6f9b1d-0324-4abb-aac6-57197e7821e4)






[MAP-1565]: https://dsdmoj.atlassian.net/browse/MAP-1565?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ