### PR TITLE
MAP-2299 - Add HMRC - Service timeout component to BaSM frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,4 +80,4 @@ Unless stated otherwise, the codebase is released under the [MIT License](./LICE
 
 ## Contribution guidelines
 
-If you want to help us improve Book a secure move, view our [contribution guidelines](./CONTRIBUTING.md)
+If you want to help us improve Book a secure move, view our [contribution guidelines](./CONTRIBUTING.md).

--- a/common/assets/javascripts/application.js
+++ b/common/assets/javascripts/application.js
@@ -17,6 +17,7 @@ import '../images/person-fallback.png'
 import '../images/person-fallback@2x.png'
 
 import * as MOJFrontend from '@ministryofjustice/frontend'
+import * as HMRCFrontend from 'hmrc-frontend/hmrc/all'
 
 import MultiFileUpload from '../../components/multi-file-upload/multi-file-upload'
 
@@ -37,7 +38,9 @@ const Analytics = require('./analytics')
 const { nodeListForEach } = require('./utils')
 
 initAll()
+HMRCFrontend.initAll()
 MOJFrontend.initAll()
+
 // eslint-disable-next-line no-new
 new AddAnother('.moj-add-another')
 

--- a/common/assets/scss/application.scss
+++ b/common/assets/scss/application.scss
@@ -65,6 +65,9 @@ $govuk-grid-widths: (
 @import "@ministryofjustice/frontend/moj/components/date-picker/date-picker";
 @import "@ministryofjustice/frontend/moj/all";
 
+// Import HMRC Frontend Components
+@import "hmrc-frontend/hmrc/components/timeout-dialog/_timeout-dialog";
+
 // Import app settings/tools/helpers
 @import "settings/all";
 @import "helpers/all";

--- a/common/templates/layouts/base.njk
+++ b/common/templates/layouts/base.njk
@@ -26,6 +26,8 @@
 {% from "moj/components/primary-navigation/macro.njk"     import mojPrimaryNavigation %}
 {% from "moj/components/date-picker/macro.njk"            import mojDatePicker %}
 
+{% from "hmrc/components/timeout-dialog/macro.njk" import hmrcTimeoutDialog %}
+
 {# App level components #}
 {% from "raw/macro.njk"               import raw %}
 {% from "add-another/macro.njk"       import appAddAnother %}
@@ -75,6 +77,7 @@
   {% endif %}
 {% endblock %}
 
+
 {% block pageTitle %}
   {{ SERVICE_NAME }}
 {% endblock %}
@@ -89,6 +92,14 @@
 
 {% block bodyStart %}
 
+  {{ hmrcTimeoutDialog ({
+    timeout: 1800,
+    countdown: 120,
+    keepAliveUrl: "?continue=true",
+    signOutUrl: "/auth/sign-out",
+    language: "en"
+  }) }}
+
   {% if GA_ID %}
     <!-- Google Tag Manager (noscript) -->
     <noscript>
@@ -97,6 +108,7 @@
     </noscript>
     <!-- End Google Tag Manager (noscript) -->
   {% endif %}
+  
 {% endblock %}
 
 {% block header %}
@@ -125,6 +137,7 @@
       items: primaryNavigation
     }) }}
   {% endblock %}
+
   {% block organisationSwitcher %}
     {% if CURRENT_LOCATION or CURRENT_REGION or canAccess("locations:all") %}
       <div class="govuk-width-container">

--- a/config/nunjucks/index.js
+++ b/config/nunjucks/index.js
@@ -9,6 +9,7 @@ module.exports = (app, { IS_DEV = false }, paths) => {
   const views = [
     paths.govukFrontend,
     paths.mojFrontend,
+    paths.hmrcFrontend,
     paths.templates,
     paths.components,
     paths.app,

--- a/config/nunjucks/index.test.js
+++ b/config/nunjucks/index.test.js
@@ -20,6 +20,7 @@ const mockPaths = {
   app: '_app/',
   govukFrontend: '_govukFrontend/',
   mojFrontend: '_mojFrontend/',
+  hmrcFrontend: '_hmrcFrontend/',
 }
 
 const nunjucksEnv = proxyquire('./', {
@@ -67,6 +68,7 @@ describe('Nunjucks', function () {
         expect(views).to.deep.equal([
           '_govukFrontend/',
           '_mojFrontend/',
+          '_hmrcFrontend/',
           '_templates/',
           '_components/',
           '_app/',

--- a/config/paths.js
+++ b/config/paths.js
@@ -18,6 +18,7 @@ module.exports = {
     'node_modules',
     '@ministryofjustice/frontend'
   ),
+  hmrcFrontend: path.resolve(root, 'node_modules', 'hmrc-frontend'),
   fixtures: path.resolve(root, 'test', 'fixtures'),
   frameworks: {
     source: path.resolve(

--- a/package-lock.json
+++ b/package-lock.json
@@ -71,6 +71,7 @@
         "hc-sticky": "2.2.7",
         "helmet": "6.0.1",
         "hmpo-form-wizard": "13.0.0",
+        "hmrc-frontend": "6.60.0",
         "i18next": "22.4.10",
         "i18next-express-middleware": "2.0.0",
         "i18next-fs-backend": "2.1.1",
@@ -8129,9 +8130,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001678",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001678.tgz",
-      "integrity": "sha512-RR+4U/05gNtps58PEBDZcPWTgEO2MBeoPZ96aQcjmfkBWRIDfN451fW2qyDA9/+HohLLIL5GqiMwA+IB1pWarw==",
+      "version": "1.0.30001707",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001707.tgz",
+      "integrity": "sha512-3qtRjw/HQSMlDWf+X79N206fepf4SOOU6SQLMaq/0KkZLmSjPxAkBOQQ+FxbHKfHmYLZFfdWsO3KA90ceHPSnw==",
       "funding": [
         {
           "type": "opencollective",
@@ -14917,9 +14918,10 @@
       }
     },
     "node_modules/govuk-frontend": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.3.1.tgz",
-      "integrity": "sha512-EzegdVdmZVwXUGTQTsBgK4TkMpMyPdOIa2g1kvwX7EeyP9Kah+amXSo97gbiI8N49L6E0J6/2H6qLW4QN3KhMQ==",
+      "version": "5.9.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.9.0.tgz",
+      "integrity": "sha512-8NzmyoDtRFYyHs413DfNPR8Zo6qw6Q02Mruxml/Yfy+EueaOI/JZ4gVM8d0pqzJmTiMcJuHhvxqYEgBRmqeoyA==",
+      "license": "MIT",
       "engines": {
         "node": ">= 4.2.0"
       }
@@ -15367,6 +15369,30 @@
       },
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/hmrc-frontend": {
+      "version": "6.60.0",
+      "resolved": "https://registry.npmjs.org/hmrc-frontend/-/hmrc-frontend-6.60.0.tgz",
+      "integrity": "sha512-mj2N6WU6kBnJTbfKtWKAivWB6p6AT3BL9Adq6SL1HZs1rH9RVlxQR3Pz5n8lcvi7wwTLuAtbsQykRQEEKFXS2g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "accessible-autocomplete": "^3.0.1",
+        "govuk-frontend": "^5.9.0"
+      }
+    },
+    "node_modules/hmrc-frontend/node_modules/accessible-autocomplete": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/accessible-autocomplete/-/accessible-autocomplete-3.0.1.tgz",
+      "integrity": "sha512-xMshgc2LT5addvvfCTGzIkRrvhbOFeylFSnSMfS/PdjvvvElZkakCwxO3/yJYBWyi1hi3tZloqOJQ5kqqJtH4g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "preact": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "preact": {
+          "optional": true
+        }
       }
     },
     "node_modules/hosted-git-info": {

--- a/package.json
+++ b/package.json
@@ -188,6 +188,7 @@
     "hc-sticky": "2.2.7",
     "helmet": "6.0.1",
     "hmpo-form-wizard": "13.0.0",
+    "hmrc-frontend": "6.60.0",
     "i18next": "22.4.10",
     "i18next-express-middleware": "2.0.0",
     "i18next-fs-backend": "2.1.1",

--- a/server.js
+++ b/server.js
@@ -145,6 +145,12 @@ module.exports = async () => {
         '/node_modules/@ministryofjustice/frontend/moj/assets'
       ),
       { maxAge: config.STATIC_ASSETS.CACHE_MAX_AGE }
+    ),
+    express.static(
+      path.join(__dirname, '/node_modules/hmrc-frontend/hmrc/all'),
+      {
+        maxAge: config.STATIC_ASSETS.CACHE_MAX_AGE,
+      }
     )
   )
 

--- a/test/unit/component-helpers.ts
+++ b/test/unit/component-helpers.ts
@@ -16,6 +16,7 @@ const views = [
   configPaths.components,
   configPaths.govukFrontend,
   configPaths.mojFrontend,
+  configPaths.hmrcFrontend,
 ]
 
 const nunjucksEnvironment = nunjucks.configure(views, {


### PR DESCRIPTION
### What changed

Added the HMRC Timeout dialog component to enable users to be notified when their session is about to expire and to inform them that they will be automatically signed out in 2 minutes. 

### Issue tracking
- MAP-2299

## Screenshots
<img width="2218" alt="Screenshot 2025-04-08 at 11 54 25" src="https://github.com/user-attachments/assets/85529595-ca62-4163-a0e4-7bd15c211881" />
<img width="2219" alt="Screenshot 2025-04-08 at 11 55 11" src="https://github.com/user-attachments/assets/21ec736a-3552-4e00-84fc-ddb0cba02f9a" />

## Checklists

### Testing

#### Automated testing

- [ ] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed

### Other considerations

Commit messages with a `fix` or `feat` type are automatically used to generate the [changelog](ministryofjustice/hmpps-book-secure-move-frontend/blob/main/CHANGELOG.md) and
[GitHub release notes](https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/releases) during the release task. Please make sure they will read well on their own in a
summary of changes and that the commit body gives a more detailed description of those changes if necessary.

- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics