### PR TITLE
[MAPB-656] Redis health check fix

### DIFF
--- a/app/healthcheck/dependencies.js
+++ b/app/healthcheck/dependencies.js
@@ -50,7 +50,7 @@ module.exports = [
     name: 'redis',
     healthcheck: async () => {
       if (redisStore) {
-        const result = (await redisStore()).client.v4.ping()
+        const result = (await redisStore()).client.ping()
 
         if (!result) {
           throw new Error('No connection')

--- a/app/healthcheck/dependencies.js
+++ b/app/healthcheck/dependencies.js
@@ -50,7 +50,13 @@ module.exports = [
     name: 'redis',
     healthcheck: async () => {
       if (redisStore) {
-        const result = (await redisStore()).client.ping()
+        const store = await redisStore()
+        const result = await Promise.race([
+          store.client.ping(),
+          new Promise((resolve, reject) =>
+            setTimeout(() => reject(new Error('Timed out')), timeout)
+          ),
+        ])
 
         if (!result) {
           throw new Error('No connection')

--- a/app/healthcheck/dependencies.test.js
+++ b/app/healthcheck/dependencies.test.js
@@ -1,0 +1,103 @@
+const proxyquire = require('proxyquire').noCallThru()
+
+function loadRedisDependency({ REDIS = {}, redisStore = () => {} } = {}) {
+  const dependencies = proxyquire('./dependencies', {
+    '../../config': {
+      AUTH_PROVIDERS: {},
+      DEFAULT_AUTH_PROVIDER: 'default',
+      API: {},
+      NOMIS_ELITE2_API: {},
+      REDIS,
+    },
+    '../../config/redis-store': redisStore,
+  })
+
+  return dependencies.find(dependency => dependency.name === 'redis')
+}
+
+describe('Healthcheck dependencies', function () {
+  describe('redis', function () {
+    context('when REDIS.SESSION is not configured', function () {
+      it('should resolve with `NOT RUNNING`', async function () {
+        const redis = loadRedisDependency({ REDIS: {} })
+
+        await expect(redis.healthcheck()).to.eventually.equal('NOT RUNNING')
+      })
+    })
+
+    context('when REDIS.SESSION is configured', function () {
+      context('when ping resolves', function () {
+        it('should resolve with `OK`', async function () {
+          const redis = loadRedisDependency({
+            REDIS: { SESSION: {} },
+            redisStore: async () => ({
+              client: { ping: sinon.stub().resolves('PONG') },
+            }),
+          })
+
+          await expect(redis.healthcheck()).to.eventually.equal('OK')
+        })
+      })
+
+      context('when ping resolves with a falsy value', function () {
+        it('should throw `No connection`', async function () {
+          const redis = loadRedisDependency({
+            REDIS: { SESSION: {} },
+            redisStore: async () => ({
+              client: { ping: sinon.stub().resolves(null) },
+            }),
+          })
+
+          await expect(redis.healthcheck()).to.be.rejectedWith(
+            'No connection'
+          )
+        })
+      })
+
+      context('when ping rejects', function () {
+        it('should propagate the error', async function () {
+          const redis = loadRedisDependency({
+            REDIS: { SESSION: {} },
+            redisStore: async () => ({
+              client: {
+                ping: sinon.stub().rejects(new Error('Connection refused')),
+              },
+            }),
+          })
+
+          await expect(redis.healthcheck()).to.be.rejectedWith(
+            'Connection refused'
+          )
+        })
+      })
+
+      context('when ping never resolves', function () {
+        let clock
+
+        beforeEach(function () {
+          clock = sinon.useFakeTimers()
+        })
+
+        afterEach(function () {
+          clock.restore()
+        })
+
+        it('should throw `Timed out` after 5 seconds', async function () {
+          const redis = loadRedisDependency({
+            REDIS: { SESSION: {} },
+            redisStore: async () => ({
+              client: { ping: () => new Promise(() => {}) },
+            }),
+          })
+
+          const result = expect(redis.healthcheck()).to.be.rejectedWith(
+            'Timed out'
+          )
+
+          await clock.tickAsync(5000)
+          await result
+        })
+      })
+    })
+  })
+})


### PR DESCRIPTION
## Proposed changes

### What changed

- The `redis` dependency check now calls `store.client.ping()` (previously `store.client.v4.ping()`), properly awaits the result, and wraps it in a 5s timeout via Promise.race.
- Added tests for redis dependencies to hopefully catch this in the future. 

### Why did it change

The previous method was replaced in redis v5 which is what caused the health check to break. 

### Issue tracking

- [MAPB-656](https://dsdmoj.atlassian.net/browse/MAPB-656)

## Checklists

### Testing

#### Automated testing

- [x] Added unit tests to cover changes

#### Manual testing

Used this `curl` command: `curl -s http://localhost:3000/healthcheck | jq` to get the current health check statuses from the app. Repeated this after terminating redis and ensured that the health check for redis displayed the correct value each time. Confirmed using `redis-cli ping` to make sure redis was up/down when it needed to be.

### Environment variables

<!--- Delete if changes DO include new environment variables -->
- [x] No environment variables were added or changed


[MAPB-656]: https://dsdmoj.atlassian.net/browse/MAPB-656?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ