### PR TITLE
[MAP-1565] Add Framework version 2.5.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "@hmpps-book-secure-move-frameworks/2.4.2": "git+https://github.com/ministryofjustice/hmpps-book-secure-move-frameworks.git#v2.4.2",
         "@hmpps-book-secure-move-frameworks/2.5.0": "git+https://github.com/ministryofjustice/hmpps-book-secure-move-frameworks.git#v2.5.0",
         "@hmpps-book-secure-move-frameworks/2.5.1": "git+https://github.com/ministryofjustice/hmpps-book-secure-move-frameworks.git#v2.5.1",
+        "@hmpps-book-secure-move-frameworks/2.5.2": "git+https://github.com/ministryofjustice/hmpps-book-secure-move-frameworks.git#v2.5.2",
         "@ministryofjustice/frontend": "2.1.2",
         "@promster/express": "7.0.6",
         "@sentry/node": "7.36.0",
@@ -3373,6 +3374,11 @@
     "node_modules/@hmpps-book-secure-move-frameworks/2.5.1": {
       "version": "2.5.1",
       "resolved": "git+ssh://git@github.com/ministryofjustice/hmpps-book-secure-move-frameworks.git#a3d765454de685e15831889b5ba26d33c21720d0",
+      "license": "MIT"
+    },
+    "node_modules/@hmpps-book-secure-move-frameworks/2.5.2": {
+      "version": "2.5.2",
+      "resolved": "git+ssh://git@github.com/ministryofjustice/hmpps-book-secure-move-frameworks.git#209ab78d65a7b63fafaac3c5f39192666c287fa8",
       "license": "MIT"
     },
     "node_modules/@humanwhocodes/config-array": {

--- a/package.json
+++ b/package.json
@@ -147,6 +147,7 @@
     "@hmpps-book-secure-move-frameworks/2.4.2": "git+https://github.com/ministryofjustice/hmpps-book-secure-move-frameworks.git#v2.4.2",
     "@hmpps-book-secure-move-frameworks/2.5.0": "git+https://github.com/ministryofjustice/hmpps-book-secure-move-frameworks.git#v2.5.0",
     "@hmpps-book-secure-move-frameworks/2.5.1": "git+https://github.com/ministryofjustice/hmpps-book-secure-move-frameworks.git#v2.5.1",
+    "@hmpps-book-secure-move-frameworks/2.5.2": "git+https://github.com/ministryofjustice/hmpps-book-secure-move-frameworks.git#v2.5.2",
     "@ministryofjustice/frontend": "2.1.2",
     "@promster/express": "7.0.6",
     "@sentry/node": "7.36.0",


### PR DESCRIPTION
[MAP-1565](https://dsdmoj.atlassian.net/browse/MAP-1565)

## Proposed changes

### What changed

[Adding Framework v2.5.2](https://github.com/ministryofjustice/hmpps-book-secure-move-frameworks/releases/tag/v2.5.2)

### Why did it change

Fixes incorrect text in Civil Disorder questions 

## Screenshots

**Overview:** 
<img width="904" alt="Screenshot 2024-10-08 at 12 12 38" src="https://github.com/user-attachments/assets/020b69fc-90d4-48dc-8b78-8c0736bb2211">

**Warnings:**
<img width="896" alt="Screenshot 2024-10-08 at 12 14 43" src="https://github.com/user-attachments/assets/daac5a17-13ff-456b-a5b4-431a9b1c16a5">

 


[MAP-1565]: https://dsdmoj.atlassian.net/browse/MAP-1565?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ