### PR TITLE
feat: MAP-2224 Change 'booked into' to 'booked for arrival at'

### DIFF
--- a/locales/en/events.json
+++ b/locales/en/events.json
@@ -436,7 +436,7 @@
     "description": "{{notes}}"
   },
   "PersonMoveBookedIntoReceivingEstablishment": {
-    "heading": "$t(events::person) booked into {{location.title}}",
+    "heading": "$t(events::person) booked for arrival at {{location.title}}",
     "description": ""
   },
   "PersonMoveDeathInCustody": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[MAP-XXXX] PR Title` -->

## Proposed changes

### What changed

<!--- Describe the changes in detail - the "what"-->

Changed the wording of the PersonMoveBookedIntoReceivingEstablishment event to "[Person] booked for arrival at [location]" 

### Why did it change

<!--- Describe the reason these changes were made - the "why" -->

To clarify that the person hasn't actually made it to the establishment and been booked in

### Issue tracking
<!--- List any related Jira tickets or GitHub issues --->
<!--- Delete/copy as appropriate --->

- MAP-2224

## Screenshots
<!--- (Optional) Include screenshots if changes update interfaces or components -->
<!--- Delete/copy as appropriate --->

| Before | After |
| ------ | ----- |
| <kbd>
<img width="614" alt="image" src="https://github.com/user-attachments/assets/2291e25d-26b9-4547-877b-79b427a197ed" />
</kbd> | <kbd><img width="650" alt="image" src="https://github.com/user-attachments/assets/b950fb33-3496-4d2e-a0cd-90819ae41b66" /></kbd> |

## Checklists

### Testing

#### Automated testing

- [ ] Added unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Internet Explorer

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed


### Other considerations

Commit messages with a `fix` or `feat` type are automatically used to generate the [changelog](ministryofjustice/hmpps-book-secure-move-frontend/blob/main/CHANGELOG.md) and
[GitHub release notes](https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/releases) during the release task. Please make sure they will read well on their own in a
summary of changes and that the commit body gives a more detailed description of those changes if necessary.

- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
