### PR TITLE
chore(MAP-2357): Update fetchBanner function to fix error

### DIFF
--- a/common/services/contentful/contentful.ts
+++ b/common/services/contentful/contentful.ts
@@ -184,14 +184,15 @@ export class ContentfulService {
       posts: await this.fetchPosts(entries),
     }
   }
-
+  
   async fetchBanner(entries?: ContentfulContent[]) {
-    
-    if (!entries) {
-      entries = await this.fetchEntries()
+    if (!Array.isArray(entries)) {
+      entries = entries !== undefined ? [entries] : [];
     }
-
-    return entries?.filter(entry => entry.isCurrent())[0]?.getBannerData()
+  
+    return entries
+      .filter(entry => typeof entry.isCurrent === 'function' && entry.isCurrent())
+      [0]?.getBannerData();
   }
 
   async fetchPosts(entries?: ContentfulContent[]) {


### PR DESCRIPTION
### What changed

Updated common / services / contentful / contentful.ts - fetchBanner() to fix the error when entries is not an array.

### Why did it change

Error being thrown when entires is not an array.

### Issue tracking

- MAP-2357

## Checklists

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Internet Explorer
