### PR TITLE
MAPB-595 Cancel Overnight Lodging button issue

### DIFF
--- a/app/move/app/view/middleware/locals.actions.js
+++ b/app/move/app/view/middleware/locals.actions.js
@@ -11,9 +11,10 @@ module.exports = function (req, res, next) {
     {
       text: 'actions::cancel_lodge',
       classes: 'app-link--destructive',
-      url: canAccess('move:lodging:cancel')
-        ? `/move/${move.id}/lodging/cancel`
-        : undefined,
+      url:
+        canAccess('move:lodging:cancel') && move.is_lodging
+          ? `/move/${move.id}/lodging/cancel`
+          : undefined,
     },
     {
       text: 'actions::cancel_move',

--- a/app/move/app/view/middleware/locals.actions.test.js
+++ b/app/move/app/view/middleware/locals.actions.test.js
@@ -88,6 +88,7 @@ describe('Move view app', function () {
       context('when lodging can be cancelled', function () {
         beforeEach(function () {
           req.canAccess.withArgs('move:lodging:cancel').returns(true)
+          req.move.is_lodging = true
 
           middleware(req, res, nextSpy)
         })
@@ -104,6 +105,24 @@ describe('Move view app', function () {
       context('when lodging cannot be cancelled', function () {
         beforeEach(function () {
           req.canAccess.withArgs('move:lodging:cancel').returns(false)
+          req.move.is_lodging = true
+
+          middleware(req, res, nextSpy)
+        })
+
+        it('should not add cancel lodging action', function () {
+          expect(res.locals.actions).not.to.deep.include({
+            text: 'actions::cancel_lodge',
+            classes: 'app-link--destructive',
+            url: '/move/12345/lodging/cancel',
+          })
+        })
+      })
+
+      context('when move does not have an overnight lodge', function () {
+        beforeEach(function () {
+          req.canAccess.withArgs('move:lodging:cancel').returns(true)
+          req.move.is_lodging = false
 
           middleware(req, res, nextSpy)
         })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Include the Jira ticket number in square brackets as prefix, eg `[MAP-XXXX] PR Title` -->

## Proposed changes

### What changed

Some moves were erroneously displaying the `cancel overnight lodging` button for moves that didn't have an overnight lodging.  

### Why did it change

Extra check was added to make sure that moves without an overnight lodging didn't displaying the `cancel overnight lodging` button.

### Issue tracking

[MAP-595](https://dsdmoj.atlassian.net/browse/MAPB-595)

## Checklists

### Testing

#### Automated testing

- [x] Updated unit tests to cover changes
- [ ] Added end-to-end tests to cover any journey changes

#### Manual testing

Has been tested in the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Internet Explorer

An example of a record that has the issue can be found fixed [here](https://hmpps-book-secure-move-frontend-pr-3529.apps.cloud-platform.service.justice.gov.uk/move/cc90383e-e897-42a4-ba54-bb1029101151/warnings)

Overnight lodge logic still works which has been tested here [here](https://hmpps-book-secure-move-frontend-pr-3529.apps.cloud-platform.service.justice.gov.uk/move/41d462a2-414b-4566-86b7-aabd1fd81ee6/warnings)

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed

### Other considerations

Commit messages with a `fix` or `feat` type are automatically used to generate the [changelog](ministryofjustice/hmpps-book-secure-move-frontend/blob/main/CHANGELOG.md) and
[GitHub release notes](https://github.com/ministryofjustice/hmpps-book-secure-move-frontend/releases) during the release task. Please make sure they will read well on their own in a
summary of changes and that the commit body gives a more detailed description of those changes if necessary.

- [x] No new [Personally Identifiable Information (PII)](https://support.google.com/analytics/answer/6366371?hl=en) is being sent via analytics
- [ ] Update [README](ministryofjustice/hmpps-book-secure-move-frontend/blob/main/README.md) with any new instructions or tasks


[MAP-595]: https://dsdmoj.atlassian.net/browse/MAP-595?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ