### PR TITLE
fix: Get e2e tests running ok locally

### DIFF
--- a/test/e2e/parallel-runner.ts
+++ b/test/e2e/parallel-runner.ts
@@ -304,10 +304,7 @@ const runTests = async () => {
         3000 + i
       } NOMIS_ELITE2_API_URL=http://localhost:${
         3999 + i
-      } FEATURE_FLAG_ADD_LODGE_BUTTON=true
-        FEATURE_FLAG_EXTRADITION_MOVES=true
-        FEATURE_FLAG_SECTION_46=true
-        node start.js`
+      } FEATURE_FLAG_ADD_LODGE_BUTTON=true FEATURE_FLAG_EXTRADITION_MOVES=true FEATURE_FLAG_SECTION_46=true node start.js`
   )
   const authCommandStrings = testBuckets.map(
     (_, i) =>


### PR DESCRIPTION
Absurdly this seems to fix the e2e tests locally...

[MAPB-377](https://dsdmoj.atlassian.net/browse/MAPB-377)

[MAPB-377]: https://dsdmoj.atlassian.net/browse/MAPB-377?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ