### PR TITLE
MAP-1976: Remove default URL

### DIFF
--- a/helm_deploy/values-production.yaml
+++ b/helm_deploy/values-production.yaml
@@ -7,7 +7,6 @@ generic-service:
   ingress:
     hosts:
       - bookasecuremove.service.justice.gov.uk
-      - hmpps-book-secure-move-frontend-production.apps.cloud-platform.service.justice.gov.uk
     tlsSecretName: hmpps-book-secure-move-frontend-production-cert
 
   env:


### PR DESCRIPTION
We never have a legitimate reason to use the `hmpps-book-secure-move-frontend-production.apps.cloud-platform.service.justice.gov.uk` URL so let's remove it as it is causing SSL cert validation errors.

MAP-1976
