### PR TITLE
Change production API_BASE_URL to support SSL certificate

### DIFF
--- a/helm_deploy/values-production.yaml
+++ b/helm_deploy/values-production.yaml
@@ -10,7 +10,7 @@ generic-service:
     tlsSecretName: hmpps-book-secure-move-frontend-production-cert
 
   env:
-    API_BASE_URL: "https://hmpps-book-secure-move-api-production.apps.cloud-platform.service.justice.gov.uk"
+    API_BASE_URL: "https://api.bookasecuremove.service.justice.gov.uk"
     AUTH_PROVIDER_URL: "https://sign-in.hmpps.service.justice.gov.uk"
     FEATURE_FLAG_ADD_LODGE_BUTTON: "false"
     FEEDBACK_URL: "https://eu.surveymonkey.com/r/3CKYXSC"


### PR DESCRIPTION
Currently, the frontend talks to the API via the hostname:
`hmpps-book-secure-move-frontend-production/hmpps-book-secure-move-frontend-production-cert`
and - at 80 characters -  that [hostname is too long to be added to the cloud platform config](https://github.com/ministryofjustice/cloud-platform-environments/blob/main/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-book-secure-move-api-production/certificate.yaml)

Instead, we change the API_BASE_URL to `https://api.bookasecuremove.service.justice.gov.uk`

https://dsdmoj.atlassian.net/browse/MAP-1976
