### PR TITLE
chore(MAP-2270): Update Axios dependency to 1.8.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -155,7 +155,7 @@
     "accessible-autocomplete": "2.0.4",
     "agentkeepalive": "4.2.1",
     "applicationinsights": "^2.6.0",
-    "axios": "1.7.2",
+    "axios": "1.8.2",
     "axios-debug-log": "1.0.0",
     "bluebird": "3.7.2",
     "chrono-node": "2.5.0",


### PR DESCRIPTION
### What changed

- dependency updates to fix the security issues listed [here ](https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/security/code-scanning)

### Why did it change

<!--- Describe the reason these changes were made - the "why" -->

- Updated Axios from version 1.7.2 to 1.8.2

- MAP-2270

## Checklists

### Testing

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Internet Explorer
