### PR TITLE
Fix critical shell-quote CVE-2026-9277 (override to 1.8.4)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5476,9 +5476,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -25064,9 +25061,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
-      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
+      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"

--- a/package.json
+++ b/package.json
@@ -379,6 +379,7 @@
     "find-versions": "6.0.0",
     "meow": "14.1.0",
     "serialize-javascript": "7.0.4",
+    "shell-quote": "1.8.4",
     "tmp": "0.2.5",
     "underscore": "^1.13.6"
   }


### PR DESCRIPTION
## What

Pins `shell-quote` to the patched **1.8.4** via npm `overrides`.

## Why

Snyk/Dependabot flagged a **critical** command-injection vulnerability, CVE-2026-9277 (`SNYK-JS-SHELLQUOTE-16799355`), in `shell-quote@1.8.3`. It is pulled in transitively via two dev tools:

- `concurrently@9.2.1` → `shell-quote@1.8.3`
- `npm-run-all@4.1.5` → `shell-quote@^1.6.1`

Because it's transitive there was no automatic Dependabot PR for it. This forces resolution to the patched 1.8.4, following the existing convention already used in `overrides` for `serialize-javascript` and `tmp`.

## Verification

- `npm install --package-lock-only` resolves a single `node_modules/shell-quote` at **1.8.4**.
- `npm audit` no longer reports shell-quote.