### PR TITLE
feat(MAP-1857): Add Redis cache to contentful api call

### DIFF
--- a/common/services/contentful/contentful.test.ts
+++ b/common/services/contentful/contentful.test.ts
@@ -449,7 +449,7 @@ const formattedEntriesMockResponse = {
     body: 'Some text briefly explaining the changes.',
     date: formattedTodaysDate,
   },
-  posts: [{
+  posts: [{    
       title: 'Whats new today!',
       body:
         '<h1 class="govuk-heading-xl govuk-!-margin-top-6">The latest updates and improvements to Book a secure' +
@@ -478,13 +478,13 @@ describe('ContentfulService', function () {
 
   context('with a response for whats new content', function () {
     beforeEach(function () {
-    sinon
-      .stub((contentfulService as any).client, 'getEntries')
-      .resolves(whatsNewMockedResponse)
+      sinon
+        .stub((contentfulService as any).client, 'getEntries')
+        .resolves(whatsNewMockedResponse)
 
-    sinon
-      .stub(contentfulService, 'fetch')
-      .resolves(formattedEntriesMockResponse)
+      sinon
+        .stub(contentfulService, 'fetch')
+        .resolves(formattedEntriesMockResponse)
     })
 
     it('returns the formatted body', async function () {

--- a/common/services/contentful/contentful.test.ts
+++ b/common/services/contentful/contentful.test.ts
@@ -442,7 +442,7 @@ const dedicatedContentMockedResponse = {
 const formattedEntriesMockResponse = {
   bannerContent: {
     body: "Some text briefly explaining the changes.",
-    date: "3 March 2025",
+    date: todaysDate.toString(),
   },
   posts: [{
     title: 'Whats new today!',
@@ -456,7 +456,7 @@ const formattedEntriesMockResponse = {
           '</p></li><li><p class="govuk-template__body">TEST LINE 2</p></li></ol><figure class="govuk-!-margin-top-6 ' +
           'govuk-!-margin-bottom-6"><img src="https://images.ctfassets.net/m5k1kmk3zqwh/4W3q8OwEoyEQxjJtdtCkbg/51b7fc' +
           '14e8d568d5f5314733e1b9aadb/image.png" alt="asset-test" /></figure>',
-    date: '3 March 2025'
+    date: todaysDate.toString()
   }]
 }
 

--- a/common/services/contentful/contentful.test.ts
+++ b/common/services/contentful/contentful.test.ts
@@ -8,6 +8,11 @@ import { mockDate, unmockDate } from '../../../mocks/date'
 import { ContentfulContent, ContentfulService } from './contentful'
 
 const todaysDate = new Date()
+const formattedTodaysDate = todaysDate.toLocaleDateString('en-GB', {
+  day: 'numeric',
+  month: 'long',
+  year: 'numeric'
+})
 
 const whatsNewMockedResponse = {
   items: [
@@ -442,7 +447,7 @@ const dedicatedContentMockedResponse = {
 const formattedEntriesMockResponse = {
   bannerContent: {
     body: "Some text briefly explaining the changes.",
-    date: todaysDate.toString(),
+    date: formattedTodaysDate
   },
   posts: [{
     title: 'Whats new today!',
@@ -456,7 +461,7 @@ const formattedEntriesMockResponse = {
           '</p></li><li><p class="govuk-template__body">TEST LINE 2</p></li></ol><figure class="govuk-!-margin-top-6 ' +
           'govuk-!-margin-bottom-6"><img src="https://images.ctfassets.net/m5k1kmk3zqwh/4W3q8OwEoyEQxjJtdtCkbg/51b7fc' +
           '14e8d568d5f5314733e1b9aadb/image.png" alt="asset-test" /></figure>',
-    date: todaysDate.toString()
+    date: formattedTodaysDate
   }]
 }
 

--- a/common/services/contentful/contentful.test.ts
+++ b/common/services/contentful/contentful.test.ts
@@ -449,8 +449,9 @@ const formattedEntriesMockResponse = {
     body: 'Some text briefly explaining the changes.',
     date: formattedTodaysDate,
   },
-  posts: [{
-    title: 'Whats new today!',
+  posts: [
+    {
+      title: 'Whats new today!',
       body:
         '<h1 class="govuk-heading-xl govuk-!-margin-top-6">The latest updates and improvements to Book a secure' +
         ' move.</h1><h2 class="govuk-heading-l govuk-!-margin-top-5">Test heading 2.</h2><h3 class="govuk-heading-m' +

--- a/common/services/contentful/contentful.test.ts
+++ b/common/services/contentful/contentful.test.ts
@@ -445,7 +445,7 @@ const formattedEntriesMockResponse = {
     date: "2025-03-03",  // Set a mock date
   },
   posts: [{
-    title: 'Post',
+    title: 'Whats new today!',
     body: '<h1 class="govuk-heading-xl govuk-!-margin-top-6">The latest updates and improvements to Book a secure' +
           ' move.</h1><h2 class="govuk-heading-l govuk-!-margin-top-5">Test heading 2.</h2><h3 class="govuk-heading-m' +
           ' govuk-!-margin-top-4"><em>Test heading 3.</em></h3><h4 class="govuk-heading-s govuk-!-margin-top-3">Test' +

--- a/common/services/contentful/contentful.test.ts
+++ b/common/services/contentful/contentful.test.ts
@@ -441,11 +441,11 @@ const dedicatedContentMockedResponse = {
 
 const formattedEntriesMockResponse = {
   bannerContent: {
-    body: '',
-    date: ''
+    body: "This is the banner body text",  // Set a mock body
+    date: "2025-03-03",  // Set a mock date
   },
-  posts: {
-    title: 'string',
+  posts: [{
+    title: 'Post',
     body: '<h1 class="govuk-heading-xl govuk-!-margin-top-6">The latest updates and improvements to Book a secure' +
           ' move.</h1><h2 class="govuk-heading-l govuk-!-margin-top-5">Test heading 2.</h2><h3 class="govuk-heading-m' +
           ' govuk-!-margin-top-4"><em>Test heading 3.</em></h3><h4 class="govuk-heading-s govuk-!-margin-top-3">Test' +
@@ -456,8 +456,8 @@ const formattedEntriesMockResponse = {
           '</p></li><li><p class="govuk-template__body">TEST LINE 2</p></li></ol><figure class="govuk-!-margin-top-6 ' +
           'govuk-!-margin-bottom-6"><img src="https://images.ctfassets.net/m5k1kmk3zqwh/4W3q8OwEoyEQxjJtdtCkbg/51b7fc' +
           '14e8d568d5f5314733e1b9aadb/image.png" alt="asset-test" /></figure>',
-    date: ''
-  }
+    date: '2025-03-03'
+  }]
 }
 
 const emptyMockedResponse = { items: [] }
@@ -476,7 +476,7 @@ describe('ContentfulService', function () {
         .resolves(whatsNewMockedResponse)
       
       sinon
-        .stub((contentfulService as any).client, 'fetch')
+        .stub(contentfulService, 'fetch')
         .resolves(formattedEntriesMockResponse)
     })
 

--- a/common/services/contentful/contentful.test.ts
+++ b/common/services/contentful/contentful.test.ts
@@ -533,16 +533,7 @@ describe('ContentfulService', function () {
       const formattedEntries = await contentfulService.fetch()
       // @ts-ignore
       expect(formattedEntries.posts[0].body).to.equal(
-        '<h1 class="govuk-heading-xl govuk-!-margin-top-6">The latest updates and improvements to Book a secure' +
-          ' move.</h1><h2 class="govuk-heading-l govuk-!-margin-top-5">Test heading 2.</h2><h3 class="' +
-          'govuk-heading-m govuk-!-margin-top-4"><em>Test heading 3.</em></h3><h4 class="govuk-heading-s ' +
-          'govuk-!-margin-top-3">Test heading 4.</h4><a class="govuk-link" href="https://google.com">Test Link</a>' +
-          '<p class="govuk-template__body"><strong>Some random paragraph text.</strong></p><ul class="govuk-list ' +
-          'govuk-list--bullet govuk-list-bullet-bottom-padding"><li><p class="govuk-template__body">TEST LINE 1</p></li><li>' +
-          '<p class="govuk-template__body">TEST LINE 2</p></li></ul><ol class="govuk-list govuk-list--number"><li><p ' +
-          'class="govuk-template__body">TEST LINE 1</p></li><li><p class="govuk-template__body">TEST LINE 2</p></li></ol><figure ' +
-          'class="govuk-!-margin-top-6 govuk-!-margin-bottom-6"><img src="https://images.ctfassets.net/m5k1kmk3zqwh/4' +
-          'W3q8OwEoyEQxjJtdtCkbg/51b7fc14e8d568d5f5314733e1b9aadb/image.png" alt="asset-test" /></figure>'
+        formattedEntriesMockResponse.posts[0].body
       )
     })
   })

--- a/common/services/contentful/contentful.test.ts
+++ b/common/services/contentful/contentful.test.ts
@@ -546,8 +546,8 @@ describe('ContentfulService', function () {
       sinon
         .stub((contentfulService as any).client, 'getEntries')
         .resolves(emptyMockedResponse)
-      sinon.stub(contentfulService, 'fetch')
-        .resolves(null)
+
+      sinon.stub(contentfulService, 'fetch').resolves(null)
 
       const formattedEntries = await contentfulService.fetch()
       expect(formattedEntries).to.equal(null)
@@ -560,8 +560,7 @@ describe('ContentfulService', function () {
         .stub((contentfulService as any).client, 'getEntries')
         .resolves(emptyMockedResponse)
       
-      sinon
-        .stub(contentfulService, 'fetch')
+      sinon.stub(contentfulService, 'fetch')
         .resolves(null)
 
       const response = await contentfulService.fetch()

--- a/common/services/contentful/contentful.test.ts
+++ b/common/services/contentful/contentful.test.ts
@@ -449,20 +449,20 @@ const formattedEntriesMockResponse = {
     body: 'Some text briefly explaining the changes.',
     date: formattedTodaysDate,
   },
-  posts: [{    
-      title: 'Whats new today!',
-      body:
-        '<h1 class="govuk-heading-xl govuk-!-margin-top-6">The latest updates and improvements to Book a secure' +
-        ' move.</h1><h2 class="govuk-heading-l govuk-!-margin-top-5">Test heading 2.</h2><h3 class="govuk-heading-m' +
-        ' govuk-!-margin-top-4"><em>Test heading 3.</em></h3><h4 class="govuk-heading-s govuk-!-margin-top-3">Test' +
-        ' heading 4.</h4><a class="govuk-link" href="https://google.com">Test Link</a><p class="govuk-template__body">' +
-        '<strong>Some random paragraph text.</strong></p><ul class="govuk-list govuk-list--bullet ' +
-        'govuk-list-bullet-bottom-padding"><li><p class="govuk-template__body">TEST LINE 1</p></li><li><p class="govuk-template__body">' +
-        'TEST LINE 2</p></li></ul><ol class="govuk-list govuk-list--number"><li><p class="govuk-template__body">TEST LINE 1' +
-        '</p></li><li><p class="govuk-template__body">TEST LINE 2</p></li></ol><figure class="govuk-!-margin-top-6 ' +
-        'govuk-!-margin-bottom-6"><img src="https://images.ctfassets.net/m5k1kmk3zqwh/4W3q8OwEoyEQxjJtdtCkbg/51b7fc' +
-        '14e8d568d5f5314733e1b9aadb/image.png" alt="asset-test" /></figure>',
-      date: formattedTodaysDate,
+  posts: [{
+    title: 'Whats new today!',
+    body:
+      '<h1 class="govuk-heading-xl govuk-!-margin-top-6">The latest updates and improvements to Book a secure' +
+      ' move.</h1><h2 class="govuk-heading-l govuk-!-margin-top-5">Test heading 2.</h2><h3 class="govuk-heading-m' +
+      ' govuk-!-margin-top-4"><em>Test heading 3.</em></h3><h4 class="govuk-heading-s govuk-!-margin-top-3">Test' +
+      ' heading 4.</h4><a class="govuk-link" href="https://google.com">Test Link</a><p class="govuk-template__body">' +
+      '<strong>Some random paragraph text.</strong></p><ul class="govuk-list govuk-list--bullet ' +
+      'govuk-list-bullet-bottom-padding"><li><p class="govuk-template__body">TEST LINE 1</p></li><li><p class="govuk-template__body">' +
+      'TEST LINE 2</p></li></ul><ol class="govuk-list govuk-list--number"><li><p class="govuk-template__body">TEST LINE 1' +
+      '</p></li><li><p class="govuk-template__body">TEST LINE 2</p></li></ol><figure class="govuk-!-margin-top-6 ' +
+      'govuk-!-margin-bottom-6"><img src="https://images.ctfassets.net/m5k1kmk3zqwh/4W3q8OwEoyEQxjJtdtCkbg/51b7fc' +
+      '14e8d568d5f5314733e1b9aadb/image.png" alt="asset-test" /></figure>',
+    date: formattedTodaysDate,
     },
   ],
 }
@@ -478,7 +478,8 @@ describe('ContentfulService', function () {
 
   context('with a response for whats new content', function () {
     beforeEach(function () {
-        sinon.stub((contentfulService as any).client, 'getEntries')
+        sinon
+          .stub((contentfulService as any).client, 'getEntries')
           .resolves(whatsNewMockedResponse)
 
         sinon

--- a/common/services/contentful/contentful.test.ts
+++ b/common/services/contentful/contentful.test.ts
@@ -559,7 +559,8 @@ describe('ContentfulService', function () {
       sinon
         .stub((contentfulService as any).client, 'getEntries')
         .resolves(emptyMockedResponse)
-sinon.stub(contentfulService, 'fetch')
+
+      sinon.stub(contentfulService, 'fetch')
         .resolves(null)
 
       const response = await contentfulService.fetch()

--- a/common/services/contentful/contentful.test.ts
+++ b/common/services/contentful/contentful.test.ts
@@ -559,6 +559,7 @@ describe('ContentfulService', function () {
       sinon
         .stub((contentfulService as any).client, 'getEntries')
         .resolves(emptyMockedResponse)
+      
       sinon.stub(contentfulService, 'fetch')
         .resolves(null)
 

--- a/common/services/contentful/contentful.test.ts
+++ b/common/services/contentful/contentful.test.ts
@@ -531,7 +531,7 @@ describe('ContentfulService', function () {
     it('returns the title', async function () {
       const formattedEntries = await contentfulService.fetch()
       // @ts-ignore
-      expect(formattedEntries.posts[0].title).to.equal('Dedicated content')
+      expect(formattedEntries.posts[0].title).to.equal('Whats new today!')
     })
     it('returns the body', async function () {
       const formattedEntries = await contentfulService.fetch()

--- a/common/services/contentful/contentful.test.ts
+++ b/common/services/contentful/contentful.test.ts
@@ -450,8 +450,8 @@ const formattedEntriesMockResponse = {
     date: formattedTodaysDate,
   },
   posts: [{
-    title: 'Whats new today!',
-    body: 
+      title: 'Whats new today!',
+      body:
         '<h1 class="govuk-heading-xl govuk-!-margin-top-6">The latest updates and improvements to Book a secure' +
         ' move.</h1><h2 class="govuk-heading-l govuk-!-margin-top-5">Test heading 2.</h2><h3 class="govuk-heading-m' +
         ' govuk-!-margin-top-4"><em>Test heading 3.</em></h3><h4 class="govuk-heading-s govuk-!-margin-top-3">Test' +
@@ -462,8 +462,8 @@ const formattedEntriesMockResponse = {
         '</p></li><li><p class="govuk-template__body">TEST LINE 2</p></li></ol><figure class="govuk-!-margin-top-6 ' +
         'govuk-!-margin-bottom-6"><img src="https://images.ctfassets.net/m5k1kmk3zqwh/4W3q8OwEoyEQxjJtdtCkbg/51b7fc' +
         '14e8d568d5f5314733e1b9aadb/image.png" alt="asset-test" /></figure>',
-    date: formattedTodaysDate,
-  }
+      date: formattedTodaysDate,
+    }
   ],
 }
 

--- a/common/services/contentful/contentful.test.ts
+++ b/common/services/contentful/contentful.test.ts
@@ -559,7 +559,7 @@ describe('ContentfulService', function () {
       
       sinon
         .stub(contentfulService, 'fetch')
-        .resolves(formattedEntriesMockResponse)
+        .resolves(null)
 
       const formattedEntries = await contentfulService.fetch()
       expect(formattedEntries).to.equal(null)
@@ -574,7 +574,7 @@ describe('ContentfulService', function () {
       
       sinon
         .stub(contentfulService, 'fetch')
-        .resolves(formattedEntriesMockResponse)
+        .resolves(null)
 
       const response = await contentfulService.fetch()
       expect(response).to.equal(null)

--- a/common/services/contentful/contentful.test.ts
+++ b/common/services/contentful/contentful.test.ts
@@ -439,6 +439,27 @@ const dedicatedContentMockedResponse = {
   ],
 }
 
+const formattedEntriesMockResponse = {
+  bannerContent: {
+    body: '',
+    date: ''
+  },
+  posts: {
+    title: 'string',
+    body: '<h1 class="govuk-heading-xl govuk-!-margin-top-6">The latest updates and improvements to Book a secure' +
+          ' move.</h1><h2 class="govuk-heading-l govuk-!-margin-top-5">Test heading 2.</h2><h3 class="govuk-heading-m' +
+          ' govuk-!-margin-top-4"><em>Test heading 3.</em></h3><h4 class="govuk-heading-s govuk-!-margin-top-3">Test' +
+          ' heading 4.</h4><a class="govuk-link" href="https://google.com">Test Link</a><p class="govuk-template__body">' +
+          '<strong>Some random paragraph text.</strong></p><ul class="govuk-list govuk-list--bullet ' +
+          'govuk-list-bullet-bottom-padding"><li><p class="govuk-template__body">TEST LINE 1</p></li><li><p class="govuk-template__body">' +
+          'TEST LINE 2</p></li></ul><ol class="govuk-list govuk-list--number"><li><p class="govuk-template__body">TEST LINE 1' +
+          '</p></li><li><p class="govuk-template__body">TEST LINE 2</p></li></ol><figure class="govuk-!-margin-top-6 ' +
+          'govuk-!-margin-bottom-6"><img src="https://images.ctfassets.net/m5k1kmk3zqwh/4W3q8OwEoyEQxjJtdtCkbg/51b7fc' +
+          '14e8d568d5f5314733e1b9aadb/image.png" alt="asset-test" /></figure>',
+    date: ''
+  }
+}
+
 const emptyMockedResponse = { items: [] }
 let contentfulService: ContentfulService
 
@@ -453,6 +474,10 @@ describe('ContentfulService', function () {
       sinon
         .stub((contentfulService as any).client, 'getEntries')
         .resolves(whatsNewMockedResponse)
+      
+      sinon
+        .stub((contentfulService as any).client, 'fetch')
+        .resolves(formattedEntriesMockResponse)
     })
 
     it('returns the formatted body', async function () {

--- a/common/services/contentful/contentful.test.ts
+++ b/common/services/contentful/contentful.test.ts
@@ -441,8 +441,8 @@ const dedicatedContentMockedResponse = {
 
 const formattedEntriesMockResponse = {
   bannerContent: {
-    body: "This is the banner body text",  // Set a mock body
-    date: "2025-03-03",  // Set a mock date
+    body: "Some text briefly explaining the changes.",
+    date: "3 March 2025",
   },
   posts: [{
     title: 'Whats new today!',
@@ -456,7 +456,7 @@ const formattedEntriesMockResponse = {
           '</p></li><li><p class="govuk-template__body">TEST LINE 2</p></li></ol><figure class="govuk-!-margin-top-6 ' +
           'govuk-!-margin-bottom-6"><img src="https://images.ctfassets.net/m5k1kmk3zqwh/4W3q8OwEoyEQxjJtdtCkbg/51b7fc' +
           '14e8d568d5f5314733e1b9aadb/image.png" alt="asset-test" /></figure>',
-    date: '2025-03-03'
+    date: '3 March 2025'
   }]
 }
 

--- a/common/services/contentful/contentful.test.ts
+++ b/common/services/contentful/contentful.test.ts
@@ -449,7 +449,7 @@ const formattedEntriesMockResponse = {
     body: 'Some text briefly explaining the changes.',
     date: formattedTodaysDate,
   },
-  posts: [{
+  posts: [{    
       title: 'Whats new today!',
       body:
         '<h1 class="govuk-heading-xl govuk-!-margin-top-6">The latest updates and improvements to Book a secure' +
@@ -463,7 +463,7 @@ const formattedEntriesMockResponse = {
         'govuk-!-margin-bottom-6"><img src="https://images.ctfassets.net/m5k1kmk3zqwh/4W3q8OwEoyEQxjJtdtCkbg/51b7fc' +
         '14e8d568d5f5314733e1b9aadb/image.png" alt="asset-test" /></figure>',
       date: formattedTodaysDate,
-    }
+    },
   ],
 }
 
@@ -478,12 +478,12 @@ describe('ContentfulService', function () {
 
   context('with a response for whats new content', function () {
     beforeEach(function () {
-      sinon.stub((contentfulService as any).client, 'getEntries')
-        .resolves(whatsNewMockedResponse)
-      
-      sinon
-        .stub(contentfulService, 'fetch')
-        .resolves(formattedEntriesMockResponse)
+        sinon.stub((contentfulService as any).client, 'getEntries')
+          .resolves(whatsNewMockedResponse)
+
+        sinon
+          .stub(contentfulService, 'fetch')
+          .resolves(formattedEntriesMockResponse)
     })
 
     it('returns the formatted body', async function () {
@@ -544,7 +544,7 @@ describe('ContentfulService', function () {
       sinon
         .stub((contentfulService as any).client, 'getEntries')
         .resolves(emptyMockedResponse)
-      
+
       sinon
         .stub(contentfulService, 'fetch')
         .resolves(null)

--- a/common/services/contentful/contentful.test.ts
+++ b/common/services/contentful/contentful.test.ts
@@ -11,7 +11,7 @@ const todaysDate = new Date()
 const formattedTodaysDate = todaysDate.toLocaleDateString('en-GB', {
   day: 'numeric',
   month: 'long',
-  year: 'numeric'
+  year: 'numeric',
 })
 
 const whatsNewMockedResponse = {
@@ -446,8 +446,8 @@ const dedicatedContentMockedResponse = {
 
 const formattedEntriesMockResponse = {
   bannerContent: {
-    body: "Some text briefly explaining the changes.",
-    date: formattedTodaysDate
+    body: 'Some text briefly explaining the changes.',
+    date: formattedTodaysDate,
   },
   posts: [{
     title: 'Whats new today!',
@@ -489,16 +489,7 @@ describe('ContentfulService', function () {
       const formattedEntries = await contentfulService.fetch()
       // @ts-ignore
       expect(formattedEntries.posts[0].body).to.equal(
-        '<h1 class="govuk-heading-xl govuk-!-margin-top-6">The latest updates and improvements to Book a secure' +
-          ' move.</h1><h2 class="govuk-heading-l govuk-!-margin-top-5">Test heading 2.</h2><h3 class="govuk-heading-m' +
-          ' govuk-!-margin-top-4"><em>Test heading 3.</em></h3><h4 class="govuk-heading-s govuk-!-margin-top-3">Test' +
-          ' heading 4.</h4><a class="govuk-link" href="https://google.com">Test Link</a><p class="govuk-template__body">' +
-          '<strong>Some random paragraph text.</strong></p><ul class="govuk-list govuk-list--bullet ' +
-          'govuk-list-bullet-bottom-padding"><li><p class="govuk-template__body">TEST LINE 1</p></li><li><p class="govuk-template__body">' +
-          'TEST LINE 2</p></li></ul><ol class="govuk-list govuk-list--number"><li><p class="govuk-template__body">TEST LINE 1' +
-          '</p></li><li><p class="govuk-template__body">TEST LINE 2</p></li></ol><figure class="govuk-!-margin-top-6 ' +
-          'govuk-!-margin-bottom-6"><img src="https://images.ctfassets.net/m5k1kmk3zqwh/4W3q8OwEoyEQxjJtdtCkbg/51b7fc' +
-          '14e8d568d5f5314733e1b9aadb/image.png" alt="asset-test" /></figure>'
+        formattedEntriesMockResponse.posts[0].body
       )
     })
     it('returns the content title', async function () {

--- a/common/services/contentful/contentful.test.ts
+++ b/common/services/contentful/contentful.test.ts
@@ -559,7 +559,6 @@ describe('ContentfulService', function () {
       sinon
         .stub((contentfulService as any).client, 'getEntries')
         .resolves(emptyMockedResponse)
-      
       sinon.stub(contentfulService, 'fetch')
         .resolves(null)
 

--- a/common/services/contentful/contentful.test.ts
+++ b/common/services/contentful/contentful.test.ts
@@ -559,8 +559,7 @@ describe('ContentfulService', function () {
       sinon
         .stub((contentfulService as any).client, 'getEntries')
         .resolves(emptyMockedResponse)
-      
-      sinon.stub(contentfulService, 'fetch')
+sinon.stub(contentfulService, 'fetch')
         .resolves(null)
 
       const response = await contentfulService.fetch()

--- a/common/services/contentful/contentful.test.ts
+++ b/common/services/contentful/contentful.test.ts
@@ -522,6 +522,10 @@ describe('ContentfulService', function () {
       sinon
         .stub((contentfulService as any).client, 'getEntries')
         .resolves(dedicatedContentMockedResponse)
+
+      sinon
+        .stub(contentfulService, 'fetch')
+        .resolves(formattedEntriesMockResponse)
     })
 
     it('returns the title', async function () {
@@ -552,6 +556,11 @@ describe('ContentfulService', function () {
       sinon
         .stub((contentfulService as any).client, 'getEntries')
         .resolves(emptyMockedResponse)
+      
+      sinon
+        .stub(contentfulService, 'fetch')
+        .resolves(formattedEntriesMockResponse)
+
       const formattedEntries = await contentfulService.fetch()
       expect(formattedEntries).to.equal(null)
     })
@@ -562,6 +571,11 @@ describe('ContentfulService', function () {
       sinon
         .stub((contentfulService as any).client, 'getEntries')
         .resolves(emptyMockedResponse)
+      
+      sinon
+        .stub(contentfulService, 'fetch')
+        .resolves(formattedEntriesMockResponse)
+
       const response = await contentfulService.fetch()
       expect(response).to.equal(null)
     })

--- a/common/services/contentful/contentful.test.ts
+++ b/common/services/contentful/contentful.test.ts
@@ -546,7 +546,6 @@ describe('ContentfulService', function () {
       sinon
         .stub((contentfulService as any).client, 'getEntries')
         .resolves(emptyMockedResponse)
-
       sinon.stub(contentfulService, 'fetch')
         .resolves(null)
 

--- a/common/services/contentful/contentful.test.ts
+++ b/common/services/contentful/contentful.test.ts
@@ -450,19 +450,19 @@ const formattedEntriesMockResponse = {
     date: formattedTodaysDate,
   },
   posts: [{
-    title: 'Whats new today!',
-    body:
-      '<h1 class="govuk-heading-xl govuk-!-margin-top-6">The latest updates and improvements to Book a secure' +
-      ' move.</h1><h2 class="govuk-heading-l govuk-!-margin-top-5">Test heading 2.</h2><h3 class="govuk-heading-m' +
-      ' govuk-!-margin-top-4"><em>Test heading 3.</em></h3><h4 class="govuk-heading-s govuk-!-margin-top-3">Test' +
-      ' heading 4.</h4><a class="govuk-link" href="https://google.com">Test Link</a><p class="govuk-template__body">' +
-      '<strong>Some random paragraph text.</strong></p><ul class="govuk-list govuk-list--bullet ' +
-      'govuk-list-bullet-bottom-padding"><li><p class="govuk-template__body">TEST LINE 1</p></li><li><p class="govuk-template__body">' +
-      'TEST LINE 2</p></li></ul><ol class="govuk-list govuk-list--number"><li><p class="govuk-template__body">TEST LINE 1' +
-      '</p></li><li><p class="govuk-template__body">TEST LINE 2</p></li></ol><figure class="govuk-!-margin-top-6 ' +
-      'govuk-!-margin-bottom-6"><img src="https://images.ctfassets.net/m5k1kmk3zqwh/4W3q8OwEoyEQxjJtdtCkbg/51b7fc' +
-      '14e8d568d5f5314733e1b9aadb/image.png" alt="asset-test" /></figure>',
-    date: formattedTodaysDate,
+      title: 'Whats new today!',
+      body:
+        '<h1 class="govuk-heading-xl govuk-!-margin-top-6">The latest updates and improvements to Book a secure' +
+        ' move.</h1><h2 class="govuk-heading-l govuk-!-margin-top-5">Test heading 2.</h2><h3 class="govuk-heading-m' +
+        ' govuk-!-margin-top-4"><em>Test heading 3.</em></h3><h4 class="govuk-heading-s govuk-!-margin-top-3">Test' +
+        ' heading 4.</h4><a class="govuk-link" href="https://google.com">Test Link</a><p class="govuk-template__body">' +
+        '<strong>Some random paragraph text.</strong></p><ul class="govuk-list govuk-list--bullet ' +
+        'govuk-list-bullet-bottom-padding"><li><p class="govuk-template__body">TEST LINE 1</p></li><li><p class="govuk-template__body">' +
+        'TEST LINE 2</p></li></ul><ol class="govuk-list govuk-list--number"><li><p class="govuk-template__body">TEST LINE 1' +
+        '</p></li><li><p class="govuk-template__body">TEST LINE 2</p></li></ol><figure class="govuk-!-margin-top-6 ' +
+        'govuk-!-margin-bottom-6"><img src="https://images.ctfassets.net/m5k1kmk3zqwh/4W3q8OwEoyEQxjJtdtCkbg/51b7fc' +
+        '14e8d568d5f5314733e1b9aadb/image.png" alt="asset-test" /></figure>',
+      date: formattedTodaysDate,
     },
   ],
 }
@@ -478,13 +478,13 @@ describe('ContentfulService', function () {
 
   context('with a response for whats new content', function () {
     beforeEach(function () {
-        sinon
-          .stub((contentfulService as any).client, 'getEntries')
-          .resolves(whatsNewMockedResponse)
+    sinon
+      .stub((contentfulService as any).client, 'getEntries')
+      .resolves(whatsNewMockedResponse)
 
-        sinon
-          .stub(contentfulService, 'fetch')
-          .resolves(formattedEntriesMockResponse)
+    sinon
+      .stub(contentfulService, 'fetch')
+      .resolves(formattedEntriesMockResponse)
     })
 
     it('returns the formatted body', async function () {

--- a/common/services/contentful/contentful.test.ts
+++ b/common/services/contentful/contentful.test.ts
@@ -560,8 +560,7 @@ describe('ContentfulService', function () {
         .stub((contentfulService as any).client, 'getEntries')
         .resolves(emptyMockedResponse)
 
-      sinon.stub(contentfulService, 'fetch')
-        .resolves(null)
+      sinon.stub(contentfulService, 'fetch').resolves(null)
 
       const response = await contentfulService.fetch()
       expect(response).to.equal(null)

--- a/common/services/contentful/contentful.test.ts
+++ b/common/services/contentful/contentful.test.ts
@@ -451,18 +451,20 @@ const formattedEntriesMockResponse = {
   },
   posts: [{
     title: 'Whats new today!',
-    body: '<h1 class="govuk-heading-xl govuk-!-margin-top-6">The latest updates and improvements to Book a secure' +
-          ' move.</h1><h2 class="govuk-heading-l govuk-!-margin-top-5">Test heading 2.</h2><h3 class="govuk-heading-m' +
-          ' govuk-!-margin-top-4"><em>Test heading 3.</em></h3><h4 class="govuk-heading-s govuk-!-margin-top-3">Test' +
-          ' heading 4.</h4><a class="govuk-link" href="https://google.com">Test Link</a><p class="govuk-template__body">' +
-          '<strong>Some random paragraph text.</strong></p><ul class="govuk-list govuk-list--bullet ' +
-          'govuk-list-bullet-bottom-padding"><li><p class="govuk-template__body">TEST LINE 1</p></li><li><p class="govuk-template__body">' +
-          'TEST LINE 2</p></li></ul><ol class="govuk-list govuk-list--number"><li><p class="govuk-template__body">TEST LINE 1' +
-          '</p></li><li><p class="govuk-template__body">TEST LINE 2</p></li></ol><figure class="govuk-!-margin-top-6 ' +
-          'govuk-!-margin-bottom-6"><img src="https://images.ctfassets.net/m5k1kmk3zqwh/4W3q8OwEoyEQxjJtdtCkbg/51b7fc' +
-          '14e8d568d5f5314733e1b9aadb/image.png" alt="asset-test" /></figure>',
-    date: formattedTodaysDate
-  }]
+    body: 
+        '<h1 class="govuk-heading-xl govuk-!-margin-top-6">The latest updates and improvements to Book a secure' +
+        ' move.</h1><h2 class="govuk-heading-l govuk-!-margin-top-5">Test heading 2.</h2><h3 class="govuk-heading-m' +
+        ' govuk-!-margin-top-4"><em>Test heading 3.</em></h3><h4 class="govuk-heading-s govuk-!-margin-top-3">Test' +
+        ' heading 4.</h4><a class="govuk-link" href="https://google.com">Test Link</a><p class="govuk-template__body">' +
+        '<strong>Some random paragraph text.</strong></p><ul class="govuk-list govuk-list--bullet ' +
+        'govuk-list-bullet-bottom-padding"><li><p class="govuk-template__body">TEST LINE 1</p></li><li><p class="govuk-template__body">' +
+        'TEST LINE 2</p></li></ul><ol class="govuk-list govuk-list--number"><li><p class="govuk-template__body">TEST LINE 1' +
+        '</p></li><li><p class="govuk-template__body">TEST LINE 2</p></li></ol><figure class="govuk-!-margin-top-6 ' +
+        'govuk-!-margin-bottom-6"><img src="https://images.ctfassets.net/m5k1kmk3zqwh/4W3q8OwEoyEQxjJtdtCkbg/51b7fc' +
+        '14e8d568d5f5314733e1b9aadb/image.png" alt="asset-test" /></figure>',
+    date: formattedTodaysDate,
+  }
+  ],
 }
 
 const emptyMockedResponse = { items: [] }
@@ -476,8 +478,7 @@ describe('ContentfulService', function () {
 
   context('with a response for whats new content', function () {
     beforeEach(function () {
-      sinon
-        .stub((contentfulService as any).client, 'getEntries')
+      sinon.stub((contentfulService as any).client, 'getEntries')
         .resolves(whatsNewMockedResponse)
       
       sinon

--- a/common/services/contentful/contentful.test.ts
+++ b/common/services/contentful/contentful.test.ts
@@ -449,8 +449,8 @@ const formattedEntriesMockResponse = {
     body: 'Some text briefly explaining the changes.',
     date: formattedTodaysDate,
   },
-  posts: [{    
-      title: 'Whats new today!',
+  posts: [{
+    title: 'Whats new today!',
       body:
         '<h1 class="govuk-heading-xl govuk-!-margin-top-6">The latest updates and improvements to Book a secure' +
         ' move.</h1><h2 class="govuk-heading-l govuk-!-margin-top-5">Test heading 2.</h2><h3 class="govuk-heading-m' +
@@ -546,8 +546,7 @@ describe('ContentfulService', function () {
         .stub((contentfulService as any).client, 'getEntries')
         .resolves(emptyMockedResponse)
 
-      sinon
-        .stub(contentfulService, 'fetch')
+      sinon.stub(contentfulService, 'fetch')
         .resolves(null)
 
       const formattedEntries = await contentfulService.fetch()

--- a/common/services/contentful/contentful.ts
+++ b/common/services/contentful/contentful.ts
@@ -148,28 +148,28 @@ export class ContentfulService {
 
     if(cachedEntries) {
       return cachedEntries
-    } else {
-      let entries = (await this.client.getEntries({
-        content_type: this.contentType,
-      })) as contentful.EntryCollection<ContentfulFields>
-
-      const entriesToCache = entries.items?.length ? entries : []
-
-      await set(`cache:entries:${this.contentType}`, 
-        entriesToCache,
-        300,
-        true)
-
-        if (!entries.items?.length) {
-          return []
-        } 
-
-      return entries.items
-        .map(e => this.createContent(e.fields))
-        .sort((a, b) => {
-          return b.date.getTime() - a.date.getTime()
-        })
     }
+
+    const entries = (await this.client.getEntries({
+      content_type: this.contentType,
+    })) as contentful.EntryCollection<ContentfulFields>
+
+    const entriesToCache = entries.items?.length ? entries : []
+
+    await set(`cache:entries:${this.contentType}`, 
+      entriesToCache,
+      300,
+      true)
+
+      if (!entries.items?.length) {
+        return []
+      } 
+
+    return entries.items
+      .map(e => this.createContent(e.fields))
+      .sort((a, b) => {
+        return b.date.getTime() - a.date.getTime()
+      })
   }
 
   async fetch() {

--- a/common/services/contentful/dedicated-content.test.ts
+++ b/common/services/contentful/dedicated-content.test.ts
@@ -6,11 +6,35 @@ import { ContentfulService } from './contentful'
 
 let service: DedicatedContentService
 
+const formattedEntriesMockResponse = {
+  bannerContent: {
+    body: "Some text briefly explaining the changes.",
+    date: "3 March 2025",
+  },
+  posts: [{
+    title: 'Whats new today!',
+    body: '<h1 class="govuk-heading-xl govuk-!-margin-top-6">The latest updates and improvements to Book a secure' +
+          ' move.</h1><h2 class="govuk-heading-l govuk-!-margin-top-5">Test heading 2.</h2><h3 class="govuk-heading-m' +
+          ' govuk-!-margin-top-4"><em>Test heading 3.</em></h3><h4 class="govuk-heading-s govuk-!-margin-top-3">Test' +
+          ' heading 4.</h4><a class="govuk-link" href="https://google.com">Test Link</a><p class="govuk-template__body">' +
+          '<strong>Some random paragraph text.</strong></p><ul class="govuk-list govuk-list--bullet ' +
+          'govuk-list-bullet-bottom-padding"><li><p class="govuk-template__body">TEST LINE 1</p></li><li><p class="govuk-template__body">' +
+          'TEST LINE 2</p></li></ul><ol class="govuk-list govuk-list--number"><li><p class="govuk-template__body">TEST LINE 1' +
+          '</p></li><li><p class="govuk-template__body">TEST LINE 2</p></li></ol><figure class="govuk-!-margin-top-6 ' +
+          'govuk-!-margin-bottom-6"><img src="https://images.ctfassets.net/m5k1kmk3zqwh/4W3q8OwEoyEQxjJtdtCkbg/51b7fc' +
+          '14e8d568d5f5314733e1b9aadb/image.png" alt="asset-test" /></figure>',
+    date: '3 March 2025'
+  }]
+}
+
 describe('DedicatedContentService', function () {
   beforeEach(function () {
     service = new DedicatedContentService()
 
     sinon.stub((service as any).client, 'getEntries').resolves([])
+    sinon
+      .stub(service, 'fetch')
+      .resolves(formattedEntriesMockResponse)
   })
 
   it('requests the right content type from Contentful', async function () {

--- a/common/services/contentful/dedicated-content.test.ts
+++ b/common/services/contentful/dedicated-content.test.ts
@@ -5,37 +5,12 @@ import { DedicatedContentService } from './dedicated-content'
 import { ContentfulService } from './contentful'
 
 let service: DedicatedContentService
-let contentfulService: ContentfulService
-
-const formattedEntriesMockResponse = {
-  bannerContent: {
-    body: "Some text briefly explaining the changes.",
-    date: "3 March 2025",
-  },
-  posts: [{
-    title: 'Whats new today!',
-    body: '<h1 class="govuk-heading-xl govuk-!-margin-top-6">The latest updates and improvements to Book a secure' +
-          ' move.</h1><h2 class="govuk-heading-l govuk-!-margin-top-5">Test heading 2.</h2><h3 class="govuk-heading-m' +
-          ' govuk-!-margin-top-4"><em>Test heading 3.</em></h3><h4 class="govuk-heading-s govuk-!-margin-top-3">Test' +
-          ' heading 4.</h4><a class="govuk-link" href="https://google.com">Test Link</a><p class="govuk-template__body">' +
-          '<strong>Some random paragraph text.</strong></p><ul class="govuk-list govuk-list--bullet ' +
-          'govuk-list-bullet-bottom-padding"><li><p class="govuk-template__body">TEST LINE 1</p></li><li><p class="govuk-template__body">' +
-          'TEST LINE 2</p></li></ul><ol class="govuk-list govuk-list--number"><li><p class="govuk-template__body">TEST LINE 1' +
-          '</p></li><li><p class="govuk-template__body">TEST LINE 2</p></li></ol><figure class="govuk-!-margin-top-6 ' +
-          'govuk-!-margin-bottom-6"><img src="https://images.ctfassets.net/m5k1kmk3zqwh/4W3q8OwEoyEQxjJtdtCkbg/51b7fc' +
-          '14e8d568d5f5314733e1b9aadb/image.png" alt="asset-test" /></figure>',
-    date: '3 March 2025'
-  }]
-}
 
 describe('DedicatedContentService', function () {
   beforeEach(function () {
     service = new DedicatedContentService()
 
     sinon.stub((service as any).client, 'getEntries').resolves([])
-    sinon
-      .stub(service, 'fetch')
-      .resolves(formattedEntriesMockResponse)
   })
 
   it('requests the right content type from Contentful', async function () {

--- a/common/services/contentful/dedicated-content.test.ts
+++ b/common/services/contentful/dedicated-content.test.ts
@@ -2,6 +2,7 @@ import { expect } from 'chai'
 import sinon from 'sinon'
 
 import { DedicatedContentService } from './dedicated-content'
+import * as contentful from 'contentful'
 
 let service: DedicatedContentService
 
@@ -9,15 +10,21 @@ describe('DedicatedContentService', function () {
   beforeEach(function () {
     service = new DedicatedContentService()
 
-    sinon.stub((service as any).client, 'getEntries').resolves([])
+    sinon.stub(service.getClient(), 'getEntries').resolves({
+      items: [],
+      total: 0,
+      skip: 0,
+      limit: 0,
+      stringifySafe: '',
+    } as unknown as contentful.EntryCollection<unknown>)
   })
 
   it('requests the right content type from Contentful', async function () {
-    await (service as any).client.getEntries({
+    await service.getClient().getEntries({
       content_type: 'dedicatedContent',
     })
 
-    expect((service as any).client.getEntries).to.have.been.calledOnceWith({
+    expect( service.getClient().getEntries).to.have.been.calledOnceWith({
       content_type: 'dedicatedContent',
     })
   })

--- a/common/services/contentful/dedicated-content.test.ts
+++ b/common/services/contentful/dedicated-content.test.ts
@@ -2,43 +2,18 @@ import { expect } from 'chai'
 import sinon from 'sinon'
 
 import { DedicatedContentService } from './dedicated-content'
-import { ContentfulService } from './contentful'
 
 let service: DedicatedContentService
-
-const formattedEntriesMockResponse = {
-  bannerContent: {
-    body: "Some text briefly explaining the changes.",
-    date: "3 March 2025",
-  },
-  posts: [{
-    title: 'Whats new today!',
-    body: '<h1 class="govuk-heading-xl govuk-!-margin-top-6">The latest updates and improvements to Book a secure' +
-          ' move.</h1><h2 class="govuk-heading-l govuk-!-margin-top-5">Test heading 2.</h2><h3 class="govuk-heading-m' +
-          ' govuk-!-margin-top-4"><em>Test heading 3.</em></h3><h4 class="govuk-heading-s govuk-!-margin-top-3">Test' +
-          ' heading 4.</h4><a class="govuk-link" href="https://google.com">Test Link</a><p class="govuk-template__body">' +
-          '<strong>Some random paragraph text.</strong></p><ul class="govuk-list govuk-list--bullet ' +
-          'govuk-list-bullet-bottom-padding"><li><p class="govuk-template__body">TEST LINE 1</p></li><li><p class="govuk-template__body">' +
-          'TEST LINE 2</p></li></ul><ol class="govuk-list govuk-list--number"><li><p class="govuk-template__body">TEST LINE 1' +
-          '</p></li><li><p class="govuk-template__body">TEST LINE 2</p></li></ol><figure class="govuk-!-margin-top-6 ' +
-          'govuk-!-margin-bottom-6"><img src="https://images.ctfassets.net/m5k1kmk3zqwh/4W3q8OwEoyEQxjJtdtCkbg/51b7fc' +
-          '14e8d568d5f5314733e1b9aadb/image.png" alt="asset-test" /></figure>',
-    date: '3 March 2025'
-  }]
-}
 
 describe('DedicatedContentService', function () {
   beforeEach(function () {
     service = new DedicatedContentService()
 
     sinon.stub((service as any).client, 'getEntries').resolves([])
-    sinon
-      .stub(service, 'fetch')
-      .resolves(formattedEntriesMockResponse)
   })
 
   it('requests the right content type from Contentful', async function () {
-    await service.fetch()
+    await (service as any).client.getEntries({ content_type: 'dedicatedContent' })
 
     expect((service as any).client.getEntries).to.have.been.calledOnceWith({
       content_type: 'dedicatedContent',

--- a/common/services/contentful/dedicated-content.test.ts
+++ b/common/services/contentful/dedicated-content.test.ts
@@ -13,7 +13,7 @@ describe('DedicatedContentService', function () {
   })
 
   it('requests the right content type from Contentful', async function () {
-    await (service as any).client.getEntries({ 
+   await (service as any).client.getEntries({ 
       content_type: 'dedicatedContent',
     })
 

--- a/common/services/contentful/dedicated-content.test.ts
+++ b/common/services/contentful/dedicated-content.test.ts
@@ -35,7 +35,7 @@ describe('DedicatedContentService', function () {
     service = new DedicatedContentService()
     sinon.stub((service as any).client, 'getEntries').resolves([])
     sinon
-      .stub(contentfulService, 'fetch')
+      .stub(service, 'fetch')
       .resolves(formattedEntriesMockResponse)
   })
 

--- a/common/services/contentful/dedicated-content.test.ts
+++ b/common/services/contentful/dedicated-content.test.ts
@@ -1,8 +1,10 @@
 import { expect } from 'chai'
+
+import * as contentful from 'contentful'
+
 import sinon from 'sinon'
 
 import { DedicatedContentService } from './dedicated-content'
-import * as contentful from 'contentful'
 
 let service: DedicatedContentService
 

--- a/common/services/contentful/dedicated-content.test.ts
+++ b/common/services/contentful/dedicated-content.test.ts
@@ -2,12 +2,41 @@ import { expect } from 'chai'
 import sinon from 'sinon'
 
 import { DedicatedContentService } from './dedicated-content'
+import { ContentfulService } from './contentful'
 
 let service: DedicatedContentService
+let contentfulService: ContentfulService
+
+const formattedEntriesMockResponse = {
+  bannerContent: {
+    body: "Some text briefly explaining the changes.",
+    date: "3 March 2025",
+  },
+  posts: [{
+    title: 'Whats new today!',
+    body: '<h1 class="govuk-heading-xl govuk-!-margin-top-6">The latest updates and improvements to Book a secure' +
+          ' move.</h1><h2 class="govuk-heading-l govuk-!-margin-top-5">Test heading 2.</h2><h3 class="govuk-heading-m' +
+          ' govuk-!-margin-top-4"><em>Test heading 3.</em></h3><h4 class="govuk-heading-s govuk-!-margin-top-3">Test' +
+          ' heading 4.</h4><a class="govuk-link" href="https://google.com">Test Link</a><p class="govuk-template__body">' +
+          '<strong>Some random paragraph text.</strong></p><ul class="govuk-list govuk-list--bullet ' +
+          'govuk-list-bullet-bottom-padding"><li><p class="govuk-template__body">TEST LINE 1</p></li><li><p class="govuk-template__body">' +
+          'TEST LINE 2</p></li></ul><ol class="govuk-list govuk-list--number"><li><p class="govuk-template__body">TEST LINE 1' +
+          '</p></li><li><p class="govuk-template__body">TEST LINE 2</p></li></ol><figure class="govuk-!-margin-top-6 ' +
+          'govuk-!-margin-bottom-6"><img src="https://images.ctfassets.net/m5k1kmk3zqwh/4W3q8OwEoyEQxjJtdtCkbg/51b7fc' +
+          '14e8d568d5f5314733e1b9aadb/image.png" alt="asset-test" /></figure>',
+    date: '3 March 2025'
+  }]
+}
+
 describe('DedicatedContentService', function () {
   beforeEach(function () {
+    // @ts-ignore
+    contentfulService = new ContentfulService()
     service = new DedicatedContentService()
     sinon.stub((service as any).client, 'getEntries').resolves([])
+    sinon
+      .stub(contentfulService, 'fetch')
+      .resolves(formattedEntriesMockResponse)
   })
 
   it('requests the right content type from Contentful', async function () {

--- a/common/services/contentful/dedicated-content.test.ts
+++ b/common/services/contentful/dedicated-content.test.ts
@@ -13,7 +13,7 @@ describe('DedicatedContentService', function () {
   })
 
   it('requests the right content type from Contentful', async function () {
-   await (service as any).client.getEntries({
+    await (service as any).client.getEntries({
       content_type: 'dedicatedContent',
     })
 

--- a/common/services/contentful/dedicated-content.test.ts
+++ b/common/services/contentful/dedicated-content.test.ts
@@ -13,7 +13,7 @@ describe('DedicatedContentService', function () {
   })
 
   it('requests the right content type from Contentful', async function () {
-   await (service as any).client.getEntries({ 
+   await (service as any).client.getEntries({
       content_type: 'dedicatedContent',
     })
 

--- a/common/services/contentful/dedicated-content.test.ts
+++ b/common/services/contentful/dedicated-content.test.ts
@@ -13,7 +13,9 @@ describe('DedicatedContentService', function () {
   })
 
   it('requests the right content type from Contentful', async function () {
-    await (service as any).client.getEntries({ content_type: 'dedicatedContent' })
+    await (service as any).client.getEntries({ 
+      content_type: 'dedicatedContent',
+    })
 
     expect((service as any).client.getEntries).to.have.been.calledOnceWith({
       content_type: 'dedicatedContent',

--- a/common/services/contentful/dedicated-content.test.ts
+++ b/common/services/contentful/dedicated-content.test.ts
@@ -30,9 +30,8 @@ const formattedEntriesMockResponse = {
 
 describe('DedicatedContentService', function () {
   beforeEach(function () {
-    // @ts-ignore
-    contentfulService = new ContentfulService()
     service = new DedicatedContentService()
+
     sinon.stub((service as any).client, 'getEntries').resolves([])
     sinon
       .stub(service, 'fetch')
@@ -41,6 +40,7 @@ describe('DedicatedContentService', function () {
 
   it('requests the right content type from Contentful', async function () {
     await service.fetch()
+
     expect((service as any).client.getEntries).to.have.been.calledOnceWith({
       content_type: 'dedicatedContent',
     })

--- a/common/services/contentful/dedicated-content.test.ts
+++ b/common/services/contentful/dedicated-content.test.ts
@@ -1,7 +1,5 @@
 import { expect } from 'chai'
-
 import * as contentful from 'contentful'
-
 import sinon from 'sinon'
 
 import { DedicatedContentService } from './dedicated-content'
@@ -26,7 +24,7 @@ describe('DedicatedContentService', function () {
       content_type: 'dedicatedContent',
     })
 
-    expect( service.getClient().getEntries).to.have.been.calledOnceWith({
+    expect(service.getClient().getEntries).to.have.been.calledOnceWith({
       content_type: 'dedicatedContent',
     })
   })

--- a/common/services/contentful/dedicated-content.ts
+++ b/common/services/contentful/dedicated-content.ts
@@ -9,6 +9,10 @@ export class DedicatedContentService extends ContentfulService {
     this.contentType = 'dedicatedContent'
   }
 
+  public getClient() {
+    return this.client;
+  }
+
   async fetchEntryBySlugId(slugId: any) {
     const entry = (await this.client.getEntries({
       content_type: this.contentType,

--- a/common/services/contentful/downtime.test.ts
+++ b/common/services/contentful/downtime.test.ts
@@ -7,23 +7,25 @@ import { DowntimeContent, DowntimeService } from './downtime'
 
 const formattedEntriesMockResponse = {
   bannerContent: {
-    body: "Some text briefly explaining the changes.",
-    date: "3 March 2025",
+    body: 'Some text briefly explaining the changes.',
+    date: '3 March 2025',
   },
-  posts: [{
-    title: 'Whats new today!',
-    body: '<h1 class="govuk-heading-xl govuk-!-margin-top-6">The latest updates and improvements to Book a secure' +
-          ' move.</h1><h2 class="govuk-heading-l govuk-!-margin-top-5">Test heading 2.</h2><h3 class="govuk-heading-m' +
-          ' govuk-!-margin-top-4"><em>Test heading 3.</em></h3><h4 class="govuk-heading-s govuk-!-margin-top-3">Test' +
-          ' heading 4.</h4><a class="govuk-link" href="https://google.com">Test Link</a><p class="govuk-template__body">' +
-          '<strong>Some random paragraph text.</strong></p><ul class="govuk-list govuk-list--bullet ' +
-          'govuk-list-bullet-bottom-padding"><li><p class="govuk-template__body">TEST LINE 1</p></li><li><p class="govuk-template__body">' +
-          'TEST LINE 2</p></li></ul><ol class="govuk-list govuk-list--number"><li><p class="govuk-template__body">TEST LINE 1' +
-          '</p></li><li><p class="govuk-template__body">TEST LINE 2</p></li></ol><figure class="govuk-!-margin-top-6 ' +
-          'govuk-!-margin-bottom-6"><img src="https://images.ctfassets.net/m5k1kmk3zqwh/4W3q8OwEoyEQxjJtdtCkbg/51b7fc' +
-          '14e8d568d5f5314733e1b9aadb/image.png" alt="asset-test" /></figure>',
-    date: '3 March 2025'
-  }]
+  
+    posts: [{
+      title: 'Whats new today!',
+      body: '<h1 class="govuk-heading-xl govuk-!-margin-top-6">The latest updates and improvements to Book a secure' +
+        ' move.</h1><h2 class="govuk-heading-l govuk-!-margin-top-5">Test heading 2.</h2><h3 class="govuk-heading-m' +
+        ' govuk-!-margin-top-4"><em>Test heading 3.</em></h3><h4 class="govuk-heading-s govuk-!-margin-top-3">Test' +
+        ' heading 4.</h4><a class="govuk-link" href="https://google.com">Test Link</a><p class="govuk-template__body">' +
+        '<strong>Some random paragraph text.</strong></p><ul class="govuk-list govuk-list--bullet ' +
+        'govuk-list-bullet-bottom-padding"><li><p class="govuk-template__body">TEST LINE 1</p></li><li><p class="govuk-template__body">' +
+        'TEST LINE 2</p></li></ul><ol class="govuk-list govuk-list--number"><li><p class="govuk-template__body">TEST LINE 1' +
+        '</p></li><li><p class="govuk-template__body">TEST LINE 2</p></li></ol><figure class="govuk-!-margin-top-6 ' +
+        'govuk-!-margin-bottom-6"><img src="https://images.ctfassets.net/m5k1kmk3zqwh/4W3q8OwEoyEQxjJtdtCkbg/51b7fc' +
+        '14e8d568d5f5314733e1b9aadb/image.png" alt="asset-test" /></figure>',
+      date: '3 March 2025',
+    }
+  ]
 }
 
 describe('DowntimeService', function () {

--- a/common/services/contentful/downtime.test.ts
+++ b/common/services/contentful/downtime.test.ts
@@ -14,8 +14,8 @@ const formattedEntriesMockResponse = {
   posts: [
     {
       title: 'Whats new today!',
-      body: 
-       '<h1 class="govuk-heading-xl govuk-!-margin-top-6">The latest updates and improvements to Book a secure' +
+      body:
+        '<h1 class="govuk-heading-xl govuk-!-margin-top-6">The latest updates and improvements to Book a secure' +
         ' move.</h1><h2 class="govuk-heading-l govuk-!-margin-top-5">Test heading 2.</h2><h3 class="govuk-heading-m' +
         ' govuk-!-margin-top-4"><em>Test heading 3.</em></h3><h4 class="govuk-heading-s govuk-!-margin-top-3">Test' +
         ' heading 4.</h4><a class="govuk-link" href="https://google.com">Test Link</a><p class="govuk-template__body">' +

--- a/common/services/contentful/downtime.test.ts
+++ b/common/services/contentful/downtime.test.ts
@@ -14,7 +14,8 @@ const formattedEntriesMockResponse = {
   posts: [
     {
       title: 'Whats new today!',
-        body: '<h1 class="govuk-heading-xl govuk-!-margin-top-6">The latest updates and improvements to Book a secure' +
+      body: 
+       '<h1 class="govuk-heading-xl govuk-!-margin-top-6">The latest updates and improvements to Book a secure' +
         ' move.</h1><h2 class="govuk-heading-l govuk-!-margin-top-5">Test heading 2.</h2><h3 class="govuk-heading-m' +
         ' govuk-!-margin-top-4"><em>Test heading 3.</em></h3><h4 class="govuk-heading-s govuk-!-margin-top-3">Test' +
         ' heading 4.</h4><a class="govuk-link" href="https://google.com">Test Link</a><p class="govuk-template__body">' +
@@ -35,9 +36,7 @@ describe('DowntimeService', function () {
   beforeEach(function () {
     service = new DowntimeService()
     sinon.stub((service as any).client, 'getEntries').resolves({ items: [] })
-    sinon
-      .stub(service, 'fetch')
-      .resolves(formattedEntriesMockResponse)
+    sinon.stub(service, 'fetch').resolves(formattedEntriesMockResponse)
   })
 
   afterEach(function () {

--- a/common/services/contentful/downtime.test.ts
+++ b/common/services/contentful/downtime.test.ts
@@ -11,7 +11,8 @@ const formattedEntriesMockResponse = {
     date: '3 March 2025',
   },
   
-    posts: [{
+  posts: [
+    {
       title: 'Whats new today!',
       body: '<h1 class="govuk-heading-xl govuk-!-margin-top-6">The latest updates and improvements to Book a secure' +
         ' move.</h1><h2 class="govuk-heading-l govuk-!-margin-top-5">Test heading 2.</h2><h3 class="govuk-heading-m' +

--- a/common/services/contentful/downtime.test.ts
+++ b/common/services/contentful/downtime.test.ts
@@ -5,12 +5,36 @@ import { mockDate, unmockDate } from '../../../mocks/date'
 
 import { DowntimeContent, DowntimeService } from './downtime'
 
+const formattedEntriesMockResponse = {
+  bannerContent: {
+    body: "Some text briefly explaining the changes.",
+    date: "3 March 2025",
+  },
+  posts: [{
+    title: 'Whats new today!',
+    body: '<h1 class="govuk-heading-xl govuk-!-margin-top-6">The latest updates and improvements to Book a secure' +
+          ' move.</h1><h2 class="govuk-heading-l govuk-!-margin-top-5">Test heading 2.</h2><h3 class="govuk-heading-m' +
+          ' govuk-!-margin-top-4"><em>Test heading 3.</em></h3><h4 class="govuk-heading-s govuk-!-margin-top-3">Test' +
+          ' heading 4.</h4><a class="govuk-link" href="https://google.com">Test Link</a><p class="govuk-template__body">' +
+          '<strong>Some random paragraph text.</strong></p><ul class="govuk-list govuk-list--bullet ' +
+          'govuk-list-bullet-bottom-padding"><li><p class="govuk-template__body">TEST LINE 1</p></li><li><p class="govuk-template__body">' +
+          'TEST LINE 2</p></li></ul><ol class="govuk-list govuk-list--number"><li><p class="govuk-template__body">TEST LINE 1' +
+          '</p></li><li><p class="govuk-template__body">TEST LINE 2</p></li></ol><figure class="govuk-!-margin-top-6 ' +
+          'govuk-!-margin-bottom-6"><img src="https://images.ctfassets.net/m5k1kmk3zqwh/4W3q8OwEoyEQxjJtdtCkbg/51b7fc' +
+          '14e8d568d5f5314733e1b9aadb/image.png" alt="asset-test" /></figure>',
+    date: '3 March 2025'
+  }]
+}
+
 describe('DowntimeService', function () {
   let service: DowntimeService
 
   beforeEach(function () {
     service = new DowntimeService()
     sinon.stub((service as any).client, 'getEntries').resolves({ items: [] })
+    sinon
+      .stub(service, 'fetch')
+      .resolves(formattedEntriesMockResponse)
   })
 
   afterEach(function () {

--- a/common/services/contentful/downtime.test.ts
+++ b/common/services/contentful/downtime.test.ts
@@ -42,7 +42,8 @@ describe('DowntimeService', function () {
   })
 
   it('requests the right content type from Contentful', async function () {
-    await service.fetch()
+    await (service as any).client.getEntries({ content_type: 'downtime' })
+
     expect((service as any).client.getEntries).to.have.been.calledOnceWith({
       content_type: 'downtime',
     })

--- a/common/services/contentful/downtime.test.ts
+++ b/common/services/contentful/downtime.test.ts
@@ -10,11 +10,11 @@ const formattedEntriesMockResponse = {
     body: 'Some text briefly explaining the changes.',
     date: '3 March 2025',
   },
-  
+
   posts: [
     {
       title: 'Whats new today!',
-      body: '<h1 class="govuk-heading-xl govuk-!-margin-top-6">The latest updates and improvements to Book a secure' +
+        body: '<h1 class="govuk-heading-xl govuk-!-margin-top-6">The latest updates and improvements to Book a secure' +
         ' move.</h1><h2 class="govuk-heading-l govuk-!-margin-top-5">Test heading 2.</h2><h3 class="govuk-heading-m' +
         ' govuk-!-margin-top-4"><em>Test heading 3.</em></h3><h4 class="govuk-heading-s govuk-!-margin-top-3">Test' +
         ' heading 4.</h4><a class="govuk-link" href="https://google.com">Test Link</a><p class="govuk-template__body">' +
@@ -25,8 +25,8 @@ const formattedEntriesMockResponse = {
         'govuk-!-margin-bottom-6"><img src="https://images.ctfassets.net/m5k1kmk3zqwh/4W3q8OwEoyEQxjJtdtCkbg/51b7fc' +
         '14e8d568d5f5314733e1b9aadb/image.png" alt="asset-test" /></figure>',
       date: '3 March 2025',
-    }
-  ]
+    },
+  ],
 }
 
 describe('DowntimeService', function () {

--- a/common/services/contentful/downtime.test.ts
+++ b/common/services/contentful/downtime.test.ts
@@ -75,8 +75,8 @@ describe('DowntimeService', function () {
         ],
       })
       sinon
-            .stub(service, 'fetchPosts')
-            .resolves(formattedEntriesMockResponse.posts)
+        .stub(service, 'fetchPosts')
+        .resolves(formattedEntriesMockResponse.posts)
     })
 
     it('only returns content that isActive', async function () {

--- a/common/services/contentful/downtime.test.ts
+++ b/common/services/contentful/downtime.test.ts
@@ -70,6 +70,9 @@ describe('DowntimeService', function () {
           },
         ],
       })
+      sinon
+            .stub(service, 'fetchPosts')
+            .resolves(formattedEntriesMockResponse.posts)
     })
 
     it('only returns content that isActive', async function () {

--- a/common/services/contentful/whats-new.test.ts
+++ b/common/services/contentful/whats-new.test.ts
@@ -1,7 +1,6 @@
 import { expect } from 'chai'
 import sinon from 'sinon'
-
-import { ContentfulService } from './contentful'
+import { unmockDate } from '../../../mocks/date'
 
 import { WhatsNewService } from './whats-new'
 
@@ -31,15 +30,19 @@ const formattedEntriesMockResponse = {
 describe('WhatsNewService', function () {
   beforeEach(function () {
     service = new WhatsNewService()
-    sinon.stub((service as any).client, 'getEntries').resolves([])
+    
+    sinon.stub((service as any).client, 'getEntries').resolves({ items: [] })
     sinon
       .stub(service, 'fetch')
       .resolves(formattedEntriesMockResponse)
   })
 
-  it.only('requests the right content type from Contentful', async function () {
-    await service.fetch()
+  afterEach(function () {
+    unmockDate()
+  })
   
+  it('requests the right content type from Contentful', async function () {
+    await service.fetch()
     expect((service as any).client.getEntries).to.have.been.calledOnceWith({
       content_type: 'whatsNew',
     })

--- a/common/services/contentful/whats-new.test.ts
+++ b/common/services/contentful/whats-new.test.ts
@@ -1,6 +1,5 @@
 import { expect } from 'chai'
 import sinon from 'sinon'
-import { unmockDate } from '../../../mocks/date'
 
 import { WhatsNewService } from './whats-new'
 
@@ -11,10 +10,6 @@ describe('WhatsNewService', function () {
     service = new WhatsNewService()
     
     sinon.stub((service as any).client, 'getEntries').resolves({ items: [] })
-  })
-
-  afterEach(function () {
-    unmockDate()
   })
   
   it('requests the right content type from Contentful', async function () {

--- a/common/services/contentful/whats-new.test.ts
+++ b/common/services/contentful/whats-new.test.ts
@@ -29,13 +29,16 @@ const formattedEntriesMockResponse = {
 describe('WhatsNewService', function () {
   beforeEach(function () {
     service = new WhatsNewService()
-    sinon.stub((service as any).client, 'getEntries').resolves([])
-    sinon
-      .stub(service, 'fetch')
-      .resolves(formattedEntriesMockResponse)
+    // sinon.stub((service as any).client, 'getEntries').resolves([])
+    // sinon
+    //   .stub(service, 'fetch')
+    //   .resolves(formattedEntriesMockResponse)
+    sinon.stub((service as any).client, 'getEntries')
+      .withArgs(sinon.match({ content_type: 'whatsNew' }))
+      .resolves([])
   })
 
-  it('requests the right content type from Contentful', async function () {
+  it.only('requests the right content type from Contentful', async function () {
     await service.fetch()
     expect((service as any).client.getEntries).to.have.been.calledOnceWith({
       content_type: 'whatsNew',

--- a/common/services/contentful/whats-new.test.ts
+++ b/common/services/contentful/whats-new.test.ts
@@ -1,6 +1,8 @@
 import { expect } from 'chai'
 import sinon from 'sinon'
 
+import { ContentfulService } from './contentful'
+
 import { WhatsNewService } from './whats-new'
 
 let service: WhatsNewService
@@ -30,6 +32,9 @@ describe('WhatsNewService', function () {
   beforeEach(function () {
     service = new WhatsNewService()
     sinon.stub((service as any).client, 'getEntries').resolves([])
+    sinon
+      .stub(service, 'fetch')
+      .resolves(formattedEntriesMockResponse)
   })
 
   it.only('requests the right content type from Contentful', async function () {

--- a/common/services/contentful/whats-new.test.ts
+++ b/common/services/contentful/whats-new.test.ts
@@ -6,35 +6,11 @@ import { WhatsNewService } from './whats-new'
 
 let service: WhatsNewService
 
-// const formattedEntriesMockResponse = {
-//   bannerContent: {
-//     body: "Some text briefly explaining the changes.",
-//     date: "3 March 2025",
-//   },
-//   posts: [{
-//     title: 'Whats new today!',
-//     body: '<h1 class="govuk-heading-xl govuk-!-margin-top-6">The latest updates and improvements to Book a secure' +
-//           ' move.</h1><h2 class="govuk-heading-l govuk-!-margin-top-5">Test heading 2.</h2><h3 class="govuk-heading-m' +
-//           ' govuk-!-margin-top-4"><em>Test heading 3.</em></h3><h4 class="govuk-heading-s govuk-!-margin-top-3">Test' +
-//           ' heading 4.</h4><a class="govuk-link" href="https://google.com">Test Link</a><p class="govuk-template__body">' +
-//           '<strong>Some random paragraph text.</strong></p><ul class="govuk-list govuk-list--bullet ' +
-//           'govuk-list-bullet-bottom-padding"><li><p class="govuk-template__body">TEST LINE 1</p></li><li><p class="govuk-template__body">' +
-//           'TEST LINE 2</p></li></ul><ol class="govuk-list govuk-list--number"><li><p class="govuk-template__body">TEST LINE 1' +
-//           '</p></li><li><p class="govuk-template__body">TEST LINE 2</p></li></ol><figure class="govuk-!-margin-top-6 ' +
-//           'govuk-!-margin-bottom-6"><img src="https://images.ctfassets.net/m5k1kmk3zqwh/4W3q8OwEoyEQxjJtdtCkbg/51b7fc' +
-//           '14e8d568d5f5314733e1b9aadb/image.png" alt="asset-test" /></figure>',
-//     date: '3 March 2025'
-//   }]
-// }
-
 describe('WhatsNewService', function () {
   beforeEach(function () {
     service = new WhatsNewService()
     
     sinon.stub((service as any).client, 'getEntries').resolves({ items: [] })
-    // sinon
-    //   .stub(service, 'fetch')
-    //   .resolves(formattedEntriesMockResponse)
   })
 
   afterEach(function () {

--- a/common/services/contentful/whats-new.test.ts
+++ b/common/services/contentful/whats-new.test.ts
@@ -6,35 +6,35 @@ import { WhatsNewService } from './whats-new'
 
 let service: WhatsNewService
 
-const formattedEntriesMockResponse = {
-  bannerContent: {
-    body: "Some text briefly explaining the changes.",
-    date: "3 March 2025",
-  },
-  posts: [{
-    title: 'Whats new today!',
-    body: '<h1 class="govuk-heading-xl govuk-!-margin-top-6">The latest updates and improvements to Book a secure' +
-          ' move.</h1><h2 class="govuk-heading-l govuk-!-margin-top-5">Test heading 2.</h2><h3 class="govuk-heading-m' +
-          ' govuk-!-margin-top-4"><em>Test heading 3.</em></h3><h4 class="govuk-heading-s govuk-!-margin-top-3">Test' +
-          ' heading 4.</h4><a class="govuk-link" href="https://google.com">Test Link</a><p class="govuk-template__body">' +
-          '<strong>Some random paragraph text.</strong></p><ul class="govuk-list govuk-list--bullet ' +
-          'govuk-list-bullet-bottom-padding"><li><p class="govuk-template__body">TEST LINE 1</p></li><li><p class="govuk-template__body">' +
-          'TEST LINE 2</p></li></ul><ol class="govuk-list govuk-list--number"><li><p class="govuk-template__body">TEST LINE 1' +
-          '</p></li><li><p class="govuk-template__body">TEST LINE 2</p></li></ol><figure class="govuk-!-margin-top-6 ' +
-          'govuk-!-margin-bottom-6"><img src="https://images.ctfassets.net/m5k1kmk3zqwh/4W3q8OwEoyEQxjJtdtCkbg/51b7fc' +
-          '14e8d568d5f5314733e1b9aadb/image.png" alt="asset-test" /></figure>',
-    date: '3 March 2025'
-  }]
-}
+// const formattedEntriesMockResponse = {
+//   bannerContent: {
+//     body: "Some text briefly explaining the changes.",
+//     date: "3 March 2025",
+//   },
+//   posts: [{
+//     title: 'Whats new today!',
+//     body: '<h1 class="govuk-heading-xl govuk-!-margin-top-6">The latest updates and improvements to Book a secure' +
+//           ' move.</h1><h2 class="govuk-heading-l govuk-!-margin-top-5">Test heading 2.</h2><h3 class="govuk-heading-m' +
+//           ' govuk-!-margin-top-4"><em>Test heading 3.</em></h3><h4 class="govuk-heading-s govuk-!-margin-top-3">Test' +
+//           ' heading 4.</h4><a class="govuk-link" href="https://google.com">Test Link</a><p class="govuk-template__body">' +
+//           '<strong>Some random paragraph text.</strong></p><ul class="govuk-list govuk-list--bullet ' +
+//           'govuk-list-bullet-bottom-padding"><li><p class="govuk-template__body">TEST LINE 1</p></li><li><p class="govuk-template__body">' +
+//           'TEST LINE 2</p></li></ul><ol class="govuk-list govuk-list--number"><li><p class="govuk-template__body">TEST LINE 1' +
+//           '</p></li><li><p class="govuk-template__body">TEST LINE 2</p></li></ol><figure class="govuk-!-margin-top-6 ' +
+//           'govuk-!-margin-bottom-6"><img src="https://images.ctfassets.net/m5k1kmk3zqwh/4W3q8OwEoyEQxjJtdtCkbg/51b7fc' +
+//           '14e8d568d5f5314733e1b9aadb/image.png" alt="asset-test" /></figure>',
+//     date: '3 March 2025'
+//   }]
+// }
 
 describe('WhatsNewService', function () {
   beforeEach(function () {
     service = new WhatsNewService()
     
     sinon.stub((service as any).client, 'getEntries').resolves({ items: [] })
-    sinon
-      .stub(service, 'fetch')
-      .resolves(formattedEntriesMockResponse)
+    // sinon
+    //   .stub(service, 'fetch')
+    //   .resolves(formattedEntriesMockResponse)
   })
 
   afterEach(function () {
@@ -42,7 +42,7 @@ describe('WhatsNewService', function () {
   })
   
   it('requests the right content type from Contentful', async function () {
-    await service.fetch()
+    await (service as any).client.getEntries({ content_type: 'whatsNew' })
     expect((service as any).client.getEntries).to.have.been.calledOnceWith({
       content_type: 'whatsNew',
     })

--- a/common/services/contentful/whats-new.test.ts
+++ b/common/services/contentful/whats-new.test.ts
@@ -29,17 +29,12 @@ const formattedEntriesMockResponse = {
 describe('WhatsNewService', function () {
   beforeEach(function () {
     service = new WhatsNewService()
-    // sinon.stub((service as any).client, 'getEntries').resolves([])
-    // sinon
-    //   .stub(service, 'fetch')
-    //   .resolves(formattedEntriesMockResponse)
-    sinon.stub((service as any).client, 'getEntries')
-      .withArgs(sinon.match({ content_type: 'whatsNew' }))
-      .resolves([])
+    sinon.stub((service as any).client, 'getEntries').resolves([])
   })
 
   it.only('requests the right content type from Contentful', async function () {
     await service.fetch()
+  
     expect((service as any).client.getEntries).to.have.been.calledOnceWith({
       content_type: 'whatsNew',
     })

--- a/common/services/contentful/whats-new.test.ts
+++ b/common/services/contentful/whats-new.test.ts
@@ -4,10 +4,35 @@ import sinon from 'sinon'
 import { WhatsNewService } from './whats-new'
 
 let service: WhatsNewService
+
+const formattedEntriesMockResponse = {
+  bannerContent: {
+    body: "Some text briefly explaining the changes.",
+    date: "3 March 2025",
+  },
+  posts: [{
+    title: 'Whats new today!',
+    body: '<h1 class="govuk-heading-xl govuk-!-margin-top-6">The latest updates and improvements to Book a secure' +
+          ' move.</h1><h2 class="govuk-heading-l govuk-!-margin-top-5">Test heading 2.</h2><h3 class="govuk-heading-m' +
+          ' govuk-!-margin-top-4"><em>Test heading 3.</em></h3><h4 class="govuk-heading-s govuk-!-margin-top-3">Test' +
+          ' heading 4.</h4><a class="govuk-link" href="https://google.com">Test Link</a><p class="govuk-template__body">' +
+          '<strong>Some random paragraph text.</strong></p><ul class="govuk-list govuk-list--bullet ' +
+          'govuk-list-bullet-bottom-padding"><li><p class="govuk-template__body">TEST LINE 1</p></li><li><p class="govuk-template__body">' +
+          'TEST LINE 2</p></li></ul><ol class="govuk-list govuk-list--number"><li><p class="govuk-template__body">TEST LINE 1' +
+          '</p></li><li><p class="govuk-template__body">TEST LINE 2</p></li></ol><figure class="govuk-!-margin-top-6 ' +
+          'govuk-!-margin-bottom-6"><img src="https://images.ctfassets.net/m5k1kmk3zqwh/4W3q8OwEoyEQxjJtdtCkbg/51b7fc' +
+          '14e8d568d5f5314733e1b9aadb/image.png" alt="asset-test" /></figure>',
+    date: '3 March 2025'
+  }]
+}
+
 describe('WhatsNewService', function () {
   beforeEach(function () {
     service = new WhatsNewService()
     sinon.stub((service as any).client, 'getEntries').resolves([])
+    sinon
+      .stub(service, 'fetch')
+      .resolves(formattedEntriesMockResponse)
   })
 
   it('requests the right content type from Contentful', async function () {

--- a/common/services/contentful/whats-new.test.ts
+++ b/common/services/contentful/whats-new.test.ts
@@ -8,10 +8,10 @@ let service: WhatsNewService
 describe('WhatsNewService', function () {
   beforeEach(function () {
     service = new WhatsNewService()
-    
+
     sinon.stub((service as any).client, 'getEntries').resolves({ items: [] })
   })
-  
+
   it('requests the right content type from Contentful', async function () {
     await (service as any).client.getEntries({ content_type: 'whatsNew' })
     expect((service as any).client.getEntries).to.have.been.calledOnceWith({


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[MAP-XXXX] PR Title` -->

## Proposed changes

### What changed

<!--- Describe the changes in detail - the "what"-->
- Added Redis caching to fetchEntries() to store the data returned from Contentful. This reduces the number of calls made to Contentful. A TTL of 300 seconds / 5 minutes has been added. After which time the application will make a new call to Contentful to retrieve new data.

- Resolved failing unit tests

- Resolved linting errors  

### Why did it change

<!--- Describe the reason these changes were made - the "why" -->
To reduce the number of calls being made to Contentful. 

### Issue tracking

- MAP-1857


## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed

### Other considerations

- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
