### PR TITLE
MAP-879: Duplicate link texts

### DIFF
--- a/app/allocation/views/view.njk
+++ b/app/allocation/views/view.njk
@@ -135,7 +135,7 @@
         {% if move.removeMoveHref %}
           <div>
             <a class="app-!-position-top-right govuk-!-margin-top-7 govuk-!-margin-right-3 app-font-weight-normal" href="{{move.removeMoveHref}}">
-              {{ t("actions::person_unassign_confirmation") }}
+              {{ t("actions::person_unassign_link", { index: loop.index }) | safe }}
             </a>
           </div>
         {% endif %}

--- a/common/components/framework-response/template.njk
+++ b/common/components/framework-response/template.njk
@@ -40,11 +40,11 @@
   {% if params.editable %}
     {% if params.prefilled %}
       <a href="{{ params.questionUrl }}">
-        {{ t("actions::review_answer") }}
+        {{ t("actions::review_answer") }}<span class="govuk-visually-hidden"> - {{ params.headerText }}</span>
       </a>
     {% else %}
       <a href="{{ params.questionUrl }}">
-        {{ t("actions::answer_question") }}
+        {{ t("actions::answer_question") }}<span class="govuk-visually-hidden"> - {{ params.headerText }}</span>
       </a>
     {% endif %}
   {% else %}

--- a/common/components/framework-response/template.test.js
+++ b/common/components/framework-response/template.test.js
@@ -209,7 +209,10 @@ describe('Framework Response component', function () {
   })
 
   context('unanswered', function () {
-    const example = examples['unanswered question']
+    const example = {
+      ...examples['unanswered question'],
+      headerText: 'What is your quest?',
+    }
 
     beforeEach(function () {
       sinon.stub(i18n, 't').returnsArg(0)
@@ -234,7 +237,7 @@ describe('Framework Response component', function () {
 
     it('should contain correct text', function () {
       expect($component.children().first().text().trim()).to.equal(
-        'actions::answer_question'
+        'actions::answer_question - What is your quest?'
       )
     })
   })
@@ -338,7 +341,10 @@ describe('Framework Response component', function () {
   })
 
   context('with prefilled answer', function () {
-    const example = examples['prefilled question']
+    const example = {
+      ...examples['prefilled question'],
+      headerText: 'What is your favourite colour?',
+    }
 
     beforeEach(function () {
       sinon.stub(i18n, 't').returnsArg(0)
@@ -363,13 +369,16 @@ describe('Framework Response component', function () {
 
     it('should contain correct text', function () {
       expect($component.children().first().text().trim()).to.equal(
-        'actions::review_answer'
+        'actions::review_answer - What is your favourite colour?'
       )
     })
   })
 
   context('without value', function () {
-    const example = examples['unanswered question']
+    const example = {
+      ...examples['unanswered question'],
+      headerText: 'What is the capital of Assyria?',
+    }
 
     beforeEach(function () {
       sinon.stub(i18n, 't').returnsArg(0)
@@ -397,13 +406,16 @@ describe('Framework Response component', function () {
 
     it('should contain correct href for anchor', function () {
       expect($component.children().first().text().trim()).to.equal(
-        'actions::answer_question'
+        'actions::answer_question - What is the capital of Assyria?'
       )
     })
   })
 
   context('without valueType', function () {
-    const example = examples['unanswered question']
+    const example = {
+      ...examples['unanswered question'],
+      headerText: 'What is the air-speed velocity of an unladen swallow?',
+    }
 
     beforeEach(function () {
       sinon.stub(i18n, 't').returnsArg(0)
@@ -431,7 +443,7 @@ describe('Framework Response component', function () {
 
     it('should contain correct href for anchor', function () {
       expect($component.children().first().text().trim()).to.equal(
-        'actions::answer_question'
+        'actions::answer_question - What is the air-speed velocity of an unladen swallow?'
       )
     })
   })

--- a/common/helpers/field/add-errorlist-to-errors.js
+++ b/common/helpers/field/add-errorlist-to-errors.js
@@ -4,6 +4,18 @@ function addErrorListToErrors(errors = {}, fields) {
   const errorList = Object.keys(errors).map(errorKey => {
     const error = errors[errorKey]
     const field = fields[error.key]
+    const { message } = error
+
+    if (
+      ['Enter the seal number', 'Select the types of property'].includes(
+        message
+      )
+    ) {
+      const { prefix } = field
+      const index = Number(prefix.match(/property-bags\[(\d+)\]/)[1])
+      error.message = `${message} for bag ${index + 1}`
+    }
+
     return {
       html: getFieldErrorMessage({
         ...field,

--- a/common/helpers/field/add-errorlist-to-errors.test.js
+++ b/common/helpers/field/add-errorlist-to-errors.test.js
@@ -10,7 +10,7 @@ const addErrorListToErrors = proxyquire('./add-errorlist-to-errors', {
 describe('Field helpers', function () {
   describe('#addErrorListToErrors()', function () {
     let errors
-    const mockFields = {
+    let mockFields = {
       fieldOne: {
         id: 'field-one',
       },
@@ -82,6 +82,78 @@ describe('Field helpers', function () {
 
       it('should get error messages correct number of times', function () {
         expect(getFieldErrorMessageStub.callCount).to.equal(2)
+      })
+
+      it('should transform errors object and add errorList property', function () {
+        expect(errors).to.deep.equal({
+          ...mockErrors,
+          errorList: [
+            {
+              href: `#${mockFields.fieldOne.id}`,
+              html: `${mockErrors.fieldOne.key}.${mockErrors.fieldOne.type}`,
+            },
+            {
+              href: `#${mockFields.fieldTwo.id}`,
+              html: `${mockErrors.fieldTwo.key}.${mockErrors.fieldTwo.type}`,
+            },
+          ],
+        })
+      })
+    })
+
+    context('when there are property bag errors', function () {
+      mockFields = {
+        fieldOne: {
+          id: 'field-one',
+          prefix: 'property-bags[0]',
+        },
+        fieldTwo: {
+          id: 'field-two',
+          prefix: 'property-bags[1]',
+        },
+      }
+
+      const mockErrors = {
+        fieldOne: {
+          key: 'fieldOne',
+          message: 'Enter the seal number',
+          type: 'required',
+          url: '/step-url',
+        },
+        fieldTwo: {
+          key: 'fieldTwo',
+          message: 'Select the types of property',
+          type: 'required',
+          url: '/step-url',
+        },
+      }
+
+      beforeEach(function () {
+        errors = addErrorListToErrors(mockErrors, mockFields)
+      })
+
+      it('should contain correct number of errors', function () {
+        expect(errors.errorList.length).to.equal(2)
+      })
+
+      it('should get error messages for fields that have errors', function () {
+        expect(getFieldErrorMessageStub).to.be.calledWithExactly({
+          ...mockFields.fieldOne,
+          ...mockErrors.fieldOne,
+        })
+        expect(getFieldErrorMessageStub).to.be.calledWithExactly({
+          ...mockFields.fieldTwo,
+          ...mockErrors.fieldTwo,
+        })
+      })
+
+      it('should get error messages with the correct args', function () {
+        expect(getFieldErrorMessageStub.getCall(0).firstArg.message).to.equal(
+          'Enter the seal number for bag 1'
+        )
+        expect(getFieldErrorMessageStub.getCall(1).firstArg.message).to.equal(
+          'Select the types of property for bag 2'
+        )
       })
 
       it('should transform errors object and add errorList property', function () {

--- a/common/presenters/framework-field-summary-list-row.js
+++ b/common/presenters/framework-field-summary-list-row.js
@@ -57,6 +57,7 @@ function frameworkFieldToSummaryListRow(stepUrl, editPermission = false) {
       questionUrl: `${stepUrl}#${id}`,
       assessmentStatus: response.assessment?.status,
       editable: response.assessment?.editable && editPermission,
+      headerText,
     }
 
     if ((response.nomis_mappings || []).length > 0) {

--- a/common/presenters/framework-field-summary-list-row.test.js
+++ b/common/presenters/framework-field-summary-list-row.test.js
@@ -48,6 +48,7 @@ describe('Presenters', function () {
               questionUrl: `${mockStepUrl}#${mockField.id}`,
               assessmentStatus: undefined,
               editable: undefined,
+              headerText: 'What is the answer?',
             }
           )
         })
@@ -86,6 +87,7 @@ describe('Presenters', function () {
               questionUrl: `${mockStepUrl}#${mockField.id}`,
               assessmentStatus: undefined,
               editable: undefined,
+              headerText: 'What is the answer?',
             }
           )
         })
@@ -139,6 +141,7 @@ describe('Presenters', function () {
                 html: 'NOMIS_HTML',
               },
               editable: undefined,
+              headerText: 'What is the answer?',
             }
           )
         })
@@ -177,6 +180,7 @@ describe('Presenters', function () {
               questionUrl: `${mockStepUrl}#${mockField.id}`,
               assessmentStatus: 'completed',
               editable: undefined,
+              headerText: 'What is the answer?',
             }
           )
         })
@@ -216,6 +220,7 @@ describe('Presenters', function () {
               questionUrl: `${mockStepUrl}#${mockField.id}`,
               assessmentStatus: undefined,
               editable: undefined,
+              headerText: 'What is the answer?',
             }
           )
         })
@@ -282,6 +287,7 @@ describe('Presenters', function () {
                 questionUrl: `${mockStepUrl}#${mockFieldWithFollowup.id}`,
                 assessmentStatus: undefined,
                 editable: undefined,
+                headerText: 'What is the answer?',
               }
             )
             expect(componentService.getComponent).to.be.calledWithExactly(
@@ -294,6 +300,7 @@ describe('Presenters', function () {
                 questionUrl: `${mockStepUrl}#${mockFieldWithFollowup.items[0].followup[0].id}`,
                 assessmentStatus: undefined,
                 editable: undefined,
+                headerText: 'What is the answer to life?',
               }
             )
           })
@@ -344,6 +351,7 @@ describe('Presenters', function () {
                 questionUrl: `${mockStepUrl}#${mockFieldWithFollowup.id}`,
                 assessmentStatus: undefined,
                 editable: undefined,
+                headerText: 'What is the answer?',
               }
             )
           })
@@ -424,6 +432,7 @@ describe('Presenters', function () {
                   questionUrl: `${mockStepUrl}#${mockField.id}`,
                   assessmentStatus: undefined,
                   editable: undefined,
+                  headerText: 'What is the answer?',
                 }
               )
             })
@@ -455,6 +464,7 @@ describe('Presenters', function () {
                   questionUrl: `${mockStepUrl}#${mockField.id}`,
                   assessmentStatus: undefined,
                   editable: undefined,
+                  headerText: 'What is the answer?',
                 }
               )
             })
@@ -489,6 +499,7 @@ describe('Presenters', function () {
               questionUrl: `${mockStepUrl}#${mockField.id}`,
               assessmentStatus: undefined,
               editable: undefined,
+              headerText: 'What is the answer?',
             }
           )
         })
@@ -522,6 +533,7 @@ describe('Presenters', function () {
               questionUrl: `${mockStepUrl}#${mockField.id}`,
               assessmentStatus: undefined,
               editable: undefined,
+              headerText: 'What is the answer?',
             }
           )
         })
@@ -663,6 +675,7 @@ describe('Presenters', function () {
                 questionUrl: `${mockStepUrl}#${test.id}`,
                 assessmentStatus: undefined,
                 editable: undefined,
+                headerText: undefined,
               }
             )
           })
@@ -685,6 +698,7 @@ describe('Presenters', function () {
               questionUrl: `${mockStepUrl}#${mockField.id}`,
               assessmentStatus: undefined,
               editable: undefined,
+              headerText: 'What is the answer?',
             }
           )
         })

--- a/locales/en/actions.json
+++ b/locales/en/actions.json
@@ -36,6 +36,7 @@
   "add_person_to_move": "Add person to this move",
   "remove_person": "Remove <span class=\"govuk-visually-hidden\">{{name}}</span>",
   "person_unassign_confirmation": "Remove from allocation",
+  "person_unassign_link": "Remove <span class=\"govuk-visually-hidden\">Person {{index}} </span>from allocation",
   "download": "Download",
   "print": "Print",
   "print_move": "Print move",

--- a/test/e2e/pages/allocation-view.js
+++ b/test/e2e/pages/allocation-view.js
@@ -30,9 +30,7 @@ class AllocationViewPage extends Page {
           .withText('Remove'),
       allocatedMoves: Selector('.app-card'),
       allocatedMovesReferences: Selector('.app-card__caption'),
-      allocatedMovesRemoveLinks: Selector('a').withText(
-        'Remove from allocation'
-      ),
+      allocatedMovesRemoveLinks: Selector('a').withText('Remove'),
       confirmationLink: count => Selector('a').withExactText(`${count} people`),
       editDetailsLink: Selector('a').withText('Change date of allocation'),
     }


### PR DESCRIPTION
## Proposed changes

### What changed

- Add question name to review/amend links on PER/YRA
- Add visually hidden text to remove person links on allocation
- Add "for bag 1" etc to property bag validation errors

### Why did it change

To comply with accessibility recommendations

### Issue tracking

- MAP-879

## Screenshots
The only visible change is the validation errors

![Screenshot 2024-11-26 at 13 17 29](https://github.com/user-attachments/assets/8247bc55-9971-4170-bffb-3400ee451bae)


