### PR TITLE
chore: Pin CI's node version to '20.18.2-browsers'

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ aliases:
   - &node_container
     executor:
       name: hmpps/node
-      tag: lts-browsers
+      tag: 20.18.2-browsers
   # Common steps
   - &install_dependencies
     run:


### PR DESCRIPTION
## What

Here we pin CI's node version to `20.18.2-browsers`

### Why

The previous `lts-browsers` appears to no longer use v20:

```
npm error code EBADENGINE
npm error engine Unsupported engine
npm error engine Not compatible with your version of node/npm: hmpps-book-secure-move-frontend@3.0.0
npm error notsup Not compatible with your version of node/npm: hmpps-book-secure-move-frontend@3.0.0
npm error notsup Required: {"node":"20","npm":"10"}
npm error notsup Actual:   {"npm":"10.9.2","node":"v22.13.1"}
```

