### PR TITLE
chore: Upgrade CI Browser Tools and use latest Chrome version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,7 +107,7 @@ jobs:
       - attach_workspace:
           at: .
       - browser-tools/install-browser-tools :
-          chrome-version: 123.0.6312.86
+          chrome-version: latest
       - run:
           name: Compile typescript, build assets and frameworks
           command: npm run build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  browser-tools: circleci/browser-tools@1.5.1
+  browser-tools: circleci/browser-tools@1.5.3
   hmpps: ministryofjustice/hmpps@7
 
 aliases:


### PR DESCRIPTION
## Proposed changes

### What changed

- Upgrade to `browser-tools@1.5.3`
- Use `latest` version of Chrome


### Why did it change

CI e2e tests were failing because `Google Chrome v123.0.6312.86 (stable) failed to install.`
